### PR TITLE
Fixed Tripal CV uninstall issue (missing functions).

### DIFF
--- a/tripal_cv/tripal_cv.install
+++ b/tripal_cv/tripal_cv.install
@@ -72,6 +72,10 @@ function tripal_cv_install() {
  */
 function tripal_cv_uninstall() {
 
+  module_load_include('inc', 'tripal_core', 'api/tripal_core.chado_general.api');
+  module_load_include('inc', 'tripal_core', 'api/tripal_core.chado_query.api');
+  module_load_include('inc', 'tripal_core', 'api/tripal_core.chado_schema.api');
+
   // drop the tripal_obo_temp table
   if (chado_table_exists('tripal_obo_temp')) {
     $sql = "DROP TABLE {tripal_obo_temp}";


### PR DESCRIPTION
When trying to uninstall Tripal CV module, the following error occurs (due to Drupal install environment not loading everything):

> PHP Fatal error:  Call to undefined function chado_table_exists() in /srv/projects/chado_controller/dev_chaco_v3/chadocontroller.info/modules/tripal/tripal_cv/tripal_cv.install on line 76

This fix loads the appropriate includes in order to successfully uninstall Tripal CV when needed.