### PR TITLE
Added warning for slow data collections when using Search API

### DIFF
--- a/tripal/views_handlers/tripal_views_handler_area_collections.inc
+++ b/tripal/views_handlers/tripal_views_handler_area_collections.inc
@@ -3,15 +3,17 @@
 class tripal_views_handler_area_collections extends views_handler_area_result {
 
   function options_form(&$form, &$form_state) {
-    // We have no options so we have to implement this function with
-    // nothing in it.
-    $form['content'] = array(
-      '#type' => 'markup',
-      '#markup' => tripal_set_message('Please note that if you have the ' . 
-        'highlighting filter enabled for the search index, it will create ' . 
-        'signficant slowness in creating data collections. If you want to use '.
-        'Tripal data collections make sure the highlighting filter is turned off'), 
-    );
+    // If this handler is attached to a view based off of a Search API index
+    // then give a warning message.
+    if (preg_match('/^search_api_index/', $this->view->base_table)) {
+      $form['content'] = array(
+        '#type' => 'markup',
+        '#markup' => tripal_set_message('Please note that if this field is added to  have the ' . 
+          'highlighting filter enabled for the search index, it will create ' . 
+          'signficant slowness in creating data collections. If you want to use '.
+          'Tripal data collections make sure the highlighting filter is turned off'), 
+      );
+    }
   }
   /**
    * Implements views_handler_area_result::render().

--- a/tripal/views_handlers/tripal_views_handler_area_collections.inc
+++ b/tripal/views_handlers/tripal_views_handler_area_collections.inc
@@ -8,10 +8,10 @@ class tripal_views_handler_area_collections extends views_handler_area_result {
     if (preg_match('/^search_api_index/', $this->view->base_table)) {
       $form['content'] = array(
         '#type' => 'markup',
-        '#markup' => tripal_set_message('Please note that if this field is added to  have the ' . 
-          'highlighting filter enabled for the search index, it will create ' . 
-          'signficant slowness in creating data collections. If you want to use '.
-          'Tripal data collections make sure the highlighting filter is turned off'), 
+        '#markup' => tripal_set_message('Please note that if this field is added while the ' .
+          'highlighting filter is enabled for the search index, it will ' .
+          'signficantly slow the creation of data collections. If you want to use '.
+          'Tripal data collections make sure the highlighting filter is turned off.'),
       );
     }
   }

--- a/tripal/views_handlers/tripal_views_handler_area_collections.inc
+++ b/tripal/views_handlers/tripal_views_handler_area_collections.inc
@@ -5,6 +5,13 @@ class tripal_views_handler_area_collections extends views_handler_area_result {
   function options_form(&$form, &$form_state) {
     // We have no options so we have to implement this function with
     // nothing in it.
+    $form['content'] = array(
+      '#type' => 'markup',
+      '#markup' => tripal_set_message('Please note that if you have the ' . 
+        'highlighting filter enabled for the search index, it will create ' . 
+        'signficant slowness in creating data collections. If you want to use '.
+        'Tripal data collections make sure the highlighting filter is turned off'), 
+    );
   }
   /**
    * Implements views_handler_area_result::render().
@@ -30,7 +37,7 @@ class tripal_views_handler_area_collections extends views_handler_area_result {
     // If we don't support this type of view, then we should tell the admin
     // so they're not left scratching their head like I was ;-).
     else {
-      tripal_set_message('Unfortunatly Tripal Collections are not supported for your current view type.');
+      tripal_set_message('Unfortunately, Tripal Collections are not supported for your current view type.');
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #436

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This isn't really a bug fix, as the code works as expected, it just adds a notice for the site developer warning that if they want to integrate data collections into the footer of the Search API results that they need to ensure that the highlighting filter is turned off.
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
There are two tests that need performing.  
1)  Go to your search view, and add the "Global: Tripal Content Data Collections" to the Footer section.  When adding you should see the blue highlighted warning message.
2)  We need to double check that in fact if you turn off highlighting that the data collections is built quickly for large result sets (> 400 results), and if it is on the data collections is built slowly.

This test is simple enough, and the code changes are small. I think only one reviewer is necessary.
## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
