### PR TITLE
Publication Importer fix Tv2

### DIFF
--- a/tripal_feature/includes/tripal_feature.gff_loader.inc
+++ b/tripal_feature/includes/tripal_feature.gff_loader.inc
@@ -650,7 +650,12 @@ function tripal_feature_load_gff3($gff_file, $organism_id, $analysis_id,
         $strand = -1;
       }
       if (strcmp($phase, '.') == 0) {
-        $phase = '';
+        if ($type == 'CDS') {
+          $phase = '0';
+        }
+        else {
+          $phase = '';
+        }
       }
       if (array_key_exists($type, $cvterm_lookup)) {
         $cvterm = $cvterm_lookup[$type];

--- a/tripal_pub/includes/importers/tripal_pub.PMID.inc
+++ b/tripal_pub/includes/importers/tripal_pub.PMID.inc
@@ -513,9 +513,7 @@ function tripal_pub_PMID_parse_article($xml, &$pub) {
           tripal_pub_PMID_parse_journal($xml, $pub);
           break;
         case 'ArticleTitle':
-          $xml->read();
-          // remoave any trailing period from the title
-          $pub['Title'] = trim(preg_replace('/\.$/', '', $xml->value));
+          $pub['Title'] = $xml->readString();
           break;
         case 'Abstract':
           tripal_pub_PMID_parse_abstract($xml, $pub);
@@ -676,16 +674,15 @@ function tripal_pub_PMID_parse_abstract($xml, &$pub) {
       switch ($element) {
         case 'AbstractText':
           $label = $xml->getAttribute('Label');
-          $xml->read();
+          $value = $xml->readString();
           if ($label) {
-            $part = "<p><b>$label</b></br>" . $xml->value . '</p>';
+            $part = "<p><b>$label</b></br>" . $value . '</p>';
             $abstract .= $part;
             $pub['Structured Abstract Part'][] = $part;
           }
           else {
-            $abstract .= "<p>" . $xml->value . "</p>";
+            $abstract .= "<p>" . $value . "</p>";
           }
-          break;
         case 'CopyrightInformation':
           $xml->read();
           $pub['Copyright'] = $xml->value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #438 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)
This publication does not import properly:  https://www.ncbi.nlm.nih.gov/pubmed/?term=29792315.  The problem is that it has embedded HTML in the title and abstract (e.g. ```<i>Juglans</i>```).  That threw off the XML importer.  This PR fixes the problem.   This is the Tripal v2 fix that was applied in PR #459 for Tv3.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Use this drush command to import the publication:
```
drush trp-import-pubs --dbxref=PMID:29792315 --username=[username]
```
(substitute the [username] tag)

Tripal v2 should have automatically synced the publication So, go find the new publication page.  You should see it has a title and an abstract.  Previously the import would fail completely and not import or it would import partially and the title would be truncated and the abstract missing.

This is such a simple PR and it has already been tested by @bradfordcondon with issue #438 that I think this only needs on reviewer. 

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
