### PR TITLE
[bugfix] unbreak cache: uncomment required files in web services

### DIFF
--- a/tripal_ws/tripal_ws.module
+++ b/tripal_ws/tripal_ws.module
@@ -20,7 +20,7 @@
  * Tripal provides an application programming interface (API) to support
  * customizations and creation of new extensions.
  * @
- *
+ */
 require_once  "api/tripal_ws.api.inc";
 require_once  "includes/tripal_ws.field_storage.inc";
 require_once  "includes/tripal_ws.fields.inc";


### PR DESCRIPTION
Addresses bug #257 

Could not find the webservices field class because all of the web services.module includes were commented out. 