### PR TITLE
Fix for web services when term vocabulary has no URL

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -358,8 +358,7 @@ function tripal_load_bundle_entity($values) {
 }
 
 /**
- * Allows a module to write to the admin notification table
- * during the cron run.
+ * Allows a module to write to the admin notification table.
  *
  * @param $title
  *   A generic phrase indicating what the notification is for.

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -389,7 +389,34 @@ function tripal_get_term_details($vocabulary, $accession) {
     $module = $stores[$keys[0]]['module'];
     $function = $module . '_vocab_get_term';
     if (function_exists($function)) {
-      return $function($vocabulary, $accession);
+      $term = $function($vocabulary, $accession);
+      
+      // Make sure the term has a URL. If it does not, then use the Tripal
+      // interface as the URL for the term.
+      $url_missing = FALSE;
+      if (!$term['url']) {
+        $url_missing = TRUE;
+        $term['url'] = url('cv/lookup/' . $term['vocabulary']['short_name'] . '/' . $term['accession'], ['absolute' => TRUE]);
+      }
+      if (!$term['vocabulary']['sw_url']) {
+        $url_missing = TRUE;
+        $term['vocabulary']['sw_url'] = url('cv/lookup/' . $term['vocabulary']['short_name'] . '/' . $term['accession'], ['absolute' => TRUE]);
+      }
+      // Let the user know that the vocabulary is missing.
+      if ($url_missing) {
+        tripal_add_notification(
+          "Missing CV term URL", 
+          t("The controlled vocabulary, %vocab, is missing a URL. Tripal will handle " .
+            "this by linking to the cv/lookup page of this site. However, the correct " .
+            "should be updated for this site", 
+            ['%vocab' => $term['vocabulary']['short_name']]),
+          'Controlled Vocabularies', 
+          NULL, 
+          'mising-vocab-' . $term['vocabulary']['short_name']
+        );
+      }
+      
+      return $term;
     }
   }
 }

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -996,11 +996,6 @@ class TripalContentService_v0_1 extends TripalWebService {
       $member->addContextItem($accession, 'vocab:' . $accession);
       $member->setType($accession);
 
-      // Make sure the term has a URL.
-      $url = $term['url'];
-      if (!$url) {
-        throw new Exception(t('Missing a URL for the term: @term.', array('@term' => $term['vocabulary']['short_name'] . ':' . $term['accession'])));
-      }
       $this->addResourceProperty($member, $label, $bundle->label . ' Collection');
       $member->addContextItem('description', 'rdfs:comment');
       // Get the bundle description. If no description is provided then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #430

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When a term is missing a vocabulary URL and URL prefix then web services would throw an error which caused web services to be totally unavailable.  This is to harsh a response.  This PR fixes that problem by automatically adding a URL to every term that is missing one.  The URL resolves to Tripal's CV lookup interface:  cv/lookup/{db_name}/{accession}.  This way web services doesn't fail and every term is always resolvable.  

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Go to Tripal > Data Loaders >Chado Databases.  Find a database that is used for a content type.  Remove the URL from it (save it so you can add it back alter).  Save the record, then go to the web services.  You should be able to navigate web services.  Also, if you look at the URL available in the @context section for the content type you will see that it has a link to the cv/lookup service of Tripal.

This is a very simple fix, it takes more than 10 lines of code, but I think it only needs 1 review.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
