### PR TITLE
Add db transaction to tripal_update_cvtermpath

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -403,10 +403,10 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
     // Rollback any database changes
     $transaction->rollback();
     throw $e;
+  } finally {
+    // Set the database back
+    chado_set_active($prev_db);
   }
-
-  // Set the database back
-  chado_set_active($prev_db);
 }
 
 /**

--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -375,7 +375,12 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
   // TODO: there's a function to determine the current Chado instance.
   // we should use that.
   $prev_db = chado_set_active('chado');
+
+  print "\nNOTE: Updating CV Term Path is performed using a database transaction. \n" .
+    "If the update fails or is terminated prematurely then any new changes \n" .
+    "made will be rolled back.\n\n";
   $transaction = db_transaction();
+
   try {
     $result = db_query('
       SELECT DISTINCT t.*

--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -400,14 +400,12 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
     }
   }
   catch (Exception $e) {
-    // If there's an exception we have to set the database back. So, do that
-    // and then rethrow the error.
-    chado_set_active($prev_db);
-
     // Rollback any database changes
     $transaction->rollback();
     throw $e;
   }
+
+  // Set the database back
   chado_set_active($prev_db);
 }
 

--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -375,6 +375,7 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
   // TODO: there's a function to determine the current Chado instance.
   // we should use that.
   $prev_db = chado_set_active('chado');
+  $transaction = db_transaction();
   try {
     $result = db_query('
       SELECT DISTINCT t.*
@@ -397,6 +398,9 @@ function tripal_update_cvtermpath($cv_id, $job_id = NULL){
     // If there's an exception we have to set the database back. So, do that
     // and then rethrow the error.
     chado_set_active($prev_db);
+
+    // Rollback any database changes
+    $transaction->rollback();
     throw $e;
   }
   chado_set_active($prev_db);


### PR DESCRIPTION
We've added db transaction support in the cvtermpath builder function to avoid having to clear the table when an error occurs during the building process.

Thanks!