### PR TITLE
Fixes the delete_me as default value. 

### DIFF
--- a/tripal/includes/TripalFields/TripalFieldWidget.inc
+++ b/tripal/includes/TripalFields/TripalFieldWidget.inc
@@ -108,8 +108,8 @@ class TripalFieldWidget {
     );
     $widget['#field'] = $this->field;
     $widget['#instance'] = $this->instance;
-    $widget['#element_validate'] = array('tripal_field_widget_form_validate');
     $widget['#theme'] = 'tripal_field_default';
+    $widget['#element_validate'] = array('tripal_field_widget_form_validate');
   }
 
   /**
@@ -125,6 +125,16 @@ class TripalFieldWidget {
 
   }
 
+  /**
+   * Performs validation of the widget form when setting defaults.
+   *
+   * Use this validate to ensure that form values are entered correctly when
+   * a user edits the defaults on the field edit page (available from the
+   * "managed fields" section of the Content type page. 
+   */
+  public function validateDefaults($element, $form, &$form_state, $langcode, $delta) {
+    
+  }
 
   /**
    * Performs extra commands when the entity form is submitted.

--- a/tripal/includes/tripal.fields.inc
+++ b/tripal/includes/tripal.fields.inc
@@ -771,7 +771,15 @@ function tripal_field_widget_form_validate($element, &$form_state, $form) {
   tripal_load_include_field_class($widget_class);
   if (class_exists($widget_class)) {
     $widget = new $widget_class($field, $instance);
-    $widget->validate($element, $form, $form_state, $langcode, $delta);
+    
+    // Set the validation function for this field widget depending on the
+    // form displaying the widget.
+    if ($form['#form_id'] == 'field_ui_field_edit_form') {
+      $widget->validateDefaults($element, $form, $form_state, $langcode, $delta);
+    }
+    else {
+      $widget->validate($element, $form, $form_state, $langcode, $delta);
+    }
   }
 }
 

--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_widget.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_widget.inc
@@ -7,7 +7,7 @@ class chado_linker__prop_widget extends ChadoFieldWidget {
   // The list of field types for which this formatter is appropriate.
   public static $field_types = array('chado_linker__prop');
 
-  /**
+    /**
    *
    * @see TripalFieldWidget::form()
    */
@@ -109,6 +109,17 @@ class chado_linker__prop_widget extends ChadoFieldWidget {
       '#value' => $rank,
     );
   }
+  
+  /**
+   * @see TripalFieldWidget::validateDefaults()
+   */
+  public function validateDefaults($element, $form, &$form_state, $langcode, $delta) {
+    $field_name = $this->field['field_name'];
+    $field_table = $this->instance['settings']['chado_table'];
+    
+    $value = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__value'];
+    $form_state['values'][$field_name]['und'][$delta]['value'] = $value;    
+  }
 
   /**
    *
@@ -121,7 +132,7 @@ class chado_linker__prop_widget extends ChadoFieldWidget {
     $field_table = $this->instance['settings']['chado_table'];
     $chado_column = $this->instance['settings']['chado_column'];
     $instance = $this->instance;
-
+       
     $schema = chado_get_schema($field_table);
     $pkey = $schema['primary key'][0];
     $base_table = $this->instance['settings']['base_table'];

--- a/tripal_chado/includes/TripalFields/data__sequence/data__sequence_widget.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence/data__sequence_widget.inc
@@ -45,8 +45,19 @@ class data__sequence_widget extends ChadoFieldWidget {
       '#cols' => 30,
     );
   }
-
-
+  
+  /**
+   * @see TripalFieldWidget::validateDefaults()
+   */
+  public function validateDefaults($element, $form, &$form_state, $langcode, $delta) {
+    $field_name = $this->field['field_name'];
+    $field_table = $this->instance['settings']['chado_table'];
+    $field_column = $this->instance['settings']['chado_column'];
+    
+    $value = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__' . $field_column];
+    $form_state['values'][$field_name]['und'][$delta]['value'] = $value;
+  }
+  
   /**
    *
    * @see TripalFieldWidget::submit()
@@ -55,7 +66,7 @@ class data__sequence_widget extends ChadoFieldWidget {
     $field_name = $this->field['field_name'];
     $field_table = $this->instance['settings']['chado_table'];
     $field_column = $this->instance['settings']['chado_column'];
-
+    
     // Remove any white spaces.
     $residues = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__' . $field_column];
     if ($residues) {

--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
@@ -99,7 +99,7 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
       '#disabled' => $db_id ? FALSE : TRUE,
     );
   }
-
+    
   /**
    * @see TripalFieldWidget::validate()
    */
@@ -111,7 +111,7 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     $field_table = $this->instance['settings']['chado_table'];
     $field_column = $this->instance['settings']['chado_column'];
     $base_table = $this->instance['settings']['base_table'];
-
+    
     $schema = chado_get_schema($table_name);
     $pkey = $schema['primary key'][0];
     $fkeys = array_values($schema['foreign keys'][$base_table]['columns']);

--- a/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_widget.inc
+++ b/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_widget.inc
@@ -123,6 +123,7 @@ class schema__alternate_name_widget extends ChadoFieldWidget {
       '#required' => $element['#required'],
     );
   }
+    
   /**
    * @see TripalFieldWidget::validate()
    */
@@ -138,7 +139,6 @@ class schema__alternate_name_widget extends ChadoFieldWidget {
     $pkey = $schema['primary key'][0];
     $fkeys = array_values($schema['foreign keys'][$base_table]['columns']);
     $fkey = $fkeys[0];
-
 
     $pub_id = $form_state['values'][$field_name]['und'][$delta]['chado-' . $table_name . '__pub_id'];
     $syn_name = $form_state['values'][$field_name]['und'][$delta]['name'];

--- a/tripal_chado/includes/TripalFields/schema__publication/schema__publication_widget.inc
+++ b/tripal_chado/includes/TripalFields/schema__publication/schema__publication_widget.inc
@@ -150,7 +150,7 @@ class schema__publication_widget extends ChadoFieldWidget {
     // it out so that the Chado field_storage infrastructure won't try to
     // write a record.
     if (!$title) {
-      $form_state['values'][$field_name]['und'][$delta]['value'] = '';
+      $form_state['values'][$field_name]['und'][$delta]['value'] = 'delete_me';
       $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__' . $fkey] = '';
       $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__pub_id'] = '';
     }

--- a/tripal_chado/includes/TripalFields/sio__annotation/sio__annotation_widget.inc
+++ b/tripal_chado/includes/TripalFields/sio__annotation/sio__annotation_widget.inc
@@ -174,7 +174,7 @@ class sio__annotation_widget extends ChadoFieldWidget {
       );
     }
   }
-
+ 
   /**
    *
    * @see TripalFieldWidget::submit()
@@ -185,7 +185,7 @@ class sio__annotation_widget extends ChadoFieldWidget {
     $field_table = $this->instance['settings']['chado_table'];
     $field_column = $this->instance['settings']['chado_column'];
     $base_table = $this->instance['settings']['base_table'];
-
+    
     // Get the FK that links to the base record.
     $schema = chado_get_schema($field_table);
     $pkey = $schema['primary key'][0];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #447

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Some of the fields would often have a default value of "delete_me" in the field when editing an entity and there was no way to make that go away.   This was most obvious on Chado Properties.

To make this fix work I had to add a validateDefaults() function the the TripalFieldWidget class.  This new function allows for validation of the field edit form separately from an entity page form.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
 Perform the following before pulling this branch:
1)  Go to the Organism content type (Structure > Tripal Content Types) and click on the 'managed fields' link for the Organism content type. 
2) If you have any Chado Property fields you can use one of those. Otherwise you need to add one.  
3) Open your Chado Property field and re-save it.  Re-open it again and you'll see the 'delete_me' text as the default value.  You can remove it and re-save but unfortunately it never goes away.
4)  Manually try to create a new Organism page (you don't have to save it).  You'll see that for the property it defaults to 'delete_me'.

Now pull the branch and do the following
1)  Go to the Organism content type page, find the Chado property that has the 'delete_me' as a default and edit the field.  Remove the 'delete_me' from the default value.  Save it.  Now re-open it.  It should now be gone.  
2)  Go back and try to create a new organism page.  The field now no longer has 'delete_me' as a default value.

There was one additional fix with this PR.  The publication field was broken in that it wouldn't let you remove a publication.  You can now do so.  To test this, just open any content type that has a publication field.  Add a publication, save the page.  The publication should show up.  Now edit the page, remove the publication, save it and now the publication should be gone. 

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
