### PR TITLE
Additional Relationship Formatter

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -304,10 +304,18 @@ class sbo__relationship extends ChadoField {
 
     // If the subject or object have a unqiuename then add that in for refernce.
     if (property_exists($relationship->$subject_id_key, 'uniquename')) {
-      $entity->{$field_name}['und'][$delta]['value']['local:relationship_subject']['data:0842'] = $relationship->$subject_id_key->uniquename;;
+      $entity->{$field_name}['und'][$delta]['value']['local:relationship_subject']['data:0842'] = $relationship->$subject_id_key->uniquename;
     }
     if (property_exists($relationship->$object_id_key, 'uniquename')) {
       $entity->{$field_name}['und'][$delta]['value']['local:relationship_object']['data:0842'] = $relationship->$object_id_key->uniquename;
+    }
+
+    // If the subject or object have an organism then add that in for reference.
+    if (property_exists($relationship->$subject_id_key, 'organism_id')) {
+      $entity->{$field_name}['und'][$delta]['value']['local:relationship_subject']['OBI:0100026'] = $relationship->$subject_id_key->organism_id->genus . ' ' . $relationship->$subject_id_key->organism_id->species;
+    }
+    if (property_exists($relationship->$object_id_key, 'organism_id')) {
+      $entity->{$field_name}['und'][$delta]['value']['local:relationship_object']['OBI:0100026'] = $relationship->$object_id_key->organism_id->genus . ' ' . $relationship->$object_id_key->organism_id->species;
     }
 
     // Add in the TripalEntity ids if these base records in the relationship
@@ -430,9 +438,11 @@ class sbo__relationship extends ChadoField {
         'type_id' => 1,
         $object_id_key => array(
           'type_id' => 1,
+          'organism_id' => 1,
         ),
         $subject_id_key  => array(
           'type_id' => 1,
+          'organism_id' => 1,
         ),
       ),
     );

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
@@ -3,7 +3,7 @@
 class sbo__relationship_formatter extends ChadoFieldFormatter {
 
   // The default lable for this field.
-  public static $default_label = 'Relationship';
+  public static $default_label = 'Relationship Statements';
 
   // The list of field types for which this formatter is appropriate.
   public static $field_types = array('sbo__relationship');

--- a/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
@@ -1,0 +1,185 @@
+<?php
+
+class sbo__relationship_table_formatter extends ChadoFieldFormatter {
+
+  // The default lable for this field.
+  public static $default_label = 'Relationship Table by Type';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('sbo__relationship');
+
+  public static $default_settings = array(
+    'title' => 'Relationship',
+    'empty' => 'There are no relationships',
+  );
+
+  /**
+   *
+   * @see TripalFieldFormatter::settingsForm()
+   */
+  public function settingsForm($view_mode, $form, &$form_state) {
+
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+    $element = array();
+    $element['title'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Table Header',
+      '#default_value' => array_key_exists('title', $settings) ? $settings['title'] : 'Relationship',
+    );
+    $element['empty'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Empty text',
+      '#default_value' => array_key_exists('empty', $settings) ? $settings['empty'] : 'There are no relationships',
+    );
+
+    return $element;
+  }
+
+  /**
+   * @see TripalFieldFormatter::settingsSummary()
+   */
+  public function settingsSummary($view_mode) {
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+
+    $summary = t('Title: @title<br>Empty: @empty',
+        array(
+          '@title' => $settings['title'],
+          '@empty' => $settings['empty'])
+        );
+
+    return $summary;
+  }
+
+  /**
+   *
+   * @see TripalFieldFormatter::view()
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+
+    // Get the settings
+    $settings = $display['settings'];
+    $headers = array(
+      'all' => array('Name', 'Unique Name', 'Species', 'Type'),
+      'nst' => array('Name', 'Species', 'Type'),
+      'nut' => array('Name', 'Unique Name', 'Type'),
+      'nt' => array('Name', 'Type'),
+    );
+    // This is an array of tables where each table corresponds to a relationship type.
+    // The header is the same for all tables and the caption includes a sentence
+    // stating the relationship type.
+    $tables = array();
+
+    foreach ($items as $delta => $item) {
+      if (empty($item['value'])) {
+        continue;
+      }
+
+      $subject_name = $item['value']['local:relationship_subject']['schema:name'];
+      $subject_uniquename = (isset($item['value']['local:relationship_subject']['data:0842'])) ? $item['value']['local:relationship_subject']['data:0842'] : NULL;
+      $subject_type = $item['value']['local:relationship_subject']['rdfs:type'];
+      $subject_species = (isset($item['value']['local:relationship_subject']['OBI:0100026'])) ? $item['value']['local:relationship_subject']['OBI:0100026'] : NULL;
+
+      $object_name = $item['value']['local:relationship_object']['schema:name'];
+      $object_uniquename = (isset($item['value']['local:relationship_object']['data:0842'])) ? $item['value']['local:relationship_object']['data:0842'] : NULL;
+      $object_type = $item['value']['local:relationship_object']['rdfs:type'];
+      $object_species = (isset($item['value']['local:relationship_object']['OBI:0100026'])) ? $item['value']['local:relationship_object']['OBI:0100026'] : NULL;
+
+      $relationship_type = $item['value']['local:relationship_type'];
+
+      // Make types more readable.
+      foreach(array('subject_type', 'object_type', 'relationship_type') as $var) {
+        $$var = ucwords(str_replace('_',' ', $$var));
+      }
+
+      // Handle some special cases.
+      // For mRNA objects we don't want to show the CDS, exons, 5' UTR, etc.
+      // we want to show the parent gene and the protein.
+      if ($object_type == 'mRNA' and
+          (in_array($subject_type, array('CDS', 'exon', 'five_prime_UTR', 'three_prime_UTR')))) {
+        continue;
+      }
+
+      // Set header type based on what values are available.
+      if ($delta == 0) {
+        $tables[$relationship_type]['header_type'] = 'all';
+        if ($subject_uniquename === NULL AND $subject_species === NULL) {
+          $tables[$relationship_type]['header_type'] = 'nt';
+        }
+        elseif ($subject_uniquename === NULL) {
+          $tables[$relationship_type]['header_type'] = 'nst';
+        }
+        elseif ($subject_species === NULL) {
+          $tables[$relationship_type]['header_type'] = 'nut';
+        }
+      }
+
+      // Convert the object/subject to a link if an entity exists for it.
+      if (array_key_exists('entity', $item['value']['local:relationship_object'])) {
+        list($entity_type, $object_entity_id) = explode(':', $item['value']['local:relationship_object']['entity']);
+        if ($object_entity_id != $entity->id) {
+          $object_name = l($object_name, 'bio_data/' . $object_entity_id);
+          if ($object_uniquename) { $object_uniquename = l($object_uniquename, 'bio_data/' . $object_entity_id); }
+        }
+      }
+      if (array_key_exists('entity', $item['value']['local:relationship_subject'])) {
+        list($entity_type, $subject_entity_id) = explode(':', $item['value']['local:relationship_subject']['entity']);
+        if ($subject_entity_id != $entity->id) {
+          $subject_name = l($subject_name, 'bio_data/' . $subject_entity_id);
+          if ($subject_uniquename) { $subject_uniquename = l($subject_uniquename, 'bio_data/' . $subject_entity_id); }
+        }
+      }
+
+      // Determine if the subject or object is the current entity.
+      $is_subject = TRUE;
+      if ($object_name == $entity->schema__name['und'][0]['value']) {
+        $is_subject = FALSE;
+      }
+
+
+      // Add the related entity to the tables array by type of relationship.
+      if ($is_subject) {
+        $tables[$relationship_type]['caption'] = t('This @type is <em>@rel_type</em> of the following <em>@content_type(s)</em>:',
+          array('@type' => $subject_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
+
+        $row = array();
+        $row['name'] = $object_name;
+        if ($object_uniquename) { $row['uniquename'] = $object_uniquename; }
+        if ($object_species) { $row['species'] = $object_species; }
+        $row['type'] = $object_type;
+
+        $tables[$relationship_type]['rows'][] = $row;
+      }
+      else {
+        $tables[$relationship_type]['caption'] = t('The following <em>@content_type(s)</em> are <em>@rel_type</em> of this @type:',
+          array('@type' => $object_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
+
+        $row = array();
+        $row['name'] = $subject_name;
+        if ($subject_uniquename) { $row['uniquename'] = $subject_uniquename; }
+        if ($subject_species) { $row['species'] = $subject_species; }
+        $row['type'] = $subject_type;
+
+        $tables[$relationship_type]['rows'][] = $row;
+      }
+    }
+
+    $element[0] = array(
+      '#type' => 'markup',
+      '#tree' => TRUE,
+    );
+
+    foreach ($tables as $relationship_type => $details) {
+      $element[0][$relationship_type] = array(
+        '#type' => 'markup',
+        '#theme' => 'table',
+        '#header' => $headers[ $details['header_type'] ],
+        '#rows' => $details['rows'],
+        '#caption' => $details['caption'],
+      );
+    }
+  }
+}
+
+

--- a/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
@@ -9,8 +9,8 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
   public static $field_types = array('sbo__relationship');
 
   public static $default_settings = array(
-    'title' => 'Relationship',
-    'empty' => 'There are no relationships',
+    'subject_caption' => 'This @type is <em>@rel_type</em> of the following <em>@content_type(s)</em>:',
+    'object_caption' => 'The following <em>@content_type(s)</em> are <em>@rel_type</em> of this @type:',
   );
 
   /**
@@ -21,16 +21,36 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
 
     $display = $this->instance['display'][$view_mode];
     $settings = $display['settings'];
+
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
     $element = array();
-    $element['title'] = array(
+    $element['subject_caption'] = array(
       '#type' => 'textfield',
-      '#title' => 'Table Header',
-      '#default_value' => array_key_exists('title', $settings) ? $settings['title'] : 'Relationship',
+      '#title' => 'Caption: where current entity is the subject.',
+      '#description' => 'This labels the relationship tables where the current entity is the subject of the relationship.',
+      '#default_value' => $settings['subject_caption'],
     );
-    $element['empty'] = array(
+
+    $element['object_caption'] = array(
       '#type' => 'textfield',
-      '#title' => 'Empty text',
-      '#default_value' => array_key_exists('empty', $settings) ? $settings['empty'] : 'There are no relationships',
+      '#title' => 'Caption: where current entity is the object.',
+      '#description' => 'This labels the relationship tables where the current entity is the object of the relationship.',
+      '#default_value' => $settings['object_caption'],
+    );
+
+    $element['tokens'] = array(
+      '#type' => 'item',
+      '#title' => 'Tokens',
+      '#markup' => 'The following tokens should be used in <strong>both the above captions</strong>:</p>
+                     <ul>
+                       <li>@type: The value of rdfs__type for the current entity.</li>
+                       <li>@rel_type: the type name of the current relationship.</li>
+                       <li>@content_type: the human-readable name of the content type for the current entity.</li>
+                     </ul>',
     );
 
     return $element;
@@ -43,10 +63,15 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
     $display = $this->instance['display'][$view_mode];
     $settings = $display['settings'];
 
-    $summary = t('Title: @title<br>Empty: @empty',
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
+    $summary = t('<strong>Subject Caption:</strong> @subject<br><strong>Object Caption:</strong> @object',
         array(
-          '@title' => $settings['title'],
-          '@empty' => $settings['empty'])
+          '@subject' => $settings['subject_caption'],
+          '@object' => $settings['object_caption'])
         );
 
     return $summary;
@@ -58,19 +83,26 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
    */
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
 
-    // Get the settings
+    // Get the settings and set defaults.
     $settings = $display['settings'];
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
+    // Headers depending on which fields are available.
     $headers = array(
       'all' => array('Name', 'Unique Name', 'Species', 'Type'),
       'nst' => array('Name', 'Species', 'Type'),
       'nut' => array('Name', 'Unique Name', 'Type'),
       'nt' => array('Name', 'Type'),
     );
+
     // This is an array of tables where each table corresponds to a relationship type.
     // The header is the same for all tables and the caption includes a sentence
     // stating the relationship type.
     $tables = array();
 
+    // For each relationship...
     foreach ($items as $delta => $item) {
       if (empty($item['value'])) {
         continue;
@@ -140,7 +172,7 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
 
       // Add the related entity to the tables array by type of relationship.
       if ($is_subject) {
-        $tables[$relationship_type]['caption'] = t('This @type is <em>@rel_type</em> of the following <em>@content_type(s)</em>:',
+        $tables[$relationship_type]['caption'] = t($settings['subject_caption'],
           array('@type' => $subject_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
 
         $row = array();
@@ -152,7 +184,7 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
         $tables[$relationship_type]['rows'][] = $row;
       }
       else {
-        $tables[$relationship_type]['caption'] = t('The following <em>@content_type(s)</em> are <em>@rel_type</em> of this @type:',
+        $tables[$relationship_type]['caption'] = t($settings['object_caption'],
           array('@type' => $object_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
 
         $row = array();

--- a/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
@@ -9,8 +9,8 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
   public static $field_types = array('sbo__relationship');
 
   public static $default_settings = array(
-    'subject_caption' => 'This @type is <em>@rel_type</em> of the following <em>@content_type(s)</em>:',
-    'object_caption' => 'The following <em>@content_type(s)</em> are <em>@rel_type</em> of this @type:',
+    'subject_caption' => 'This @content_type is <em>@rel_type</em> the following:',
+    'object_caption' => 'The following are <em>@rel_type</em> this @content_type:',
   );
 
   /**
@@ -47,7 +47,6 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
       '#title' => 'Tokens',
       '#markup' => 'The following tokens should be used in <strong>both the above captions</strong>:</p>
                      <ul>
-                       <li>@type: The value of rdfs__type for the current entity.</li>
                        <li>@rel_type: the type name of the current relationship.</li>
                        <li>@content_type: the human-readable name of the content type for the current entity.</li>
                      </ul>',
@@ -173,7 +172,7 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
       // Add the related entity to the tables array by type of relationship.
       if ($is_subject) {
         $tables[$relationship_type]['caption'] = t($settings['subject_caption'],
-          array('@type' => $subject_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
+          array('@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
 
         $row = array();
         $row['name'] = $object_name;
@@ -185,7 +184,7 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
       }
       else {
         $tables[$relationship_type]['caption'] = t($settings['object_caption'],
-          array('@type' => $object_type, '@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
+          array('@rel_type' => $relationship_type, '@content_type' => $entity->rdfs__type['und'][0]['value']));
 
         $row = array();
         $row['name'] = $subject_name;

--- a/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship_table/sbo__relationship_table_formatter.inc
@@ -134,7 +134,7 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
       }
 
       // Set header type based on what values are available.
-      if ($delta == 0) {
+      if (!isset($tables[$relationship_type])) {
         $tables[$relationship_type]['header_type'] = 'all';
         if ($subject_uniquename === NULL AND $subject_species === NULL) {
           $tables[$relationship_type]['header_type'] = 'nt';
@@ -203,12 +203,19 @@ class sbo__relationship_table_formatter extends ChadoFieldFormatter {
     );
 
     foreach ($tables as $relationship_type => $details) {
+
+      $table_id = 'sbo__relationship-'.$item['value']['local:relationship_subject']['rdfs:type']; //$this->getPagerElementID();
       $element[0][$relationship_type] = array(
         '#type' => 'markup',
         '#theme' => 'table',
         '#header' => $headers[ $details['header_type'] ],
         '#rows' => $details['rows'],
         '#caption' => $details['caption'],
+        '#sticky' => FALSE,
+        '#attributes' => array(
+          'class' => 'tripal-data-table',
+          'id' => $table_id,
+        ),
       );
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #523

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Currently the relationship formatter for Tripal 3 states all relationships in sentence form in a single-columned table. This is quite different from the format for relationships used in Tripal 2 with a multi-columned table per relationship type.

This formatter mimics the Tripal 2 format providing one table per relationship type with the columns name, uniquename, species, type of related item; eg. stock. I think this one belongs in core since it allows admin to mimic the old pages during upgrade.

Things of interest:
- Supports related tables where there is no uniquename and/or organism_id by simply not including those tables.
- Required backwards compatible update to the sbo__relationship field to load the organism information.
- Should be similar performance as the original formatter (both loop through all relationships to add to a table)
- Doesn't support paging since Tripal 3 `TripalFormatter->ajaxifyPager()` currently only supports a single pager per field.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Pick a content type with relationships to test and navigate to Admin > Structure > Tripal Content Types > [your content type] > Manage Fields.
2. Clear the cache and click find new fields.
3. Navigate to Manage Display, you should now see two items in the format drop-down for the relationship field: "Relationship Statements" (original formatter) and "Relationship Table" (this formatter).
4. Switch the formatter to "Relationship Table" and click "Save" at the bottom of the page.
5. Navigate to an entity page of that type with relationships and confirm the field now looks similar to the screenshot below.

## Screenshots (if appropriate):
The following screenshot shows an example of the relationship formatter in use on a stock-based content type. As you can see, it follows the relationships in both directions (current entity can be subject or object) and provides the same readable sentence describing the relationship above the table the way it was done in Tripal 2.
![screen shot 2018-08-03 at 8 57 08 am](https://user-images.githubusercontent.com/1566301/43649856-85a8415a-96fb-11e8-9484-db00a4ca483d.png)

The following screenshot shows the configuration of this formatter. It provides default "sentences" for use at the top of each table as shown in the screenshot above. The admin can change these sentences to make them more intuitive to their user base. Supports use of a few tokens for embedding type information in the sentence and different sentences based on whether the current entity is the subject or object in the relationship.
![screen shot 2018-08-03 at 8 58 42 am](https://user-images.githubusercontent.com/1566301/43649859-879d4f50-96fb-11e8-8766-941732407547.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
