### PR TITLE
Cache set check

### DIFF
--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -655,7 +655,9 @@ class TripalEntityController extends EntityAPIController {
                   FIELD_LOAD_CURRENT, $options);
               // Cache the field.
               if ($field_cache) {
-                cache_set($cfid, $entity->$field_name, 'cache_field');
+                if (property_exists($entity, $field_name)) {
+                  cache_set($cfid, $entity->$field_name, 'cache_field');
+                }
               }
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;
             }


### PR DESCRIPTION
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #389

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Fields that are not set for an entity caused this warning:

```
Notice: Undefined property: TripalEntity::$tripal__ena_last_update in TripalEntityController->attachLoad() (line 658 of /var/www/html/sites/all/modules/custom/tripal/tripal/includes/TripalEntityController.inc).
```

So for example, if you set a chado_property for a content type, and then open another entity with that property not set, you will get this error.  This error is present on my live site (with warnings enabled) and dev site.

However, @laceysanderson was not able to duplicate on her system.  
It's such a minor fix that I'm hoping that won't be an issue.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->


## Screenshots (if appropriate):

* add a chado property
* fill out for one entity but not another
* clear cache
* visit the entity lacking the entity's page.

before fix
![screen shot 2018-06-05 at 1 33 47 pm](https://user-images.githubusercontent.com/7063154/40992788-bd085522-68c5-11e8-9c14-4587d90e7b3c.png)

after fix
![with_patch](https://user-images.githubusercontent.com/7063154/40992778-b7e4da02-68c5-11e8-817e-251350aeaae3.png)


## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
