### PR TITLE
Removed unwanted comma in SQL

### DIFF
--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -549,7 +549,7 @@ function tripal_chado_fix_v1_3_custom_tables() {
 
   // Update the featuremap_dbxref table by adding an is_current field.
   if (!chado_column_exists('featuremap_dbxref', 'is_current')) {
-    chado_query("ALTER TABLE {featuremap_dbxref} ADD COLUMN is_current boolean DEFAULT true NOT NULL,;");
+    chado_query("ALTER TABLE {featuremap_dbxref} ADD COLUMN is_current boolean DEFAULT true NOT NULL;");
   }
 
   // Remove the previously managed custom tables from the

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -225,8 +225,10 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     drush_print("Creating common Tripal Content Types...");
+    drush_print("This may take awhile if you are upgrading a site that has lots of data...");
 
     // Create the 'Organism' entity type. This uses the obi:organism term.
+    drush_print("Creating Organism...");
     $error = '';
     $args = array(
       'vocabulary' => 'OBI',
@@ -251,6 +253,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'Analysis' entity type. This uses the local:analysis term.
+    drush_print("Creating Analysis...");
     $error = '';
     $args = array(
       'vocabulary' => 'operation',
@@ -275,6 +278,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'Project' entity type. This uses the local:project term.
+    drush_print("Creating Project...");
     $error = '';
     $args = array(
       'vocabulary' => 'local',
@@ -299,6 +303,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'Map' entity type. This uses the local:project term.
+    drush_print("Creating Map...");
     $error = '';
     $args = array(
       'vocabulary' => 'data',
@@ -334,6 +339,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     chado_import_pub_by_dbxref('PMID:24163125');
 
     // Create the 'Publication' entity type.
+    drush_print("Creating Publication...");
     $error = '';
     $args = array(
       'vocabulary' => 'TPUB',
@@ -377,6 +383,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'Gene' entity type.
+    drush_print("Creating Gene...");
     $error = '';
     $args = array(
       'vocabulary' => 'SO',
@@ -402,6 +409,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'mRNA' entity type.
+    drush_print("Creating mRNA...");
     $error = '';
     $args = array(
       'vocabulary' => 'SO',
@@ -427,6 +435,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'biological sample' entity type.
+    drush_print("Creating Biological Sample...");
     $error = '';
     $args = array(
       'vocabulary' => 'sep',
@@ -451,6 +460,7 @@ function tripal_chado_prepare_chado($job = NULL) {
     }
 
     // Create the 'Phylogenetic tree' entity type.
+    drush_print("Creating Phylogenetic tree...");
     $error = '';
     $args = array(
       'vocabulary' => 'data',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #N/A

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I came across an unwanted comma in an SQL statement that occurs during the step of preparing Chado. It only is a problem if the featuremap_dbxref custom table was pre-added.  So not many folks will ever hit on this one.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

No need to test. Just look at the 1 line fix of code.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
