### PR TITLE
Fix for File Collections File Permissions

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -644,7 +644,9 @@ function tripal_create_bundle_fields($bundle, $term) {
   foreach ($modules as $module) {
     $function = $module . '_bundle_fields_info';
     $temp = $function('TripalEntity', $bundle);
-    $info = array_merge($info, $temp);
+    if (is_array($temp)) {
+      $info = array_merge($info, $temp);
+    }
   }
 
   // Allow modules to alter which fields should be attached to content

--- a/tripal/api/tripal.files.api.inc
+++ b/tripal/api/tripal.files.api.inc
@@ -138,6 +138,9 @@ function tripal_get_files_stream($module_name = FALSE) {
  *
  * @return string
  *   A formatted string indicating the size of the file
+ *   
+ *   
+ * @ingroup tripal_files_api
  */
 function tripal_format_bytes($bytes, $precision = 2) {
   $units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -155,6 +158,7 @@ function tripal_format_bytes($bytes, $precision = 2) {
 
 /**
  * Retrieves the list of files uploaded by a user.
+ * 
  * @param $uid
  *   The ID of the user whose files should be retrieved.
  * @param $allowed_types
@@ -164,6 +168,8 @@ function tripal_format_bytes($bytes, $precision = 2) {
  *      
  * @return
  *   A list of file objects.
+ *   
+ * @ingroup tripal_files_api
  */
 function tripal_get_user_uploads($uid, $allowed_types = array(), $module = 'tripal') {
   $user = user_load($uid);
@@ -188,4 +194,55 @@ function tripal_get_user_uploads($uid, $allowed_types = array(), $module = 'trip
   }
   
   return $files_list;
+}
+
+/**
+ * Retrieves the URI for the dedicated directory for a user's files.
+ * 
+ * This directory is used by the file uploader and by data collections.
+ * 
+ * @param $user
+ *   A Drupal user object.
+ *   
+ * @return 
+ *   The URI of the directory.
+ *   
+ * @ingroup tripal_files_api
+ */
+function tripal_get_user_files_dir($user) {
+  
+  $user_dir = 'public://tripal/users/' . $user->uid;
+    
+  return $user_dir;
+}
+
+/**
+ * Checks if the user's dedicated directory is accessible and writeable. 
+ * 
+ * @param $user
+ *   A Drupal user object.
+ *   
+ * @return
+ *   TRUE if the user's directory is writeable. FALSE otherwise.
+ *   
+ * @ingroup tripal_files_api
+ */
+function tripal_is_user_files_dir_writeable($user) {
+  $user_dir = tripal_get_user_files_dir($user);
+   
+  // First, make sure the directory exists.
+  if (!file_prepare_directory($user_dir, FILE_CREATE_DIRECTORY)) {
+    return FALSE;
+  }
+  
+  // It has been reported that file_prepare_directory is not properly
+  // detecting if the directory is writeable, so we'll do another
+  // round of checks to be sure.
+  if (!is_dir($user_dir)) {
+    return FALSE;
+  }
+  if (!is_writeable($user_dir)) {
+    return FALSE;
+  }
+  return TRUE;
 }

--- a/tripal/includes/TripalFieldDownloaders/TripalFieldDownloader.inc
+++ b/tripal/includes/TripalFieldDownloaders/TripalFieldDownloader.inc
@@ -160,16 +160,10 @@ abstract class TripalFieldDownloader {
       $collection_bundle->fields = unserialize($collection_bundle->fields);
       $this->collection_bundles[] = $collection_bundle;
     }
-
-    if (!file_prepare_directory($user_dir, FILE_CREATE_DIRECTORY)) {
-      $message = 'Could not access the directory on the server for storing this file.';
-      watchdog('tripal', $message, array(), WATCHDOG_ERROR);
-      drupal_json_output(array(
-        'status'  => 'failed',
-        'message' => $message,
-        'file_id' => '',
-      ));
-      return;
+ 
+    $user_dir = tripal_get_user_files_dir($user);
+    if (!tripal_is_user_files_dir_writeable($user)) {
+      throw new Exception(t("The user's data directory is not writeable: !user_dir.", array('!user_dir' => $user_dir)));
     }
 
     // Map the fields to their term accessions.

--- a/tripal/includes/tripal.upload.inc
+++ b/tripal/includes/tripal.upload.inc
@@ -7,11 +7,10 @@ function tripal_file_upload($type, $filename, $action = NULL, $chunk = 0) {
   $file_size = array_key_exists('file_size', $_GET) ? $_GET['file_size'] : '';
   $chunk_size = array_key_exists('chunk_size', $_GET) ? $_GET['chunk_size'] : '';
 
-  $user_dir = 'public://tripal/users/' . $user->uid;
-
-  if (!file_prepare_directory($user_dir, FILE_CREATE_DIRECTORY)) {
-    $message = 'Could not access the directory on the server for storing this file.';
-    watchdog('tripal', $message, array(), WATCHDOG_ERROR);
+  $user_dir = tripal_get_user_files_dir($user);
+  if (!tripal_is_user_files_dir_writeable($user)) {
+    $message = 'The user\'s data directory is not writeable: !user_dir.';
+    watchdog('tripal', $message, array('!user_dir' => $user_dir), WATCHDOG_ERROR);
     drupal_json_output(array(
       'status'  => 'failed',
       'message' => $message,


### PR DESCRIPTION
This is a fix for issue #293.   Here is a summary of the changes:

1.  Two new API functions were added to the tripal.files.api.inc function for getting a User's file directory and for checking if it is writeable.  This unifies the code between the uploader and the collections with a single set of API calls.
2.   I added a few additional checks to see if the directory exists and is writeable to ensure that if the file_prepare_directory does not properly check we have the backup checks.
3.  I updated the uploader and data collections to use the new API functions.

You can check this by 

1.  Changing permissions in the default/sites/files/tripal/users so that it is not writeable by the user running the job queue.
2.  Creating a data collection
3.  Generating the files and running the job manually using drush.