### PR TITLE
return false if no term is supplied

### DIFF
--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -378,6 +378,7 @@ function tripal_get_term_details($vocabulary, $accession) {
 
   if (empty($vocabulary) OR empty($accession)) {
     tripal_report_error('tripal_term', TRIPAL_ERROR, "Unable to retrieve details for term due to missing vocabulary and/or accession");
+    return FALSE;
   }
 
   // TODO: we need some sort of administrative interface that lets the user
@@ -390,7 +391,7 @@ function tripal_get_term_details($vocabulary, $accession) {
     $function = $module . '_vocab_get_term';
     if (function_exists($function)) {
       $term = $function($vocabulary, $accession);
-      
+
       // Make sure the term has a URL. If it does not, then use the Tripal
       // interface as the URL for the term.
       $url_missing = FALSE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #479 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
There are nice warnings reported if there is no term supplied for a field.  However they are lost in the error notices.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

* create a field without a cvterm assigned to it attached to a bundle.  I used chado property on organism.
* The problem should occur even if field isn't enabled.
* visit an organism page.  You should see man yundefined index notices, but no official warning.
* Switch to this branch and revisit the page: you should see a handsome warning now.

## Screenshots (if appropriate):
### before:
![screen shot 2018-06-26 at 11 42 48 am](https://user-images.githubusercontent.com/7063154/41923688-1a5a8918-7936-11e8-8f93-e0005e92a607.png)

### after:

![screen shot 2018-06-26 at 11 42 55 am](https://user-images.githubusercontent.com/7063154/41923694-1d9fb3b4-7936-11e8-9985-22a06445de24.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
