### PR TITLE
Fix small warning

### DIFF
--- a/tripal_core/api/tripal_core.chado_nodes.api.inc
+++ b/tripal_core/api/tripal_core.chado_nodes.api.inc
@@ -883,7 +883,7 @@ function chado_node_sync_records($base_table, $max_sync = FALSE,
   if ($where) {
     $query .= $where;
   }
-  $query .- " ORDER BY " . $base_table_id;
+  $query .= " ORDER BY " . $base_table_id;
 
   // If Maximum number to Sync is supplied
   if ($max_sync) {


### PR DESCRIPTION
Hi,
A small fix for a warning I get on this line: "A non-numeric value encountered tripal_core.chado_nodes.api.inc:886    [warning]"
I'm not sure what exactly is supposed to do ".-", I guess it was just a typo