### PR TITLE
Fix duplicate files directories (7.x-2.x)

### DIFF
--- a/tripal_core/api/tripal_core.files.api.inc
+++ b/tripal_core/api/tripal_core.files.api.inc
@@ -89,7 +89,7 @@ function tripal_get_files_dir($module_name = FALSE) {
     $data_dir .= "/$module_name";
 
     // Make sure the directory exists.
-    tripal_create_files_dir($module_name, "/$module_name");
+    tripal_create_files_dir($module_name);
 
   }
 
@@ -120,7 +120,7 @@ function tripal_get_files_stream($module_name = FALSE) {
     $stream .= "/$module_name";
 
     // Make sure the directory exists.
-    tripal_create_files_dir($module_name, "/$module_name");
+    tripal_create_files_dir($module_name);
   }
 
   return $stream;


### PR DESCRIPTION
Currently when using tripal_get_files_dir an empty identically-named subdirectory is automatically created within the actual files directory (e.g. real files directory is files/tripal_organism and this is what is returned, but another folder files/tripal_organism/tripal_organism is also created). This fixes that.
