### PR TITLE
Fix for issue #204

### DIFF
--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -43,6 +43,7 @@ function tripal_chado_field_storage_write($entity_type, $entity, $op, $fields) {
 
   // Convert the fields into a key/value list of fields and their values.
   $field_vals = tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $entity);
+// dpm($field_vals);
 
   // First, write the record for the base table.  If we have a record id then
   // this is an update and we need to set the primary key.  If not, then this
@@ -799,6 +800,10 @@ function tripal_chado_field_storage_bundle_mapping_form($form, &$form_state,
       and $form_state['values']['type_column']) {
     $default['type_column'] = $form_state['values']['type_column'];
   }
+  if (array_key_exists('type_column_ignore', $form_state['values'])
+    and $form_state['values']['type_column_ignore']) {
+      $default['type_column_ignore'] = $form_state['values']['type_column_ignore'];
+  } 
   if (array_key_exists('prop_term_name', $form_state['values'])
       and $form_state['values']['prop_term_name']) {
     $default['prop_term_name'] = $form_state['values']['prop_term_name'];
@@ -883,7 +888,13 @@ function tripal_chado_field_storage_bundle_mapping_form($form, &$form_state,
     $submit_disabled = FALSE;
     return $form;
   }
-
+  
+  // If the type column is not disabled and the user has not selected
+  // a type then return.
+  if (!$default['type_column_ignore'] and empty($default['type_column'])) {
+    return $form;
+  }
+    
   // Let's set the names of the linker and prop table for use below.
   $linker_table = $default['table'] . '_cvterm';
   $prop_table = $default['table']. 'prop';
@@ -891,7 +902,7 @@ function tripal_chado_field_storage_bundle_mapping_form($form, &$form_state,
   $prop_exists = chado_table_exists($prop_table);
 
   // Ask the user if they want to use a linker table if it exists.
-  if($prop_exists) {
+  if ($prop_exists) {
 
     tripal_chado_field_storage_bundle_mapping_form_add_prop($form,
         $form_state, $term, $prop_table, $default);
@@ -958,8 +969,10 @@ function tripal_chado_field_storage_bundle_mapping_form_add_type(&$form,
     $default['type_column'] = '';
     return;
   }
-
+  
+  $default_column_ignore = !empty($default['type_column_ignore']) ? $default['type_column_ignore'] : 0;
   $default_column = !empty($default['type_column']) ? $default['type_column'] : 'type_id';
+   
   $form['type_column'] = array(
     '#type' => 'select',
     '#title' => 'Type Column',
@@ -970,6 +983,18 @@ function tripal_chado_field_storage_bundle_mapping_form_add_type(&$form,
       if you the type can be identified using a property or linker table.
       Only fields that have a foreign key to the cvterm table will be listed.',
     '#default_value' => $default_column,
+    '#ajax' => array(
+      'callback' => "tripal_admin_add_type_form_ajax_callback",
+      'wrapper' => "tripal-vocab-select-form",
+      'effect' => 'fade',
+      'method' => 'replace'
+    ),
+    '#disabled' => $default_column_ignore,
+  );
+  $form['type_column_ignore'] = array(
+    '#type' => 'checkbox',
+    '#title' => 'The type column does not distinguish the type',
+    '#default_value' => $default_column_ignore,
     '#ajax' => array(
       'callback' => "tripal_admin_add_type_form_ajax_callback",
       'wrapper' => "tripal-vocab-select-form",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #204 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Previously when creating content types if a table had a column with a FK to the cvterm table then it would assume that one of those fields was the type_id.  However for the featuremap table this is not the case. The column unitype_id is not a type for the map.  The create content type form should allow the user to skip the type and use the property table instead.
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
To test, create a new content type of type 'Genetic Map'.  Select the 'featuremap' table, and when it asks if all records in the table are of type 'Genetic Map' click 'No'.  Then click the checkbox to ignore the type column.  Finally use 'map type' for the property type and 'genetic' as the value.  This should allow you to create a content type of type 'Genetic Map' where it can be distinguished using the featuremapprop table.
## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
