### PR TITLE
Fixed a major bug with web service field alter but minor code change

### DIFF
--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -302,7 +302,7 @@ class TripalImporter {
           foreach ($fids as $fid) {
             $file = file_load($fid);
             $arguments['files'][] = array(
-              'file_path' => base_path() . drupal_realpath($file->uri),
+              'file_path' => drupal_realpath($file->uri),
               'fid' => $fid
             );
             $has_file++;
@@ -313,14 +313,14 @@ class TripalImporter {
           $fid = $file_details['fid'];
           $file = file_load($fid);
           $arguments['files'][] = array(
-            'file_path' => base_path() . drupal_realpath($file->uri),
+            'file_path' => drupal_realpath($file->uri),
             'fid' => $fid
           );
           $has_file++;
 
           // For backwards compatibility add the old 'file' element.
           $arguments['file'] = array(
-            'file_path' => base_path() . drupal_realpath($file->uri),
+            'file_path' => drupal_realpath($file->uri),
             'fid' => $fid
           );
         }

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -1054,7 +1054,7 @@ function tripal_chado_form_field_ui_field_edit_form_alter(&$form, &$form_state, 
 
     // If this is a Chado field we need to preserve the Chado elements of the
     // settings or they will be lost if a user edits the field settings.
-    if (array_key_Exists('chado_table', $form['#instance']['settings'])) {
+    if (array_key_exists('chado_table', $form['#instance']['settings'])) {
       $form['instance']['settings']['base_table'] = array(
         '#type' => 'value',
         '#value' => $form['#instance']['settings']['base_table'],

--- a/tripal_ws/tripal_ws.module
+++ b/tripal_ws/tripal_ws.module
@@ -438,8 +438,12 @@ function tripal_ws_load_remote_entity($site_id, $api_version, $ctype, $id) {
 }
 
 function tripal_ws_form_field_ui_field_edit_form_alter(&$form, &$form_state, $form_id) {
+  // Don't let the user change the cardinality of web services fields
   if ($form['#instance']['entity_type'] == 'TripalEntity') {
+    if ($form['#field']['storage']['type'] == 'field_tripal_ws_storage') {
       $form['field']['cardinality']['#access'] = FALSE;
+      $form['instance']['required']['#access'] = FALSE;
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue # N/A

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a bug I came across that doesn't have an issue but was a really easy fix.  It's actually quite a major bug because it prevents you from changing the cardinality of any field.  For example, if you add a link field to your content type the form elements for allowing you to specify how many links are allowed does not show up.  This fix corrects that.
 
## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Before pulling the branch, try adding a link field to your content type you'll see there is no form for setting the number of values.  Pull the branch, return to the newly added link field, edit it and you'll see you can now set the cardinality. 

This is a simple fix with < 10 lines adjusted.  I think it only needs one review.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
