### PR TITLE
Fix PDO exception on editing a cvterm

### DIFF
--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -633,7 +633,7 @@ function tripal_chado_menu() {
     'title' => 'Edit a Controlled Vocabulary Term',
     'description' => 'Edit an existing controlled vocabulary term.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('tripal_cv_cvterm_edit_form', 4, 7),
+    'page arguments' => array('tripal_cv_cvterm_edit_form', 5, 8),
     'access arguments' => array('administer controlled vocabularies'),
     'file' => 'includes/tripal_chado.cv.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -258,7 +258,7 @@ function tripal_chado_menu() {
     'title' => 'Create Materialized View',
     'description' => t('Materialized views are used to improve speed of large or complex queries.'),
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('tripal_mviews_delete_form', 5),
+    'page arguments' => array('tripal_mviews_delete_form', 6),
     'access arguments' => array('administer chado mviews'),
     'type' => MENU_CALLBACK,
     'file' => 'includes/tripal_chado.mviews.inc',


### PR DESCRIPTION
Simple fix for #242 . 

Simply, editing a cvterm returns a PDO error.  This is because the argument given is one off from the wildcard.  Shifting the args down resolves the error. 
    