### PR TITLE
Update to prepare instructions + removed skip

### DIFF
--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -19,23 +19,14 @@ function tripal_chado_prepare_form($form, $form_state) {
     '#description' => t("Before a Drupal site can use Chado (via Tripal), both
         Chado and Drupal must be prepared a bit more.  Tripal will add some new
         materialized views, custom tables and controlled vocabularies to Chado.
-        It will also add some management tables to Drupal. You only are
-        required to prepare your Drupal site if this is a brand-new Drupal
-        installation or if Chado was installed outside of Tripal.  If you
-        installed Chado using Tripal then you do not need to run this step.
-        If you are upgrading from a previous version of Tripal, you do not
-        need to prepare your site, and you can click the 'Skip' button."),
+        It will also add some management tables to Drupal and add some default
+        content types for biological and ancillary data."),
   );
 
   $form['prepare-button'] = array(
     '#type' => 'submit',
     '#value' => t('Prepare this site'),
     '#name' => 'prepare-chado',
-  );
-  $form['skip-button'] = array(
-    '#type' => 'submit',
-    '#value' => t('Skip'),
-    '#name' => 'prepare-skip',
   );
   return $form;
 }
@@ -56,9 +47,6 @@ function tripal_chado_prepare_form_submit($form, $form_state) {
      tripal_add_job('Prepare Chado', 'tripal_chado',
        'tripal_chado_prepare_chado', $args,
        $user->uid, 10, $includes);
-   }
-   if ($form_state['clicked_button']['#name'] == "prepare-skip") {
-     variable_set('tripal_chado_is_prepared', TRUE);
    }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #405 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a very simple fix.  It responds to issue #405 and updates the prepare instructions.  It also removes the skip button.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Go to the Tripal > Data Storage > Chado > Prepare Chado page and make sure the text reads as follows: 

> Before a Drupal site can use Chado (via Tripal), both Chado and Drupal must be prepared a bit more. Tripal will add some new materialized views, custom tables and controlled vocabularies to Chado. It will also add some management tables to Drupal and add some default content types for biological and ancillary data.

The "Skip" button should also be gone.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
