### PR TITLE
Deleting Fields

### DIFF
--- a/tripal/includes/tripal.field_storage.inc
+++ b/tripal/includes/tripal.field_storage.inc
@@ -76,10 +76,18 @@ function tripal_field_storage_query($query) {
   $select->join('tripal_bundle', 'TB', 'TE.bundle = TB.name');
   $select->fields('TE', array('id'));
   $select->fields('TB', array('name'));
+  
+  // Apply any entity condition filters.
+  if ($query->entityConditions) {
+    if (array_key_exists('bundle', $query->entityConditions)) {
+      $select->condition('TB.name', $query->entityConditions['bundle']['value']);
+    }
+  }
 
   // Add in any filters to the query.
   foreach ($query->fieldConditions as $index => $condition) {
     $field = $condition['field'];
+    
     // Skip conditions that don't belong to this storage type.
     if ($field['storage']['type'] != 'tripal_no_storage') {
       continue;
@@ -106,6 +114,18 @@ function tripal_field_storage_query($query) {
     if ($field['field_name'] == 'content_type') {
       $select->orderBy('TB.label', $direction);
     }
+  }
+  
+  // Add a range of records to retrieve
+  if (isset($query->range)) {
+    $select->range($query->range['start'], $query->range['length']);
+  }
+  
+  // Only include records that are deleted.  Tripal doesn't keep track of
+  // records that are deleted that need purging separately so we can do nothing
+  // with this.
+  if (isset($query->deleted)) {
+    // do nothing.
   }
 
   // Perform the query and return the results.

--- a/tripal/includes/tripal.field_storage.inc
+++ b/tripal/includes/tripal.field_storage.inc
@@ -125,7 +125,9 @@ function tripal_field_storage_query($query) {
   // records that are deleted that need purging separately so we can do nothing
   // with this.
   if (isset($query->deleted)) {
-    // do nothing.
+    // There won't ever be field data marked as deleted so just created a 
+    // condition that always evaluates to false.
+    $select->where('1=0');
   }
 
   // Perform the query and return the results.

--- a/tripal_chado/api/tripal_chado.variables.api.inc
+++ b/tripal_chado/api/tripal_chado.variables.api.inc
@@ -788,9 +788,12 @@ function chado_expand_var($object, $type, $to_expand, $table_options = array()) 
       }
       $foreign_table_desc = chado_get_schema($foreign_table);
 
-      // TODO: if we don't get a foreign_table (which could happen of a custom 
+      // If we don't get a foreign_table (which could happen of a custom 
       // table is not correctly defined or the table name is mispelled then we 
       // should return gracefully.
+      if(!is_array($foreign_table_desc)) {
+        return $object;
+      }
 
       // BASE CASE: If it's connected to the base table via a FK constraint
       // then we have all the information needed to expand it now.

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -727,6 +727,16 @@ function tripal_chado_field_storage_query($query) {
       } // end foreach ($field['bundles']['TripalEntity'] as $bundle_name) {
     } // end if ($sort['type'] == 'field') {
   } // end foreach ($query->order as $index => $sort) {
+  
+  
+  // Only include records that are deleted.  Tripal doesn't keep track of
+  // records that are deleted that need purging separately so we can do nothing
+  // with this.
+  if (isset($query->deleted)) {
+    // There won't ever be field data marked as deleted so just created a
+    // condition that always evaluates to false.
+    $cquery->where('1=0');
+  }
 
  //dpm($cquery->__toString());
  //dpm($cquery->getArguments());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #375

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a fix for issue #375.   When deleting a TripalField (as opposed to a ChadoField) the tripal_field_storage_query() function is called but that function was not properly setup to handle all of the query filters and it caused slowness and problems.  This PR adds support for more of those filters and should fix the problem.
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Delete a field associated with any Tripal content type.  The test works best with a large Tripal site with lots of content.   Try deleting the Resource Type field as this is a TripalField.  But don't do it on a production site as this field is necessary and it doesn't seem to come back if you "Check for new fields" afterwards.
 
## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
