### PR TITLE
Issue253

### DIFF
--- a/tripal/tripal.drush.inc
+++ b/tripal/tripal.drush.inc
@@ -372,12 +372,9 @@ function drush_tripal_trp_set_permissions() {
 
   drush_tripal_set_user($username);
   $permissions = array();
-  $bundles =
-  db_select('tripal_bundle', 'TB')
-    ->fields('TB', array('name'))
-    ->execute()
-    ->fetchAll();
-  print_r($bundles);
+    
+  $bundles = tripal_get_content_types();
+
   foreach ($bundles as $bundles => $bundle) {
     array_push($permissions, ' view ' . $bundle->name, ' create ' . $bundle->name,
       ' edit ' . $bundle->name, ' delete ' . $bundle->name);

--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -387,7 +387,8 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
 
     // Iterate through each root level term.
     $record = $result->fetchAll();
-    $roots = array();
+    $roots = [];
+
     foreach ($record as $item){
       tripal_update_cvtermpath_root_loop($item->cvterm_id, $item->cv_id, $roots);
     }
@@ -416,16 +417,24 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
  * @ingroup tripal_chado_cv_api
  */
 function tripal_update_cvtermpath_root_loop($rootid, $cvid, &$roots) {
-
   // Get's the cvterm record for this "root".
-  $ttype = db_select('cvterm', 'cv')
-          ->fields('cv', array('cvterm_id'));
-  $db_or = db_or();
-  $db_or->condition('cv.name', "isa", '=');
-  $db_or->condition('cv.name', "is_a", '=');
-  $ttype->condition($db_or);
-  $result = $ttype->execute()->fetchObject();
+  // $ttype = db_select('cvterm', 'cv')
+  //         ->fields('cv', array('cvterm_id'));
+  // $db_or = db_or();
+  // $db_or->condition('cv.name', "isa", '=');
+  // $db_or->condition('cv.name', "is_a", '=');
+  // $ttype->condition($db_or);
+  $ttype = db_query(
+    'SELECT cv.cvterm_id 
+    FROM cvterm cv
+    WHERE cv.name = :isa 
+          OR cv.name = :is_a
+    '
+    ,
+    array(':isa' => "isa", ':is_a' => "is_a")
+  );
 
+  $result = $ttype->fetchObject();
   $term_id = $rootid . '|' . $rootid . '|' . $cvid . '|' . $result->cvterm_id;
   // If the child_id matches any other id in the array then we've hit a loop.
   foreach ($roots as $element_id) {
@@ -437,9 +446,9 @@ function tripal_update_cvtermpath_root_loop($rootid, $cvid, &$roots) {
   $roots[] = $term_id;
 
   // Descends through the branch starting at this "root" term.
-  $tree_path = array();
-  $matched_rows = array();
-  $possible_start_of_loop = array();
+  $tree_path = [];
+  $matched_rows = [];
+  $possible_start_of_loop = [];
   $depth = 0;
   tripal_update_cvtermpath_loop($rootid, $rootid, $cvid, $result->cvterm_id, $depth,
                                 0, $tree_path, FALSE, $matched_rows, $possible_start_of_loop, FALSE);
@@ -451,7 +460,7 @@ function tripal_update_cvtermpath_root_loop($rootid, $cvid, &$roots) {
       FROM cvterm_relationship
       WHERE object_id = :rootid
     ',
-    array(':rootid' => $rootid)
+    [':rootid' => $rootid]
   );
   while ($cterm_result = $cterm->fetchAssoc()) {
     tripal_update_cvtermpath_root_loop($cterm_result['subject_id'], $cvid, $roots);
@@ -510,7 +519,7 @@ function tripal_update_cvtermpath_loop(
   $no_loop_skip_test) {
 
   // We have not detected a loop, so it's safe to insert the term.
-  $new_match_rows = array();
+  $new_match_rows = [];
   if (!empty($possible_start_of_loop)) {
     // Go through each matched_row.
     if (count($matched_rows) === 1) {
@@ -523,7 +532,7 @@ function tripal_update_cvtermpath_loop(
           FROM cvtermpath
           WHERE cvtermpath_id = :cvtermpath_id
         ',
-        array(':cvtermpath_id' => $cvtermpath_id)
+        [':cvtermpath_id' => $cvtermpath_id]
       );
       $next_row = $next_row->fetchObject();
 
@@ -541,7 +550,7 @@ function tripal_update_cvtermpath_loop(
         // The next_row is equal to start of loop, so we've reached the end
         // and confirmed that this is a loop.
         $possible_loop == FALSE;
-        $matched_rows = array();
+        $matched_rows = [];
         tripal_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
         $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
         $new_match_rows, $possible_start_of_loop, $no_loop_skip_test);
@@ -560,7 +569,7 @@ function tripal_update_cvtermpath_loop(
             FROM cvtermpath
             WHERE cvtermpath_id = :cvtermpath_id
           ',
-          array(':cvtermpath_id' => $cvtermpath_id)
+          [':cvtermpath_id' => $cvtermpath_id]
         );
         $next_row = $next_row->fetchObject();
 
@@ -578,7 +587,7 @@ function tripal_update_cvtermpath_loop(
           // The next_row is equal to start of loop, so we've reached the end
           // and confirmed that this is a loop.
           $possible_loop == FALSE;
-          $matched_rows = array();
+          $matched_rows = [];
           tripal_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
           $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
           $new_match_rows, $possible_start_of_loop, $no_loop_skip_test);
@@ -589,7 +598,7 @@ function tripal_update_cvtermpath_loop(
     // If $match_rows is empty there is no loop.
     if (empty($new_match_rows)) {
       $possible_loop == FALSE;
-      $matched_rows = array();
+      $matched_rows = [];
       unset($new_match_rows);
       $no_loop_skip_test = TRUE;
       // There is not loop so pass it back the possible_start_of_loop info
@@ -669,20 +678,21 @@ function tripal_update_cvtermpath_loop_increment(
   if ($possible_loop === FALSE && empty($possible_start_of_loop)) {
     chado_set_active('chado');
     $count = db_query(
-      'SELECT *
+      ' SELECT *
         FROM cvtermpath
-        WHERE cv_id = :cvid
-        AND object_id = :origin
+        WHERE object_id = :origin
         AND subject_id = :child_id
         AND pathdistance = :depth
+        AND type_id = :type_id
       ',
-      array(
-        ':cvid' => $cv_id,
+      [
         ':origin' => $origin,
         ':child_id' => $child_id,
-        ':depth' => $depth
-      )
+        ':depth' => $depth,
+        ':type_id' => $type_id
+      ]
     );
+    $count->fetchAll();
     $count_total = $count->rowCount();
     if ($count_total > 0) {
       return $count;
@@ -691,7 +701,8 @@ function tripal_update_cvtermpath_loop_increment(
     $term_id = $origin . '|' . $child_id . '|' . $cv_id . '|' . $type_id;
 
     if ($no_loop_skip_test === FALSE) {
-      // Now check if the most recent entry already exists in the array.
+      // If the increment of depth is 0 then it's the first time and we need to skip
+      // the test so we can build the tree_path which will be tested against.
       if ($increment_of_depth != 0) {
         // Search the $tree_path for the new $child_id in the build_id column.
         foreach ($tree_path as $parent) {
@@ -702,19 +713,19 @@ function tripal_update_cvtermpath_loop_increment(
             $possible_loop = TRUE;
             // Find all the results in the table that might be the start of the loop.
             $matching_rows = db_query(
-              'SELECT *
-              FROM cvtermpath
-              WHERE cv_id = :cvid
-              AND object_id = :origin
-              AND subject_id = :child_id
-              AND type_id = :type_id
+              ' SELECT *
+                FROM cvtermpath
+                WHERE cv_id = :cvid
+                AND object_id = :origin
+                AND subject_id = :child_id
+                AND type_id = :type_id
               ',
-              array(
+              [
                 ':cvid' => $cv_id,
                 ':origin' => $origin,
                 ':child_id' => $child_id,
                 ':type_id' => $type_id
-              )
+              ]
             );
             $matched_rows = $matching_rows->fetchAll();
             $possible_start_of_loop = array(
@@ -736,7 +747,14 @@ function tripal_update_cvtermpath_loop_increment(
           'type_id' => $type_id,
           'pathdistance' => $depth,
         ]);
-      $rows = $query->execute();
+
+      try {
+        $rows = $query->execute();
+      } catch (Exception $e) {
+        $error = $e->getMessage();
+        tripal_report_error('tripal_chado', TRIPAL_ERROR, "Could not fill cvtermpath term: @error", array('@error' => $error));
+        return false;
+      }
 
       // Then add that new entry to the $tree_path.
       $tree_path[$increment_of_depth] = [
@@ -746,10 +764,10 @@ function tripal_update_cvtermpath_loop_increment(
     }
     // Reset to FALSE  and empty variable if passed in as TRUE.
     $no_loop_skip_test == FALSE;
-    $possible_start_of_loop = array();
+    $possible_start_of_loop = [];
 
     // Get all of the relationships of this child term, and recursively
-    // call the tripal_update_cvtermpath_loop() function to continue
+    // call the tripal_update_cvtermpath_loop_increment() function to continue
     // descending down the tree.
     $query = db_select('cvterm_relationship', 'cvtr')
       ->fields('cvtr')

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -576,21 +576,6 @@ class OBOImporter extends TripalImporter {
     }
     // If the 'default-namespace' is missing.
     else {
-      // Look to see if an 'ontology' key is present.  It is part of the v1.4
-      // specification so it shouldn't be in the file, but just in case
-      // if (array_key_exists('ontology', $header)) {
-      //   $defaultcv = tripal_insert_cv(strtoupper($header['ontology'][0]), '');
-      //   if (!$defaultcv) {
-      //     throw new Exception('Cannot add namespace ' . strtoupper($header['ontology'][0]));
-      //   }
-      //   $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
-      // }
-      // if (!empty($obo_name)) {
-      //   $defaultcv = tripal_insert_cv(strtoupper($obo_name), '');
-      //   if (!$defaultcv) {
-      //     throw new Exception('Cannot add namespace ' . strtoupper($header['ontology'][0]));
-      //   }
-      //   $this->newcvs[strtoupper(strtoupper($obo_name))] = $defaultcv->cv_id;
       // Grab the first term accession from the file and get the short name for the cv
       $fh = fopen($file, 'r');
       while ($line = fgets($fh)) {
@@ -610,7 +595,6 @@ class OBOImporter extends TripalImporter {
       try {
         $results = $this->oboEbiLookup($short_name, 'default_namespace');       
         if (array_key_exists('default-namespace', $results['config']['annotations'])) {
-          print_r("results default_namespace: $results \n");
           $results = $results['config']['annotations']['default-namespace'];
         }
         elseif (array_key_exists('namespace', $results['config'])) {
@@ -634,7 +618,6 @@ class OBOImporter extends TripalImporter {
         "should go.  Instead, those terms will be placed in the '!vocab' vocabulary.",
         array('!vocab' => $defaultcv->name), TRIPAL_WARNING);
     }
-    exit;
     // Add any typedefs to the vocabulary first.
     $this->logMessage("Step 2: Loading type defs...");
     $this->loadTypeDefs($defaultcv, $default_db);
@@ -943,7 +926,42 @@ class OBOImporter extends TripalImporter {
    */
   private function addRelationship($cvterm, $defaultcv, $rel,
       $objname, $object_is_relationship = 0, $default_db = 'OBO_REL') {
-
+    // If an accession was passed we need to see if we can find the actual label.
+    if (strpos($rel, ':')) {
+      $pair = explode(":", $rel);    
+      $ontology_id = $pair[0];
+      $accession_num = $pair[1];
+      if (strlen($accession_num) > 6) {
+        $results = $this->oboEbiLookup($rel, 'query');
+        if (!empty($results)) {
+          if (array_key_exists('docs', $results)){
+            if(!empty($results['docs'])) {
+              $rel = $results['docs']['label'];
+            }
+            else {
+              // The first search doesn't work, so let's try a broader one.
+              $results = $this->oboEbiLookup($rel, 'query-non-local');
+              if (!empty($results)) {
+                if (array_key_exists('docs', $results)){
+                  if(!empty($results['docs'])) {
+                    $accession = $rel;
+                    $accession_underscore = str_replace(":", "_", $accession);
+                    foreach ($results['docs'] as $item) {
+                      if ($item['label'] != $accession && $item['label'] != $accession_underscore) {
+                        //Found the first place a label is other than the accession is used, so take
+                        // that info and then end the loop.
+                        $rel = $item['label'];
+                        break;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }    
     // Make sure the relationship cvterm exists.
     $term = array(
       'name' => $rel,
@@ -973,7 +991,7 @@ class OBOImporter extends TripalImporter {
         throw new Exception("Cannot find the relationship term in the current ontology or in the relationship ontology: $rel\n");
       }
     }
-
+  
     // Get the object term.
     $oterm = $this->getTerm($objname);
     if (!$oterm) {
@@ -1218,8 +1236,31 @@ class OBOImporter extends TripalImporter {
       $matches = array();
       if ($tag == 'id' and preg_match('/^(.+?):.*$/', $value, $matches)) {
         $default_db = $matches[1];
+        dpm("default_db: $default_db\n");
+        // Check that the default_db is in the cv table.
+        $sql =  "
+          SELECT CV.name 
+          FROM {cv} CV 
+          WHERE CV.name = '$default_db'
+        ";
+        $results = chado_query($sql)->fetchObject();
+        dpm("results: $results\n");
+        if (!$results){
+          //The controlled vocabulary is not in the cv term table and needs to be added.
+          $ontology_info = $this->oboEbiLookup($default_db, 'ontology');
+          if (array_key_exists('default-namespace', $ontology_info['config']['annotations'])) {
+            $results = $ontology_info['config']['annotations']['default-namespace'];
+          }
+          elseif (array_key_exists('namespace', $ontology_info['config'])) {
+            $results = $ontology_info['config']['namespace'];
+          }
+          $defaultcv = tripal_insert_cv($results, '');
+          if($default_cv) {
+            $default_db = $default_cv;
+          }
+        }
       }
-
+      dpm("default_db: $default_db\n");
       $tag = preg_replace("/\|-\|-\|/", "\:", $tag); // return the escaped colon
       $value = preg_replace("/\|-\|-\|/", "\:", $value);
       if ($in_header) {
@@ -1446,6 +1487,30 @@ class OBOImporter extends TripalImporter {
       $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':' , '_', $accession)));
       $options = array();
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'terms/' . $iri;
+      $response = drupal_http_request($full_url, $options);
+      if(!empty($response)){
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif($type_of_search == 'query') {    
+      $options = array();
+      $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';
+      $response = drupal_http_request($full_url, $options);
+      if(!empty($response)){
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif($type_of_search == 'ontology') {    
+      $options = array();
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
+      $response = drupal_http_request($full_url, $options);
+      if(!empty($response)){
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif($type_of_search == 'query-non-local') {    
+      $options = array();
+      $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
       $response = drupal_http_request($full_url, $options);
       if(!empty($response)){
         $response = drupal_json_decode($response->data);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -239,7 +239,8 @@ class OBOImporter extends TripalImporter {
       '#type'          => 'textfield',
       '#title'         => t('New Vocabulary Name'),
       '#description'   => t('Please provide a name for this vocabulary.  After upload, this name will appear in the drop down
-                             list above for use again later.'),
+                             list above for use again later. Additionally, if a default namespace is not provided in the OBO
+                             header this name will be used as the default_namespace.'),
     );
 
     $form['obo_new']['obo_url']= array(
@@ -488,7 +489,7 @@ class OBOImporter extends TripalImporter {
       tripal_insert_obo($obo_name, $file);
     }
 
-    $success = $this->loadOBO_v1_2($file);
+    $success = $this->loadOBO_v1_2($file, $obo_name);
   }
 
   /**
@@ -531,7 +532,7 @@ class OBOImporter extends TripalImporter {
     }
 
     // second, parse the OBO
-    $this->loadOBO_v1_2($temp);
+    $this->loadOBO_v1_2($temp, $obo_name);
 
     // now remove the temp file
     unlink($temp);
@@ -549,8 +550,7 @@ class OBOImporter extends TripalImporter {
    *
    * @ingroup tripal_obo_loader
    */
-  private function loadOBO_v1_2($file) {
-
+  private function loadOBO_v1_2($file, $obo_name) {
     $header = array();
     $ret = array();
 
@@ -576,24 +576,65 @@ class OBOImporter extends TripalImporter {
     }
     // If the 'default-namespace' is missing.
     else {
-
       // Look to see if an 'ontology' key is present.  It is part of the v1.4
       // specification so it shouldn't be in the file, but just in case
-      if (array_key_exists('ontology', $header)) {
-        $defaultcv = tripal_insert_cv(strtoupper($header['ontology'][0]), '');
-        if (!$defaultcv) {
-          throw new Exception('Cannot add namespace ' . strtoupper($header['ontology'][0]));
+      // if (array_key_exists('ontology', $header)) {
+      //   $defaultcv = tripal_insert_cv(strtoupper($header['ontology'][0]), '');
+      //   if (!$defaultcv) {
+      //     throw new Exception('Cannot add namespace ' . strtoupper($header['ontology'][0]));
+      //   }
+      //   $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
+      // }
+      // if (!empty($obo_name)) {
+      //   $defaultcv = tripal_insert_cv(strtoupper($obo_name), '');
+      //   if (!$defaultcv) {
+      //     throw new Exception('Cannot add namespace ' . strtoupper($header['ontology'][0]));
+      //   }
+      //   $this->newcvs[strtoupper(strtoupper($obo_name))] = $defaultcv->cv_id;
+      // Grab the first term accession from the file and get the short name for the cv
+      $fh = fopen($file, 'r');
+      while ($line = fgets($fh)) {
+        // Grab the first item's id info to break apart.
+        if (preg_match('/^\s*\[/', $line)) {
+          $stanza = TRUE;
+          continue;
         }
-        $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
+        if ($stanza === TRUE && (substr($line, 0, 3) === "id:")) {
+          $parts = explode(':', $line);
+          $short_name = strtolower($parts[1]);
+          $short_name = preg_replace('/\s+/', '', $short_name);
+          break;
+        }
       }
-      else {
+      // Check if the EBI ontology search has this ontology:
+      try {
+        $results = $this->oboEbiLookup($short_name, 'default_namespace');       
+        if (array_key_exists('default-namespace', $results['config']['annotations'])) {
+          print_r("results default_namespace: $results \n");
+          $results = $results['config']['annotations']['default-namespace'];
+        }
+        elseif (array_key_exists('namespace', $results['config'])) {
+          $results = $results['config']['namespace'];
+        }
+        else {
+          $results = $short_name;
+        }
+        $defaultcv = tripal_insert_cv(strtoupper($results), '');
+        $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))]  = $defaultcv->cv_id;
+      }
+      catch (Exception $e) {
+        watchdog_exception('OBOImporter no such accession found in EBI Ontology Search', $e);
+      }
+    
+      if (empty($defaultcv)) {
         throw new Exception("Could not find a namespace for this OBO file: $file");
       }
       $this->logMessage("This OBO is missing the 'default-namespace' header. It " .
-          "is not possible to determine which vocabulary terms without a 'namespace' key " .
-          "should go.  Instead, those terms will be placed in the '!vocab' vocabulary.",
-          array('!vocab' => $defaultcv->name), TRIPAL_WARNING);
-    }!
+        "is not possible to determine which vocabulary terms without a 'namespace' key " .
+        "should go.  Instead, those terms will be placed in the '!vocab' vocabulary.",
+        array('!vocab' => $defaultcv->name), TRIPAL_WARNING);
+    }
+    exit;
     // Add any typedefs to the vocabulary first.
     $this->logMessage("Step 2: Loading type defs...");
     $this->loadTypeDefs($defaultcv, $default_db);
@@ -1374,6 +1415,46 @@ class OBOImporter extends TripalImporter {
     }
     return $result[0];
   }
+
+
+  /**
+   * API call to Ontology Lookup Service provided by
+   * https://www.ebi.ac.uk/ols/docs/api#resources-terms
+   *
+   * @param ontology
+   *   The OLS ontology id e.g. go
+   * @param accession
+   *   Accession term for query
+   *
+   * @ingroup tripal_obo_loader
+   */
+  private function oboEbiLookup($accession, $type_of_search) {
+    //Grab just the ontology from the $accession.
+    $parts = explode(':', $accession);
+    $ontology = strtolower($parts[0]);
+    $ontology = preg_replace('/\s+/', '', $ontology);
+    if ($type_of_search == 'default_namespace') {
+      $options = array();
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
+      $response = drupal_http_request($full_url, $options);
+      if(!empty($response)){
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif ($type_of_search == 'term') {
+      //The IRI of the terms, this value must be double URL encoded
+      $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':' , '_', $accession)));
+      $options = array();
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'terms/' . $iri;
+      $response = drupal_http_request($full_url, $options);
+      if(!empty($response)){
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    return $response;
+  }
+
+  //drush php-eval "module_load_include('inc', 'tripal_chado', 'sites/all/modules/tripal/tripal_chado/includes/TripalImporter'); oboEbiLookup('BFO:0000050')"
 }
 
 /**
@@ -1382,3 +1463,4 @@ class OBOImporter extends TripalImporter {
 function tripal_cv_obo_form_ajax_callback($form, $form_state) {
   return $form['class_elements']['obo_existing'];
 }
+

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -591,9 +591,10 @@ class OBOImporter extends TripalImporter {
           break;
         }
       }
+      fclose($fh);
       // Check if the EBI ontology search has this ontology:
       try {
-        $results = $this->oboEbiLookup($short_name, 'default_namespace');       
+        $results = $this->oboEbiLookup($short_name, 'ontology');  
         if (array_key_exists('default-namespace', $results['config']['annotations'])) {
           $results = $results['config']['annotations']['default-namespace'];
         }
@@ -604,7 +605,7 @@ class OBOImporter extends TripalImporter {
           $results = $short_name;
         }
         $defaultcv = tripal_insert_cv(strtoupper($results), '');
-        $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))]  = $defaultcv->cv_id;
+        $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
       }
       catch (Exception $e) {
         watchdog_exception('OBOImporter no such accession found in EBI Ontology Search', $e);
@@ -1179,7 +1180,6 @@ class OBOImporter extends TripalImporter {
     // iterate through the lines in the OBO file and parse the stanzas
     $fh = fopen($obo_file, 'r');
     while ($line = fgets($fh)) {
-
       $line_num++;
       $size = drupal_strlen($line);
       $num_read += $size;
@@ -1236,7 +1236,6 @@ class OBOImporter extends TripalImporter {
       $matches = array();
       if ($tag == 'id' and preg_match('/^(.+?):.*$/', $value, $matches)) {
         $default_db = $matches[1];
-        dpm("default_db: $default_db\n");
         // Check that the default_db is in the cv table.
         $sql =  "
           SELECT CV.name 
@@ -1244,7 +1243,6 @@ class OBOImporter extends TripalImporter {
           WHERE CV.name = '$default_db'
         ";
         $results = chado_query($sql)->fetchObject();
-        dpm("results: $results\n");
         if (!$results){
           //The controlled vocabulary is not in the cv term table and needs to be added.
           $ontology_info = $this->oboEbiLookup($default_db, 'ontology');
@@ -1254,13 +1252,12 @@ class OBOImporter extends TripalImporter {
           elseif (array_key_exists('namespace', $ontology_info['config'])) {
             $results = $ontology_info['config']['namespace'];
           }
-          $defaultcv = tripal_insert_cv($results, '');
+          $defaultcv = tripal_insert_cv($results[0], '');
           if($default_cv) {
             $default_db = $default_cv;
           }
         }
       }
-      dpm("default_db: $default_db\n");
       $tag = preg_replace("/\|-\|-\|/", "\:", $tag); // return the escaped colon
       $value = preg_replace("/\|-\|-\|/", "\:", $value);
       if ($in_header) {
@@ -1474,7 +1471,7 @@ class OBOImporter extends TripalImporter {
     $parts = explode(':', $accession);
     $ontology = strtolower($parts[0]);
     $ontology = preg_replace('/\s+/', '', $ontology);
-    if ($type_of_search == 'default_namespace') {
+    if ($type_of_search == 'ontology') {
       $options = array();
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
       $response = drupal_http_request($full_url, $options);
@@ -1495,14 +1492,6 @@ class OBOImporter extends TripalImporter {
     elseif($type_of_search == 'query') {    
       $options = array();
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';
-      $response = drupal_http_request($full_url, $options);
-      if(!empty($response)){
-        $response = drupal_json_decode($response->data);
-      }
-    }
-    elseif($type_of_search == 'ontology') {    
-      $options = array();
-      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
       $response = drupal_http_request($full_url, $options);
       if(!empty($response)){
         $response = drupal_json_decode($response->data);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1466,10 +1466,10 @@ class OBOImporter extends TripalImporter {
    * API call to Ontology Lookup Service provided by
    * https://www.ebi.ac.uk/ols/docs/api#resources-terms
    *
-   * @param ontology
-   *   The OLS ontology id e.g. go
    * @param accession
    *   Accession term for query
+   * @param type_of_search
+   *   Either ontology, term, query, or query-non-local
    *
    * @ingroup tripal_obo_loader
    */
@@ -1514,8 +1514,6 @@ class OBOImporter extends TripalImporter {
     }
     return $response;
   }
-
-  //drush php-eval "module_load_include('inc', 'tripal_chado', 'sites/all/modules/tripal/tripal_chado/includes/TripalImporter'); oboEbiLookup('BFO:0000050')"
 }
 
 /**

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -419,8 +419,6 @@ class OBOImporter extends TripalImporter {
     // Upate the cvtermpath table for each newly added CV.
     $this->logMessage("Updating cvtermpath table.  This may take a while...");
     foreach ($this->newcvs as $namespace => $cvid) {
-      print_r($cv_id);
-      print_r("\n");
       $this->logMessage("- Loading paths for @vocab", array('@vocab' => $namespace));
       tripal_update_cvtermpath($cvid);
     }

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -739,6 +739,29 @@ class OBOImporter extends TripalImporter {
       throw new Exception("Cannot add the term: no namespace defined. " . $term['id'][0]);
     }
 
+    // Check that the default_cv is in the cv table.
+    $sql =  "
+      SELECT CV.name 
+      FROM {cv} CV 
+      WHERE CV.name = '$defaultcv'
+    ";
+    $results = chado_query($sql)->fetchObject();
+    if (!$results){
+      //The controlled vocabulary is not in the cv term table and needs to be added.
+      $ontology_info = $this->oboEbiLookup($defaultcv, 'ontology');
+      if (!empty($ontology_info)){
+        if (array_key_exists('default-namespace', $ontology_info['config']['annotations'])) {
+          $results = $ontology_info['config']['annotations']['default-namespace'];
+        }
+        elseif (array_key_exists('namespace', $ontology_info['config'])) {
+          $results = $ontology_info['config']['namespace'];
+        }
+        $cv_returned = tripal_insert_cv($results[0], '');
+        if($cv_returned) {
+          $defaultcv = $cv_returned;
+        }
+      }
+    }
     // construct the term array for sending to the tripal_chado_add_cvterm function
     // for adding a new cvterm
     $t = array();
@@ -1236,27 +1259,6 @@ class OBOImporter extends TripalImporter {
       $matches = array();
       if ($tag == 'id' and preg_match('/^(.+?):.*$/', $value, $matches)) {
         $default_db = $matches[1];
-        // Check that the default_db is in the cv table.
-        $sql =  "
-          SELECT CV.name 
-          FROM {cv} CV 
-          WHERE CV.name = '$default_db'
-        ";
-        $results = chado_query($sql)->fetchObject();
-        if (!$results){
-          //The controlled vocabulary is not in the cv term table and needs to be added.
-          $ontology_info = $this->oboEbiLookup($default_db, 'ontology');
-          if (array_key_exists('default-namespace', $ontology_info['config']['annotations'])) {
-            $results = $ontology_info['config']['annotations']['default-namespace'];
-          }
-          elseif (array_key_exists('namespace', $ontology_info['config'])) {
-            $results = $ontology_info['config']['namespace'];
-          }
-          $defaultcv = tripal_insert_cv($results[0], '');
-          if($default_cv) {
-            $default_db = $default_cv;
-          }
-        }
       }
       $tag = preg_replace("/\|-\|-\|/", "\:", $tag); // return the escaped colon
       $value = preg_replace("/\|-\|-\|/", "\:", $value);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -419,6 +419,8 @@ class OBOImporter extends TripalImporter {
     // Upate the cvtermpath table for each newly added CV.
     $this->logMessage("Updating cvtermpath table.  This may take a while...");
     foreach ($this->newcvs as $namespace => $cvid) {
+      print_r($cv_id);
+      print_r("\n");
       $this->logMessage("- Loading paths for @vocab", array('@vocab' => $namespace));
       tripal_update_cvtermpath($cvid);
     }
@@ -594,9 +596,12 @@ class OBOImporter extends TripalImporter {
       fclose($fh);
       // Check if the EBI ontology search has this ontology:
       try {
-        $results = $this->oboEbiLookup($short_name, 'ontology');  
+        $results = $this->oboEbiLookup($short_name, 'ontology');
         if (array_key_exists('default-namespace', $results['config']['annotations'])) {
           $results = $results['config']['annotations']['default-namespace'];
+          if (is_array($results)) {
+            $results = $results[0];
+          }
         }
         elseif (array_key_exists('namespace', $results['config'])) {
           $results = $results['config']['namespace'];
@@ -605,7 +610,7 @@ class OBOImporter extends TripalImporter {
           $results = $short_name;
         }
         $defaultcv = tripal_insert_cv(strtoupper($results), '');
-        $this->newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
+        $this->newcvs[$defaultcv->name] = $defaultcv->cv_id;
       }
       catch (Exception $e) {
         watchdog_exception('OBOImporter no such accession found in EBI Ontology Search', $e);
@@ -738,6 +743,23 @@ class OBOImporter extends TripalImporter {
     if (!array_key_exists('namespace', $term) and !($defaultcv or $defaultcv == '')) {
       throw new Exception("Cannot add the term: no namespace defined. " . $term['id'][0]);
     }
+   // construct the term array for sending to the tripal_chado_add_cvterm function
+    // for adding a new cvterm
+    $t = array();
+    $t['id'] = $term['id'][0];
+    $t['name'] = $term['name'][0];
+    if (array_key_exists('def', $term)) {
+      $t['definition'] = $term['def'][0];
+    }
+    if (array_key_exists('subset', $term)) {
+      $t['subset'] = $term['subset'][0];
+    }
+    if (array_key_exists('namespace', $term)) {
+      $t['namespace'] = $term['namespace'][0];
+    }
+    if (array_key_exists('is_obsolete', $term)) {
+      $t['is_obsolete'] = $term['is_obsolete'][0];
+    }
 
     // Check that the default_cv is in the cv table.
     $sql =  "
@@ -757,28 +779,13 @@ class OBOImporter extends TripalImporter {
           $results = $ontology_info['config']['namespace'];
         }
         $cv_returned = tripal_insert_cv($results[0], '');
+        // If name && definition are both empty then look up the term from the ontology you just loaded.
         if($cv_returned) {
           $defaultcv = $cv_returned;
         }
       }
     }
-    // construct the term array for sending to the tripal_chado_add_cvterm function
-    // for adding a new cvterm
-    $t = array();
-    $t['id'] = $term['id'][0];
-    $t['name'] = $term['name'][0];
-    if (array_key_exists('def', $term)) {
-      $t['definition'] = $term['def'][0];
-    }
-    if (array_key_exists('subset', $term)) {
-      $t['subset'] = $term['subset'][0];
-    }
-    if (array_key_exists('namespace', $term)) {
-      $t['namespace'] = $term['namespace'][0];
-    }
-    if (array_key_exists('is_obsolete', $term)) {
-      $t['is_obsolete'] = $term['is_obsolete'][0];
-    }
+ 
 
     $t['cv_name'] = $defaultcv;
     $t['is_relationship'] = $is_relationship;
@@ -955,7 +962,7 @@ class OBOImporter extends TripalImporter {
       $pair = explode(":", $rel);    
       $ontology_id = $pair[0];
       $accession_num = $pair[1];
-      if (strlen($accession_num) > 6) {
+      if (is_numeric($accession_num)) {
         $results = $this->oboEbiLookup($rel, 'query');
         if (!empty($results)) {
           if (array_key_exists('docs', $results)){

--- a/tripal_chado/includes/tripal_chado.cv.inc
+++ b/tripal_chado/includes/tripal_chado.cv.inc
@@ -823,3 +823,22 @@ function tripal_cv_cvtermpath_form_submit($form, &$form_state) {
         'tripal_update_cvtermpath', $job_args, $user->uid, 10);
   }
 }
+
+function tripal_cv_obo_ebi_lookup($accession) {
+  print_r("accession: $accession\n");
+  //The IRI of the terms, this value must be double URL encoded
+  $iri = urlencode("http://purl.obolibrary.org/obo/" . $accession);
+  //Grab just the ontology from the $accession.
+  $parts = explode(':', $accession);
+  $ontology = $parts[0];
+  print_r("ontology: $ontology\n");
+  $options = array();
+  $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'terms/' . $iri;
+  $response = drupal_http_request($full_url, $options);
+  if(!empty($response)){
+    $response = drupal_json_decode($response->data);
+  }
+  print_r($response);
+  return $response;
+  // php-eval "module_load_include('inc', 'tripal_chado', 'sites/all/modules/tripal/tripal_chado/includes/tripal_chado.cv'); tripal_cv_obo_ebi_lookup('BFO:0000050')"
+}


### PR DESCRIPTION
The changed in this pull request address issues:

- https://github.com/tripal/tripal/issues/253
- https://github.com/tripal/tripal/issues/188
- https://github.com/tripal/tripal/issues/186

This contains:

- 1 small change to a drush_tripal_trp_set_permissions(), which can be tested by running drush trp-set-permissions and should set all tripal content types to be editable (edit, create, view, delete) by administrators.

- The creation and integration of an EBI lookup function during the OBOImporter run to catch files that do not have default-namespaces and to catch terms referencing other ontologies that are not loaded in chado at time of run. 
        - To test try running the Plana ontology: https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/plana.obo

- An update to the cvtermpathupdate functions when checking for duplicate records. The original db_query was written just like the chado stored procedure which uses cv_id as a testing parameter for dups. However, the cvtermpath_c1  constraint (UNIQUE (subject_id, object_id, type_id, pathdistance)) on the cvtermpath table does not include cv_id so a unique violation was being thrown when two (or more) cv's would try to load the same subject_id, child_id, type_id, pathdistance into cvtermpath. Removing this also results in significantly more rows being added to the cvtermpath table, specifically rows with a pathdistance of zero (http://gmod.org/wiki/Chado_Tables#Table:_cvtermpath). I also cleaned up some formatting.
        -To test load goslim (http://www.geneontology.org/ontology/subsets/goslim_plant.obo) or the full gene ontology on a fresh site.
