### PR TITLE
Added analysis field 

### DIFF
--- a/tripal_chado/includes/TripalFields/data__accession/data__accession_widget.inc
+++ b/tripal_chado/includes/TripalFields/data__accession/data__accession_widget.inc
@@ -94,6 +94,14 @@ class data__accession_widget extends ChadoFieldWidget {
     $dbxref_id = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'];
     $db_id = $form_state['values'][$field_name]['und'][$delta]['db_id'];
     $accession = $form_state['values'][$field_name]['und'][$delta]['accession'];
+    
+    // Is this field required?
+    if ($element['#required'] and !$db_id) {
+      form_set_error($field_name . '][und][0][db_id', "A database for the accession must be provided.");
+    }
+    if ($element['#required'] and !$accession) {
+      form_set_error($field_name . '][und][0][accession', "An accession number must be provided.");
+    }
 
     // If user did not select a database, we want to remove dbxref_id from the
     // field. We use '__NULL__' because this field is part of the base table

--- a/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis.inc
+++ b/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis.inc
@@ -36,44 +36,9 @@ class operation__analysis extends ChadoField {
 
 
   /**
-   * @see TripalField::validate()
-   */
-  public function validate($entity_type, $entity, $langcode, $items, &$errors) {
-
-    // If we don't have an entity then we don't want to validate.  The case
-    // where this could happen is when a user is editing the field settings
-    // and trying to set a default value. In that case there's no entity and
-    // we don't want to validate.  There will always be an entity for creation
-    // and update operations of a content type.
-    if (!$entity) {
-      return;
-    }
-    $settings = $this->field['settings'];
-    $field_name = $this->field['field_name'];
-    $field_type = $this->field['type'];
-    $field_table = $this->instance['settings']['chado_table'];
-    $field_column = $this->instance['settings']['chado_column'];
-    $linker_field = 'chado-' . $field_table . '__' . $field_column;
-    
-    // Get the field values.
-    foreach ($items as $delta => $values) {
-
-      // Get the field values.
-      $analysis_id = $values[$linker_field];
-      if (!$analysis_id or $analysis_id == 0) {
-        $errors[$field_name]['und'][0][] = [
-          'message' =>  t("Please specify an analysis."),
-          'error' => 'operation__analysis'
-        ];
-      }
-    }
-  }
-
-  /**
    * @see TripalField::load()
    */
   public function load($entity) {
-
     $record = $entity->chado_record;
     $settings = $this->instance['settings'];
 

--- a/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis.inc
+++ b/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis.inc
@@ -1,0 +1,180 @@
+<?php
+
+class operation__analysis extends ChadoField {
+
+  // The default lable for this field.
+  public static $default_label = 'Analysis';
+
+  // The default description for this field.
+  public static $description = 'Application of analytical methods to existing data of a specific type.';
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instnace.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings  = [
+    // The short name for the vocabulary (e.g. shcema, SO, GO, PATO, etc.).
+    'term_vocabulary' => 'operation',
+    // The name of the term.
+    'term_name' => 'Analysis',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => '2945',
+    // Set to TRUE if the site admin is allowed to change the term
+    // type. This will create form elements when editing the field instance
+    // to allow the site admin to change the term settings above.
+    'term_fixed' => FALSE,
+  ];
+
+  // The default widget for this field.
+  public static $default_widget = 'operation__analysis_widget';
+
+  // The default formatter for this field.
+  public static $default_formatter = 'operation__analysis_formatter';
+
+
+  /**
+   * @see TripalField::validate()
+   */
+  public function validate($entity_type, $entity, $langcode, $items, &$errors) {
+
+    // If we don't have an entity then we don't want to validate.  The case
+    // where this could happen is when a user is editing the field settings
+    // and trying to set a default value. In that case there's no entity and
+    // we don't want to validate.  There will always be an entity for creation
+    // and update operations of a content type.
+    if (!$entity) {
+      return;
+    }
+    $settings = $this->field['settings'];
+    $field_name = $this->field['field_name'];
+    $field_type = $this->field['type'];
+    $field_table = $this->instance['settings']['chado_table'];
+    $field_column = $this->instance['settings']['chado_column'];
+    $linker_field = 'chado-' . $field_table . '__' . $field_column;
+    
+    // Get the field values.
+    foreach ($items as $delta => $values) {
+
+      // Get the field values.
+      $analysis_id = $values[$linker_field];
+      if (!$analysis_id or $analysis_id == 0) {
+        $errors[$field_name]['und'][0][] = [
+          'message' =>  t("Please specify an analysis."),
+          'error' => 'operation__analysis'
+        ];
+      }
+    }
+  }
+
+  /**
+   * @see TripalField::load()
+   */
+  public function load($entity) {
+
+    $record = $entity->chado_record;
+    $settings = $this->instance['settings'];
+
+    $field_name = $this->field['field_name'];
+    $field_type = $this->field['type'];
+    $field_table = $this->instance['settings']['chado_table'];
+    $field_column = $this->instance['settings']['chado_column'];
+
+    // Get the terms for each of the keys for the 'values' property.
+    $name_term = chado_get_semweb_term('analysis', 'name');
+
+    // Set some defaults for the empty record.
+    $entity->{$field_name}['und'][0] = [
+      'value' => [],
+    ];
+
+    if (!$record or !$record->analysis_id) {
+      return;
+    }
+    $linker_field = 'chado-' . $field_table . '__' . $field_column;
+    $entity->{$field_name}['und'][0]['value'] = [
+      $name_term => $record->{$field_column}->name,
+    ];
+    $entity->{$field_name}['und'][0][$linker_field] = $record->{$field_column}->analysis_id;
+
+    // Is there a published entity for this analysis?
+    if (property_exists($record->{$field_column}, 'entity_id')) {
+      $entity->{$field_name}['und'][0]['value']['entity'] = 'TripalEntity:' . $record->{$field_column}->entity_id;
+    }
+  }
+
+  
+  /**
+   * @see TripalField::elementInfo()
+   */
+  public function elementInfo() {
+    $field_term = $this->getFieldTermID();
+
+    $name_term = chado_get_semweb_term('analysis', 'name');
+    
+    return [
+      $field_term => [
+        'operations' => ['eq', 'contains', 'starts'],
+        'sortable' => TRUE,
+        'searchable' => TRUE,
+        'readonly' => FALSE,
+        'type' => 'xs:complexType',
+        'elements' => [
+          $name_term => [
+            'searchable' => TRUE,
+            'name' => 'name',
+            'operations' => ['eq', 'ne', 'contains', 'starts'],
+            'sortable' => FALSE,
+            'type' => 'xs:string',
+            'readonly' => TRUE,
+            'required' => FALSE,
+          ],
+          'entity' => [
+            'searchable' => FALSE,
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @see ChadoField::query()
+   */
+  public function query($query, $condition) {
+    $alias = $this->field['field_name'];
+    $operator = $condition['operator'];
+
+    $field_term_id = $this->getFieldTermID();
+    $name_term = $field_term_id . ',' . chado_get_semweb_term('analysis', 'name');
+
+    // Join to the organism table for this field.
+    $this->queryJoinOnce($query, 'analysis', $alias, "base.analysis_id = $alias.analysis_id");
+
+    // If the column is the field name then we're during a search on the full
+    // scientific name.
+    if ($condition['column'] == $field_term_id or 
+        $condition['column'] == $name_term) {      
+      $query->condition("$alias.name", $condition['value'], $operator);
+    }
+  }
+
+  /**
+   * @see ChadoField::queryOrder()
+   */
+  public function queryOrder($query, $order) {
+    $alias = $this->field['field_name'];
+
+    $field_term_id = $this->getFieldTermID();
+    $name_term = $field_term_id . ',' . chado_get_semweb_term('analysis', 'name');
+
+    // Join to the organism table for this field.
+    $this->queryJoinOnce($query, 'analysis', $alias, "base.analysis_id = $alias.analysis_id");
+
+    // Now perform the sort.
+    if ($order['column'] == $name_term) {
+      $query->orderBy("$alias.name", $order['direction']);
+    }
+  }
+}

--- a/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis_formatter.inc
+++ b/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis_formatter.inc
@@ -1,0 +1,33 @@
+<?php
+
+class operation__analysis_formatter extends ChadoFieldFormatter {
+
+  // The default lable for this field.
+  public static $default_label = 'Analysis';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = ['operation__analysis'];
+
+  /**
+   * @see TripalFieldFormatter::view()
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+    if (count($items) > 0) {
+      
+      $name_term = chado_get_semweb_term('analysis', 'name');
+      
+      $content = $items[0]['value'][$name_term];
+      if (array_key_exists('entity', $items[0]['value'])) {
+        list($entity_type, $entity_id) = explode(':', $items[0]['value']['entity']);
+        $content = l($content, 'bio_data/' . $entity_id);
+      }
+
+      // The cardinality of this field is 1 so we don't have to
+      // iterate through the items array, as there will never be more than 1.
+      $element[0] = [
+        '#type' => 'markup',
+        '#markup' => $content,
+      ];
+    }
+  }
+}

--- a/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis_widget.inc
+++ b/tripal_chado/includes/TripalFields/operation__analysis/operation__analysis_widget.inc
@@ -1,0 +1,72 @@
+<?php
+
+class operation__analysis_widget extends ChadoFieldWidget {
+
+  // The default lable for this field.
+  public static $default_label = 'Analysis';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = ['operation__analysis'];
+
+
+  /**
+   * @see TripalFieldWidget::form()
+   */
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+
+    $settings = $this->field['settings'];
+    $field_name = $this->field['field_name'];
+    $field_type = $this->field['type'];
+    $field_table = $this->instance['settings']['chado_table'];
+    $field_column = $this->instance['settings']['chado_column'];
+
+    // Set the linker field appropriately.
+    $linker_field = 'chado-' . $field_table . '__' . $field_column;
+
+    $analysis_id = 0;
+    if (count($items) > 0 and array_key_exists($linker_field, $items[0])) {
+      $analysis_id = $items[0][$linker_field];
+    }
+
+    $widget['value'] = [
+      '#type' => 'value',
+      '#value' => array_key_exists($delta, $items) ? $items[$delta]['value'] : '',
+    ];
+    $sql = "SELECT analysis_id, name FROM {analysis} ORDER BY name";
+    $results = chado_query($sql);
+    $options = ['' => '- Select an analysis -'];
+    while ($r = $results->fetchObject()) {
+      $options[$r->analysis_id] = $r->name;
+    }
+    $widget[$linker_field] = [
+      '#type' => 'select',
+      '#title' => $element['#title'],
+      '#description' => $element['#description'],
+      '#options' => $options,
+      '#default_value' => $analysis_id,
+      '#required' => $element['#required'],
+      '#weight' => isset($element['#weight']) ? $element['#weight'] : 0,
+      '#delta' => $delta,
+    ];
+  }
+
+  /**
+   * @see TripalFieldWidget::validate()
+   */
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+
+    $field_name = $this->field['field_name'];
+    $field_type = $this->field['type'];
+    $field_table = $this->instance['settings']['chado_table'];
+    $field_column = $this->instance['settings']['chado_column'];
+
+    // Set the linker field appropriately.
+    $linker_field = 'chado-' . $field_table . '__' . $field_column;
+    
+    // Make sure the value is set to the organism_id
+    $analysis_id = $form_state['values'][$field_name]['und'][0][$linker_field];
+    $form_state['values'][$field_name]['und'][0]['value'] = $analysis_id;
+  }
+}

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -554,6 +554,21 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
       ),
     );
   } 
+  
+  // Analysis Id
+  if (array_key_exists('analysis_id', $schema['fields'])) {
+    $field_name = 'operation__analysis';
+    $field_type = 'operation__analysis';
+    $info[$field_name] = array(
+      'field_name' => $field_name,
+      'type' => $field_type,
+      'cardinality' => 1,
+      'locked' => FALSE,
+      'storage' => array(
+        'type' => 'field_chado_storage',
+      ),
+    );
+  }
 
 }
 
@@ -1527,6 +1542,10 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
   // BASE DBXREF
   if (array_key_exists('dbxref_id', $schema['fields'])) {
     $field_name = 'data__accession';
+    $required = FALSE;
+    if ($table == 'phylotree') {
+      $required = TRUE;
+    }
     $info[$field_name] = array(
       'field_name' => $field_name,
       'entity_type' => $entity_type,
@@ -1534,7 +1553,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
       'label' => 'Accession',
       'description' => 'This field specifies the unique stable accession (ID) for
         this record. It requires that this site have a database entry.',
-      'required' => FALSE,
+      'required' => $required,
       'settings' => array(
         'auto_attach' => TRUE,
         'chado_table' => $table_name,
@@ -2028,6 +2047,46 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
       ),
     );
   } 
+  // Analysis Id
+  if (array_key_exists('analysis_id', $schema['fields'])) {
+    $field_name = 'operation__analysis';
+    $is_required = FALSE;
+    if (array_key_exists('not null', $schema['fields']['analysis_id']) and
+        $schema['fields']['analysis_id']['not null']) {
+      $is_required = TRUE;
+    }
+    $info[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'Analysis',
+      'description' => 'Application of analytical methods to existing data of a specific type.',
+      'required' => $is_required,
+      'settings' => array(
+        'auto_attach' => TRUE,
+        'chado_table' => $table_name,
+        'chado_column' => 'analysis_id',
+        'base_table' => $table_name,
+        'term_vocabulary' => 'operation',
+        'term_name' => 'Analysis',
+        'term_accession' => '2945',
+        
+      ),
+      'widget' => array(
+        'type' => 'operation__analysis_widget',
+        'settings' => array(
+          'display_label' => 0,
+        ),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'inline',
+          'type' => 'operation__analysis_formatter',
+          'settings' => array(),
+        ),
+      ),
+    );
+  }
 }
 
 /**

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -847,7 +847,9 @@ function tripal_chado_bundle_instances_info($entity_type, $bundle) {
   tripal_chado_bundle_instances_info_base($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_custom($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_linker($info, $entity_type, $bundle, $details);
-dpm($info);
+
+  // dpm($info);
+
   return $info;
 
 }

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -847,7 +847,7 @@ function tripal_chado_bundle_instances_info($entity_type, $bundle) {
   tripal_chado_bundle_instances_info_base($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_custom($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_linker($info, $entity_type, $bundle, $details);
-
+dpm($info);
   return $info;
 
 }
@@ -1543,7 +1543,8 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
   if (array_key_exists('dbxref_id', $schema['fields'])) {
     $field_name = 'data__accession';
     $required = FALSE;
-    if ($table == 'phylotree') {
+    if (array_key_exists('not null', $schema['fields']['dbxref_id']) and
+        $schema['fields']['dbxref_id']['not null']) {
       $required = TRUE;
     }
     $info[$field_name] = array(

--- a/tripal_chado/includes/tripal_chado.phylotree.inc
+++ b/tripal_chado/includes/tripal_chado.phylotree.inc
@@ -5,6 +5,11 @@
  * @param $phylotree
  */
 function tripal_phylogeny_prepare_tree_viewer($phylotree) {
+  
+  // If the phylotree is not provided then just return;
+  if (!$phylotree) {
+    tripal_report_error('tripal_phylotree', TRIPAL_ERROR, 'tripal_phylogeny_prepare_tree_viewer: must provide a $phylotree argument.');
+  }
 
   // Don't prepare for viewing more than once.
   if (property_exists($phylotree, 'prepared_to_view') and
@@ -24,7 +29,7 @@ function tripal_phylogeny_prepare_tree_viewer($phylotree) {
 
   // Don't show tick marks for the taxonomy tree.
   $skip_ticks = 0;
-  if ($phylotree->type_id->name == 'taxonomy' or $phylotree->type_id->name == 'Species tree') {
+  if (!is_null($phylotree->type_id) and ($phylotree->type_id->name == 'taxonomy' or $phylotree->type_id->name == 'Species tree')) {
     $skip_ticks = 1;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #210

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This adds an analysis field.  Currently the only content type that uses this is the Phylogenetic Tree.  It also fixes the accession field (corresponds to phylotree.dbxref_id column) as it is supposed to be required.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

1)  Go to the Phylogenetic Tree content type page Structure > Tripal Content Types and click "manage fields" for the Phylogenetic Tree.  On that page, delete the Analysis (operation__analysis) and the Accession (data__accession) fields.  Once those are gone, click the "Check for new fields" and those field should be re-added.  Make sure that both fields appear on the page by reviewing the "Manage Display" tab.
4)  Create a new Phylogenetic Tree entity (page).  On the form, the Analysis element should be a select box that lists the available analyses.  You can select one, fill out the other fields and save the entity.  The page should appear as expected with an analysis value.
5)  Now that the entity exists, test editing it selecting a different analysis and saving.  You should see the updated analysis.
6) Test that the analysis shows up in web services.  Go to your site's web-services and navigate to the Phylogenetic Tree you added (using a JSON viewer in the browser helps navigate easily).  You should see the analysis name.
7) You should be able to search for your Phylogenetic Tree using the analysis name from a web services query like this:  http://[tripal_site]/web-services/content/v0.1/Phylogenetic_Tree?analysis,name=[analysis_name].  Experiment with changing the value of [analysis_name] to ensure that you see no results.
8) You can test searching for the Phylogenetic Tree using the analysis  in the Views based searches that Tripal creates for each content type.  Go to http://[tripal_site]/data_search/data_search/phylogenetic_tree, click the link when you mouse over the upper right of the form to edit the view.  Add the Analysis field as an exposed filter.  Save the view.  You should now be able to search for your Phylogenetic Tree using the Analysis name.  Experiment with correct and incorrect names to make sure the search is fully working.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
