### PR TITLE
if contact field  empty set field to null

### DIFF
--- a/tripal_chado/includes/TripalFields/local__contact/local__contact.inc
+++ b/tripal_chado/includes/TripalFields/local__contact/local__contact.inc
@@ -11,11 +11,11 @@ class local__contact extends ChadoField {
   // the field and it's default widget and formatter.
   // --------------------------------------------------------------------------
 
-  // The default lable for this field.
+  // The default label for this field.
   public static $default_label = 'Contact';
 
   // The default description for this field.
-  public static $description = 'An indviddual or organization that serves as a contact for this record.';
+  public static $description = 'An indvidual or organization that serves as a contact for this record.';
 
   // Provide a list of instance specific settings. These can be access within
   // the instanceSettingsForm.  When the instanceSettingsForm is submitted
@@ -24,8 +24,8 @@ class local__contact extends ChadoField {
   // If you override this variable in a child class be sure to replicate the
   // term_name, term_vocab, term_accession and term_fixed keys as these are
   // required for all TripalFields.
-  public static $default_instance_settings  = array(
-    // The short name for the vocabulary (e.g. shcema, SO, GO, PATO, etc.).
+  public static $default_instance_settings = [
+    // The short name for the vocabulary (e.g. schema, SO, GO, PATO, etc.).
     'term_vocabulary' => 'local',
     // The name of the term.
     'term_name' => 'contact',
@@ -35,7 +35,7 @@ class local__contact extends ChadoField {
     // type. This will create form elements when editing the field instance
     // to allow the site admin to change the term settings above.
     'term_fixed' => FALSE,
-  );
+  ];
 
 
   // The default widget for this field.
@@ -50,6 +50,7 @@ class local__contact extends ChadoField {
   // An array containing details about the field. The format of this array
   // is the same as that returned by field_info_fields()
   protected $field;
+
   // An array containing details about an instance of the field. A field does
   // not have to have an instance.  But if dealing with an instance (such as
   // when using the widgetForm, formatterSettingsForm, etc.) it should be set.
@@ -65,46 +66,48 @@ class local__contact extends ChadoField {
     $name_term = tripal_get_chado_semweb_term('contact', 'name');
     $description_term = tripal_get_chado_semweb_term('contact', 'description');
 
-    return array(
-      $field_term => array(
-        'operations' => array('eq', 'contains', 'starts'),
+    return [
+      $field_term => [
+        'operations' => ['eq', 'contains', 'starts'],
         'sortable' => TRUE,
         'searchable' => TRUE,
         'type' => 'string',
-        'elements' => array(
-          $type_term => array(
+        'elements' => [
+          $type_term => [
             'searchable' => TRUE,
             'label' => 'Contact Type',
             'help' => 'The type of contact',
-            'operations' => array('eq', 'ne', 'contains', 'starts'),
+            'operations' => ['eq', 'ne', 'contains', 'starts'],
             'sortable' => TRUE,
-          ),
-          $name_term => array(
+          ],
+          $name_term => [
             'searchable' => TRUE,
             'label' => 'Contact Name',
             'help' => 'The name of the contact.',
-            'operations' => array('eq', 'ne', 'contains', 'starts'),
+            'operations' => ['eq', 'ne', 'contains', 'starts'],
             'sortable' => TRUE,
-          ),
-          $description_term => array(
+          ],
+          $description_term => [
             'searchable' => TRUE,
             'label' => 'Contact Description',
             'help' => 'A descriptoin of the contact.',
-            'operations' => array('contains'),
+            'operations' => ['contains'],
             'sortable' => TRUE,
-          ),
-          'entity' => array(
+          ],
+          'entity' => [
             'searchable' => FALSE,
-          ),
-        ),
-      )
-    );
+          ],
+        ],
+      ],
+    ];
   }
+
   /**
    *
    * @see TripalField::load()
    */
   public function load($entity) {
+
     $record = $entity->chado_record;
 
     $field_name = $this->field['field_name'];
@@ -119,22 +122,27 @@ class local__contact extends ChadoField {
 
 
     // Set some defaults for the empty record.
-    $entity->{$field_name}['und'][0] = array(
-      'value' => array(),
-    );
+    $entity->{$field_name}['und'][0] = [
+      'value' => [],
+    ];
 
     // Handle the biomaterial table.
     if ($field_table == 'biomaterial') {
       if ($record) {
         $contact = $record->biosourceprovider_id;
-        $entity->{$field_name}['und'][0] = array(
-          'value' => array(
+
+        if (!$contact) {
+          $entity->{$field_name}['und'][0]['value'] = NULL;
+          return;
+        }
+        $entity->{$field_name}['und'][0] = [
+          'value' => [
             $type_term => $contact->type_id ? $contact->type_id->name : '',
             $name_term => $contact->name,
             $description_term => $contact->description,
-          ),
+          ],
           $entity->{$field_name}['und'][0]['chado-biomaterial__biosourceprovider_id'] = $contact->contact_id,
-        );
+        ];
         if (property_exists($contact, 'entity_id')) {
           $entity->{$field_name}['und'][0]['value']['entity'] = 'TripalEntity:' . $contact->entity_id;
         }
@@ -149,6 +157,7 @@ class local__contact extends ChadoField {
   public function query($query, $condition) {
     $alias = $this->field['field_name'];
     $operator = $condition['operator'];
+    $field_table = $this->instance['settings']['chado_table'];
 
     $field_term_id = $this->getFieldTermID();
     $type_term = tripal_get_chado_semweb_term('contact', 'type_id');
@@ -156,28 +165,25 @@ class local__contact extends ChadoField {
     $description_term = tripal_get_chado_semweb_term('contact', 'description');
 
     if ($field_table == 'biomaterial') {
-      if ($record) {
-        $contact = $record->biosourceprovider_id;
 
-        // Join the contact table
-        $calias = $alias . '_provider_id';
-        $this->queryJoinOnce($query, 'contact', $calias, "base.biosourceprovider_id = $calias.contact_id");
+      // Join the contact table
+      $calias = $alias . '_provider_id';
+      $this->queryJoinOnce($query, 'contact', $calias, "base.biosourceprovider_id = $calias.contact_id");
 
-        // Search by the contact name
-        if ($condition['column'] == $field_term_id or
-            $condition['column'] == $field_term_id . ',' . $name_term) {
-          $query->condition("$calias.name", $condition['value'], $operator);
-        }
-        // Search on the contact description.
-        if ($condition['column'] == $field_term_id . ',' . $description_term) {
-          $query->condition("$calias.description", $condition['value'], $operator);
-        }
-        // Search on the contact type.
-        if ($condition['column'] == $field_term_id . ',' . $type_term) {
-          $talias = $alias . 'provider_contact_type';
-          $this->queryJoinOnce($query, 'cvterm', $talias, "$calias.type_id = $talias.cvterm_id");
-          $query->condition("$talias.name", $condition['value'], $operator);
-        }
+      // Search by the contact name
+      if ($condition['column'] == $field_term_id or
+        $condition['column'] == $field_term_id . ',' . $name_term) {
+        $query->condition("$calias.name", $condition['value'], $operator);
+      }
+      // Search on the contact description.
+      if ($condition['column'] == $field_term_id . ',' . $description_term) {
+        $query->condition("$calias.description", $condition['value'], $operator);
+      }
+      // Search on the contact type.
+      if ($condition['column'] == $field_term_id . ',' . $type_term) {
+        $talias = $alias . 'provider_contact_type';
+        $this->queryJoinOnce($query, 'cvterm', $talias, "$calias.type_id = $talias.cvterm_id");
+        $query->condition("$talias.name", $condition['value'], $operator);
       }
     }
   }
@@ -191,30 +197,28 @@ class local__contact extends ChadoField {
     $type_term = tripal_get_chado_semweb_term('contact', 'type_id');
     $name_term = tripal_get_chado_semweb_term('contact', 'name');
     $description_term = tripal_get_chado_semweb_term('contact', 'description');
+    $field_table = $this->instance['settings']['chado_table'];
 
     if ($field_table == 'biomaterial') {
-      if ($record) {
-        $contact = $record->biosourceprovider_id;
 
-        // Join the contact linker table and then join the contact table.
-        $calias = $alias . '_provider_id';
-        $this->queryJoinOnce($query, 'contact', $calias, "base.biosourceprovider_id = $calias.contact_id");
+      // Join the contact linker table and then join the contact table.
+      $calias = $alias . '_provider_id';
+      $this->queryJoinOnce($query, 'contact', $calias, "base.biosourceprovider_id = $calias.contact_id");
 
-        // Search by the contact name
-        if ($order['column'] == $field_term_id or
-            $order['column'] == $field_term_id . ',' . $name_term) {
-          $query->orderBy("$calias.name", $order['direction']);
-        }
-        // Search on the contact description.
-        if ($order['column'] == $field_term_id . ',' . $description_term) {
-          $query->orderBy("$calias.description", $order['direction']);
-        }
-        // Search on the contact type.
-        if ($order['column'] == $field_term_id . ',' . $type_term) {
-          $talias = $alias . 'provider_contact_type';
-          $this->queryJoinOnce($query, 'cvterm', $talias, "$calias.type_id = $talias.cvterm_id", "LEFT OUTER");
-          $query->orderBy("$talias.name", $order['direction']);
-        }
+      // Search by the contact name
+      if ($order['column'] == $field_term_id or
+        $order['column'] == $field_term_id . ',' . $name_term) {
+        $query->orderBy("$calias.name", $order['direction']);
+      }
+      // Search on the contact description.
+      if ($order['column'] == $field_term_id . ',' . $description_term) {
+        $query->orderBy("$calias.description", $order['direction']);
+      }
+      // Search on the contact type.
+      if ($order['column'] == $field_term_id . ',' . $type_term) {
+        $talias = $alias . 'provider_contact_type';
+        $this->queryJoinOnce($query, 'cvterm', $talias, "$calias.type_id = $talias.cvterm_id", "LEFT OUTER");
+        $query->orderBy("$talias.name", $order['direction']);
       }
     }
   }


### PR DESCRIPTION
The contact field throws errors for biosamples without entries, and displays an empty table.  I set the value to null if there is no contact.

Also the query methods looks for arguments that dont exist, so I've removed those.