### PR TITLE
point users to the admin menu report area

### DIFF
--- a/.github/ISSUE-TEMPLATE.md
+++ b/.github/ISSUE-TEMPLATE.md
@@ -1,7 +1,7 @@
 INSTRUCTIONS: The following template is meant to provide the information that will help other Tripal developers diagnose and reproduce your issue. Follow the directions below to complete the template. If the template is not appropriate for your issue you may remove it and describe your issue.
 
 ### System information
-<!--Please enter the following information (if able).  All information is available in your site's administrator report area. You can find this in the admin menu at Administer (or Administration) > Reports > Status report."  -->
+<!--Please enter the following information (if able). All information is available in your site's administrator report area (Administration Toolbar > Reports > Status Report) -->
 
 * Tripal Version:
 * Drupal Version:

--- a/.github/ISSUE-TEMPLATE.md
+++ b/.github/ISSUE-TEMPLATE.md
@@ -1,13 +1,12 @@
 INSTRUCTIONS: The following template is meant to provide the information that will help other Tripal developers diagnose and reproduce your issue. Follow the directions below to complete the template. If the template is not appropriate for your issue you may remove it and describe your issue.
 
 ### System information
-<!--Please enter the following information (if known)  -->
+<!--Please enter the following information (if able).  All information is available in your site's administrator report area. You can find this in the admin menu at Administer (or Administration) > Reports > Status report."  -->
 
 * Tripal Version:
 * Drupal Version:
 * PostgreSQL Version:
 * PHP Version:
-* Operating System:
 
 
 ### Issue description


### PR DESCRIPTION
Remove OS from the spec request.  Point users to the admin panel area which has all other spec information.  As per discussion #251 discussion