### PR TITLE
fix warnings for pr 470

### DIFF
--- a/tripal/includes/TripalFieldQuery.inc
+++ b/tripal/includes/TripalFieldQuery.inc
@@ -140,7 +140,15 @@ class TripalFieldQuery extends EntityFieldQuery {
     if (array_key_exists('first_results', $current_results)) {
       return $new_results;
     }
-    
+
+    // set defaults to prevent warnings
+    if (empty($new_results)){
+    $new_results['TripalEntity'] = [];
+    }
+    if (empty($current_results)){
+      $current_results['TripalEntity'] = [];
+    }
+
     // Iterate through all of the new results and only include those that
     // exist in both the current and new.
     $intersection = [];


### PR DESCRIPTION
This PR sets some defaults to prevent warnings if there are no results in the view.

Note this PR is to branch 467( pr #470 ) and is therefore not subject to standard PR guidelines.

### Issue

Pr #470  Adds support for views tripal entity relationship. However, if no results are returned because of the tripal field query, we get warnings.  This PR fixes that by setting some defaults.

### Testing

* Specify a tag in the view search, and also specify a publication year that will yield no results.  There will be no warnings with this PR.
 

Please see my [comments in the PR for images](https://github.com/tripal/tripal/pull/470#pullrequestreview-132831612).

