### PR TITLE
Fix "theme is missing" warning

### DIFF
--- a/tripal_core/tripal_core.module
+++ b/tripal_core/tripal_core.module
@@ -81,11 +81,9 @@ function tripal_core_init() {
   }
 
   // add some variables for all javasript to use for building URLs
-  $theme_dir = drupal_get_path('theme', 'tripal');
   $clean_urls = variable_get('clean_url', 0);
   drupal_add_js(
     " var baseurl  = '$base_url';
-      var themedir = '$theme_dir';
       var isClean  =  $clean_urls;",
     'inline', 'header');
 


### PR DESCRIPTION
On a fresh install of tripal 2.0 or 2.1b3 I get the following warning on most of the pages, even if I only enable the tripal_core module:

```
User warning: The following theme is missing from the file system: tripal. In order to fix this, put the theme back in its original location. For more information, see the documentation page. in _drupal_trigger_error_with_delayed_logging() (line 1128 of /var/www/html/includes/bootstrap.inc).
```

As it seems like there is no tripal theme anymore, I simply removed the line that triggered the warning, I don't know if it still should be declared somehow (for compatibility maybe?)
