### PR TITLE
Fixes the placeholder name collision between old and new data in chado_update_record() function.

### DIFF
--- a/tripal_core/api/tripal_core.chado_query.api.inc
+++ b/tripal_core/api/tripal_core.chado_query.api.inc
@@ -708,8 +708,8 @@ function chado_update_record($table, $match, $values, $options = NULL) {
       $sql .= " $field = NULL AND ";
     }
     else {
-      $sql .= " $field = :$field AND ";
-      $args[":$field"] = $value;
+      $sql .= " $field = :old_$field AND ";
+      $args[":old_$field"] = $value;
     }
   }
   $sql = drupal_substr($sql, 0, -4);  // get rid of the trailing 'AND'


### PR DESCRIPTION
When using chado_update_record and trying to change a field that is also used to select the record, it does nothing. The place holders used by the query argument for both the selection and the updated value use the field name as place holder name while they should be different. For instance, if I'd like to update stock_cvterm.cvterm_id, the argument array will use the key ':cvterm_id' for both the selection value and the new value and therefore, the selection value will be replaced by the new value in the argument array and the corresponding record will not be found and not updated. This fix just prefixes the selection value place holder name with 'old_' in order to avoid name collision. It has been tested and appears to work correctly.

Co-authored-by: SheilaBarron <sheilabarron@me.com>
Co-authored-by: guignonv <guignonv@gmail.com>