### PR TITLE
Fix tripal ds build error

### DIFF
--- a/tripal_ds/api/tripal_ds.pane.api.inc
+++ b/tripal_ds/api/tripal_ds.pane.api.inc
@@ -32,6 +32,12 @@
  *  tripal_ds_field_create_field($field_label, $field, $bundle);
  */
 function tripal_ds_field_create_field($field_label, $field_name, $bundle_name) {
+
+  if (isset($field_name['field_name'])){
+    $field_name = $field_name['field_name'];
+  }
+
+
   $field_name = str_replace(' ', '_', strtolower($field_name));
   //Build the rest of the passes parameters.
   $group_field_name = 'gp_'.$field_name;

--- a/tripal_ds/api/tripal_ds.pane.api.inc
+++ b/tripal_ds/api/tripal_ds.pane.api.inc
@@ -31,12 +31,7 @@
  *  field_create_instance($instance);
  *  tripal_ds_field_create_field($field_label, $field, $bundle);
  */
-function tripal_ds_field_create_field($field_label, $field_name, $bundle_name) {
-
-  if (isset($field_name['field_name'])){
-    $field_name = $field_name['field_name'];
-  }
-
+function tripal_ds_field_create_field_but_not_the_hook($field_label, $field_name, $bundle_name) {
 
   $field_name = str_replace(' ', '_', strtolower($field_name));
   //Build the rest of the passes parameters.

--- a/tripal_ds/api/tripal_ds.pane.api.inc
+++ b/tripal_ds/api/tripal_ds.pane.api.inc
@@ -31,8 +31,7 @@
  *  field_create_instance($instance);
  *  tripal_ds_field_create_field($field_label, $field, $bundle);
  */
-function tripal_ds_field_create_field_but_not_the_hook($field_label, $field_name, $bundle_name) {
-
+function tripal_ds_create_field($field_label, $field_name, $bundle_name) {
   $field_name = str_replace(' ', '_', strtolower($field_name));
   //Build the rest of the passes parameters.
   $group_field_name = 'gp_'.$field_name;

--- a/tripal_ds/tripal_ds.module
+++ b/tripal_ds/tripal_ds.module
@@ -381,6 +381,11 @@ function tripal_ds_pane_addition_button_form_submit($form, &$form_state) {
   //Build the rest of the passed variables.
   $field_name = $form_state['input']['field_name'];
   $field_label = $form_state['input']['field_name'];
+
+  if (!$field_name){
+    return;
+  }
+
   tripal_ds_field_create_field($field_label, $field_name, $bundle_name);
   drupal_goto("admin/structure/bio_data/manage/$bundle_name/display");
 }

--- a/tripal_ds/tripal_ds.module
+++ b/tripal_ds/tripal_ds.module
@@ -381,12 +381,8 @@ function tripal_ds_pane_addition_button_form_submit($form, &$form_state) {
   //Build the rest of the passed variables.
   $field_name = $form_state['input']['field_name'];
   $field_label = $form_state['input']['field_name'];
-
-  if (!$field_name){
-    return;
-  }
-
-  tripal_ds_field_create_field($field_label, $field_name, $bundle_name);
+  
+  tripal_ds_field_create_field_but_not_the_hook($field_label, $field_name, $bundle_name);
   drupal_goto("admin/structure/bio_data/manage/$bundle_name/display");
 }
 

--- a/tripal_ds/tripal_ds.module
+++ b/tripal_ds/tripal_ds.module
@@ -7,7 +7,7 @@ require_once "includes/tripal_ds.field_formatter.inc";
 require_once "includes/tripal_ds.field_formatter.inc";
 
 // Import the full Tripal_DS API into scope.
-tripal_ds_import_api(); 
+tripal_ds_import_api();
 
 /**
  * Implements hook_init().
@@ -381,8 +381,8 @@ function tripal_ds_pane_addition_button_form_submit($form, &$form_state) {
   //Build the rest of the passed variables.
   $field_name = $form_state['input']['field_name'];
   $field_label = $form_state['input']['field_name'];
-  
-  tripal_ds_field_create_field_but_not_the_hook($field_label, $field_name, $bundle_name);
+
+  tripal_ds_create_field($field_label, $field_name, $bundle_name);
   drupal_goto("admin/structure/bio_data/manage/$bundle_name/display");
 }
 


### PR DESCRIPTION
`tripal_ds_field_create_field` accidentally implemented hook field_create_field.

Renamed the call to avoid this.

This was also what prevented tripal from installing.