### PR TITLE
Fix remote site fatal error by supplying the correct site id

### DIFF
--- a/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
+++ b/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
@@ -205,7 +205,7 @@ class remote__data extends WebServicesField {
        list($ctype, $qdata) = explode('?', $query);
      }
 
-     $data = tripal_get_remote_content($this->remote_site->site_id, $query);
+     $data = tripal_get_remote_content($this->remote_site->id, $query);
 
      return $data;
    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #423 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The error was caused by attempting to access an unavailable property `site_id` when it should've been `id`
