### PR TITLE
Publication layout fix

### DIFF
--- a/tripal_ds/includes/tripal_ds.ds.inc
+++ b/tripal_ds/includes/tripal_ds.ds.inc
@@ -304,7 +304,7 @@ function _ds_layout_pub_settings_info($bundle_name, $instances) {
         field_update_instance($instance);
       }
       elseif($instance_name == 'schema__additional_type' || $instance_name == 'tpub__doi'
-        || $instance_name == 'tpub__publication_date' || 'tpub__abstract' ||
+        || $instance_name == 'tpub__publication_date' || $instance_name == 'tpub__abstract' ||
         $instance_name == 'tpub__citation') {
         array_push($properties, $instance_name);
       }


### PR DESCRIPTION
Issue #496

## Type(s) of Change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
The publication ds layout wasn't working, ie the fields were not coming through as disabled and therefore on initial content type build they all went into the right side and didn't get menu links. When the tripal_ds module was initially built the publications received a different and specific layout which was not being applied but is in this branch. 

The problem was being caused by a very small typo, so I corrected that and everything appears to be working on my local.

## Testing?
To test:

1. Checkout 496-tv3-pub_layout_fix, pull, drush cc all
2. Delete the publication content type here admin/structure/bio_data.
3. Add the publication content type back admin/structure/bio_data/add. In the autocomplete field type pub, choose the first publication in the drop down. In the 'chado table' select list choose 'pub' and then choose 'yes' under 'Are all records in the "pub" table of type "publication". Like this:
![screen shot 2018-07-18 at 9 40 08 am](https://user-images.githubusercontent.com/24374002/42885328-b3dacdde-8a6e-11e8-85de-7ec6f636fd6a.png)
4. Click 'create content type'.
5. Now create a test publication and ensure there are no random fields in the display, it should NOT looks like this: 
![42120919-a2300346-7bd8-11e8-87df-26cc6da0a7a8](https://user-images.githubusercontent.com/24374002/42885414-dd7ac8ba-8a6e-11e8-9928-18a6ea94fe03.png)
It should look like this:
![screen shot 2018-07-18 at 10 37 35 am](https://user-images.githubusercontent.com/24374002/42888631-a61c5ebc-8a76-11e8-8f61-b2bc0afdbbdc.png)

I also tested through a new site creation to make sure the layout was correct when a new site is stood up.

## Additional Notes (if any):
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
