### PR TITLE
Issue #208: Fix ignoring of duplicates for cron jobs.

### DIFF
--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -1059,14 +1059,30 @@ function tripal_cron() {
     $modules = module_implements('tripal_cron_notification');
     foreach ($modules as $module) {
       $function = $module . '_tripal_cron_notification';
-      tripal_add_job("Cron: Checking for '$module' notifications.", 'tripal',
-        $function, $args, 1, $includes, TRUE);
+      tripal_add_job(
+        "Cron: Checking for '$module' notifications.",    // Job Name
+        'tripal',                                         // Module Name
+        $function,                                        // Callback
+        $args,                                            // Arguements
+        1,                                                // User UID
+        1,                                                // Priority (1-10)
+        $includes,                                        // Includes
+        TRUE                                              // Ignore Duplicates
+      );
     }
   }
 
   // Check for expired collections.
-  tripal_add_job('Cron: Checking expired collections', 'tripal',
-    'tripal_expire_collections', $args, 1, $includes, TRUE);
+  tripal_add_job(
+    'Cron: Checking expired collections',             // Job Name
+    'tripal',                                         // Module Name
+    'tripal_expire_collections',                      // Callback
+    $args,                                            // Arguements
+    1,                                                // User UID
+    1,                                                // Priority (1-10)
+    $includes,                                        // Includes
+    TRUE                                              // Ignore Duplicates
+  );
 }
 
 /**


### PR DESCRIPTION
There was a parameter shift when using tripal_add_jobs() to add the cron jobs. Specifically, the `priority` was missing which caused `ignore_duplicates` to use it's default value. When this was changed for backwards compatibility this error resurfaced.

This pull request sets the `priority` to `1` (the lowest priority) and thus shifts the parameters so `ignore_duplicates` is `TRUE`. This is assuming that the `uid` should be set to `1` to ensure these jobs are submitted as the administrator user.