### PR TITLE
Fixes for PHP 7.2 compatibility and typo on call to API function

### DIFF
--- a/tests/tripal_chado/TaxonomyImporterTest.php
+++ b/tests/tripal_chado/TaxonomyImporterTest.php
@@ -43,8 +43,31 @@ class TaxonomyImporterTest extends TripalTestCase {
     $this->assertNotEmpty($result);
 
   }
-//
-//  public function testImportOrganismFromTaxID() {
-//
-//  }
+
+  /**
+   * the importer can also load an array of pubmed ids.  We use the pillbug again.
+   *
+   * https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=96821
+   *
+   * @throws \Exception
+   */
+  public function testImportOrganismFromTaxID() {
+
+    $file = [];
+    $run_args = ['taxonomy_ids' => '96821']; //its the pillbug again!
+    $importer = new \TaxonomyImporter();
+
+    ob_start();
+    $importer->create($run_args, $file);
+    $importer->run();
+    ob_end_clean();
+
+    $query = db_select('chado.organism', 'o');
+    $query->fields('o', ['genus'])
+      ->condition('o.species', 'officinalis');
+    $result = $query->execute()->fetchField();
+    $this->assertEquals('Armadillo', $result);
+
+  }
+
 }

--- a/tests/tripal_chado/TaxonomyImporterTest.php
+++ b/tests/tripal_chado/TaxonomyImporterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\tripal_chado;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+require_once(__DIR__ . '/../../tripal_chado/includes/TripalImporter/TaxonomyImporter.inc');
+
+
+class TaxonomyImporterTest extends TripalTestCase {
+  use DBTransaction;
+
+
+  /*
+   * Adds an organism and checks that the importer runs and adds some properties to it.
+   */
+  public function testImportExistingTaxonomyLoader() {
+    $org = [
+      'genus' => 'Armadillo',
+      'species' => 'officinalis',
+      'abbreviation' => 'A. officinalis',
+      'common_name' => 'pillbug',
+      'type_id' => null
+    ];
+
+    $organism = factory('chado.organism')->create($org);
+  //  $this->publish('organism');
+    $file = [];
+    $run_args = ['import_existing' => TRUE];
+    $importer = new \TaxonomyImporter();
+    ob_start();
+    $importer->create($run_args, $file);
+    $importer->run();
+    ob_end_clean();
+
+
+    $query = db_select('chado.organism', 'o');
+    $query->join('chado.organismprop', 'op', 'o.organism_id = op.organism_id');
+    $query->fields('op', ['value'])
+      ->condition('o.organism_id', $organism->organism_id);
+    $result = $query->execute()->fetchAll();
+    $this->assertNotEmpty($result);
+
+  }
+//
+//  public function testImportOrganismFromTaxID() {
+//
+//  }
+}

--- a/tripal/includes/TripalJob.inc
+++ b/tripal/includes/TripalJob.inc
@@ -160,17 +160,19 @@ class TripalJob {
     }
 
     $includes = $details['includes'];
-    foreach ($includes as $path) {
-      $full_path = $_SERVER['DOCUMENT_ROOT'] . base_path() . $path;
-      if (!empty($path)) {
-        if (file_exists($path)) {
-          require_once($path);
-        }
-        elseif (file_exists($full_path)) {
-          require_once($path);
-        }
-        elseif (!empty($path)) {
-          throw new Exception("Included files for Tripal Job must exist. This path ($full_path) doesn't exist.");
+    if ($path and is_array($path)) {
+      foreach ($includes as $path) {
+        $full_path = $_SERVER['DOCUMENT_ROOT'] . base_path() . $path;
+        if (!empty($path)) {
+          if (file_exists($path)) {
+            require_once($path);
+          }
+          elseif (file_exists($full_path)) {
+            require_once($path);
+          }
+          elseif (!empty($path)) {
+            throw new Exception("Included files for Tripal Job must exist. This path ($full_path) doesn't exist.");
+          }
         }
       }
     }

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1037,7 +1037,7 @@ function chado_delete_record($table, $match, $options = NULL) {
   foreach ($delete_matches as $field => $value) {
     // If we have an array values then this is an "IN" clasue.
 
-    if (count($value) > 1) {
+    if (is_array($value) and count($value) > 1) {
       $sql .= "$field IN (";
       $index = 0;
       foreach ($value as $v) {

--- a/tripal_chado/includes/TripalImporter/NewickImporter.inc
+++ b/tripal_chado/includes/TripalImporter/NewickImporter.inc
@@ -108,7 +108,6 @@ class NewickImporter extends TripalImporter {
       '#maxlength' => 255,
     ];
 
-    $type_cv = tripal_get_default_cv('phylotree', 'type_id');
     $so_cv = chado_get_cv(['name' => 'sequence']);
     $cv_id = $so_cv->cv_id;
     if (!$so_cv) {

--- a/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
+++ b/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
@@ -912,6 +912,9 @@ class TaxonomyImporter extends TripalImporter {
       'dbxref_id' => $dbxref->dbxref_id,
       'organism_id' => $organism_id,
     );
-    chado_insert_record('organism_dbxref', $values);
+
+   if (!chado_select_record('organism_dbxref', ['organism_dbxref_id'], $values)) {
+     chado_insert_record('organism_dbxref', $values);
+   }
   }
 }

--- a/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
+++ b/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
@@ -312,7 +312,7 @@ class TaxonomyImporter extends TripalImporter {
     $lineage_nodes[] = array();
 
     // Get the "rank" cvterm. It requires that the TAXRANK vocabulary is loaded.
-    $rank_cvterm = tripal_chado_get_cvtermget_cvterm(array(
+    $rank_cvterm = chado_get_cvterm(array(
       'name' => 'rank',
       'cv_id' => array('name' => 'local')
     ));


### PR DESCRIPTION
These are very small fixes to fix PHP v7.2 errors and a typo when calling an API function call.

I realize that upgrading your site to PHP 7.2 just for testing this would be extremely time consuming and will have a lot of side effects.  I personally think just a quick look at the code changes would be a sufficient review.  Otherwise, to test:

To test you need PHP 7.2
1)  Add any job and you get an Drupal error
2)  Try deleting a record using chado_delete_record and be sure that the matching criteria are single values (no arrays)

To test the bad API Call  (PHP 7.2 not required):
3)  Just run the NCBI taxonomy importer. It will fail without this fix because of the bad function call for a function that doesn't exist.
 
