### PR TITLE
fix tripal 3 loader  #154

### DIFF
--- a/tripal/includes/tripal.upload.inc
+++ b/tripal/includes/tripal.upload.inc
@@ -22,33 +22,37 @@ function tripal_file_upload($type, $filename, $action = NULL, $chunk = 0) {
 
   // Allow the module that will own the file to make some checks. The module
   // is allowed to stop the upload as needed.
-  $hook_name = $module . '_file_upload_check';
-  if (function_exists($hook_name)) {
-    $details = array(
-      'filename' => $filename,
-      'file_size' => $file_size,
-      'chunk_size' => $chunk_size,
-    );
-    $message = '';
-    $status = $hook_name($action, $details, $message);
-    if ($status === FALSE) {
-      drupal_json_output(array(
-        'status' => 'failed',
-        'message' => $message,
-        'file_id' => '',
-      ));
-      return;
-    }
-  }
 
-  switch ($action) {
+    if ($action == 'check' ) {
+        $hook_name = $module.'_file_upload_check';
+        if (function_exists($hook_name)) {
+            $details = [
+                'filename' => $filename,
+                'file_size' => $file_size,
+                'chunk_size' => $chunk_size,
+            ];
+            $message = '';
+            $status = $hook_name($action, $details, $message);
+            if ($status === false) {
+                drupal_json_output([
+                    'status' => 'failed',
+                    'message' => $message,
+                    'file_id' => '',
+                ]);
+
+                return;
+            }
+        }
+    }
+
+    switch ($action) {
     // If the action is 'put' then the callee is sending a chunk of the file
     case 'save':
       tripal_file_upload_put($filename, $chunk, $user_dir);
       break;
-    case 'check':
-      tripal_file_upload_check($filename, $chunk, $user_dir);
-      break;
+    //case 'check':
+    //  tripal_file_upload_check($filename, $chunk, $user_dir);
+    //  break;
     case 'merge':
       tripal_file_upload_merge($filename, $type, $user_dir);
       break;

--- a/tripal/theme/js/TripalUploadFile.js
+++ b/tripal/theme/js/TripalUploadFile.js
@@ -173,7 +173,6 @@
       if (this.curr_chunk >= this.total_chunks) {
         this.updateStatus();
         this._onUploadComplete();
-
         return;
       }
 


### PR DESCRIPTION
The JSON error was from returning malformed JSON: check was running when it wasnt supposed to.  To fix this, we make sure the check only runs when the action is check. 

see #154 