### PR TITLE
Fix for namespace conflicts (same term is used) for fields.

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -628,6 +628,8 @@ function tripal_get_content_type($bundle_name) {
  *
  * @param $bundle_name
  *   The name of the bundle to refresh (e.g. bio_data_4).
+ * @param $term
+ *   The term object for the bundle.
  *
  * @return
  *   The array of field instance names that were added.
@@ -635,38 +637,34 @@ function tripal_get_content_type($bundle_name) {
  * @ingroup tripal_entities_api
  */
 function tripal_create_bundle_fields($bundle, $term) {
-
   $added = array();
 
   // Allow modules to add fields to the new bundle.
   $modules = module_implements('bundle_fields_info');
-  $info = array();
+  $field_info = array();
   foreach ($modules as $module) {
     $function = $module . '_bundle_fields_info';
     $temp = $function('TripalEntity', $bundle);
     if (is_array($temp)) {
       // TODO: it would be good to check this array to make sure it follows
       // protocol.  It would help identify potential errors.
-      $info = array_merge($info, $temp);
+      $field_info = array_merge($field_info, $temp);
     }
   }
 
   // Allow modules to alter which fields should be attached to content
   // types they create.
-  drupal_alter('bundle_fields_info', $info, $bundle, $term);
+  drupal_alter('bundle_fields_info', $field_info, $bundle, $term);
 
   // Iterate through all of the fields and create them.
-  foreach ($info as $field_name => $details) {
+  foreach ($field_info as $field_name => $details) {
     $field_type = $details['type'];
-
-    // TODO: make sure the field term exits. If not then
-    // skip it.
 
     // If the field already exists then skip it.
     $field = field_info_field($details['field_name']);
     if ($field) {
       continue;
-    }
+    }    
 
     // Create the field.
     $field = field_create_field($details);
@@ -678,35 +676,99 @@ function tripal_create_bundle_fields($bundle, $term) {
 
   // Allow modules to add instances to the new bundle.
   $modules = module_implements('bundle_instances_info');
-  $info = array();
+  $instance_info = array();
   foreach ($modules as $module) {
     $function = $module . '_bundle_instances_info';
     $temp = $function('TripalEntity', $bundle);
     if (is_array($temp)) {
       // TODO: it would be good to check this array to make sure it follows
       // protocol.  It would help identify potential errors.
-      $info = array_merge($info, $temp);
+      $instance_info = array_merge($instance_info, $temp);
     }
   }
 
   // Allow modules to alter which fields should be attached to content
   // types they create.
-  drupal_alter('bundle_instances_info', $info, $bundle, $term);
-
+  drupal_alter('bundle_instances_info', $instance_info, $bundle, $term);
+  
+  // Get the list of existing instances
+  $existing_instances = field_info_instances('TripalEntity', $bundle->name);
+  
   // Iterate through all of the field instances and create them.
-  foreach ($info as $field_name => $details) {
+  foreach ($instance_info as $instance_name => $details) {
+    
+    // Make sure the instance has a term. If not, report it and skip the field.
+    if (!array_key_exists('term_vocabulary', $details['settings'])) {
+      tripal_report_error('tripal_fields', TRIPAL_WARNING,
+        'The field instance, !field, is missing the "term_vocabulary" setting. The field instance cannot be added. Please check the field settings.',
+        ['!field' => $instance_name], ['drupal_set_message' => TRUE]);
+        continue;
+    }
+    if (!array_key_exists('term_accession', $details['settings'])) {
+      tripal_report_error('tripal_fields', TRIPAL_WARNING,
+        'The field instance, !field, is missing the "term_accession" setting. The field instance cannot be added. Please check the field settings.',
+        ['!field' => $instance_name], ['drupal_set_message' => TRUE]);
+        continue;}
+    
+    // Make sure the term exists. If not, skip the field instance and 
+    // report an error.
+    $field_term_id = $details['settings']['term_vocabulary'] . ':' . $details['settings']['term_accession'];    
+    $field_term = tripal_get_term_details($details['settings']['term_vocabulary'], $details['settings']['term_accession']);
+    if (!$field_term) {
+      tripal_report_error('tripal_fields', TRIPAL_WARNING, 
+        'The term, !term, for the field, !field, does not exist in the database. The  ' .
+        'field instance cannot be added. Please make sure the term is correct and add it if necessary.',
+        ['!term' => $field_term_id,
+          '!field' => $instance_name],
+        ['drupal_set_message' => TRUE]);
+      continue;
+    }
+    
+    // Make sure the term is not used for any other existing field instance.
+    $skip = TRUE;
+    foreach ($existing_instances as $existing_name => $existing_instance) {
+      // If this instance term is the same as this exsiting term and the 
+      // instance name is not the same then we have a problem.
+      $existing_term_id = $existing_instance['settings']['term_vocabulary'] . ':' . $existing_instance['settings']['term_accession'];
+      $existing_field = field_info_field($existing_name);
+      if ($existing_term_id == $field_term_id and $instance_name != $existing_name) {
+        tripal_report_error('tripal_fields', TRIPAL_WARNING,
+          'The field, !field, uses a term, !term, that is already in use on this content type. The ' .
+          'field instance cannot be added.',
+          ['!term' => $existing_term_id,
+            '!field' => $instance_name],
+          ['drupal_set_message' => TRUE]);
+        $skip = TRUE;
+      }
+      
+      // If the instance term is the same as this exsting term but the storage
+      // types are different then we have a problem.
+      $existing_storage = $existing_field['storage']['type'];
+      $this_field_storage = $field_info[$details['field_name']]['storage']['type'];
+      if ($existing_term_id == $field_term_id and $existing_storage != $this_field_storage) {
+        tripal_report_error('tripal_fields', TRIPAL_WARNING,
+          'The field, !field, provided by the storage type, !type, uses a term, !term, that is already in use on this content type and provided by another storage backend. The ' .
+          'field instance cannot be added.  Perhaps, consider a different term and adjust the data in the database.',
+          ['!term' => $existing_term_id,
+           '!type' => $this_field_storage,
+           '!field' => $instance_name],
+          ['drupal_set_message' => TRUE]);
+        $skip = TRUE;
+      }
+    }
+    if ($skip) {
+      continue;
+    }
 
     // If the field is already attached to this bundle then skip it.
-    $field = field_info_field($details['field_name']);
-    if ($field and array_key_exists('bundles', $field) and
-        array_key_exists('TripalEntity', $field['bundles']) and
-        in_array($bundle->name, $field['bundles']['TripalEntity'])) {
+    if (array_key_exists($instance_name, $existing_instances)) {
       continue;
     }
 
     // Create the field instance.
     $instance = field_create_instance($details);
-    $added[] = $field_name;
+    $existing_instances[$instance_name] = $instance;
+    $added[] = $instance_name;
   }
   return $added;
 }

--- a/tripal/api/tripal.notice.api.inc
+++ b/tripal/api/tripal.notice.api.inc
@@ -58,6 +58,8 @@ define('TRIPAL_DEBUG',7);
  *   An array of options. Some available options include:
  *     - print: prints the error message to the terminal screen. Useful when
  *       display is the command-line
+ *     - drupal_set_message: set to TRUE to call drupal_set_message with the 
+ *       same error.
  *
  * @ingroup tripal_notify_api
  */
@@ -113,7 +115,7 @@ function tripal_report_error($type, $severity, $message, $variables = array(), $
     watchdog($type, $message, $variables, $severity);
   }
   catch (Exception $e) {
-    print "CRITICAL (TRIPAL): Unable to register error message with watchdog: " . $e->getMessage(). "\n.";
+    print "CRITICAL (TRIPAL): Unable to add error message with watchdog: " . $e->getMessage(). "\n.";
     $options['print'] = TRUE;
   }
 
@@ -128,6 +130,19 @@ function tripal_report_error($type, $severity, $message, $variables = array(), $
   // If print option supplied then print directly to the screen.
   if (isset($options['print'])) {
     print $severity_string . ' (' . strtoupper($type) . '): ' . $print_message . "\n";
+  }
+  
+  if (isset($options['drupal_set_message'])) {
+    if (in_array($severity, [TRIPAL_CRITICAL, TRIPAL_ERROR])) {
+      $status = 'error';
+    }
+    elseif ($severity == TRIPAL_WARNING) {
+      $status = 'warning';
+    }
+    else {
+      $status = 'status';
+    }
+    drupal_set_message($print_message, $status);
   }
 
   // Print to the Tripal error log but only if the severity is not info.

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -47,7 +47,6 @@ class TripalEntityController extends EntityAPIController {
       $function = $module . '_entity_create';
       $function($entity, $values['type']);
     }
-
     return $entity;
 
   }
@@ -360,6 +359,9 @@ class TripalEntityController extends EntityAPIController {
         $invocation = 'entity_update';
         $pkeys = array('id');
       }
+      if (property_exists($entity, 'publish') and $entity->publish == TRUE) {
+        $invocation = 'entity_publish';
+      }
 
       // Invoke hook_entity_presave().
       module_invoke_all('entity_presave', $entity, $entity->type);
@@ -389,11 +391,14 @@ class TripalEntityController extends EntityAPIController {
       // Now we need to either insert or update the fields which are
       // attached to this entity. We use the same primary_keys logic
       // to determine whether to update or insert, and which hook we
-      // need to invoke.
+      // need to invoke.  We do not attach fields when publishing an entity.
+      // This is because a field may have default values and if so, those fields
+      // will be attached and the storage backend may then try to insert
+      // fields which should not be inserted because they already exist.
       if ($invocation == 'entity_insert') {
         field_attach_insert('TripalEntity', $entity);
       }
-      else {
+      if ($invocation == 'entity_update') {
         field_attach_update('TripalEntity', $entity);
       }
 

--- a/tripal/includes/tripal.fields.inc
+++ b/tripal/includes/tripal.fields.inc
@@ -265,6 +265,15 @@ function tripal_form_field_ui_field_overview_form_alter(&$form, &$form_state, $f
     $field = field_info_field($field_name);
     $instance = field_info_instance('TripalEntity', $field_name, $form['#bundle']);
     
+    // Warn users if a field is missing a term.
+    if ($instance and $instance['entity_type'] == 'TripalEntity' and 
+        array_key_exists('settings', $instance) and is_array($instance['settings']) and
+        (!array_key_exists('term_vocabulary', $instance['settings']) or !$instance['settings']['term_vocabulary'])) {
+      tripal_report_error('tripal_fields', TRIPAL_WARNING,
+          'The field, !field, is missing a controlled vocabulary term. Please edit the field and set a term, otherwise this field may not work properly.',
+          ['!field' => $field_name],
+          ['drupal_set_message' => TRUE]);
+    }
     // Warn users if any of the terms are not unique.
     if ($instance and array_key_exists('settings', $instance) and is_array($instance['settings']) and 
         array_key_exists('term_vocabulary', $instance['settings'])) {

--- a/tripal/includes/tripal.fields.inc
+++ b/tripal/includes/tripal.fields.inc
@@ -271,10 +271,12 @@ function tripal_form_field_ui_field_overview_form_alter(&$form, &$form_state, $f
       $term = $instance['settings']['term_vocabulary'] . ':' . $instance['settings']['term_accession'];
       if (array_key_exists($term, $used_terms)) {
         $used_terms[$term][] = $field_name;
-        drupal_set_message(t('The term !term is in use by multiple fields: !fields. 
-          This is not allowed. Every field must have a different controlled vocabulary term. 
-          Please correct the term assignments.', 
-          array('!term' => $term, '!fields' => implode(', ', $used_terms[$term]))), 'error');
+        tripal_report_error('tripal_fields', TRIPAL_WARNING,
+          'The term !term is in use by multiple fields: !fields. ' .
+          'This is not allowed. Every field must have a different controlled vocabulary term. ' . 
+          'Please correct the term assignments.',
+          ['!term' => $term, '!fields' => implode(', ', $used_terms[$term])], 
+          ['drupal_set_message' => TRUE]);
       }
       $used_terms[$term][] = $field_name;
     }
@@ -732,6 +734,19 @@ function tripal_field_instance_settings_form_alter_validate($form, &$form_state)
           $num_selected++;
           $has_default =  TRUE;
         }
+      }
+    }
+    
+    // Make sure this term is not already used.    
+    $bundle_name = $form_state['values']['instance']['bundle'];
+    $existing_instances = field_info_instances('TripalEntity', $bundle_name);
+    $field_term_id = $form_state['values']['instance']['settings']['term_vocabulary'] . ':' . $form_state['values']['instance']['settings']['term_accession'];
+    $field_name = $form_state['values']['instance']['field_name'];  
+    foreach ($existing_instances as $existing_name => $existing_instance) {
+      $existing_term_id = $existing_instance['settings']['term_vocabulary'] . ':' . $existing_instance['settings']['term_accession'];
+      if ($existing_term_id == $field_term_id and $field_name != $existing_name) {       
+        form_set_error('term-', t('The term, !term, is already in use on this content type.  A term can only be used once per content type. Please choose a different term.',
+          ['!term' => $field_term_id]));
       }
     }
 

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -225,6 +225,7 @@ function chado_publish_records($values, $job_id = NULL) {
         // can deal with it.
         'chado_record' => chado_generate_var($table, array($pkey_field => $record_id)),
         'chado_record_id' => $record_id,
+        'publish' => TRUE,
       ));
       $entity = $entity->save();
       if (!$entity) {

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -42,12 +42,10 @@ function tripal_chado_field_storage_write($entity_type, $entity, $op, $fields) {
   $base_pkey = $base_schema['primary key'][0];
 
   // Convert the fields into a key/value list of fields and their values.
-  $field_vals = tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $entity);
-// dpm($field_vals);
-
-  // First, write the record for the base table.  If we have a record id then
-  // this is an update and we need to set the primary key.  If not, then this
-  // is an insert and we need to set the type_id if the table supports it.
+  list($field_vals, $field_items) = tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $entity);
+  // dpm($field_vals);  
+  
+  // First, write the record for the base table.
   $values = $field_vals[$base_table];
   if ($record_id) {
     $values[$base_pkey] = $record_id;
@@ -55,8 +53,10 @@ function tripal_chado_field_storage_write($entity_type, $entity, $op, $fields) {
   elseif ($type_field and !$linker) {
     $values[$type_field] = $cvterm->cvterm_id;
   }
-
   $base_record_id = tripal_chado_field_storage_write_table($base_table, $values, $base_table);
+  if (!$base_record_id) {
+    throw new Exception('Unable to write fields to Chado: ' . print_r($field_items, TRUE));
+  }
 
   // If this is an insert then add the chado_entity record.
   if ($op == FIELD_STORAGE_INSERT) {
@@ -381,6 +381,7 @@ function tripal_chado_field_storage_load($entity_type, $entities, $age,
 function tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $entity) {
   $all_fields = array();
   $base_fields = array();
+  $field_items = array();
 
   // Iterate through all of the fields and organize them into a
   // new fields array keyed by the table name
@@ -405,6 +406,7 @@ function tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $e
     // are multi-valued.
     $items = field_get_items($entity_type, $entity, $field_name);
     $temp = array();
+    $field_items[$field_name] = $items;
     foreach ($items as $delta => $item) {
 
       // A field may have multiple items. The field can use items
@@ -453,7 +455,7 @@ function tripal_chado_field_storage_write_merge_fields($fields, $entity_type, $e
   }
 
   $all_fields = array_merge($base_fields, $all_fields);
-  return $all_fields;
+  return [$all_fields, $field_items];
 }
 
 /**

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -532,17 +532,6 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
           'type' => 'field_chado_storage',
         ),
       );
-      $field_name = 'efo__array_design';
-      $field_type = 'efo__array_design';
-      $info[$field_name] = array(
-        'field_name' => $field_name,
-        'type' => $field_type,
-        'cardinality' => 1,
-        'locked' => FALSE,
-        'storage' => array(
-          'type' => 'field_chado_storage',
-        ),
-      );
     }
   
   // For the pub_id field in the base table.
@@ -2071,80 +2060,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-    
-    $field_name = 'efo__array_design';
-    $info[$field_name] =  array(
-      'field_name' => $field_name,
-      'entity_type' => $entity_type,
-      'bundle' => $bundle->name,
-      'label' => 'Array design',
-      'description' => 'An instrument design which describes the design of the array.',
-      'required' => TRUE,
-      'settings' => array(
-        'auto_attach' => TRUE,
-        'chado_table' => 'assay',
-        'chado_column' => 'arraydesign_id',
-        'base_table' => 'assay',
-        'term_vocabulary' => 'EFO',
-        'term_name' => 'array design',
-        'term_accession' => '0000269',
-        
-      ),
-      'widget' => array(
-        'type' => 'efo__array_design_widget',
-        'settings' => array(
-          'display_label' => 1,
-        ),
-      ),
-      'display' => array(
-        'default' => array(
-          'label' => 'inline',
-          'type' => 'efo__array_design_formatter',
-          'settings' => array(),
-        ),
-      ),
-    );
   } 
-  // Analysis Id
-  if (array_key_exists('analysis_id', $schema['fields'])) {
-    $field_name = 'operation__analysis';
-    $is_required = FALSE;
-    if (array_key_exists('not null', $schema['fields']['analysis_id']) and
-        $schema['fields']['analysis_id']['not null']) {
-      $is_required = TRUE;
-    }
-    $info[$field_name] =  array(
-      'field_name' => $field_name,
-      'entity_type' => $entity_type,
-      'bundle' => $bundle->name,
-      'label' => 'Analysis',
-      'description' => 'Application of analytical methods to existing data of a specific type.',
-      'required' => $is_required,
-      'settings' => array(
-        'auto_attach' => TRUE,
-        'chado_table' => $table_name,
-        'chado_column' => 'analysis_id',
-        'base_table' => $table_name,
-        'term_vocabulary' => 'operation',
-        'term_name' => 'Analysis',
-        'term_accession' => '2945',
-        
-      ),
-      'widget' => array(
-        'type' => 'operation__analysis_widget',
-        'settings' => array(
-          'display_label' => 0,
-        ),
-      ),
-      'display' => array(
-        'default' => array(
-          'label' => 'inline',
-          'type' => 'operation__analysis_formatter',
-          'settings' => array(),
-        ),
-      ),
-    );
-  }
 }
 
 /**

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -532,6 +532,17 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
           'type' => 'field_chado_storage',
         ),
       );
+      $field_name = 'efo__array_design';
+      $field_type = 'efo__array_design';
+      $info[$field_name] = array(
+        'field_name' => $field_name,
+        'type' => $field_type,
+        'cardinality' => 1,
+        'locked' => FALSE,
+        'storage' => array(
+          'type' => 'field_chado_storage',
+        ),
+      );
     }
   
   // For the pub_id field in the base table.
@@ -554,7 +565,6 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
       ),
     );
   } 
-
 }
 
 /**
@@ -702,8 +712,24 @@ function tripal_chado_bundle_fields_info_linker(&$info, $details, $entity_type, 
       }
 
       $field_name = strtolower(preg_replace('/[^\w]/','_', $term->dbxref_id->db_id->name . '__' . $term->name));
-      $field_name = substr($field_name, 0, 32);
+
+      // The field name can only be 32 chars, but if our name is longer we need
+      // to add some random chars to ensure we don't have naming conflicts 
+      // with other terms (e.g. mitochondrial_genetic_code and 
+      // mitochondrial_genetic_code_name)
+      if (strlen($field_name) >= 32) {
+        $field_name = substr($field_name, 0, 20) . '_' . $term->cvterm_id;
+      }
       $field_type = 'chado_linker__prop';
+      
+      // Don't try to add a property that uses the same term as another field.
+      if (array_key_exists($field_name, $info)) {
+        tripal_report_error('chado_fields', TRIPAL_WARNING, 
+          'A field of type !type already exists, yet a property wants to use the same term. The property cannot be added.',
+         ['!type' => $field_name],
+         ['drupal_set_message' => TRUE]);
+        continue;
+      }
       $info[$field_name] = array(
         'field_name' => $field_name,
         'type' => $field_type,
@@ -832,7 +858,6 @@ function tripal_chado_bundle_instances_info($entity_type, $bundle) {
   tripal_chado_bundle_instances_info_base($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_custom($info, $entity_type, $bundle, $details);
   tripal_chado_bundle_instances_info_linker($info, $entity_type, $bundle, $details);
-
   return $info;
 
 }
@@ -1016,11 +1041,11 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
     }
     if ($base_info['label'] == 'Timeaccessioned') {
       $base_info['label'] = 'Time Accessioned';
-      $base_info['description'] = 'Please enter the time that this record was first added to the database.';
+      $base_info['description'] = 'The time that this record was first added to the database.';
     }
     if ($base_info['label'] == 'Timelastmodified') {
       $base_info['label'] = 'Time Last Modified';
-      $base_info['description'] = 'Please enter the time that this record was last modified. The default is the current time.';
+      $base_info['description'] = 'The time that this record was last modified. The default is the current time.';
     }
 
     // Sometimes the boolean fields are listed as integer.  We need to
@@ -1178,6 +1203,8 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
       if ($column_name == 'name') {
         $base_info['widget']['type'] = 'text_textfield';
         $base_info['settings']['text_processing'] = '0';
+        $base_info['required'] = TRUE;
+        $base_info['description'] = 'A unique name for this assay..';
       }
       if ($column_name == 'protcol_id') {
         $base_info['label'] = 'Protocol';
@@ -1186,20 +1213,24 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
         $base_info['label'] = 'Array Batch Identifier';
         $base_info['widget']['type'] = 'text_textfield';
         $base_info['settings']['text_processing'] = '0';
+        $base_info['description'] = 'A unique identifier for the array batch.';
       }
       if ($column_name == 'operator_id') {
         $base_info['label'] = 'Operator';
+        $base_info['description'] = 'The individual who performed the assay.';
       }
       if ($column_name == 'arrayidentifier') {
         $base_info['label'] = 'Array Identifier';
         $base_info['widget']['type'] = 'text_textfield';
         $base_info['settings']['text_processing'] = '0';
+        $base_info['description'] = 'A unique alternate identifier for the array.';
       }
       if ($column_name == 'arraydesign_id') {
         $base_info['label'] = 'Array Design';
       }
       if ($column_name == 'assaydate') {
         $base_info['label'] = 'Assay Date';
+        $base_info['description'] = 'The date the assay was performed';
       }
     }
     //
@@ -1287,6 +1318,9 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'base_table' => $table_name,
         'vocabulary' => $default_vocab,
         'parent_term' => $parent_term,
+        'term_vocabulary' => 'schema',
+        'term_name' => 'additionalType',
+        'term_accession' => 'additionalType',
       ),
       'widget' => array(
         'type' => 'schema__additional_type_widget',
@@ -1527,6 +1561,10 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
   // BASE DBXREF
   if (array_key_exists('dbxref_id', $schema['fields'])) {
     $field_name = 'data__accession';
+    $required = FALSE;
+    if ($table == 'phylotree') {
+      $required = TRUE;
+    }
     $info[$field_name] = array(
       'field_name' => $field_name,
       'entity_type' => $entity_type,
@@ -1534,7 +1572,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
       'label' => 'Accession',
       'description' => 'This field specifies the unique stable accession (ID) for
         this record. It requires that this site have a database entry.',
-      'required' => FALSE,
+      'required' => $required,
       'settings' => array(
         'auto_attach' => TRUE,
         'chado_table' => $table_name,
@@ -1772,6 +1810,9 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'chado_table' => 'organism',
         'chado_column' => 'type_id',
         'base_table' => 'organism',
+        'term_vocabulary' => 'TAXRANK',
+        'term_name' => 'infraspecific_taxon',
+        'term_accession' => '0000046',
       ),
       'widget' => array(
         'type' => 'taxrank__infraspecific_taxon_widget',
@@ -1973,6 +2014,9 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'chado_table' => $table_name,
         'chado_column' => 'pub_id',
         'base_table' => $table_name,
+        'term_accession' => 'publication',
+        'term_vocabulary' => 'schema',
+        'term_name' => 'publication',
       ),
       'widget' => array(
         'type' => 'schema__publication_widget',
@@ -2027,7 +2071,80 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
+    
+    $field_name = 'efo__array_design';
+    $info[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'Array design',
+      'description' => 'An instrument design which describes the design of the array.',
+      'required' => TRUE,
+      'settings' => array(
+        'auto_attach' => TRUE,
+        'chado_table' => 'assay',
+        'chado_column' => 'arraydesign_id',
+        'base_table' => 'assay',
+        'term_vocabulary' => 'EFO',
+        'term_name' => 'array design',
+        'term_accession' => '0000269',
+        
+      ),
+      'widget' => array(
+        'type' => 'efo__array_design_widget',
+        'settings' => array(
+          'display_label' => 1,
+        ),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'inline',
+          'type' => 'efo__array_design_formatter',
+          'settings' => array(),
+        ),
+      ),
+    );
   } 
+  // Analysis Id
+  if (array_key_exists('analysis_id', $schema['fields'])) {
+    $field_name = 'operation__analysis';
+    $is_required = FALSE;
+    if (array_key_exists('not null', $schema['fields']['analysis_id']) and
+        $schema['fields']['analysis_id']['not null']) {
+      $is_required = TRUE;
+    }
+    $info[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'Analysis',
+      'description' => 'Application of analytical methods to existing data of a specific type.',
+      'required' => $is_required,
+      'settings' => array(
+        'auto_attach' => TRUE,
+        'chado_table' => $table_name,
+        'chado_column' => 'analysis_id',
+        'base_table' => $table_name,
+        'term_vocabulary' => 'operation',
+        'term_name' => 'Analysis',
+        'term_accession' => '2945',
+        
+      ),
+      'widget' => array(
+        'type' => 'operation__analysis_widget',
+        'settings' => array(
+          'display_label' => 0,
+        ),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'inline',
+          'type' => 'operation__analysis_formatter',
+          'settings' => array(),
+        ),
+      ),
+    );
+  }
 }
 
 /**
@@ -2095,6 +2212,9 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
         'chado_table' => $dbxref_table,
         'chado_column' => $pkey,
         'base_table' => $table_name,
+        'term_vocabulary' => 'SBO',
+        'term_name' => 'Database Cross Reference',
+        'term_accession' => '0000554',
       ),
       'widget' => array(
         'type' => 'sbo__database_cross_reference_widget',
@@ -2377,7 +2497,13 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
          }
 
          $field_name = strtolower(preg_replace('/[^\w]/','_', $term->dbxref_id->db_id->name . '__' . $term->name));
-         $field_name = substr($field_name, 0, 32);
+         // The field name can only be 32 chars, but if our name is longer we need
+         // to add some random chars to ensure we don't have naming conflicts
+         // with other terms (e.g. mitochondrial_genetic_code and
+         // mitochondrial_genetic_code_name)
+         if (strlen($field_name) >= 32) {
+           $field_name = substr($field_name, 0, 20) . '_' . $term->cvterm_id;
+         }
          $info[$field_name] = array(
            'field_name' => $field_name,
            'entity_type' => $entity_type,
@@ -2448,6 +2574,9 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
         'chado_table' => $term_table,
         'chado_column' => $pkey,
         'base_table' => $table_name,
+        'term_vocabulary' => 'SIO',
+        'term_name' => 'annotation',
+        'term_accession' => '001166',
       ),
       'widget' => array(
         'type' => 'sio__annotation_widget',
@@ -2483,6 +2612,9 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
         'chado_table' => $pub_table,
         'chado_column' => $pkey,
         'base_table' => $table_name,
+        'term_accession' => 'publication',
+        'term_vocabulary' => 'schema',
+        'term_name' => 'publication',
       ),
       'widget' => array(
         'type' => 'schema__publication_widget',
@@ -2555,6 +2687,9 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
         'chado_table' => $rel_table,
         'chado_column' => $pkey,
         'base_table' => $table_name,
+        'term_vocabulary' => 'SBO',
+        'term_name' => 'Relationship',
+        'term_accession' => '0000374',
       ),
       'widget' => array(
         'type' => 'sbo__relationship_widget',


### PR DESCRIPTION
…e. the same term is used multiple times

<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #141 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
It was possible for two fields to have the exact same term.  In a previous PR (#161) this was partially addressed by warning the user if two fields had the same term.  This PR fixes several problems.
1)  If a property in a prop table uses a term that is already used by another field then the Chado Propety field for that type doesn't show and no warning or error message is given.  The user is left wondering what happened to it.
2)  A user could manually add a new Chado property with a term that already existed.
3) Fields terms are used to build the property field names.  But if a term name is longer than 32 chars it was truncated.  This caused problems with fields such as mitochondrial_genetic_code and mitochondrial_genetic_code_name.  They both got truncated to the same length and one didn't get added because they looked like the same field.
4) Many of the fields were missing their term vocabs in the info arrays.  A check was added when creating new fields that made sure the term info was there and it caught this problem. This was corrected.


## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1) Go to the organism Content Type.   Click the 'check for new fields' link.  You should receive this message ```The term local:mitochondrial_genetic_code_name is in use by multiple fields: local__mitochondrial_2845, local__mitochondrial_genetic_cod. This is not allowed. Every field must have a different controlled vocabulary term. Please correct the term assignments.```. This occurs because of problem 3.  Delete the field with the machine name local__mitochondrial_genetic_cod and the message should go away.
2)  Add a new property  of type 'rdfs:type' to the organismprop table.  Use this SQL code provided by @laceysanderson in issue #141.  ``` INSERT INTO chado.organismprop (organism_id, type_id, value) 
SELECT 1 as organism_id, cvt.cvterm_id as type_id, 'Testing this out #141' as value 
FROM chado.cvterm cvt 
LEFT JOIN chado.cv ON cv.cv_id=cvt.cv_id 
WHERE cv.name='rdfs' AND cvt.name='type';```
Now back on the Organism content type page, click the 'Check for new fields' link.  You should see the following warning message: ```
Warning message
The field, rdfs__type, provided by the storage type, field_chado_storage, uses a term, rdfs:type, that is already in use on this content type and provided by another storage backend. The field instance cannot be added. Perhaps, consider a different term and adjust the data in the database.```
3)  Next, add a new Chado Property field to the content type. Name it whatever you want.  But set the term at the bottom to be 'TAXRANK:0000005' (i.e. the term genus).  It should not let you save the new field and should give you this error message: ```The term, TAXRANK:0000005, is already in use on this content type. A term can only be used once per content type. Please choose a different term.```
4) Without fixing the term for the new Chado Property, return to the Organism content type page.  The new field should be there, but without a term. You should now see a warning message: ```The field, [your field name], is missing a controlled vocabulary term. Please edit the field and set a term, otherwise this field may not work properly.```
## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I made one other change to the tripal_report_error API function. I added a 'drupal_set_message' option so that you can make the message appear on the screen within Drupal as well as log to watchdog.