### PR TITLE
Fixed issue #305

### DIFF
--- a/tripal/includes/TripalFields/TripalField.inc
+++ b/tripal/includes/TripalFields/TripalField.inc
@@ -56,6 +56,14 @@ class TripalField {
       'TripalTabDownloader',
       'TripalCSVDownloader',
     ),
+    // Set to TRUE if the field should be automatically attached to an entity
+    // when it is loaded. Otherwise, the callee must attach the field
+    // manually.  This is useful to prevent really large fields from slowing
+    // down page loads.  However, if the content type display is set to
+    // "Hide empty fields" then this has no effect as all fields must be
+    // attached to determine which are empty.  It should always work with
+    // web services.
+    'auto_attach' => TRUE,
   );
 
   // The default widget for this field.

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -747,16 +747,42 @@ function tripal_import_api() {
 }
 
 /**
- * Implements hook_form_alter().
+ *
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * The field_ui_field_edit_form is used for customizing the settings of
+ * a field attached to an entity.
+ *
+ * This alter function disables some of the form widgets when the storage
+ * backend indicates they are not appropriate.
  */
-function tripal_form_alter(&$form, $form_state, $form_id) {
+function tripal_form_field_ui_field_edit_form_alter(&$form, &$form_state, $form_id) {
   // If this is the field_ui_field_edit_form (i.e. the form that appears
   // when editing a field that is attached to an entity). Then we want
   // to add term settings for any field attached to a TripalEntity
   // content type.
-  if ($form_id == 'field_ui_field_edit_form' and $form['#instance']['entity_type'] == 'TripalEntity') {
+  if ($form['#instance']['entity_type'] == 'TripalEntity') {
+
+    // Add the form elements for setting the vocabulary terms.
     tripal_field_instance_settings_form_alter($form, $form_state);
+
+    // Make sure we preserve the auto_attach settings.
+    $auto_attach = TRUE;
+    if (array_key_exists('auto_attach', $form['#instance']['settings'])) {
+      $auto_attach = $form['#instance']['settings']['auto_attach'];
+    }
+    $form['instance']['settings']['auto_attach'] = array(
+      '#type' => 'value',
+      '#value' => $auto_attach,
+    );
   }
+}
+
+
+/**
+ * Implements hook_form_alter().
+ */
+function tripal_form_alter(&$form, $form_state, $form_id) {
 
   // Remove fields that have no form. It's just a bit too confusing to have
   // widgets appear in the form but without any form elements inside them.

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -1024,22 +1024,40 @@ function tripal_chado_node_delete($node) {
  * backend indicates they are not appropriate.
  */
 function tripal_chado_form_field_ui_field_edit_form_alter(&$form, &$form_state, $form_id) {
-  // For entity fields added by Tripal Entities we don't want the
-  // the end-user to change the cardinality and the required fields
-  // such that record can't be saved in Chado.
 
-  // TODO: we shouldn't check for specific field types here
-  // (e.g. chado_linker_prop). That should be done via the TripalField
-  // functions.
   if ($form['#instance']['entity_type'] == 'TripalEntity') {
+
+    // For entity fields added by Tripal Entities we don't want the
+    // the end-user to change the cardinality and the required fields
+    // such that record can't be saved in Chado.
+    // TODO: we shouldn't check for specific field types here
+    // (e.g. chado_linker_prop). That should be done via the TripalField
+    // functions.
     if ($form['#field']['storage']['type'] == 'field_chado_storage' and
         $form['#field']['type'] != 'chado_linker__prop') {
       $form['field']['cardinality']['#access'] = FALSE;
       $form['instance']['required']['#access'] = FALSE;
     }
+
+    // If this is a Chado field we need to preserve the Chado elements of the
+    // settings or they will be lost if a user edits the field settings.
+    if (array_key_Exists('chado_table', $form['#instance']['settings'])) {
+      $form['instance']['settings']['base_table'] = array(
+        '#type' => 'value',
+        '#value' => $form['#instance']['settings']['base_table'],
+      );
+      $form['instance']['settings']['chado_table'] = array(
+        '#type' => 'value',
+        '#value' => $form['#instance']['settings']['chado_table'],
+      );
+      $form['instance']['settings']['chado_column'] = array(
+        '#type' => 'value',
+        '#value' => $form['#instance']['settings']['chado_column'],
+      );
+    }
   }
 
-  // TODO: don't the the maximum length be larger than the field size.
+  // TODO: don't let the maximum length be larger than the field size.
 }
 
 


### PR DESCRIPTION
This is a fix reported for issue #305.  Chado properties added to field settings were not being preserved when the field settings were updated using the UI.  This caused problems inserting records afterwards.