### PR TITLE
Bug Fix: Ensure that empty chado property fields are not rendered.

### DIFF
--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop.inc
@@ -127,6 +127,10 @@ class chado_linker__prop extends ChadoField {
 
     // Ensure there are no values if there are no properties.
     // This is necessary to make sure the field is not rendered when there are no properies.
+    // @todo: We should revisit this in the future as none of the other fields do this.
+    //        It was added here to make it easier to detect when the field was empty
+    //        but in hindsight, we would just check $entity->{$field_name}['und'][$i]['value']
+    //        in the formatter.
     if (empty($properties)) {
       unset($entity->{$field_name});
     }

--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop.inc
@@ -124,6 +124,12 @@ class chado_linker__prop extends ChadoField {
         );
       }
     }
+
+    // Ensure there are no values if there are no properties.
+    // This is necessary to make sure the field is not rendered when there are no properies.
+    if (empty($properties)) {
+      unset($entity->{$field_name});
+    }
   }
 
   /**

--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
@@ -29,6 +29,11 @@ class chado_linker__prop_formatter extends ChadoFieldFormatter {
       $list[$index] = $item['value'];
     }
 
+    // Also need to make sure to not return markup if the field is empty.
+    if (empty($list)) {
+      return;
+    }
+
     // If more than one value has been found display all values in an unordered
     // list.
     if (count($list) > 1) {


### PR DESCRIPTION
Expected Behavior: When all form fields for a specific chado property are left blank, they shouldn't be rendered on the page.

How to Test: Edit any entity with chado properties. Leave the field blank and save. Clear the cache! You shouldn't see the label for that field rendered. :-)