### PR TITLE
allow many extensions for Fasta Importer

### DIFF
--- a/tripal_chado/includes/TripalImporter/FASTAImporter.inc
+++ b/tripal_chado/includes/TripalImporter/FASTAImporter.inc
@@ -21,7 +21,7 @@ class FASTAImporter extends TripalImporter {
   /**
    * An array containing the extensions of allowed file types.
    */
-  public static $file_types = array('fasta');
+  public static $file_types = array('fasta', 'txt', 'fa', 'aa', 'pep', 'nuc');
 
 
   /**


### PR DESCRIPTION
Fasta files are coming from a variety of sources, and they are famously inconsistent in extension naming.  Having to rename all extensions to `.fasta` is a hassle.  I propose updating the importer to allow all of the extensions I've seen in my journeys.