### PR TITLE
Alternate Tripal2-like Sequence Coordinate Formatter

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates.inc
@@ -243,8 +243,11 @@ class data__sequence_coordinates extends ChadoField {
         if ($featureloc->strand == 1) {
           $strand = '+';
         }
-        else {
+        elseif ($featureloc->strand == -1) {
           $strand = '-';
+        }
+        else {
+          $strand = '';
         }
         $fmin = $featureloc->fmin + 1;
         $fmax = $featureloc->fmax;

--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates/data__sequence_coordinates_formatter.inc
@@ -2,7 +2,7 @@
 
 class data__sequence_coordinates_formatter extends ChadoFieldFormatter {
   // The default lable for this field.
-  public static $default_label = 'Sequence Coordinates';
+  public static $default_label = 'Sequence Coordinate List';
 
   // The list of field types for which this formatter is appropriate.
   public static $field_types = array('data__sequence_coordinates');

--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
@@ -8,7 +8,7 @@ class data__sequence_coordinates_table_formatter extends ChadoFieldFormatter {
   public static $field_types = array('data__sequence_coordinates');
 
   public static $default_settings = array(
-    'caption' => 'This @content_type is aligned to the following:',
+    'caption' => 'This @content_type has the following sequence coordinates:',
     'expand_strand' => TRUE,
   );
 

--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
@@ -1,0 +1,110 @@
+<?php
+
+class data__sequence_coordinates_table_formatter extends ChadoFieldFormatter {
+  // The default lable for this field.
+  public static $default_label = 'Sequence Coordinate Table';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('data__sequence_coordinates');
+
+  public static $default_settings = array(
+    'caption' => 'This @content_type is aligned to the following:',
+  );
+
+  /**
+   *
+   * @see TripalFieldFormatter::settingsForm()
+   */
+  public function settingsForm($view_mode, $form, &$form_state) {
+
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
+    $element = array();
+    $element['caption'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Caption',
+      '#description' => 'Provides a caption for the table describing the purpose to the user.',
+      '#default_value' => $settings['caption'],
+    );
+
+    $element['tokens'] = array(
+      '#type' => 'item',
+      '#title' => 'Tokens',
+      '#markup' => 'The following tokens should be used in <strong>both the above captions</strong>:</p>
+                     <ul>
+                       <li>@content_type: the human-readable name of the content type for the current entity.</li>
+                     </ul>',
+    );
+
+    return $element;
+  }
+  /**
+   * @see TripalFieldFormatter::settingsSummary()
+   */
+  public function settingsSummary($view_mode) {
+
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
+    $summary = t('<strong>Caption:</strong> ' . $settings['caption']);
+
+    return $summary;
+  }
+
+  /**
+   *
+   * @see TripalFieldFormatter::view()
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+
+    // Get the settings and set defaults.
+    $settings = $display['settings'];
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) { $settings[$key] = $value; }
+    }
+
+    // Replace tokens in the caption.
+    $settings['caption'] = t($settings['caption'],
+      array('@content_type' => $entity->rdfs__type['und'][0]['value']));
+
+    // Determine the terms for each column.
+    $reference_term = 'data:3002';
+    $fmin_term = chado_get_semweb_term('featureloc', 'fmin');
+    $fmax_term = chado_get_semweb_term('featureloc', 'fmax');
+    $strand_term = chado_get_semweb_term('featureloc', 'strand');
+    $phase_term = chado_get_semweb_term('featureloc', 'phase');
+
+    // For each location, add it to the table.
+    $header = array('Name','Location','Strand');
+    $rows = array();
+    foreach ($items as $item) {
+      if (!empty($item['value'])) {
+        $rows[] = array(
+          $item['value'][$reference_term],
+          $item['value'][$fmin_term] . '..' . $fmax = $item['value'][$fmax_term],
+          $item['value'][$strand_term]
+        );
+      }
+    }
+
+    // Add the markup for the table.
+    $element[0] = array(
+      '#type' => 'markup',
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#caption' => $settings['caption'],
+    );
+  }
+}

--- a/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_coordinates_table/data__sequence_coordinates_table_formatter.inc
@@ -9,6 +9,7 @@ class data__sequence_coordinates_table_formatter extends ChadoFieldFormatter {
 
   public static $default_settings = array(
     'caption' => 'This @content_type is aligned to the following:',
+    'expand_strand' => TRUE,
   );
 
   /**
@@ -26,6 +27,14 @@ class data__sequence_coordinates_table_formatter extends ChadoFieldFormatter {
     }
 
     $element = array();
+
+    $element['expand_strand'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Expand Strand',
+      '#description' => 'Expands the strand to full words versus "+" or "-".',
+      '#default_value' => $settings['expand_strand'],
+    );
+
     $element['caption'] = array(
       '#type' => 'textfield',
       '#title' => 'Caption',
@@ -90,10 +99,24 @@ class data__sequence_coordinates_table_formatter extends ChadoFieldFormatter {
     $rows = array();
     foreach ($items as $item) {
       if (!empty($item['value'])) {
+
+        $strand = $item['value'][$strand_term];
+        if ($settings['expand_strand']) {
+          if ($item['value'][$strand_term] == '+') {
+            $strand = 'positive';
+          }
+          elseif ($item['value'][$strand_term] == '-') {
+            $strand = 'negative';
+          }
+          else {
+            $strand = '<span style="color:#B3B3B3">unknown</span>';
+          }
+        }
+
         $rows[] = array(
           $item['value'][$reference_term],
           $item['value'][$fmin_term] . '..' . $fmax = $item['value'][$fmax_term],
-          $item['value'][$strand_term]
+          $strand
         );
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue n/a

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Currently the sequence coordinate formatter for Tripal 3 lists all coordinates in compact form. This is quite different from the format for the featureloc alignments used in Tripal 2 with a multi-columned table breaking down the location.

This formatter mimics the Tripal 2 format providing a table with the name, location and strand of the features the current entity is aligned to. I think this one belongs in core since it allows admin to mimic the old pages during upgrade.

**NOTE: This PR also includes a small bug fix to the sequence coordinate field. Originally, it was assuming the strand was set in featureloc so if it wasn't, the strand was reported as -. I just expanded the if-else to be more specific and catch the case where strand is not set.**

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Pick a content type with sequence coordinates (featureloc records) to test and navigate to Admin > Structure > Tripal Content Types > [your content type] > Manage Fields.
2. Clear the cache and click find new fields.
3. Navigate to Manage Display, you should now see two items in the format drop-down for the sequence coordinate field: "Sequence Coordinate List" (original formatter) and "Sequence Coordinate Table" (this formatter).
4. Switch the formatter to "Sequence Coordinate Table" and click "Save" at the bottom of the page.
5. Navigate to an entity page of that type with sequence coordinates and confirm the field now looks similar to the screenshot below.

## Screenshots (if appropriate):
![screen shot 2018-08-08 at 11 42 33 am](https://user-images.githubusercontent.com/1566301/43854479-3ad0f182-9b00-11e8-8290-6bd96500f082.png)

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
