### PR TITLE
Remove unused vars + fix 'operator not supported for strings' error

### DIFF
--- a/tripal_core/api/tripal_core.chado_query.api.inc
+++ b/tripal_core/api/tripal_core.chado_query.api.inc
@@ -1091,8 +1091,6 @@ function chado_select_record($table, $columns, $values, $options = NULL) {
     return FALSE;
   }
 
-  $select = '';
-  $from = '';
   $where = array();
   $args = array();
 
@@ -1196,8 +1194,6 @@ function chado_select_record($table, $columns, $values, $options = NULL) {
       );
       return array();
     }
-
-    $select[] = $field;
 
     // CASE 1: We have an array for a value.
     if (is_array($value)) {


### PR DESCRIPTION
Hi,
This should fix the error reported in https://github.com/erasche/docker-tripal/issues/15 by removing some unused vars