### PR TITLE
make child term lookup distinct  for chado cvterm get children

### DIFF
--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -230,9 +230,9 @@ function tripal_chado_vocab_get_term_children($vocabulary, $accession) {
   $cvterm = chado_expand_var($cvterm, 'field', 'cvterm.definition');
 
 
-  // Get the children
+  // Get the children.
   $sql = "
-    SELECT subject_id
+    SELECT DISTINCT subject_id
     FROM {cvterm_relationship} CVTR
     WHERE object_id = :object_id
   ";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #421 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
* The cv browser can have duplicates, if the same subject/object relationship exists in cvterm_relationship with different type_ids.
* This simple PR will prevent duplicates from being returned.


## Testing?
Testing is a bit tricky because it depends on the OBO files you have loaded.  I dont find duplicates in an easy OBO file (IE goslim) so i dont have a quick way to test for you.  The demo site also doesnt have this issue for some reason- I'm assuming its because the same OBO was loaded with different versions of the OBO loader.

## Screenshots (if appropriate):
Before:
 (note duplication of the term molecular function regulator)

![image](https://user-images.githubusercontent.com/7063154/42058713-469c2256-7aef-11e8-9eb7-3cad3ad130e8.png)

After:
<img width="592" alt="screen shot 2018-06-28 at 4 20 47 pm" src="https://user-images.githubusercontent.com/7063154/42058701-3ece9946-7aef-11e8-9a7e-0c2d6612a868.png">



## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
