### PR TITLE
Tested and determined bulk loader does not need legacy code

### DIFF
--- a/tripal_bulk_loader/tripal_bulk_loader.info
+++ b/tripal_bulk_loader/tripal_bulk_loader.info
@@ -5,5 +5,4 @@ project = tripal
 package = Tripal
 version = 7.x-3.0-rc2
 
-dependencies[] = tripal_core
 dependencies[] = tripal_chado_views


### PR DESCRIPTION
This is just a very simple fix to remove the tripal_core legacy module as a dependency for the bulk loader. I tested upload using the online tutorial (http://tripal.info/tutorials/v3.x/bulk_loader) and all worked fine.  The tripal_core module was not enabled.