### PR TITLE
Add support for #weight to TripalImporter form.

### DIFF
--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -20,7 +20,7 @@ function tripal_get_importer_form($form, &$form_state, $class) {
     $form['file'] = array(
       '#type' => 'fieldset',
       '#title' => t($class::$upload_title),
-      '#description' => t($class::$upload_description)
+      '#description' => t($class::$upload_description),
       '#weight' => -15,
     );
   }

--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -94,9 +94,18 @@ function tripal_get_importer_form($form, &$form_state, $class) {
     );
   }
 
+  // Retrieve the forms from the custom TripalImporter class
+  // for this loader.
   $importer = new $class();
   $element = array();
-  $form['class_elements'] = $importer->form($element, $form_state);
+  $element_form = $importer->form($element, $form_state);
+  // Quick check to make sure we had an array returned so array_merge() works.
+  if (!is_array($element_form)) $element_form = arry();
+ 
+  // Merge the custom form with our default one.
+  // This way, the custom TripalImporter can use the #weight property
+  // to change the order of their elements in reference to the default ones.
+  $form = array_merge($form, $element_form);
 
   $form['button'] = array(
     '#type' => 'submit',

--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -21,6 +21,7 @@ function tripal_get_importer_form($form, &$form_state, $class) {
       '#type' => 'fieldset',
       '#title' => t($class::$upload_title),
       '#description' => t($class::$upload_description)
+      '#weight' => -15,
     );
   }
 
@@ -91,6 +92,7 @@ function tripal_get_importer_form($form, &$form_state, $class) {
         'a minimum it indicates the source of the data.'),
       '#required' => $class::$require_analysis,
       '#options' => $analyses,
+      '#weight' => -14,
     );
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #416 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
This PR adds the ability for custom TripalImporter classes to change the order of their form elements in reference to the default form elements. Before the TripalImporter form grouped all the form elements provided by the custom class:
https://github.com/tripal/tripal/blob/7.x-3.x/tripal/includes/tripal.importer.inc#L99
```php
  $importer = new $class();
  $element = array();
  $form['class_elements'] = $importer->form($element, $form_state);
```
This caused any #weight attributes set on the custom form elements to only apply to ordering each other and ensures the file upload is always at the top.

After discussion it was determined the cleanest way to fix this was to use array_merge() to combine the custom form elements into the form at the save level as the default form elements.

## Testing?
This PR is super simple to test!
### Backwards Compatible
1. Go to any Tripal Loader at Administration Toolbar > Tripal > Data Loaders and ensure the file upload form element is still at the top.

### New Functionality
1. Download [tripal_bibtex](https://github.com/UofS-Pulse-Binfo/tripal_bibtex/), and enable it.
2. Go to Administration Toolbar > Tripal > Data Loaders > Chado BibTeX Loader. 
3. Then confirm the introduction message is at the top (above file upload) as shown in the following screenshot.
![screen shot 2018-06-10 at 10 41 06 am](https://user-images.githubusercontent.com/1566301/41203912-df1bf85c-6c9a-11e8-8501-35e90659433c.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
    - Uses the old format for array's until the coding style change PR is merged.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
