### PR TITLE
fix the form params for chado/views-integration

### DIFF
--- a/tripal_chado_views/tripal_chado_views.module
+++ b/tripal_chado_views/tripal_chado_views.module
@@ -74,7 +74,7 @@ function tripal_chado_views_menu() {
   $items['admin/tripal/storage/chado/views-integration/edit/%'] = array(
     'title' => 'Edit Views Integration',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('tripal_chado_views_integration_form', 4),
+    'page arguments' => array('tripal_chado_views_integration_form', 6),
     'access arguments' => array('manage tripal_views_integration'),
     'type' => MENU_CALLBACK,
   );


### PR DESCRIPTION
This is a fix for https://github.com/tripal/tripal/issues/228

Right now the views-integration form is unusable - it passes the wrong param throwing a PDO error.