### PR TITLE
add cvalue support for properties

### DIFF
--- a/tripal_chado/api/tripal_chado.property.api.inc
+++ b/tripal_chado/api/tripal_chado.property.api.inc
@@ -169,6 +169,7 @@ function chado_insert_property($record, $property, $options = array()) {
   $cv_id       = array_key_exists('cv_id', $property) ? $property['cv_id'] : '';
   $value       = array_key_exists('value', $property) ? $property['value'] : '';
   $rank        = array_key_exists('rank', $property) ? $property['rank'] : 0;
+  $cvalue_id   = array_key_exists('cvalue_id', $property) ? $property['cvalue_id'] : '';
 
   $update_if_present = array_key_exists('update_if_present', $options) ? $options['update_if_present'] : FALSE;
   $force_rank = array_key_exists('force_rank', $options) ? $options['force_rank'] : FALSE;
@@ -249,6 +250,20 @@ function chado_insert_property($record, $property, $options = array()) {
       array('%property' => print_r($property, TRUE)));    return FALSE;
   }
 
+
+    //Check that the cvalue property exists
+    if ($cvalue_id){
+        $term = chado_select_record('cvterm', array('cvterm_id'), array('cvterm_id' => $cvalue_id), $options);
+       if (!$term or count($term) == 0) {
+            tripal_report_error('tripal_chado', TRIPAL_ERROR, "chado_insert_property: " .
+                "Cannot find the term for the property value described by: %property.",
+                array('%property' => print_r($property, TRUE)));
+           return FALSE;
+    }
+    $values['cvalue'] = $cvalue_id;
+  }
+
+
   // Get the foreign key for this property table
   $table_desc = chado_get_schema($base_table . 'prop');
   $fkcol = key($table_desc['foreign keys'][$base_table]['columns']);
@@ -310,6 +325,7 @@ function chado_update_property($record, $property, $options = array()) {
   $cv_id       = array_key_exists('cv_id', $property) ? $property['cv_id'] : '';
   $value       = array_key_exists('value', $property) ? $property['value'] : '';
   $rank        = array_key_exists('rank', $property) ? $property['rank'] : 0;
+  $cvalue_id   = array_key_exists('cvalue_id', $property) ? $property['cvalue_id'] : '';
 
   $insert_if_missing = array_key_exists('insert_if_missing', $options) ? $options['insert_if_missing'] : FALSE;
 
@@ -383,6 +399,18 @@ function chado_update_property($record, $property, $options = array()) {
   $values['value'] = $value;
   if ($rank) {
     $values['rank'] = $rank;
+  }
+
+  // If a cvalue_id is supplied, check that it is a valid cvterm
+    if ($cvalue_id) {
+        $term = chado_select_record('cvterm', array('cvterm_id'), array('cvterm_id' => $cvalue_id), $options);
+        if (!$term or count($term) == 0) {
+            tripal_report_error('tripal_chado', TRIPAL_ERROR, "chado_insert_property: " .
+                "Cannot find the term for the property value described by: %property.",
+                array('%property' => print_r($property, TRUE)));
+            return FALSE;
+    }
+    $values['cvalue_id'] = $cvalue_id;
   }
 
   // If we have the unique property_id then we can also update the type

--- a/tripal_chado/api/tripal_chado.property.api.inc
+++ b/tripal_chado/api/tripal_chado.property.api.inc
@@ -302,6 +302,9 @@ function chado_insert_property($record, $property, $options = array()) {
  *     -cv_name: The name of the CV that contains the term.
  *     -value: The specific value for the property.
  *     -rank: The specific rank for the property.
+ *     -cvalue_id: The cvterm_id of the value for the property.
+ *      **note** cvalue_id is an anticipated column in the the next Chado release (1.4).  It is included here for early adopters.
+ *
  * @param $options
  *   An associative array containing the following keys:
  *     -insert_if_missing: A boolean indicating whether a record should be
@@ -544,6 +547,9 @@ function chado_delete_property($record, $property) {
  *     -cv_name: The name of the CV that contains the term.
  *     -value: The specific value for the property.
  *     -rank: The specific rank for the property.
+ *     -cvalue_id: The cvterm_id of the value for the property.
+ *      **note** cvalue_id is an anticipated column in the the next Chado release (1.4).  It is included here for early adopters.
+ * 
  * @param $options
  *   An array of options supported by chado_generate_var(). These keys
  *   are used for generating the cvterm objects returned by this function.


### PR DESCRIPTION
The [next version of Chado](https://github.com/GMOD/Chado/pull/54) will include a `cvalue_id` column for each prop table.  Supporting this is a pressing goal for us at HWG so I've already added support to our [Biomaterial Importer](https://github.com/tripal/tripal_analysis_expression/pull/198).  For those unaware, this means that instead of only support free-text for the property value in the `value` column, you can instead supply a cvterm for the value as well as the property type.

However we use `chado_insert_property` in our module.  So, this PR allows `cvalue_id` support.  It has no effect on calls to this method that don't supply a `cvalue_id`.


Thanks @laceysanderson for the easy workaround cleaning up my PR #294 