### PR TITLE
Some empty fields rendered when Tripal pane not hidden on display.

### DIFF
--- a/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
+++ b/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
@@ -321,6 +321,12 @@ class ogi__location_on_map extends ChadoField {
         $i++;
       }
     }
+
+    // If there are no map positions expanded above then remove the stub.
+    // This is needed to ensure this field isn't displayed when there are no locations.
+    if (!isset($feature->featurepos->feature_id) OR (sizeof($feature->featurepos->feature_id) == 0)) {
+      unset($entity->{$field_name});
+    }
   }
 
 }

--- a/tripal_chado/includes/TripalFields/schema__publication/schema__publication.inc
+++ b/tripal_chado/includes/TripalFields/schema__publication/schema__publication.inc
@@ -83,13 +83,18 @@ class schema__publication extends ChadoField {
     $field_table = $this->instance['settings']['chado_table'];
     $field_column = $this->instance['settings']['chado_column'];
     $base_table = $this->instance['settings']['base_table'];
-    
+
     // These fields are used when the publications come through a linker table.
     $pkey = '';
     $fkey_lcolumn = '';
     $fkey_rcolumn = '';
-    $linker_table = '';   
-    
+    $linker_table = '';
+
+    // If we don't have a chado record return before creating a stub for this field!
+    if (!$record) {
+      return;
+    }
+
     // If the field table and the base table are not the same thing then
     // we are going through a linker table.
     if ($field_table != $base_table) {
@@ -116,10 +121,6 @@ class schema__publication extends ChadoField {
         'chado-' . $field_table . '__' . $field_column => '',
       );
     }
-    
-    if (!$record) {
-      return;
-    }
 
     // Get the list of publications
     $pubs = array();
@@ -132,7 +133,7 @@ class schema__publication extends ChadoField {
         $i = 0;
         foreach ($record->$linker_table as $index => $linker) {
           $pub = $linker->pub_id;
-          $pubs[$pub->pub_id] = $pub;          
+          $pubs[$pub->pub_id] = $pub;
         }
       }
     }
@@ -142,7 +143,13 @@ class schema__publication extends ChadoField {
         $pubs[$pub->pub_id] = $pub;
       }
     }
-    
+
+    // Ensure we don't have a value if there are no publications.
+    // This is needed due to stubbing out the field above.
+    if (sizeof($pubs) == 0) {
+      unset($entity->{$field_name});
+    }
+
     $i = 0;
     foreach ($pubs as $pub_id => $pub) {
       $pub_details = chado_get_minimal_pub_info($pub);

--- a/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
+++ b/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
@@ -15,6 +15,11 @@ class schema__publication_formatter extends ChadoFieldFormatter {
     $list_items = array();
     $chado_table = $this->instance['settings']['chado_table'];
 
+    // If there are no items, we don't want to return any markup.
+    if (empty($items)) {
+      return;
+    }
+
     foreach ($items as $delta => $item) {
 
       $title = isset($item['value']['TPUB:0000039']) ? $item['value']['TPUB:0000039'] : '';

--- a/tripal_chado/includes/TripalFields/sio__annotation/sio__annotation.inc
+++ b/tripal_chado/includes/TripalFields/sio__annotation/sio__annotation.inc
@@ -328,6 +328,12 @@ class sio__annotation extends ChadoField {
         $entity->{$field_name}['und'][$i]['chado-' . $field_table . '__pub_id'] = $linker->pub_id;
       }
     }
+
+    // If there are no cvterms selected above then remove the stub.
+    // This is needed to ensure this field isn't displayed when there are no annotations.
+    if (sizeof($fcvterms) == 0) {
+      unset($entity->{$field_name});
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue: none open

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Empty fields are not supposed to be rendered even when the Tripal pane containing them is set to show by default. This allows admin to indicate they want a pane shown by default if there is data for that particular page but not otherwise. However, I noticed a few fields on feature-based content types that were not respecting this: specifically ogi__location_on_map, sio__annotation, and schema__publication.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Ensure you have a feature-based content type (e.g. gene) with the above fields added to the display.
2. On the "Manage Display" UI for that content type, click the settings gear for the Tripal pane containing each field and uncheck the "Hide panel on page load" checkbox then click "Update" for each pane. Finally, remember to click "Save" at the bottom of the page or your changes will not take effect.
3. Clear the cache :-)
4. Create or navigate to a page where there is no data for those three fields. 
    - on 7.x-3.x (left screenshot): you should see an empty table for ogi__location_on_map, sio__annotation and an empty pane for schema__publication. Note: the Tripal panes will appear on the page despite not being included in the table of contents.
    - on empty_fields branch (right screenshot): all three fields should not be rendered including the Tripal pane they are in (assuming they are the only field in the tripal pane).

## Screenshots (if appropriate):
### Left: 7.x-3.x; Right: this branch
- Panes to notice: "Location on Map", "Annotations" and "Publication". These panes should not be shown because they have no data for this page.
![screen shot 2018-07-24 at 3 16 59 pm](https://user-images.githubusercontent.com/1566301/43166753-acf43f9c-8f54-11e8-9795-7da70dd80803.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
