### PR TITLE
Data Search Views Fix

### DIFF
--- a/tripal/tripal_views_query.inc
+++ b/tripal/tripal_views_query.inc
@@ -132,6 +132,42 @@ class tripal_views_query extends views_plugin_query {
       $this->cquery->fieldCondition($field_name, $element_name, $value, $operator);
     }
   }
+  
+  /**
+   * Add's a where exression clause to a query.
+   * 
+   * @param $group
+   *   The WHERE group to add these to; groups are used to create AND/OR
+   *   sections. Groups cannot be nested. Use 0 as the default group. If the
+   *   group does not yet exist it will be created as an AND group.
+   * @param $snippet
+   *   The snippet to check. This can be either a column or a complex 
+   *   expression like "UPPER(table.field) = 'value'".
+   * @param $args
+   *   An associative array of arguments.
+   */
+  public function add_where_expression($group, $snippet, $args = array()) {
+    
+    // Ensure all variants of 0 are actually 0. Thus '', 0 and NULL are all
+    // the default group.
+    if (empty($group)) {
+      $group = 0;
+    }
+    
+    // TODO: this function needs to be adjusted to pull out the element from
+    // snippet (see the code for the add_where function above for an example.
+    // for now this function will not properly work.
+    
+    // Check for a group.
+    if (!isset($this->where[$group])) {
+      $this->set_where_group('AND', $group);
+    }
+    $this->where[$group]['conditions'][] = array(
+      'field' => $snippet,
+      'value' => $args,
+      'operator' => 'formula',
+    );
+  }
 
   /**
    * Overrides add_orderby().
@@ -326,4 +362,13 @@ class tripal_views_query extends views_plugin_query {
     $view->execute_time = microtime(TRUE) - $start;
   }
 
+  /**
+   * Provides a unique placeholders for handlers.
+   */
+  public function placeholder() {
+    // TODO: this function doesn't currently work. It is used by the
+    // words, all words, shorter than, longer than filters, but those
+    // are currently commented out.
+    //return $this->query->placeholder($this->options['table'] . '_' . $this->options['field']);
+  }
 }

--- a/tripal/views_handlers/tripal_views_handler_filter_string.inc
+++ b/tripal/views_handlers/tripal_views_handler_filter_string.inc
@@ -36,18 +36,20 @@ class tripal_views_handler_filter_string extends tripal_views_handler_filter {
         'method' => 'op_contains',
         'values' => 1,
       ),
-      'word' => array(
-        'title' => t('Contains any word'),
-        'short' => t('has word'),
-        'method' => 'op_word',
-        'values' => 1,
-      ),
-      'allwords' => array(
-        'title' => t('Contains all words'),
-        'short' => t('has all'),
-        'method' => 'op_word',
-        'values' => 1,
-      ),
+      // TODO: These two filters are a bit problematic with fields.
+      // The require a tripal_views_query::placeholder() function
+//       'word' => array(
+//         'title' => t('Contains any word'),
+//         'short' => t('has word'),
+//         'method' => 'op_word',
+//         'values' => 1,
+//       ),
+//       'allwords' => array(
+//         'title' => t('Contains all words'),
+//         'short' => t('has all'),
+//         'method' => 'op_word',
+//         'values' => 1,
+//       ),
       'starts' => array(
         'title' => t('Starts with'),
         'short' => t('begins'),
@@ -78,18 +80,22 @@ class tripal_views_handler_filter_string extends tripal_views_handler_filter {
         'method' => 'op_not',
         'values' => 1,
       ),
-      'shorterthan' => array(
-        'title' => t('Length is shorter than'),
-        'short' => t('shorter than'),
-        'method' => 'op_shorter',
-        'values' => 1,
-      ),
-      'longerthan' => array(
-        'title' => t('Length is longer than'),
-        'short' => t('longer than'),
-        'method' => 'op_longer',
-        'values' => 1,
-      ),
+      // TODO: These two filters are a bit problematic with fields.
+      // The require a tripal_views_query::add_where_expression function
+      // that can properly separate the field out of the "snippet". For now
+      // we'll just comment them out.
+//       'shorterthan' => array(
+//         'title' => t('Length is shorter than'),
+//         'short' => t('shorter than'),
+//         'method' => 'op_shorter',
+//         'values' => 1,
+//       ),
+//       'longerthan' => array(
+//         'title' => t('Length is longer than'),
+//         'short' => t('longer than'),
+//         'method' => 'op_longer',
+//         'values' => 1,
+//       ),
     );
     // if the definition allows for the empty operator, add it.
     if (!empty($this->definition['allow empty'])) {

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -55,7 +55,6 @@ function tripal_chado_field_storage_write($entity_type, $entity, $op, $fields) {
     $values[$type_field] = $cvterm->cvterm_id;
   }
 
-
   $base_record_id = tripal_chado_field_storage_write_table($base_table, $values, $base_table);
 
   // If this is an insert then add the chado_entity record.
@@ -537,11 +536,12 @@ function tripal_chado_field_storage_query($query) {
 
           $matches = array();
           $key = $condition['value'];
-          $op = '=';
+          $op = array_key_exists('operator', $condition) ? $condition['operator'] : '=';
           if (preg_match('/^(.+);(.+)$/', $key, $matches)) {
             $key = $matches[1];
             $op = $matches[2];
           }
+
           switch ($op) {
             case 'eq':
               $op = '=';
@@ -558,12 +558,22 @@ function tripal_chado_field_storage_query($query) {
             case 'lte':
               $op = '<=';
               break;
+            case '<>':
             case 'ne':
-              $op = '<>';
+              $op = '!=';
               break;
+            case 'LIKE':
             case 'contains':
               $op = 'LIKE';
-              $key = '%' . $key . '%';
+              if (!preg_match('/\%/', $key)) {
+                $key = '%' . $key . '%';
+              }
+              break;
+            case 'NOT LIKE':              
+              $op = 'NOT LIKE';
+              if (!preg_match('/\%/', $key)) {
+                $key = '%' . $key . '%';
+              }
               break;
             case 'starts':
               $op = 'LIKE';
@@ -718,8 +728,8 @@ function tripal_chado_field_storage_query($query) {
     } // end if ($sort['type'] == 'field') {
   } // end foreach ($query->order as $index => $sort) {
 
-// dpm($cquery->__toString());
-// dpm($cquery->getArguments());
+ //dpm($cquery->__toString());
+ //dpm($cquery->getArguments());
 
   $records = $cquery->execute();
 


### PR DESCRIPTION
This is a fix related to issue #341 where the filters are not working with fields that do not have a TripalField class implementation.  These include fields that use the Drupal native fields (e.g. names, identifiers, and other plain text fields).  

Prior to this fix, any of the filters on the Data Search for these fields did not work.  They should all now work.  It should be easy to test. Just pull this branch and test that you can use all the filters on the name, or identifier (or other non TripalField field).