### PR TITLE
Bug Fix: Sequence Coordinates field only showed the last location.

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates.inc
@@ -248,7 +248,7 @@ class data__sequence_coordinates extends ChadoField {
         }
         $fmin = $featureloc->fmin + 1;
         $fmax = $featureloc->fmax;
-        $entity->{$field_name}['und'][0] = array(
+        $entity->{$field_name}['und'][$index] = array(
           'value' => array(
             $description => $srcfeature . ':' . $fmin . '-' . $fmax . $strand,
             $reference_term => $srcfeature,

--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates_formatter.inc
@@ -20,7 +20,7 @@ class data__sequence_coordinates_formatter extends ChadoFieldFormatter {
     $strand_term = chado_get_semweb_term('featureloc', 'strand');
     $phase_term = chado_get_semweb_term('featureloc', 'phase');
 
-    $content = '';
+    $locations = array();
     foreach ($items as $item) {
       if (!empty($item['value'])) {
         $srcfeature = $item['value'][$reference_term];
@@ -28,11 +28,14 @@ class data__sequence_coordinates_formatter extends ChadoFieldFormatter {
         $fmax = $item['value'][$fmax_term];
         $phase = $item['value'][$phase_term];
         $strand = $item['value'][$strand_term];
-        $content .= $srcfeature . ':' . $fmin . '..' . $fmax . $strand;
+        $locations[] = $srcfeature . ':' . $fmin . '..' . $fmax . $strand;
       }
     }
-    if (!$content) {
+    if (!$locations) {
       $content = 'This feature is not located on any sequence.';
+    }
+    else {
+      $content = implode('<br />', $locations);
     }
     $element[0] = array(
       '#type' => 'markup',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue n/a

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The Sequence Coordinates field (data__sequence_coordinates) only showed the coordinate with the highest rank. This was due to a small bug in the field::load() causing each subsequent coordinate to overwrite the previous one. Additionally, once I fixed the field to display multiple location, I noticed the formatter simply concatenated them together which was not readable.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Ensure you have a feature-based content type (e.g. gene) with the Sequence Coordinates field (data__sequence_coordinates) added to the display.
2. Create or navigate to a page where there a multiple locations saved (in featureloc table).
     - on 7.x-3.x: a single coordinate will be listed, specifically the "last" one based on rank
     - on this branch: all coordinates should be listed, each on their own line.

## Screenshots (if appropriate):
### On 7.x-3.x: only shows a single coordinate despite there being two for this page.
![screen shot 2018-07-24 at 4 58 36 pm](https://user-images.githubusercontent.com/1566301/43170593-232a864a-8f63-11e8-9ad5-379b3b731bb2.png)
### After fix to allow multiple but before format change.
![screen shot 2018-07-24 at 5 01 45 pm](https://user-images.githubusercontent.com/1566301/43170628-4793c9ce-8f63-11e8-822b-3dd00025bdae.png)
### On this branch: what you should see when testing.
![screen shot 2018-07-24 at 4 54 47 pm](https://user-images.githubusercontent.com/1566301/43170596-2749b85e-8f63-11e8-90f0-ccc4bb28e873.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
