### PR TITLE
Tripal Content Types are no alphabetical and list the ontology term

### DIFF
--- a/tripal/includes/TripalBundleUIController.inc
+++ b/tripal/includes/TripalBundleUIController.inc
@@ -56,6 +56,55 @@ class TripalBundleUIController extends EntityDefaultUIController {
 
     return $forms;
   }
+  
+  /**
+   * Renders the Bundle overview table
+   */
+  public function overviewTable($conditions = array()) {
+    $entities = entity_load($this->entityType, FALSE, $conditions);
+
+    // Sort the entities by label.
+    $sorted = [];    
+    foreach ($entities as $entity) {
+      $sorted[$entity->label] = $entity;
+    }
+    ksort($sorted, SORT_STRING|SORT_FLAG_CASE);
+    
+    $rows = array();
+    foreach ($sorted as $entity) {
+      // Get the term for this content type
+      $additional_cols = [$entity->term->name . ' (' . l($entity->accession, 'cv/lookup/' . $entity->term->vocab->vocabulary . '/' . $entity->term->accession) . ')'];
+      $rows[] = $this->overviewTableRow($conditions, 
+        entity_id($this->entityType, $entity), $entity,
+        $additional_cols);
+    }
+    // Assemble the right table header.
+    $header = array(t('Label'));
+    if (!empty($this->entityInfo['exportable'])) {
+      $header[] = t('Status');
+    }
+    $header[] = array(
+      'data' => t('Term'),
+    );
+    // Add operations with the right colspan.
+    $field_ui = !empty($this->entityInfo['bundle of']) && module_exists('field_ui');
+    $exportable = !empty($this->entityInfo['exportable']);
+    $colspan = 3;
+    $colspan = $field_ui ? $colspan + 2 : $colspan;
+    $colspan = $exportable ? $colspan + 1 : $colspan;
+    $header[] = array(
+      'data' => t('Operations'),
+      'colspan' => $colspan,
+    );
+    
+    $render = array(
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => t('None.'),
+    );
+    return $render;
+  }
 
 }
 

--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -316,7 +316,7 @@ function tripal_view_entity($entity, $view_mode = 'full') {
        $query->propertyCondition('status', 0);
      }
    }
-   //$query->propertyOrderBy('created', 'DESC');
+   $query->propertyOrderBy('label', 'ASC');
 
    // Find out the total number of records and determine what page we're on, and
    // initialize the pager.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #449

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The Tripal Content Type page was not sorting content types alphabetically.  This PR fixes that and adds the term to the table as well.
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Just go to the Administer > Structure > Tripal Content Types page and see that the content types are no in alphanumeric order and a new Term column is present.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
