### PR TITLE
Fix for chado_db_select: doesn't use up all db connections.

### DIFF
--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -2066,7 +2066,7 @@ function chado_db_select($table, $alias = NULL, array $options = array()) {
     $options['target'] = 'default';
   }
    
-  // We only want one connection for chado_db_select, so the first ime we
+  // We only want one connection for chado_db_select, so the first time we
   // create it, we'll save it in the $GLOBALS array for use next time this
   // function is called. If we don't do this, then the function will
   // open too many connections and cause the database server to block.

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -2065,7 +2065,19 @@ function chado_db_select($table, $alias = NULL, array $options = array()) {
   if (empty($options['target'])) {
     $options['target'] = 'default';
   }
-  $conninfo = Database::getConnectionInfo();
-  $conn = new ChadoDatabaseConnection($conninfo['default']);
+   
+  // We only want one connection for chado_db_select, so the first ime we
+  // create it, we'll save it in the $GLOBALS array for use next time this
+  // function is called. If we don't do this, then the function will
+  // open too many connections and cause the database server to block.
+  $conn = NULL;
+  if (!array_key_exists('chado_db_select_connnection', $GLOBALS)) {
+    $conninfo = Database::getConnectionInfo();
+    $conn = new ChadoDatabaseConnection($conninfo['default']);
+    $GLOBALS['chado_db_select_connnection'] = $conn;
+  }
+  else {
+    $conn = $GLOBALS['chado_db_select_connnection'];
+  }
   return $conn->select($table, $alias, $options);
 }


### PR DESCRIPTION
…o many db connections

<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #139 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When calling chado_db_select() multiple times (such as in a loop), it uses up all available database connections and causes a blank page.  A message similar to the following is received:
```
PDOException: SQLSTATE[08006] [7] FATAL: remaining connection slots are reserved for non-replication superuser connections in chado_db_select() (line 2017 of /local/sites/tripal3/sites/all/modules/tripal/tripal_chado/api/tripal_chado.query.api.inc).
```
This PR fixes that problem.
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Testing is simple, just run this drush command.  If you run it before you pull the branch you should receive an error about using up the db connections. If you run it after you pull the branch you should not receive the error. 

```
drush php-eval 'for ($i = 0; $i < 1000; $i++) { $org = chado_db_select("organism", "O")->fields("O")->execute()->fetchObject(); print ($i + 1) . ": " . $org->genus . " " . $org->species . "\n";}'
```
This is such a simple fix, I don't think it needs more than one reviewer.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
