### PR TITLE
Backport of OBO and cvtermpath updates to Tripal v2

### DIFF
--- a/tripal_analysis/theme/templates/tripal_analysis_properties.tpl.php
+++ b/tripal_analysis/theme/templates/tripal_analysis_properties.tpl.php
@@ -5,7 +5,7 @@ $analysis = $variables['node']->analysis;
 $analysis = chado_expand_var($analysis,'table', 'analysisprop', array('return_array' => 1));
 $properties = $analysis->analysisprop;
 
-if (count($properties) > 0) { ?>
+if (is_array($properties) and count($properties) > 0) { ?>
   <div class="tripal_analysis-data-block-desc tripal-data-block-desc">Additional information about this analysis:</div><?php
   
   // the $headers array is an array of fields to use as the colum headers.

--- a/tripal_analysis/tripal_analysis.views_default.inc
+++ b/tripal_analysis/tripal_analysis.views_default.inc
@@ -141,7 +141,7 @@ function tripal_analysis_defaultvalue_admin_analysis() {
   $handler->display->display_options['header']['action_links_area']['empty'] = TRUE;
   $handler->display->display_options['header']['action_links_area']['link-1'] = array(
     'label-1' => 'Add Analysis',
-    'path-1' => 'node/add/tripal-analysis',
+    'path-1' => 'node/add/chado-analysis',
   );
   $handler->display->display_options['header']['action_links_area']['link-2'] = array(
     'label-2' => '',

--- a/tripal_core/api/tripal_core.chado_query.api.inc
+++ b/tripal_core/api/tripal_core.chado_query.api.inc
@@ -870,7 +870,7 @@ function chado_delete_record($table, $match, $options = NULL) {
   foreach ($delete_matches as $field => $value) {
     // if we have an array values then this is an "IN" clasue.
 
-    if (count($value) > 1) {
+    if (is_array($value) and count($value) > 1) {
       $sql .= "$field IN (";
       $index = 0;
       foreach ($value as $v) {

--- a/tripal_core/api/tripal_core.chado_query.api.inc
+++ b/tripal_core/api/tripal_core.chado_query.api.inc
@@ -1449,17 +1449,15 @@ function chado_select_record_check_value_type(&$op, &$value, $type) {
 }
 
 /**
- * Use this function instead of db_query() to avoid switching databases
- * when making query to the chado database.
+ * Use instead of db_query() when making a query to the Chado database.
  *
- * Will use a chado persistent connection if it already exists.
- *
- * NOTE: When writting SQL queries it is important to enclose the chado table name in
- * curley brackets (ie: {feature}) in order to enusure proper prefixing. Furthermore,
- * if you need to join between tables in separate schemas (ie: chado and drupal) then
- * you should enclose the drupal table in square brackets (ie: [chado_feature]).
- * Keep in mind JOINING BETWEEN SCHEMA'S IS NOT RECOMMENDED since it will break functionality
- * for sites with external chado databases.
+ * When writting SQL queries it is important to enclose the chado table 
+ * name in curley brackets (ie: {feature}) in order to enusure proper prefixing. 
+ * Furthermore, if you need to join between tables in separate schemas (ie: 
+ * chado and drupal) then you should enclose the drupal table in square 
+ * brackets (ie: [chado_feature]). Keep in mind JOINING BETWEEN SCHEMA'S IS 
+ * NOT RECOMMENDED since it will break functionality for sites with external 
+ * chado databases.
  *
  * @param $sql
  *   The sql statement to execute
@@ -1473,15 +1471,19 @@ function chado_select_record_check_value_type(&$op, &$value, $type) {
  *
  * Example usage:
  * @code
- * $sql = "SELECT F.name, CVT.name as type_name, ORG.common_name
- *          FROM {feature} F
- *          LEFT JOIN {cvterm} CVT ON F.type_id = CVT.cvterm_id
- *          LEFT JOIN {organism} ORG ON F.organism_id = ORG.organism_id
- *          WHERE
- *            F.uniquename = :feature_uniquename";
- * $args = array( ':feature_uniquename' => $form_state['values']['uniquename'] );
- * $result = chado_query( $sql, $args );
- * foreach ($result as $r) { [Do something with the records here] }
+ * $sql = "
+ *   SELECT F.name, CVT.name as type_name, ORG.common_name
+ *   FROM {feature} F
+ *     LEFT JOIN {cvterm} CVT ON F.type_id = CVT.cvterm_id
+ *     LEFT JOIN {organism} ORG ON F.organism_id = ORG.organism_id
+ *   WHERE
+ *     F.uniquename = :feature_uniquename
+ * ";
+ * $args = [':feature_uniquename' => $form_state['values']['uniquename']];
+ * $result = chado_query($sql, $args);
+ * foreach ($result as $r) {
+ *   // Do something with the records here 
+ * }
  * @endcode
  *
  * @ingroup tripal_chado_query_api
@@ -1541,11 +1543,9 @@ function chado_query($sql, $args = array()) {
   // Check for any cross schema joins (ie: both drupal and chado tables represented
   // and if present don't execute the query but instead warn the administrator.
   elseif (preg_match('/\[(\w*?)\]/', $sql)) {
-    tripal_report_error(
-      'chado_query',
-      TRIPAL_ERROR,
+    tripal_report_error('chado_query', TRIPAL_ERROR,
       'The following query does not support external chado databases. Please file an issue
-      with the Drupal.org Tripal Project. Query: @query',
+       with the Drupal.org Tripal Project. Query: @query',
       array('@query' => $sql)
     );
     return FALSE;

--- a/tripal_core/api/tripal_core.tripal.api.inc
+++ b/tripal_core/api/tripal_core.tripal.api.inc
@@ -125,7 +125,7 @@ function tripal_report_error($type, $severity, $message, $variables = array(), $
   }
 
   // Format the message for printing (either to the screen, log or both)
-  if (sizeof($variables) > 0) {
+  if (is_array($variables) and sizeof($variables) > 0) {
     $print_message = str_replace(array_keys($variables), $variables, $message);
   }
   else {

--- a/tripal_cv/api/tripal_cv.api.inc
+++ b/tripal_cv/api/tripal_cv.api.inc
@@ -303,28 +303,426 @@ function tripal_get_cvterm_select_options($cv_id) {
  * @ingroup tripal_cv_api
  */
 function tripal_update_cvtermpath($cv_id, $job_id = NULL) {
-  // TODO: need better error checking in this function
-
-  // first get the controlled vocabulary name:
-  $sql = "SELECT * FROM {cv} WHERE cv_id = :cv_id";
-  $cv = chado_query($sql, array(':cv_id' => $cv_id))->fetchObject();
-
-  print "\nUpdating cvtermpath for $cv->name...\n";
-
-  $previous = chado_set_active('chado');
+  // TODO: there's a function to determine the current Chado instance.
+  // we should use that.
+  $prev_db = chado_set_active('chado');
   try {
-    $sql = "SELECT * FROM fill_cvtermpath(:name)";
-    db_query($sql, array(':name' => $cv->name));
-    chado_set_active($previous);
+    $result = db_query('
+      SELECT DISTINCT t.*
+      FROM cvterm t
+        LEFT JOIN cvterm_relationship r ON (t.cvterm_id = r.subject_id)
+        INNER JOIN cvterm_relationship r2 ON (t.cvterm_id = r2.object_id)
+      WHERE t.cv_id = :cvid AND r.subject_id is null',
+      array(':cvid' => $cv_id)
+      );
+    
+    // Iterate through each root level term.
+    $record = $result->fetchAll();
+    $roots = [];
+    
+    foreach ($record as $item){
+      _chado_update_cvtermpath_root_loop($item->cvterm_id, $item->cv_id, $roots);
+    }
   }
   catch (Exception $e) {
-    chado_set_active($previous);
-    $error = $e->getMessage();
-    tripal_report_error('tripal_cv', TRIPAL_ERROR, "Could not fill cvtermpath table: @error", array('@error' => $error));
-    return FALSE;
+    // If there's an exception we have to set the database back. So, do that
+    // and then rethrow the error.
+    chado_set_active($prev_db);
+    throw $e;
   }
+  chado_set_active($prev_db);
+}
+/**
+ *  Duplicate of _fill_cvtermpath4root() stored procedure in Chado.
+ *
+ *  This function process a "branch" of the ontology.  Initially, the
+ *  "root" starts at the top of the tree. But, as the cvtermpath is populated
+ *  the "root" becomes terms deeper in the tree.
+ *
+ * @param $rootid
+ *   The term ID from the cvterm table of Chado (i.e. cvterm.cvterm_id).
+ * @param $cvid
+ *   The controlled vocabulary ID from the cv table of Chado (i.e. cv.cv_id).
+ *
+ * @ingroup tripal_chado_cv_api
+ */
+function _chado_update_cvtermpath_root_loop($rootid, $cvid, &$roots) {
+  $ttype = db_query(
+    'SELECT cv.cvterm_id
+     FROM cvterm cv
+     WHERE cv.name = :isa
+      OR cv.name = :is_a
+    ',
+    array(':isa' => "isa", ':is_a' => "is_a")
+  );
+  
+  $result = $ttype->fetchObject();
+  $term_id = $rootid . '|' . $rootid . '|' . $cvid . '|' . $result->cvterm_id;
+  // If the child_id matches any other id in the array then we've hit a loop.
+  foreach ($roots as $element_id) {
+    if ($element_id == $term_id) {
+      return;
+    }
+  }
+  // Then add that new entry to the $tree_path.
+  $roots[] = $term_id;
+  
+  // Descends through the branch starting at this "root" term.
+  $tree_path = [];
+  $matched_rows = [];
+  $possible_start_of_loop = [];
+  $depth = 0;
+  _chado_update_cvtermpath_loop($rootid, $rootid, $cvid, $result->cvterm_id, $depth,
+    0, $tree_path, FALSE, $matched_rows, $possible_start_of_loop, FALSE);
+  
+  // Get's the children terms of this "root" term and then recursively calls
+  // this function making each child root.
+  $cterm = db_query(
+    'SELECT *
+      FROM cvterm_relationship
+      WHERE object_id = :rootid
+    ',
+    [':rootid' => $rootid]
+  );
+  while ($cterm_result = $cterm->fetchAssoc()) {
+    _chado_update_cvtermpath_root_loop($cterm_result['subject_id'], $cvid, $roots);
+  }
+}
 
-  return TRUE;
+/**
+ *
+ * @param $origin
+ *   The root terms cvterm_id.
+ * @param $child_id
+ *   The cvterm_id of the current child term.  The child term is a descendent
+ *   of the origin.
+ * @param $cv_id
+ *   The controlled vocabulary ID from the cv table of Chado (i.e. cv.cv_id).
+ * @param $type_id
+ *   The relationship type between the origin term and the child.
+ * @param $depth
+ *   The depth of the recursion.
+ * @param $increment_of_depth.
+ *   An integer tailing the number of children that have been walked down.
+ * @param $tree_path.
+ *   The array of every term between the current child and the origin. Each
+ *   element in the array is an associative array with the keys:
+ *     -build_id: an string identifier for the child that combines the origin,
+ *      child cvterm_id,cv_id, and the type_id.
+ *     -depth: the depth that a child was inserted into the cvtermpath table.
+ * @param $possible_loop
+ *    A boolean flag.
+ * @param $matched_row
+ *    An array of rows that are currently in the cvtermpath table that match the
+ *    build_id of the current term trying to be written to the table
+ * @param $possible_start_of_ loop
+ *    The array of the possible loop item between the current child and the
+ *    origin. Each element in the array is an associative array with the keys:
+ *     - cvid : $cv_id
+ *     - subject_id:
+ *     - child_id : $child_id,
+ *     - type_id : $type_id,
+ *     - depth : $depth,
+ * @param $no_loop_skip_test
+ *     A boolean used when the possible loop has been ruled out as a loop.
+ *
+ *
+ * @ingroup tripal_chado_cv_api
+ */
+function _chado_update_cvtermpath_loop($origin, $child_id, $cv_id, $type_id,
+  $depth, $increment_of_depth, $tree_path, $possible_loop, $matched_rows,
+  $possible_start_of_loop, $no_loop_skip_test) {
+    
+  // We have not detected a loop, so it's safe to insert the term.
+  $new_match_rows = [];
+  if (!empty($possible_start_of_loop)) {
+    // Go through each matched_row.
+    if (count($matched_rows) === 1) {
+      // Get the cvtermpath_id and then increment down one row.
+      $cvtermpath_id = (int) $matched_rows[0]->cvtermpath_id;
+      $cvtermpath_id = $cvtermpath_id + 1;
+      chado_set_active('chado');
+      $next_row = db_query(
+        'SELECT *
+        FROM cvtermpath
+        WHERE cvtermpath_id = :cvtermpath_id
+      ',
+        [':cvtermpath_id' => $cvtermpath_id]
+      );
+      $next_row = $next_row->fetchObject();
+      
+      // If the next row matches the values passed we can't rule out a loop.
+      if (($next_row->type_id === $type_id) &&
+          ($next_row->subject_id === $child_id) &&
+          ($next_row->object_id === $origin) &&
+          ($next_row->cv_id === $cv_id)) {
+        $new_match_rows[] = $next_row;
+      }
+      elseif (($next_row->type_id === $possible_start_of_loop['type_id']) &&
+              ($next_row->subject_id === $possible_start_of_loop['subject_id']) &&
+              ($next_row->object_id === $possible_start_of_loop['object_id']) &&
+              ($next_row->cv_id === $possible_start_of_loop['cv_id'])) {
+        // The next_row is equal to start of loop, so we've reached the end
+        // and confirmed that this is a loop.
+        $possible_loop == FALSE;
+        $matched_rows = [];
+        _chado_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
+          $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+          $new_match_rows, $possible_start_of_loop, $no_loop_skip_test);
+          
+      }
+    }
+    else {
+      foreach ($matched_rows as $matched_row) {
+        // Get the cvtermpath_id and then increment down one row.
+        $cvtermpath_id = (int) $match_row->cvtermpath_id;
+        // Get the cvtermpath_id and then increment down one row.
+        $cvtermpath_id = $cvtermpath_id + 1;
+        chado_set_active('chado');
+        $next_row = db_query(
+          'SELECT *
+          FROM cvtermpath
+          WHERE cvtermpath_id = :cvtermpath_id
+        ',
+          [':cvtermpath_id' => $cvtermpath_id]
+        );
+        $next_row = $next_row->fetchObject();
+        
+        // If the next row matches the values passed we can't rule out a loop.
+        if (($next_row->type_id === $type_id) &&
+            ($next_row->subject_id === $child_id) &&
+            ($next_row->object_id === $origin) &&
+            ($next_row->cv_id === $cv_id)) {
+          $new_match_rows[] = $next_row;
+        }
+        elseif (($next_row->type_id === $possible_start_of_loop['type_id']) &&
+                ($next_row->subject_id === $possible_start_of_loop['subject_id']) &&
+                ($next_row->object_id === $possible_start_of_loop['object_id']) &&
+                ($next_row->cv_id === $possible_start_of_loop['cv_id'])) {
+          // The next_row is equal to start of loop, so we've reached the end
+          // and confirmed that this is a loop.
+          $possible_loop == FALSE;
+          $matched_rows = [];
+          _chado_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
+            $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+            $new_match_rows, $possible_start_of_loop, $no_loop_skip_test);
+        }
+      }
+    }
+    // If $match_rows is empty there is no loop.
+    if (empty($new_match_rows)) {
+      $possible_loop == FALSE;
+      $matched_rows = [];
+      unset($new_match_rows);
+      $no_loop_skip_test = TRUE;
+      // There is not loop so pass it back the possible_start_of_loop info
+      // and a flag telling it to skip the loop check.
+      _chado_update_cvtermpath_loop_increment($possible_start_of_loop->subject_id,
+        $possible_start_of_loop->child_id, $possible_start_of_loop->cvid,
+        $possible_start_of_loop->type_id, $possible_start_of_loop->depth,
+        $increment_of_depth, $tree_path, $possible_loop, $matched_rows,
+        $possible_start_of_loop, $no_loop_skip_test);
+    }
+      // If $match_rows is not empty we need to keep trying rows.
+    else {
+      _chado_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
+        $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+        $match_rows, $possible_start_of_loop, $no_loop_skip_test);
+    }
+  }
+  elseif ($possible_loop === FALSE) {
+    _chado_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
+      $type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+      $matched_rows, $possible_start_of_loop, $no_loop_skip_test);
+  }
+}
+
+/**
+ *
+ * @param $origin
+ *   The root terms cvterm_id.
+ * @param $child_id
+ *   The cvterm_id of the current child term.  The child term is a descendent
+ *   of the origin.
+ * @param $cv_id
+ *   The controlled vocabulary ID from the cv table of Chado (i.e. cv.cv_id).
+ * @param $type_id
+ *   The relationship type between the origin term and the child.
+ * @param $depth
+ *   The depth of the recursion.
+ * @param $increment_of_depth.
+ *   An integer.
+ * @param $tree_path.
+ *   The array of every term between the current child and the origin. Each
+ *   element in the array is an associative array with the keys:
+ *     -build_id: an string identifier for the child that combines the origin,
+ *      child cvterm_id,cv_id, and the type_id.
+ *     -depth: the depth that a child was inserted into the cvtermpath table.
+ * @param $possible_loop
+ *    A boolean flag.
+ * @param $matched_row
+ *    An array of rows that are currently in the cvtermpath table that match the
+ *    build_id of the current term trying to be written to the table
+ * @param $possible_start_of_ loop
+ *    The array of the possible loop item between the current child and the origin.
+ *    Each element in the array is an associative array with the keys:
+ *     - cvid : $cv_id
+ *     - subject_id:
+ *     - child_id : $child_id,
+ *     - type_id : $type_id,
+ *     - depth : $depth,
+ * @param $no_loop_skip_test
+ *     A boolean used when the possible loop has been ruled out as a loop.
+ * @return multitype: Either a number that represents the row count of existing
+ * rows that already match these specification or a Boolean false.
+ *
+ * @ingroup tripal_chado_cv_api
+ */
+function _chado_update_cvtermpath_loop_increment($origin, $child_id, $cv_id,
+  $type_id, $depth, $increment_of_depth, $tree_path, $possible_loop,
+  $matched_rows, &$possible_start_of_loop, $no_loop_skip_test) {
+    
+  // Check to see if a row with these values already exists.
+  if ($possible_loop === FALSE && empty($possible_start_of_loop)) {
+    chado_set_active('chado');
+    $count = db_query(
+      ' SELECT *
+      FROM cvtermpath
+      WHERE object_id = :origin
+      AND subject_id = :child_id
+      AND pathdistance = :depth
+      AND type_id = :type_id
+    ',
+      [
+        ':origin' => $origin,
+        ':child_id' => $child_id,
+        ':depth' => $depth,
+        ':type_id' => $type_id
+      ]
+    );
+    $count->fetchAll();
+    $count_total = $count->rowCount();
+    if ($count_total > 0) {
+      return $count;
+    }
+    // Build the ID.
+    $term_id = $origin . '|' . $child_id . '|' . $cv_id . '|' . $type_id;
+    
+    if ($no_loop_skip_test === FALSE) {
+      // If the increment of depth is 0 then it's the first time and we need to
+      // skip the test so we can build the tree_path which will be tested against.
+      if ($increment_of_depth != 0) {
+        // Search the $tree_path for the new $child_id in the build_id column.
+        foreach ($tree_path as $parent) {
+          // If this child is the same as a parent term that has already been
+          // processed then we have a potential loop.
+          if ($parent['build_id'] == $term_id) {
+            // Tell the function this is a possible loop and to stop writing to
+            // the table.
+            $possible_loop = TRUE;
+            // Find all the results in the table that might be the start of the
+            // loop.
+            $matching_rows = db_query(
+              ' SELECT *
+              FROM cvtermpath
+              WHERE cv_id = :cvid
+              AND object_id = :origin
+              AND subject_id = :child_id
+              AND type_id = :type_id
+            ',
+              [
+                ':cvid' => $cv_id,
+                ':origin' => $origin,
+                ':child_id' => $child_id,
+                ':type_id' => $type_id
+              ]
+              );
+            $matched_rows = $matching_rows->fetchAll();
+            $possible_start_of_loop = array(
+              'cvid' => $cv_id,
+              'subject_id' => $origin,
+              'child_id' => $child_id,
+              'type_id' => $type_id,
+              'depth' => $depth,
+            );
+          }
+        }
+      }
+      
+      $find_query = db_select('chado.cvtermpath', 'CVTP');
+      $find_query->fields('CVTP', ['subject_id']);
+      $find_query->condition('object_id', $origin);
+      $find_query->condition('subject_id', $child_id);
+      $find_query->condition('type_id', $type_id);
+      $find_query->condition('pathdistance', $depth);
+      $exists = $find_query->execute()->fetchObject();
+      
+      if(!$exists){
+        $query = db_insert('cvtermpath')
+        ->fields([
+          'object_id' => $origin,
+          'subject_id' => $child_id,
+          'cv_id' => $cv_id,
+          'type_id' => $type_id,
+          'pathdistance' => $depth,
+        ]);
+        try {
+          $rows = $query->execute();
+        } 
+        catch (Exception $e) {
+          $error = $e->getMessage();
+          tripal_report_error('tripal_chado', TRIPAL_ERROR, "Could not fill cvtermpath term: @error", array('@error' => $error));
+          return false;
+        }
+      }
+      
+      // Then add that new entry to the $tree_path.
+      $tree_path[$increment_of_depth] = [
+        'build_id' => $term_id,
+        'depth' => $depth
+      ];
+    }
+    // Reset to FALSE  and empty variable if passed in as TRUE.
+    $no_loop_skip_test == FALSE;
+    $possible_start_of_loop = [];
+    
+    // Get all of the relationships of this child term, and recursively
+    // call the _chado_update_cvtermpath_loop_increment() function to continue
+    // descending down the tree.
+    $query = db_select('cvterm_relationship', 'cvtr')
+    ->fields('cvtr')
+    ->condition('cvtr.object_id', $child_id, '=')
+    ->execute();
+    $cterm_relationships = $query->fetchAll();
+    
+    foreach ($cterm_relationships as $item) {
+      $increment_of_depth++;
+      _chado_update_cvtermpath_loop_increment($origin, $item->subject_id, $cv_id,
+        $item->type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+        $matched_rows, $possible_start_of_loop, $no_loop_skip_test);
+    }
+  }
+  elseif ($possible_loop === FALSE && !empty($possible_start_of_loop)) {
+    // This means a loop has been identified and the recursive call can move
+    // on to the next item and skip the rest of this run.
+    return $possible_start_of_loop;
+  }
+  elseif ($possible_loop === TRUE) {
+    // Get all of the relationships of this child term, and recursively
+    // call the _chado_update_cvtermpath_loop() function to continue
+    // descending down the tree.
+    $query = db_select('cvterm_relationship', 'cvtr')
+    ->fields('cvtr')
+    ->condition('cvtr.object_id', $child_id, '=')
+    ->execute();
+    $cterm_relationships = $query->fetchAll();
+    foreach ($cterm_relationships as $item) {
+      $increment_of_depth++;
+      _chado_update_cvtermpath_loop($origin, $item->subject_id, $cv_id,
+        $item->type_id, $depth + 1, $increment_of_depth, $tree_path, $possible_loop,
+        $matched_rows, $possible_start_of_loop, $no_loop_skip_test);
+    }
+  }
 }
 
 /**

--- a/tripal_cv/includes/tripal_cv.obo_loader.inc
+++ b/tripal_cv/includes/tripal_cv.obo_loader.inc
@@ -571,7 +571,7 @@ function tripal_cv_load_obo_v1_2($file, $jobid = NULL, &$newcvs) {
       fclose($fh);
       // Check if the EBI ontology search has this ontology:
       try {
-        $results = tripl_cv_obo_EBI_Lookup($short_name, 'ontology');
+        $results = tripal_cv_obo_EBI_lookup($short_name, 'ontology');
         if (array_key_exists('default-namespace', $results['config']['annotations'])) {
           $results = $results['config']['annotations']['default-namespace'];
           if (is_array($results)) {
@@ -594,10 +594,12 @@ function tripal_cv_load_obo_v1_2($file, $jobid = NULL, &$newcvs) {
       if (empty($defaultcv)) {
         throw new Exception("Could not find a namespace for this OBO file: $file");
       }
-      tripal_report_error('T_obo_loader', "This OBO is missing the 'default-namespace' header. It " .
-        "is not possible to determine which vocabulary terms without a 'namespace' key " .
-        "should go.  Instead, those terms will be placed in the '!vocab' vocabulary.", 
-        array('!vocab' => $defaultcv->name), 'error');
+      tripal_report_error('T_obo_loader', TRIPAL_WARNING, "This OBO is missing " . 
+        "the 'default-namespace' header. It is therefore, not possible to " .
+        "determine which vocabulary a term belongs to if it does not have " . 
+        "a 'namespace' key.  Instead, terms without a 'namespace' key " .
+        "will be placed in the '!vocab' vocabulary.", 
+        array('!vocab' => $defaultcv->name));
     }
 
     // add any typedefs to the vocabulary first
@@ -654,7 +656,7 @@ function tripal_cv_obo_quiterror($message) {
  * @ingroup tripal_obo_loader
  */
 function tripal_cv_obo_load_typedefs($defaultcv, $newcvs, $default_db, $jobid) {
-  $sql = "SELECT * FROM {tripal_obo_temp} WHERE type = 'Typedef' ";
+  $sql = "SELECT * FROM {tripal_obo_temp} WHERE type = 'Typedef'";
   $typedefs = chado_query($sql);
 
   $sql = "
@@ -720,11 +722,7 @@ function tripal_cv_obo_process_terms($defaultcv, $jobid = NULL, &$newcvs, $defau
   $i = 0;
 
   // iterate through each term from the OBO file and add it
-  $sql = "
-    SELECT * FROM {tripal_obo_temp}
-    WHERE type = 'Term'
-    ORDER BY id
-  ";
+  $sql = "SELECT * FROM {tripal_obo_temp} WHERE type = 'Term' ORDER BY id";
   $terms = chado_query($sql);
 
   $sql = "
@@ -822,7 +820,7 @@ function tripal_cv_obo_process_term($term, $defaultcv, $is_relationship = 0, &$n
   $results = chado_query($sql)->fetchObject();
   if (!$results){
     //The controlled vocabulary is not in the cv term table and needs to be added.
-    $ontology_info = tripal_cv_obo_EBI_Lookup($defaultcv, 'ontology');
+    $ontology_info = tripal_cv_obo_EBI_lookup($defaultcv, 'ontology');
     if (!empty($ontology_info)){
       if (array_key_exists('default-namespace', $ontology_info['config']['annotations'])) {
         $results = $ontology_info['config']['annotations']['default-namespace'];
@@ -1015,7 +1013,7 @@ function tripal_cv_obo_add_relationship($cvterm, $defaultcv, $rel,
     $ontology_id = $pair[0];
     $accession_num = $pair[1];
     if (is_numeric($accession_num)) {
-      $results = tripal_cv_obo_EBI_Lookup($rel, 'query');
+      $results = tripal_cv_obo_EBI_lookup($rel, 'query');
       if (!empty($results)) {
         if (array_key_exists('docs', $results)){
           if(!empty($results['docs'])) {
@@ -1023,7 +1021,7 @@ function tripal_cv_obo_add_relationship($cvterm, $defaultcv, $rel,
           }
           else {
             // The first search doesn't work, so let's try a broader one.
-            $results = tripal_cv_obo_EBI_Lookup($rel, 'query-non-local');
+            $results = tripal_cv_obo_EBI_lookup($rel, 'query-non-local');
             if (!empty($results)) {
               if (array_key_exists('docs', $results)){
                 if(!empty($results['docs'])) {
@@ -1554,7 +1552,7 @@ function tripal_cv_obo_form_ajax_callback($form, $form_state) {
  *
  * @ingroup tripal_obo_loader
  */
-function tripal_cv_obo_EBI_Lookup($accession, $type_of_search) {
+function tripal_cv_obo_EBI_lookup($accession, $type_of_search) {
   
   //Grab just the ontology from the $accession.
   $parts = explode(':', $accession);

--- a/tripal_cv/includes/tripal_cv.obo_loader.inc
+++ b/tripal_cv/includes/tripal_cv.obo_loader.inc
@@ -553,22 +553,51 @@ function tripal_cv_load_obo_v1_2($file, $jobid = NULL, &$newcvs) {
     }
     // if the 'default-namespace' is missing
     else {
-
-      // look to see if an 'ontology' key is present.  It is part of the v1.4
-      // specification so it shouldn't be in the file, but just in case
-      if (array_key_exists('ontology', $header)) {
-        $defaultcv = tripal_insert_cv(strtoupper($header['ontology'][0]), '');
-        if (!$defaultcv) {
-          tripal_cv_obo_quiterror('Cannot add namespace ' . strtoupper($header['ontology'][0]));
+      // Grab the first term accession from the file and get the short name for the cv
+      $fh = fopen($file, 'r');
+      while ($line = fgets($fh)) {
+        // Grab the first item's id info to break apart.
+        if (preg_match('/^\s*\[/', $line)) {
+          $stanza = TRUE;
+          continue;
         }
-        $newcvs[strtoupper(strtoupper($header['ontology'][0]))] = $defaultcv->cv_id;
+        if ($stanza === TRUE && (substr($line, 0, 3) === "id:")) {
+          $parts = explode(':', $line);
+          $short_name = strtolower($parts[1]);
+          $short_name = preg_replace('/\s+/', '', $short_name);
+          break;
+        }
       }
-      else {
-        $defaultcv = tripal_insert_cv('_global', '');
-        $newcvs['_global'] = $defaultcv->cv_id;
+      fclose($fh);
+      // Check if the EBI ontology search has this ontology:
+      try {
+        $results = tripl_cv_obo_EBI_Lookup($short_name, 'ontology');
+        if (array_key_exists('default-namespace', $results['config']['annotations'])) {
+          $results = $results['config']['annotations']['default-namespace'];
+          if (is_array($results)) {
+            $results = $results[0];
+          }
+        }
+        elseif (array_key_exists('namespace', $results['config'])) {
+          $results = $results['config']['namespace'];
+        }
+        else {
+          $results = $short_name;
+        }
+        $defaultcv = tripal_insert_cv(strtoupper($results), '');
+        $newcvs[$defaultcv->name] = $defaultcv->cv_id;
       }
-      watchdog('t_obo_loader', "This OBO is missing the 'default-namespace' header. It is not possible to determine which vocabulary terms without a 'namespace' key should go.  Instead, those terms will be placed in the '%vocab' vocabulary.",
-        array('%vocab' => $defaultcv->name), WATCHDOG_WARNING);
+      catch (Exception $e) {
+        watchdog_exception('OBOImporter no such accession found in EBI Ontology Search', $e);
+      }
+      
+      if (empty($defaultcv)) {
+        throw new Exception("Could not find a namespace for this OBO file: $file");
+      }
+      tripal_report_error('T_obo_loader', "This OBO is missing the 'default-namespace' header. It " .
+        "is not possible to determine which vocabulary terms without a 'namespace' key " .
+        "should go.  Instead, those terms will be placed in the '!vocab' vocabulary.", 
+        array('!vocab' => $defaultcv->name), 'error');
     }
 
     // add any typedefs to the vocabulary first
@@ -783,6 +812,31 @@ function tripal_cv_obo_process_term($term, $defaultcv, $is_relationship = 0, &$n
   if (array_key_exists('is_obsolete', $term)) {
     $t['is_obsolete'] = $term['is_obsolete'][0];
   }
+  
+  // Check that the default_cv is in the cv table.
+  $sql =  "
+    SELECT CV.name
+    FROM {cv} CV
+    WHERE CV.name = '$defaultcv'
+  ";
+  $results = chado_query($sql)->fetchObject();
+  if (!$results){
+    //The controlled vocabulary is not in the cv term table and needs to be added.
+    $ontology_info = tripal_cv_obo_EBI_Lookup($defaultcv, 'ontology');
+    if (!empty($ontology_info)){
+      if (array_key_exists('default-namespace', $ontology_info['config']['annotations'])) {
+        $results = $ontology_info['config']['annotations']['default-namespace'];
+      }
+      elseif (array_key_exists('namespace', $ontology_info['config'])) {
+        $results = $ontology_info['config']['namespace'];
+      }
+      $cv_returned = tripal_insert_cv($results[0], '');
+      // If name && definition are both empty then look up the term from the ontology you just loaded.
+      if($cv_returned) {
+        $defaultcv = $cv_returned;
+      }
+    }
+  }
 
   $t['cv_name'] = $defaultcv;
   $t['is_relationship'] = $is_relationship;
@@ -793,6 +847,14 @@ function tripal_cv_obo_process_term($term, $defaultcv, $is_relationship = 0, &$n
   if (!$cvterm) {
     tripal_cv_obo_quiterror("Cannot add the term " . $term['id'][0]);
   }
+  
+  // Remove any relationships that this term already has (in case it was
+  // updated) and we'll re-add them.
+  $sql = "
+      DELETE FROM {cvterm_relationship} CVTR
+      WHERE CVTR.subject_id = :cvterm_id
+    ";
+  chado_query($sql, array(':cvterm_id' => $cvterm->cvterm_id));
 
   if (array_key_exists('namespace', $term)) {
     $newcvs[$term['namespace'][0]] = $cvterm->cv_id;
@@ -947,6 +1009,43 @@ function tripal_cv_obo_process_term($term, $defaultcv, $is_relationship = 0, &$n
 function tripal_cv_obo_add_relationship($cvterm, $defaultcv, $rel,
   $objname, $object_is_relationship = 0, $default_db = 'OBO_REL') {
 
+  // If an accession was passed we need to see if we can find the actual label.
+  if (strpos($rel, ':')) {
+    $pair = explode(":", $rel);
+    $ontology_id = $pair[0];
+    $accession_num = $pair[1];
+    if (is_numeric($accession_num)) {
+      $results = tripal_cv_obo_EBI_Lookup($rel, 'query');
+      if (!empty($results)) {
+        if (array_key_exists('docs', $results)){
+          if(!empty($results['docs'])) {
+            $rel = $results['docs']['label'];
+          }
+          else {
+            // The first search doesn't work, so let's try a broader one.
+            $results = tripal_cv_obo_EBI_Lookup($rel, 'query-non-local');
+            if (!empty($results)) {
+              if (array_key_exists('docs', $results)){
+                if(!empty($results['docs'])) {
+                  $accession = $rel;
+                  $accession_underscore = str_replace(":", "_", $accession);
+                  foreach ($results['docs'] as $item) {
+                    if ($item['label'] != $accession && $item['label'] != $accession_underscore) {
+                      //Found the first place a label is other than the accession is used, so take
+                      // that info and then end the loop.
+                      $rel = $item['label'];
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } 
+  
   // make sure the relationship cvterm exists
   $term = array(
     'name' => $rel,
@@ -960,7 +1059,21 @@ function tripal_cv_obo_add_relationship($cvterm, $defaultcv, $rel,
   $relcvterm = tripal_insert_cvterm($term, array('update_existing' => FALSE));
 
   if (!$relcvterm) {
-    tripal_cv_obo_quiterror("Cannot find the relationship term in the current ontology: $rel\n");
+    // If the relationship term couldn't be found in the default_db provided
+    // then do on more check to find it in the relationship ontology
+    $term = array(
+      'name' => $rel,
+      'id' => "OBO_REL:$rel",
+      'definition' => '',
+      'is_obsolete' => 0,
+      'cv_name' => $defaultcv,
+      'is_relationship' => TRUE,
+      'db_name' => 'OBO_REL'
+    );
+    $relcvterm = chado_insert_cvterm($term, array('update_existing' => FALSE));
+    if (!$relcvterm) {
+      tripal_cv_obo_quiterror("Cannot find the relationship term in the current or relationship ontology: $rel\n");
+    }    
   }
 
   // get the object term
@@ -1137,7 +1250,7 @@ function tripal_cv_obo_add_synonyms($term, $cvterm) {
 function tripal_cv_obo_parse($obo_file, &$header, $jobid) {
   $in_header = 1;
   $stanza = array();
-  $default_db = '_global';
+  $default_db = '';
   $line_num = 0;
   $num_read = 0;
   $intv_read = 0;
@@ -1177,9 +1290,8 @@ function tripal_cv_obo_parse($obo_file, &$header, $jobid) {
       continue;
     }
 
-    //remove comments from end of lines
-    $line = preg_replace('/^(.*?)\!.*$/', '\1', $line);  // TODO: if the explamation is escaped
-    $type = '';
+    // Remove comments from end of lines
+    $line = preg_replace('/^(.*?)\!.*$/', '\1', $line);  
 
     // at the first stanza we're out of header
     if (preg_match('/^\s*\[/', $line)) {
@@ -1207,6 +1319,7 @@ function tripal_cv_obo_parse($obo_file, &$header, $jobid) {
       $stanza = array();
       continue;
     }
+    
     // break apart the line into the tag and value but ignore any escaped colons
     preg_replace("/\\:/", "|-|-|", $line); // temporarily replace escaped colons
     $pair = explode(":", $line, 2);
@@ -1428,4 +1541,58 @@ function tripal_cv_obo_add_dbxref($db_id, $accession, $version='', $description=
 
 function tripal_cv_obo_form_ajax_callback($form, $form_state) {
   return $form['obo_existing'];
+}
+
+/**
+ * API call to Ontology Lookup Service provided by
+ * https://www.ebi.ac.uk/ols/docs/api#resources-terms
+ *
+ * @param accession
+ *   Accession term for query
+ * @param type_of_search
+ *   Either ontology, term, query, or query-non-local
+ *
+ * @ingroup tripal_obo_loader
+ */
+function tripal_cv_obo_EBI_Lookup($accession, $type_of_search) {
+  
+  //Grab just the ontology from the $accession.
+  $parts = explode(':', $accession);
+  $ontology = strtolower($parts[0]);
+  $ontology = preg_replace('/\s+/', '', $ontology);
+  if ($type_of_search == 'ontology') {
+    $options = array();
+    $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
+    $response = drupal_http_request($full_url, $options);
+    if(!empty($response)){
+      $response = drupal_json_decode($response->data);
+    }
+  }
+  elseif ($type_of_search == 'term') {
+    //The IRI of the terms, this value must be double URL encoded
+    $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':' , '_', $accession)));
+    $options = array();
+    $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'terms/' . $iri;
+    $response = drupal_http_request($full_url, $options);
+    if(!empty($response)){
+      $response = drupal_json_decode($response->data);
+    }
+  }
+  elseif($type_of_search == 'query') {
+    $options = array();
+    $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';
+    $response = drupal_http_request($full_url, $options);
+    if(!empty($response)){
+      $response = drupal_json_decode($response->data);
+    }
+  }
+  elseif($type_of_search == 'query-non-local') {
+    $options = array();
+    $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
+    $response = drupal_http_request($full_url, $options);
+    if(!empty($response)){
+      $response = drupal_json_decode($response->data);
+    }
+  }
+  return $response;
 }

--- a/tripal_organism/theme/templates/tripal_organism_properties.tpl.php
+++ b/tripal_organism/theme/templates/tripal_organism_properties.tpl.php
@@ -5,7 +5,7 @@ $options = array('return_array' => 1);
 $organism = chado_expand_var($organism, 'table', 'organismprop', $options);
 $properties = $organism->organismprop;
 
-if(count($properties) > 0){ 
+if(is_array($properties) and count($properties) > 0){ 
     
   // the $headers array is an array of fields to use as the colum headers.
   // additional documentation can be found here

--- a/tripal_organism/theme/templates/tripal_organism_references.tpl.php
+++ b/tripal_organism/theme/templates/tripal_organism_references.tpl.php
@@ -6,7 +6,7 @@ $references = array();
 $options = array('return_array' => 1);
 $organism = chado_expand_var($organism, 'table', 'organism_dbxref', $options);
 $organism_dbxrefs = $organism->organism_dbxref;
-if (count($organism_dbxrefs) > 0 ) {
+if (is_array($organism_dbxrefs) and count($organism_dbxrefs) > 0 ) {
   foreach ($organism_dbxrefs as $organism_dbxref) {    
     if($organism_dbxref->dbxref_id->db_id->name == 'GFF_source'){
       // check to see if the reference 'GFF_source' is there.  This reference is
@@ -19,7 +19,7 @@ if (count($organism_dbxrefs) > 0 ) {
 }
 
 
-if(count($references) > 0){ ?>
+if(is_array($references) and count($references) > 0){ ?>
   <div class="tripal_organism-data-block-desc tripal-data-block-desc">External references for this organism</div><?php
    
   // the $headers array is an array of fields to use as the colum headers.

--- a/tripal_organism/tripal_organism.views_default.inc
+++ b/tripal_organism/tripal_organism.views_default.inc
@@ -268,7 +268,7 @@ function tripal_organism_admin_defaultview_organisms() {
   $handler->display->display_options['header']['action_links_area']['empty'] = TRUE;
   $handler->display->display_options['header']['action_links_area']['link-1'] = array(
     'label-1' => 'Add Organism',
-    'path-1' => 'node/add/tripal_organism',
+    'path-1' => 'node/add/chado-organism',
   );
   /* No results behavior: Global: Text area */
   $handler->display->display_options['empty']['text']['id'] = 'area';


### PR DESCRIPTION
**NOTE: this is a PR for update to Tripal v2** 

This pull request responds to the last comment of issue #253. We have made many fixes to the OBO importer and cvtermpath importer of Tripal v3 that did not get included into Tripal v2. This pull request fixes that.

With this PR I can successfully node the full GO on a Tripal v2 site with the following number of entries added to the cvtermpath:

biological_process: 1,656,785
molecular_function: 43,944
cellular_component: 152,030

I can also load the Plant GO Slim without issues.