### PR TITLE
Optimization of Publishing Entities

### DIFF
--- a/tripal/includes/TripalEntity.inc
+++ b/tripal/includes/TripalEntity.inc
@@ -15,4 +15,20 @@ class TripalEntity extends Entity {
     return array('path' => 'TripalEntity/' . $this->id);
   }
 
+  /**
+   * Permanently saves the entity.
+   *
+   * @param DatabaseTransaction $transaction
+   *    (OPTIONAL) Allows you to pass in your current transaction to save nested transaction overhead.
+   * @param boolean $clear_cached_fields
+   *    (OPTIONAL) Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
+   *    must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
+   *    The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
+   *
+   * @see entity_save()
+   */
+  public function save(DatabaseTransaction $transaction = NULL, $clear_cached_fields = TRUE) {
+    return entity_get_controller($this->entityType)->save($this, $transaction, $clear_cached_fields);
+  }
+
 }

--- a/tripal/includes/TripalEntity.inc
+++ b/tripal/includes/TripalEntity.inc
@@ -18,17 +18,23 @@ class TripalEntity extends Entity {
   /**
    * Permanently saves the entity.
    *
-   * @param DatabaseTransaction $transaction
-   *    (OPTIONAL) Allows you to pass in your current transaction to save nested transaction overhead.
-   * @param boolean $clear_cached_fields
-   *    (OPTIONAL) Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
-   *    must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
-   *    The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
-   *
+   * @param $cache
+   *   This array is used to store objects you want to cache for performance reasons,
+   *   as well as, cache related options. The following are supported:
+   *   - DatabaseTransaction $transaction
+   *       Allows you to pass in your current transaction to save nested transaction overhead.
+   *   - boolean $clear_cached_fields
+   *       Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
+   *       must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
+   *       The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
+   *   - TripalBundle $bundle
+   *       The bundle for the current entity.
+   *   - TripalTerm $term
+   *       The term for the current entity.
    * @see entity_save()
    */
-  public function save(DatabaseTransaction $transaction = NULL, $clear_cached_fields = TRUE) {
-    return entity_get_controller($this->entityType)->save($this, $transaction, $clear_cached_fields);
+  public function save($cache = array()) {
+    return entity_get_controller($this->entityType)->save($this, $cache);
   }
 
 }

--- a/tripal/includes/TripalEntity.inc
+++ b/tripal/includes/TripalEntity.inc
@@ -21,8 +21,6 @@ class TripalEntity extends Entity {
    * @param $cache
    *   This array is used to store objects you want to cache for performance reasons,
    *   as well as, cache related options. The following are supported:
-   *   - DatabaseTransaction $transaction
-   *       Allows you to pass in your current transaction to save nested transaction overhead.
    *   - boolean $clear_cached_fields
    *       Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
    *       must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -45,7 +45,12 @@ class TripalEntityController extends EntityAPIController {
     $modules = module_implements('entity_create');
     foreach ($modules as $module) {
       $function = $module . '_entity_create';
-      $function($entity, $values['type']);
+      if (isset($values['bundle_object'])) {
+        $function($entity, $values['type'], $values['bundle_object']);
+      }
+      else {
+        $function($entity, $values['type']);
+      }
     }
     return $entity;
 
@@ -102,20 +107,20 @@ class TripalEntityController extends EntityAPIController {
    *   The entity whose title should be changed.
    * @param $title
    *   The title to use. It can contain tokens the correspond to field values.
-   *   Token should be be compatible with those returned by 
+   *   Token should be be compatible with those returned by
    *   tripal_get_entity_tokens().
    */
   public function setTitle($entity, $title = NULL) {
-    
+
     $bundle = tripal_load_bundle_entity(array('name' => $entity->bundle));
-    
+
     // If no title was supplied then we should try to generate one using the
     // default format set by admins.
-    if (!$title) {     
+    if (!$title) {
       $title = tripal_get_title_format($bundle);
     }
     $title = tripal_replace_entity_tokens($title, $entity, $bundle);
-    
+
     if ($title) {
       db_update('tripal_entity')
         ->fields(array(
@@ -128,12 +133,12 @@ class TripalEntityController extends EntityAPIController {
 
   /**
    * Sets the URL alias for an entity.
-   * 
+   *
    * @param $entity
    *   The entity whose URL alias should be changed.
    * @param $alias
    *   The alias to use. It can contain tokens the correspond to field values.
-   *   Token should be be compatible with those returned by 
+   *   Token should be be compatible with those returned by
    *   tripal_get_entity_tokens().
    */
   public function setAlias($entity, $alias = NULL) {
@@ -155,17 +160,17 @@ class TripalEntityController extends EntityAPIController {
     // the term name and entity id.
     if (!$alias) {
 
-      // Load the term for this TripalEntity. Set a default based on the term 
-      // name and entity id. Then replace all the tokens with values from 
+      // Load the term for this TripalEntity. Set a default based on the term
+      // name and entity id. Then replace all the tokens with values from
       // the entity fields.
       $term = entity_load('TripalTerm', array('id' => $entity->term_id));
       $term = reset($term);
       $alias = str_replace(' ', '', $term->name) . '/[TripalEntity__entity_id]';
       $alias = tripal_replace_entity_tokens($alias, $entity, $bundle_entity);
     }
-    
-    // Check if the passed alias has tokens. Load the TripalBundle entity for 
-    // this TripalEntity. Then replace all the tokens with values from the 
+
+    // Check if the passed alias has tokens. Load the TripalBundle entity for
+    // this TripalEntity. Then replace all the tokens with values from the
     // entity fields.
     if($alias && (preg_match_all("/\[[^\]]*\]/", $alias, $bundle_tokens))) {
       $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
@@ -243,7 +248,7 @@ class TripalEntityController extends EntityAPIController {
           drupal_write_record('url_alias', $values);
         }
       }
-      // If there is only one alias matching then it might just be that we 
+      // If there is only one alias matching then it might just be that we
       // already assigned this alias to this entity in a previous save.
       elseif ($num_aliases == 1) {
 

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -203,6 +203,10 @@ class TripalEntityController extends EntityAPIController {
         // SQL statement that gets called somewhere by Drupal:
         // SELECT DISTINCT SUBSTRING_INDEX(source, '/', 1) AS path FROM url_alias.
         // Perhaps we should write our own SQL to avoid this issue.
+        // This happens in drupal_path_alias_whitelist_rebuild(). It appears we can
+        // get around it by whitelisting our paths before it's called...
+        // @lacey: drupal_path_alias_whitelist_rebuild() isn't getting called for me during publish.
+        // @performance
         $values =  array(
           'source' => $source_url,
           'alias' => $alias,
@@ -313,24 +317,29 @@ class TripalEntityController extends EntityAPIController {
    *
    * @param $entity
    *   A TripalEntity object to save.
+   * @param $transaction
+   *   If you have a transaction open, you can pass it through to avoid the overhead of
+   *   creating nested transactions.
+   * @param $clear_cached_fields
+   *   Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
+   *   must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
+   *   The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
    *
    * @return
    *   The saved entity object with updated properties.
    */
-  public function save($entity, DatabaseTransaction $transaction = NULL) {
+  public function save($entity, DatabaseTransaction $transaction = NULL, $clear_cached_fields = TRUE) {
     global $user;
     $pkeys = array();
 
-    // Get the author information.
-    $author = $user;
-    if (property_exists($entity, 'uid')) {
-      $author = user_load($entity->uid);
-    }
+    // @performance remove after development
+    // @performance $started_at = microtime(true);
 
     $changed_date = time();
     $create_date = $changed_date;
     if (property_exists($entity, 'created')) {
       if (!is_numeric($entity->created)) {
+        print "IM CREATING A DATE!\n";
         $temp = new DateTime($entity->created);
         $create_date = $temp->getTimestamp();
       }
@@ -348,7 +357,7 @@ class TripalEntityController extends EntityAPIController {
       // If our entity has no id, then we need to give it a
       // time of creation.
       if (empty($entity->id)) {
-        $entity->created = time();
+        $entity->created = $created_date;
         $invocation = 'entity_insert';
       }
       else {
@@ -362,13 +371,15 @@ class TripalEntityController extends EntityAPIController {
       // Invoke hook_entity_presave().
       module_invoke_all('entity_presave', $entity, $entity->type);
 
+      // @performance print '      - After entity_presave :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+
       // Write out the entity record.
       $record = array(
         'term_id'   => $entity->term_id,
         'type'      => $entity->type,
         'bundle'    => $entity->bundle,
         'title'     => $entity->title,
-        'uid'       => $author->uid,
+        'uid'       => $entity->uid,
         'created'   => $create_date,
         'changed'   => $changed_date,
         'status'    => $status,
@@ -384,6 +395,8 @@ class TripalEntityController extends EntityAPIController {
         $entity->id = $record['id'];
       }
 
+      // @performance print '      - After drupal_write_record :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+
       // Now we need to either insert or update the fields which are
       // attached to this entity. We use the same primary_keys logic
       // to determine whether to update or insert, and which hook we
@@ -391,6 +404,7 @@ class TripalEntityController extends EntityAPIController {
       // This is because a field may have default values and if so, those fields
       // will be attached and the storage backend may then try to insert
       // fields which should not be inserted because they already exist.
+      // @performance print "      - Invocation: $invocation.\n";
       if ($invocation == 'entity_insert') {
         field_attach_insert('TripalEntity', $entity);
       }
@@ -401,17 +415,28 @@ class TripalEntityController extends EntityAPIController {
       // Set the title for this entity.
       $this->setTitle($entity);
 
+      // @performance print '      - After setTitle :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+
       // Set the path/url alias for this entity.
       $this->setAlias($entity);
 
+      // @performance print '      - After setAlias :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+
       // Invoke either hook_entity_update() or hook_entity_insert().
       module_invoke_all('entity_postsave', $entity, $entity->type);
+
+      // @performance print '      - After entity_postsave :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+
       module_invoke_all($invocation, $entity, $entity->type);
+
+      // @performance print "      - After $invocation :" . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
       // Clear any cache entries for this entity so it can be reloaded using
       // the values that were just saved.
-      $cid = 'field:TripalEntity:' . $entity->id;
-      cache_clear_all($cid, 'cache_field', TRUE);
+      if ($clear_cached_fields) {
+        $cid = 'field:TripalEntity:' . $entity->id;
+        cache_clear_all($cid, 'cache_field', TRUE);
+      }
 
       return $entity;
     }

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -225,15 +225,13 @@ class TripalEntityController extends EntityAPIController {
         // First delete any previous alias' for this entity.
         // Then save the new one.
 
-        // TODO: publishing an entity can be very slow if there are lots of
+        // @performance: Look into this further.
+        // @spficklin publishing an entity can be very slow if there are lots of
         // entries in the url_alias table, due to this type of
-        // SQL statement that gets called somewhere by Drupal:
+        // SQL statement that gets called in drupal_path_alias_whitelist_rebuild():
         // SELECT DISTINCT SUBSTRING_INDEX(source, '/', 1) AS path FROM url_alias.
         // Perhaps we should write our own SQL to avoid this issue.
-        // This happens in drupal_path_alias_whitelist_rebuild(). It appears we can
-        // get around it by whitelisting our paths before it's called...
         // @lacey: drupal_path_alias_whitelist_rebuild() isn't getting called for me during publish.
-        // @performance
         $values =  array(
           'source' => $source_url,
           'alias' => $alias,
@@ -460,7 +458,9 @@ class TripalEntityController extends EntityAPIController {
 
       // Clear any cache entries for this entity so it can be reloaded using
       // the values that were just saved.
-      if ($cache['clear_cached_fields']) {
+      // Also, we don't need to clear cached fields when publishing because we
+      // didn't attach any (see above).
+      if ($cache['clear_cached_fields'] AND ($invocation != 'entity_publish')) {
         $cid = 'field:TripalEntity:' . $entity->id;
         cache_clear_all($cid, 'cache_field', TRUE);
       }

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -355,8 +355,6 @@ class TripalEntityController extends EntityAPIController {
    * @param $cache
    *   This array is used to store objects you want to cache for performance reasons,
    *   as well as, cache related options. The following are supported:
-   *   - DatabaseTransaction $transaction
-   *       Allows you to pass in your current transaction to save nested transaction overhead.
    *   - boolean $clear_cached_fields
    *       Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
    *       must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
@@ -391,7 +389,7 @@ class TripalEntityController extends EntityAPIController {
       }
     }
 
-    $transaction = isset($cache['transaction']) ? $cache['transaction'] : db_transaction();
+    $transaction = db_transaction();
     try {
       // If our entity has no id, then we need to give it a
       // time of creation.

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -109,10 +109,20 @@ class TripalEntityController extends EntityAPIController {
    *   The title to use. It can contain tokens the correspond to field values.
    *   Token should be be compatible with those returned by
    *   tripal_get_entity_tokens().
+   * @param $cache
+   *   This array is used to store objects you want to cache for performance reasons,
+   *   as well as, cache related options. The following are supported:
+   *   - TripalBundle $bundle
+   *       The bundle for the current entity.
    */
-  public function setTitle($entity, $title = NULL) {
+  public function setTitle($entity, $title = NULL, $cache = array()) {
 
-    $bundle = tripal_load_bundle_entity(array('name' => $entity->bundle));
+    if (isset($cache['bundle'])) {
+      $bundle = $cache['bundle'];
+    }
+    else {
+      $bundle = tripal_load_bundle_entity(array('name' => $entity->bundle));
+    }
 
     // If no title was supplied then we should try to generate one using the
     // default format set by admins.
@@ -140,18 +150,30 @@ class TripalEntityController extends EntityAPIController {
    *   The alias to use. It can contain tokens the correspond to field values.
    *   Token should be be compatible with those returned by
    *   tripal_get_entity_tokens().
+   * @param $cache
+   *   This array is used to store objects you want to cache for performance reasons,
+   *   as well as, cache related options. The following are supported:
+   *   - TripalBundle $bundle
+   *       The bundle for the current entity.
+   *   - TripalTerm $term
+   *       The term for the current entity.
    */
-  public function setAlias($entity, $alias = NULL) {
+  public function setAlias($entity, $alias = NULL, $cache = array()) {
     $source_url = "bio_data/$entity->id";
 
     // If no alias was supplied then we should try to generate one using the
     // default format set by admins.
     if (!$alias) {
 
-      // Load the TripalBundle entity for this TripalEntity.
+      // Load the TripalBundle entity for this TripalEntity (if it's not cached).
       // First get the format for the url alias based on the bundle of the entity.
       // Then replace all the tokens with values from the entity fields.
-      $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      if (isset($cache['bundle'])) {
+        $bundle_entity = $cache['bundle'];
+      }
+      else {
+        $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      }
       $alias = tripal_get_bundle_variable('url_format', $bundle_entity->id);
       $alias = tripal_replace_entity_tokens($alias, $entity, $bundle_entity);
     }
@@ -163,7 +185,7 @@ class TripalEntityController extends EntityAPIController {
       // Load the term for this TripalEntity. Set a default based on the term
       // name and entity id. Then replace all the tokens with values from
       // the entity fields.
-      $term = entity_load('TripalTerm', array('id' => $entity->term_id));
+      $term = (isset($cache['term'])) ? $cache['term'] : entity_load('TripalTerm', array('id' => $entity->term_id));
       $term = reset($term);
       $alias = str_replace(' ', '', $term->name) . '/[TripalEntity__entity_id]';
       $alias = tripal_replace_entity_tokens($alias, $entity, $bundle_entity);
@@ -173,7 +195,12 @@ class TripalEntityController extends EntityAPIController {
     // this TripalEntity. Then replace all the tokens with values from the
     // entity fields.
     if($alias && (preg_match_all("/\[[^\]]*\]/", $alias, $bundle_tokens))) {
-      $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      if (isset($cache['bundle'])) {
+        $bundle_entity = $cache['bundle'];
+      }
+      else {
+        $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      }
       $alias = tripal_replace_entity_tokens($alias, $entity, $bundle_entity);
     }
 
@@ -256,7 +283,12 @@ class TripalEntityController extends EntityAPIController {
       // already assigned this alias to this entity in a previous save.
       elseif ($num_aliases == 1) {
 
-        $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+        if (isset($cache['bundle'])) {
+          $bundle_entity = $cache['bundle'];
+        }
+        else {
+          $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+        }
 
         // Check to see if the single alias is for the same entity and if not
         // warn the admin that the alias is already used (ie: not unique?)
@@ -284,7 +316,12 @@ class TripalEntityController extends EntityAPIController {
       // If there are more then one alias' matching what we generated then there's
       // a real problem and we need to warn the administrator.
       else {
-        $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+        if (isset($cache['bundle'])) {
+          $bundle_entity = $cache['bundle'];
+        }
+        else {
+          $bundle_entity = tripal_load_bundle_entity(array('name' => $entity->bundle));
+        }
 
         $aliases = db_query('SELECT source FROM {url_alias} WHERE alias=:alias',
           array(':alias' => $alias))->fetchAll();
@@ -317,29 +354,33 @@ class TripalEntityController extends EntityAPIController {
    *
    * @param $entity
    *   A TripalEntity object to save.
-   * @param $transaction
-   *   If you have a transaction open, you can pass it through to avoid the overhead of
-   *   creating nested transactions.
-   * @param $clear_cached_fields
-   *   Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
-   *   must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
-   *   The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
+   * @param $cache
+   *   This array is used to store objects you want to cache for performance reasons,
+   *   as well as, cache related options. The following are supported:
+   *   - DatabaseTransaction $transaction
+   *       Allows you to pass in your current transaction to save nested transaction overhead.
+   *   - boolean $clear_cached_fields
+   *       Clearing cached fields is NECESSARY. IF you choose to set this to false then YOU
+   *       must clear the cache yourself using cache_clear_all('field:TripalEntity:[entity_id]', 'cache_field', TRUE).
+   *       The only known reason to set this to FALSE is to clear the cache in bulk for perfomance reasons.
+   *   - TripalBundle $bundle
+   *       The bundle for the current entity.
+   *   - TripalTerm $term
+   *       The term for the current entity.
    *
    * @return
    *   The saved entity object with updated properties.
    */
-  public function save($entity, DatabaseTransaction $transaction = NULL, $clear_cached_fields = TRUE) {
+  public function save($entity, $cache = array()) {
     global $user;
     $pkeys = array();
 
-    // @performance remove after development
-    // @performance $started_at = microtime(true);
+    if (!isset($cache['clear_cached_fields'])) $cache['clear_cached_fields'] = TRUE;
 
     $changed_date = time();
     $create_date = $changed_date;
     if (property_exists($entity, 'created')) {
       if (!is_numeric($entity->created)) {
-        print "IM CREATING A DATE!\n";
         $temp = new DateTime($entity->created);
         $create_date = $temp->getTimestamp();
       }
@@ -352,7 +393,7 @@ class TripalEntityController extends EntityAPIController {
       }
     }
 
-    $transaction = isset($transaction) ? $transaction : db_transaction();
+    $transaction = isset($cache['transaction']) ? $cache['transaction'] : db_transaction();
     try {
       // If our entity has no id, then we need to give it a
       // time of creation.
@@ -370,8 +411,6 @@ class TripalEntityController extends EntityAPIController {
 
       // Invoke hook_entity_presave().
       module_invoke_all('entity_presave', $entity, $entity->type);
-
-      // @performance print '      - After entity_presave :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
       // Write out the entity record.
       $record = array(
@@ -395,8 +434,6 @@ class TripalEntityController extends EntityAPIController {
         $entity->id = $record['id'];
       }
 
-      // @performance print '      - After drupal_write_record :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
-
       // Now we need to either insert or update the fields which are
       // attached to this entity. We use the same primary_keys logic
       // to determine whether to update or insert, and which hook we
@@ -404,7 +441,6 @@ class TripalEntityController extends EntityAPIController {
       // This is because a field may have default values and if so, those fields
       // will be attached and the storage backend may then try to insert
       // fields which should not be inserted because they already exist.
-      // @performance print "      - Invocation: $invocation.\n";
       if ($invocation == 'entity_insert') {
         field_attach_insert('TripalEntity', $entity);
       }
@@ -413,27 +449,18 @@ class TripalEntityController extends EntityAPIController {
       }
 
       // Set the title for this entity.
-      $this->setTitle($entity);
-
-      // @performance print '      - After setTitle :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+      $this->setTitle($entity, NULL, $cache);
 
       // Set the path/url alias for this entity.
-      $this->setAlias($entity);
-
-      // @performance print '      - After setAlias :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
+      $this->setAlias($entity, NULL, $cache);
 
       // Invoke either hook_entity_update() or hook_entity_insert().
       module_invoke_all('entity_postsave', $entity, $entity->type);
-
-      // @performance print '      - After entity_postsave :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
-
       module_invoke_all($invocation, $entity, $entity->type);
-
-      // @performance print "      - After $invocation :" . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
       // Clear any cache entries for this entity so it can be reloaded using
       // the values that were just saved.
-      if ($clear_cached_fields) {
+      if ($cache['clear_cached_fields']) {
         $cid = 'field:TripalEntity:' . $entity->id;
         cache_clear_all($cid, 'cache_field', TRUE);
       }
@@ -446,8 +473,6 @@ class TripalEntityController extends EntityAPIController {
       drupal_set_message("Could not save the entity: " . $e->getMessage(), "error");
       return FALSE;
     }
-
-
   }
 
   /**

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -55,6 +55,9 @@ function chado_publish_records($values, $job_id = NULL) {
     $report_progress = TRUE;
   }
 
+  // Start an array for caching objects to save performance.
+  $cache = array();
+
   // Make sure we have the required options: bundle_name.
   if (!array_key_exists('bundle_name', $values) or !$values['bundle_name']) {
     tripal_report_error('tripal_chado', TRIPAL_ERROR,
@@ -73,11 +76,10 @@ function chado_publish_records($values, $job_id = NULL) {
   // to be processed per chunk is set here:
   $chunk_size = 500;
 
-  // @performance remove after development: 0.00059294700622559s
-
   // Load the bundle entity so we can get information about which Chado
   // table/field this entity belongs to.
   $bundle = tripal_load_bundle_entity(array('name' => $bundle_name));
+  $cache['bundle'] = $bundle;
   if (!$bundle) {
     tripal_report_error('tripal_chado', TRIPAL_ERROR,
         "Unknown bundle. Could not publish record: @error",
@@ -85,8 +87,6 @@ function chado_publish_records($values, $job_id = NULL) {
     return FALSE;
   }
   $chado_entity_table = chado_get_bundle_entity_table($bundle);
-
-  // @performance remove after development: 0.05065393447876s
 
   // Get the mapping of the bio data type to the Chado table.
   $chado_bundle = db_select('chado_bundle', 'cb')
@@ -100,19 +100,19 @@ function chado_publish_records($values, $job_id = NULL) {
     return FALSE;
   }
 
+  // Load the term for use in setting the alias for each entity created.
+  $term = entity_load('TripalTerm', array('id' => $entity->term_id));
+  $cache['term'] = $term;
+
   $table = $chado_bundle->data_table;
   $type_column = $chado_bundle->type_column;
   $type_linker_table = $chado_bundle->type_linker_table;
   $cvterm_id  = $chado_bundle->type_id;
   $type_value = $chado_bundle->type_value;
 
-  // @performance remove after development:0.051163911819458s
-
   // Get the table information for the Chado table.
   $table_schema = chado_get_schema($table);
   $pkey_field = $table_schema['primary key'][0];
-
-  // @performance remove after development:0.05134105682373s
 
   // Construct the SQL for identifying which records should be published.
   // @performance find a way to optimize this?
@@ -198,17 +198,12 @@ function chado_publish_records($values, $job_id = NULL) {
     }
   }
 
-  // @performance remove after development:0.060441970825195s
-
   // First get the count
   // @performance optimize, estimate or remove this. It's only used for reporting progress on the command-line.
   $sql = "SELECT count(*) as num_records " . $from . $where;
   $result = chado_query($sql, $args);
   $count = $result->fetchField();
   print "\nThere are $count records to publish.\n";
-
-  // @performance remove after development:0.25212502479553s
-  // @performance print 'Count amount to do :' . (microtime(true) - $started_at) . "s.\n";
 
   print "\nNOTE: publishing records is performed using database transactions. If the job fails\n" .
           "or is terminated prematurely then the current set of $chunk_size is rolled back with\n" .
@@ -246,22 +241,17 @@ function chado_publish_records($values, $job_id = NULL) {
     // transactions. A better albeit more complicated approach might be to break the job into
     // chunks where each one is a single transaction.
     $transaction = db_transaction();
+    $cache['transaction'] = $transaction;
 
     try {
       $i = 0;
       while($record = $records->fetchObject()) {
-
-        // @performance remove after development
-        // @performance print 'Start current entity :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
         // First save the tripal_entity record.
         // @performace This is likely a bottleneck. Too bad we can't create
         // multiple entities at once... sort of like the copy method.
         $record_id = $record->record_id;
         $ec = entity_get_controller('TripalEntity');
-
-        // @performance remove after development
-        // @performance print '  - After get controller :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
         $entity = $ec->create(array(
           'bundle' => $bundle_name,
@@ -275,22 +265,14 @@ function chado_publish_records($values, $job_id = NULL) {
           'bundle_object' => $bundle,
         ));
 
-        // @performance remove after development
-        // @performance print '  - After tripal_chado_entity_create() :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
-
         // We pass in the transaction and tell save not to clear the field cache for
         // for performance reasons. We will clear the field cache in bulk below.
         // @todo clear the field cache in bulk below ;-p
-        $entity = $entity->save($transaction, FALSE);
+        $cache['clear_cached_fields'] = FALSE;
+        $entity = $entity->save($cache);
         if (!$entity) {
           throw new Exception('Could not create entity.');
         }
-
-        // @performance remove after development
-        // @performance print '  - After entity save :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
-
-          // @performance remove after development: this takes 0.2-0.3s.
-          //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";
 
         // Next save the chado entity record.
         $entity_record = array(
@@ -309,9 +291,6 @@ function chado_publish_records($values, $job_id = NULL) {
         if(!$result){
           throw new Exception('Could not create mapping of entity to Chado record.');
         }
-
-        // @performance remove after development: this takes <0.001s.
-        // @performance print '  - Relate back to chado :' . number_format(microtime(true) - $started_at,4) . "s.\n";
 
         $i++;
         $total_published++;
@@ -334,11 +313,7 @@ function chado_publish_records($values, $job_id = NULL) {
     unset($transaction);
   }
 
-  drupal_set_message("Succesfully published $i " . $bundle->label . " record(s).");
-
-  // @performance remove after development
-  // @performance print 'Complete! Runtime:' . number_format(microtime(true) - $started_at) . " seconds.\n";
-
+  drupal_set_message("Succesfully published $total_published " . $bundle->label . " record(s).");
   return TRUE;
 }
 

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -231,8 +231,12 @@ function chado_publish_records($values, $job_id = NULL) {
         $total_published, $count, $complete * 3, number_format(memory_get_usage()), number_format((microtime(true) - $started_at)/60, 2));
     }
 
+    // There is no need to cache transactions since Drupal handles nested transactions
+    // "by performing no transactional operations (as far as the database sees) within
+    // the inner nesting layers". Effectively, Drupal ensures nested trasactions work the
+    // same as passing a transaction through to the deepest level and not starting a new
+    // transaction if we are already in one.
     $transaction = db_transaction();
-    $cache['transaction'] = $transaction;
 
     try {
       $i = 0;

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -252,7 +252,7 @@ function chado_publish_records($values, $job_id = NULL) {
       while($record = $records->fetchObject()) {
 
         // @performance remove after development
-        // print 'Start current entity :' . (microtime(true) - $started_at) . "s.\n";
+        // @performance print 'Start current entity :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
         // First save the tripal_entity record.
         // @performace This is likely a bottleneck. Too bad we can't create
@@ -261,7 +261,7 @@ function chado_publish_records($values, $job_id = NULL) {
         $ec = entity_get_controller('TripalEntity');
 
         // @performance remove after development
-        // print 'After get controller :' . (microtime(true) - $started_at) . "s.\n";
+        // @performance print '  - After get controller :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
         $entity = $ec->create(array(
           'bundle' => $bundle_name,
@@ -276,15 +276,18 @@ function chado_publish_records($values, $job_id = NULL) {
         ));
 
         // @performance remove after development
-        // print 'After tripal_chado_entity_create() :' . (microtime(true) - $started_at) . "s.\n";
+        // @performance print '  - After tripal_chado_entity_create() :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
-        $entity = $entity->save();
+        // We pass in the transaction and tell save not to clear the field cache for
+        // for performance reasons. We will clear the field cache in bulk below.
+        // @todo clear the field cache in bulk below ;-p
+        $entity = $entity->save($transaction, FALSE);
         if (!$entity) {
           throw new Exception('Could not create entity.');
         }
 
         // @performance remove after development
-        // print 'After entity save :' . (microtime(true) - $started_at) . "s.\n";
+        // @performance print '  - After entity save :' . number_format(microtime(true) - $started_at, 4) . "s.\n";
 
           // @performance remove after development: this takes 0.2-0.3s.
           //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";
@@ -308,7 +311,7 @@ function chado_publish_records($values, $job_id = NULL) {
         }
 
         // @performance remove after development: this takes <0.001s.
-        // print 'Relate back to chado :' . (microtime(true) - $started_at) . "s.\n";
+        // @performance print '  - Relate back to chado :' . number_format(microtime(true) - $started_at,4) . "s.\n";
 
         $i++;
         $total_published++;
@@ -332,8 +335,10 @@ function chado_publish_records($values, $job_id = NULL) {
   }
 
   drupal_set_message("Succesfully published $i " . $bundle->label . " record(s).");
-    // @performance remove after development
-  print 'Complete! Runtime:' . number_format(microtime(true) - $started_at) . " seconds.\n";
+
+  // @performance remove after development
+  // @performance print 'Complete! Runtime:' . number_format(microtime(true) - $started_at) . " seconds.\n";
+
   return TRUE;
 }
 

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -227,17 +227,10 @@ function chado_publish_records($values, $job_id = NULL) {
     // @performance print 'Perform Query :' . (microtime(true) - $started_at) . "s.\n\n";
     $records = chado_query($sql, $args);
 
-    // @performance evaluate this transaction. Long running transactions can have serious
-    // performance issues in PostgreSQL. One option is to move the transaction within the
-    // loop so that each one is not very long but then we end up with more overhead creating
-    // transactions. A better albeit more complicated approach might be to break the job into
-    // chunks where each one is a single transaction.
-    $transaction = db_transaction();
-
-    // update the job status every chunk start.
+    // Update the job status every chunk start.
+    // Because this is outside of hte transaction, we can update the admin through the jobs UI.
     $complete = ($total_published / $count) * 33.33333333;
-    // Currently don't support setting job progress within a transaction.
-    // if ($report_progress) { $job->setProgress(intval($complete * 3)); }
+    if ($report_progress) { $job->setProgress(intval($complete * 3)); }
     if ($total_published === 0) {
       printf("%d of %d records. (%0.2f%%) Memory: %s bytes.\r",
         $i, $count, 0, number_format(memory_get_usage()), 0);
@@ -246,6 +239,13 @@ function chado_publish_records($values, $job_id = NULL) {
       printf("%d of %d records. (%0.2f%%) Memory: %s bytes; Current run time: %s minutes.\r",
         $total_published, $count, $complete * 3, number_format(memory_get_usage()), number_format((microtime(true) - $started_at)/60, 2));
     }
+
+    // @performance evaluate this transaction. Long running transactions can have serious
+    // performance issues in PostgreSQL. One option is to move the transaction within the
+    // loop so that each one is not very long but then we end up with more overhead creating
+    // transactions. A better albeit more complicated approach might be to break the job into
+    // chunks where each one is a single transaction.
+    $transaction = db_transaction();
 
     try {
       $i = 0;

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -39,7 +39,7 @@
  */
 function chado_publish_records($values, $job_id = NULL) {
 
-  // @performance remove after development
+  // Used for adding runtime to the progress report.
   $started_at = microtime(true);
 
   // We want the job object in order to report progress.
@@ -115,7 +115,6 @@ function chado_publish_records($values, $job_id = NULL) {
   $pkey_field = $table_schema['primary key'][0];
 
   // Construct the SQL for identifying which records should be published.
-  // @performance find a way to optimize this?
   $args = array();
   $select = "SELECT T.$pkey_field as record_id ";
   $from = "
@@ -217,9 +216,6 @@ function chado_publish_records($values, $job_id = NULL) {
   $total_published = 0;
   while ($more_records_to_publish) {
 
-    // @performance remove after development:0.43729090690613s
-    // @performance limiting this query DRASTICALLY decreases query execution time: 0.26s
-    // @performance print 'Perform Query :' . (microtime(true) - $started_at) . "s.\n\n";
     $records = chado_query($sql, $args);
 
     // Update the job status every chunk start.
@@ -235,11 +231,6 @@ function chado_publish_records($values, $job_id = NULL) {
         $total_published, $count, $complete * 3, number_format(memory_get_usage()), number_format((microtime(true) - $started_at)/60, 2));
     }
 
-    // @performance evaluate this transaction. Long running transactions can have serious
-    // performance issues in PostgreSQL. One option is to move the transaction within the
-    // loop so that each one is not very long but then we end up with more overhead creating
-    // transactions. A better albeit more complicated approach might be to break the job into
-    // chunks where each one is a single transaction.
     $transaction = db_transaction();
     $cache['transaction'] = $transaction;
 
@@ -265,10 +256,6 @@ function chado_publish_records($values, $job_id = NULL) {
           'bundle_object' => $bundle,
         ));
 
-        // We pass in the transaction and tell save not to clear the field cache for
-        // for performance reasons. We will clear the field cache in bulk below.
-        // @todo clear the field cache in bulk below ;-p
-        $cache['clear_cached_fields'] = FALSE;
         $entity = $entity->save($cache);
         if (!$entity) {
           throw new Exception('Could not create entity.');

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -4,7 +4,7 @@
  * @file
  *
  * This file contains miscellaneous API functions specific to working with
- * records in Chado that do not have a home in any other sub category of 
+ * records in Chado that do not have a home in any other sub category of
  * API functions.
  */
 
@@ -12,9 +12,9 @@
  * @defgroup tripal_chado_api Chado
  *
  * @ingroup tripal_api
- * The Tripal Chado API is a set of functions for interacting with data 
+ * The Tripal Chado API is a set of functions for interacting with data
  * inside of a Chado relational database. Entities (or pages) in Drupal
- * that are provided by Tripal can supply data from any supported database 
+ * that are provided by Tripal can supply data from any supported database
  * back-end, and Chado is the default. This API contains a variety of sub
  * categories (or groups) where functions are organized.  Any extension module
  * that desires to work with data in Chado will find these functions useful.
@@ -38,6 +38,9 @@
  * @ingroup tripal_chado_api
  */
 function chado_publish_records($values, $job_id = NULL) {
+
+  // @performance remove after development
+  $started_at = microtime(true);
 
   // We want the job object in order to report progress.
   if (is_object($job_id)) {
@@ -65,6 +68,8 @@ function chado_publish_records($values, $job_id = NULL) {
   $filters = array_key_exists('filters', $values) ? $values['filters'] : array();
   $sync_node = array_key_exists('sync_node', $values) ? $values['sync_node'] : '';
 
+  // @performance remove after development: 0.00059294700622559s
+
   // Load the bundle entity so we can get information about which Chado
   // table/field this entity belongs to.
   $bundle = tripal_load_bundle_entity(array('name' => $bundle_name));
@@ -76,6 +81,7 @@ function chado_publish_records($values, $job_id = NULL) {
   }
   $chado_entity_table = chado_get_bundle_entity_table($bundle);
 
+  // @performance remove after development: 0.05065393447876s
 
   // Get the mapping of the bio data type to the Chado table.
   $chado_bundle = db_select('chado_bundle', 'cb')
@@ -95,11 +101,16 @@ function chado_publish_records($values, $job_id = NULL) {
   $cvterm_id  = $chado_bundle->type_id;
   $type_value = $chado_bundle->type_value;
 
+  // @performance remove after development:0.051163911819458s
+
   // Get the table information for the Chado table.
   $table_schema = chado_get_schema($table);
   $pkey_field = $table_schema['primary key'][0];
 
+  // @performance remove after development:0.05134105682373s
+
   // Construct the SQL for identifying which records should be published.
+  // @performance find a way to optimize this?
   $args = array();
   $select = "SELECT T.$pkey_field as record_id ";
   $from = "
@@ -181,7 +192,11 @@ function chado_publish_records($values, $job_id = NULL) {
       }
     }
   }
+
+  // @performance remove after development:0.060441970825195s
+
   // First get the count
+  // @performance optimize, estimate or remove this. It's only used for reporting progress on the command-line.
   $sql = "SELECT count(*) as num_records " . $from . $where;
   $result = chado_query($sql, $args);
   $count = $result->fetchField();
@@ -192,9 +207,21 @@ function chado_publish_records($values, $job_id = NULL) {
     $interval = 1;
   }
 
+  // @performance remove after development:0.25212502479553s
+  print 'Count amount to do :' . (microtime(true) - $started_at) . "s.\n";
+
   // Perform the query.
   $sql = $select . $from . $where;
   $records = chado_query($sql, $args);
+
+  // @performance remove after development:0.43729090690613s
+  print 'Perform Query :' . (microtime(true) - $started_at) . "s.\n";
+
+  // @performance evaluate this transaction. Long running transactions can have serious
+  // performance issues in PostgreSQL. One option is to move the transaction within the
+  // loop so that each one is not very long but then we end up with more overhead creating
+  // transactions. A better albeit more complicated approach might be to break the job into
+  // chunks where each one is a single transaction.
   $transaction = db_transaction();
 
   print "\nNOTE: publishing records is performed using a database transaction. \n" .
@@ -206,6 +233,9 @@ function chado_publish_records($values, $job_id = NULL) {
   try {
     while($record = $records->fetchObject()) {
 
+      // @performance remove after development
+      print 'Start current entity :' . (microtime(true) - $started_at) . "s.\n";
+
       // update the job status every interval
       if ($i % $interval == 0) {
         $complete = ($i / $count) * 33.33333333;
@@ -215,6 +245,8 @@ function chado_publish_records($values, $job_id = NULL) {
       }
 
       // First save the tripal_entity record.
+      // @performace This is likely a bottleneck. Too bad we can't create
+      // multiple entities at once... sort of like the copy method.
       $record_id = $record->record_id;
       $ec = entity_get_controller('TripalEntity');
       $entity = $ec->create(array(
@@ -223,6 +255,7 @@ function chado_publish_records($values, $job_id = NULL) {
         // Add in the Chado details for when the hook_entity_create()
         // is called and our tripal_chado_entity_create() implementation
         // can deal with it.
+        // @performance maybe there is something we can easily do here?
         'chado_record' => chado_generate_var($table, array($pkey_field => $record_id)),
         'chado_record_id' => $record_id,
         'publish' => TRUE,
@@ -231,6 +264,9 @@ function chado_publish_records($values, $job_id = NULL) {
       if (!$entity) {
         throw new Exception('Could not create entity.');
       }
+
+        // @performance remove after development: this takes 0.2-0.3s.
+        //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";
 
       // Next save the chado entity record.
       $entity_record = array(
@@ -250,6 +286,9 @@ function chado_publish_records($values, $job_id = NULL) {
         throw new Exception('Could not create mapping of entity to Chado record.');
       }
 
+      // @performance remove after development: this takes <0.001s.
+      // print 'Relate back to chado :' . (microtime(true) - $started_at) . "s.\n";
+
       $i++;
     }
   }
@@ -261,6 +300,8 @@ function chado_publish_records($values, $job_id = NULL) {
     return FALSE;
   }
   drupal_set_message("Succesfully published $i " . $bundle->label . " record(s).");
+    // @performance remove after development
+  print 'Complete :' . (microtime(true) - $started_at) . "s.\n";
   return TRUE;
 }
 
@@ -271,7 +312,7 @@ function chado_publish_records($values, $job_id = NULL) {
  *    The name of a base table in Chado.
  * @return
  *    An array of tokens where the key is the machine_name of the token.
- * 
+ *
  * @ingroup tripal_chado_api
  */
 function chado_get_tokens($base_table) {
@@ -329,7 +370,7 @@ function chado_get_tokens($base_table) {
  *
  * @return
  *   The string will all tokens replaced with values.
- * 
+ *
  *  @ingroup tripal_chado_api
  */
 function chado_replace_tokens($string, $record) {

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -68,6 +68,11 @@ function chado_publish_records($values, $job_id = NULL) {
   $filters = array_key_exists('filters', $values) ? $values['filters'] : array();
   $sync_node = array_key_exists('sync_node', $values) ? $values['sync_node'] : '';
 
+  // We want to break the number of records to publish into chunks in order to ensure
+  // transactions do not run for too long (performance issue). The number of records
+  // to be processed per chunk is set here:
+  $chunk_size = 500;
+
   // @performance remove after development: 0.00059294700622559s
 
   // Load the bundle entity so we can get information about which Chado
@@ -200,108 +205,124 @@ function chado_publish_records($values, $job_id = NULL) {
   $sql = "SELECT count(*) as num_records " . $from . $where;
   $result = chado_query($sql, $args);
   $count = $result->fetchField();
-
-  // calculate the interval for updates
-  $interval = intval($count / 50);
-  if ($interval < 1) {
-    $interval = 1;
-  }
+  print "\nThere are $count records to publish.\n";
 
   // @performance remove after development:0.25212502479553s
-  print 'Count amount to do :' . (microtime(true) - $started_at) . "s.\n";
+  // @performance print 'Count amount to do :' . (microtime(true) - $started_at) . "s.\n";
+
+  print "\nNOTE: publishing records is performed using database transactions. If the job fails\n" .
+          "or is terminated prematurely then the current set of $chunk_size is rolled back with\n" .
+          "no changes to the database. Simply re-run the publishing job to publish any remaining\n".
+          "content after fixing the issue that caused the job to fail.\n\n" .
+          "Also, the following progress only updates every $chunk_size records.\n";
 
   // Perform the query.
-  $sql = $select . $from . $where;
-  $records = chado_query($sql, $args);
+  $sql = $select . $from . $where . ' LIMIT '.$chunk_size;
+  $more_records_to_publish = TRUE;
+  $total_published = 0;
+  while ($more_records_to_publish) {
 
-  // @performance remove after development:0.43729090690613s
-  print 'Perform Query :' . (microtime(true) - $started_at) . "s.\n";
+    // @performance remove after development:0.43729090690613s
+    // @performance limiting this query DRASTICALLY decreases query execution time: 0.26s
+    // @performance print 'Perform Query :' . (microtime(true) - $started_at) . "s.\n\n";
+    $records = chado_query($sql, $args);
 
-  // @performance evaluate this transaction. Long running transactions can have serious
-  // performance issues in PostgreSQL. One option is to move the transaction within the
-  // loop so that each one is not very long but then we end up with more overhead creating
-  // transactions. A better albeit more complicated approach might be to break the job into
-  // chunks where each one is a single transaction.
-  $transaction = db_transaction();
+    // @performance evaluate this transaction. Long running transactions can have serious
+    // performance issues in PostgreSQL. One option is to move the transaction within the
+    // loop so that each one is not very long but then we end up with more overhead creating
+    // transactions. A better albeit more complicated approach might be to break the job into
+    // chunks where each one is a single transaction.
+    $transaction = db_transaction();
 
-  print "\nNOTE: publishing records is performed using a database transaction. \n" .
-      "If the load fails or is terminated prematurely then the entire set of \n" .
-      "is rolled back with no changes to the database\n\n";
-
-  $i = 0;
-  printf("%d of %d records. (%0.2f%%) Memory: %s bytes\r", $i, $count, 0, number_format(memory_get_usage()));
-  try {
-    while($record = $records->fetchObject()) {
-
-      // @performance remove after development
-      print 'Start current entity :' . (microtime(true) - $started_at) . "s.\n";
-
-      // update the job status every interval
-      if ($i % $interval == 0) {
-        $complete = ($i / $count) * 33.33333333;
-        // Currently don't support setting job progress within a transaction.
-        // if ($report_progress) { $job->setProgress(intval($complete * 3)); }
-        printf("%d of %d records. (%0.2f%%) Memory: %s bytes\r", $i, $count, $complete * 3, number_format(memory_get_usage()));
-      }
-
-      // First save the tripal_entity record.
-      // @performace This is likely a bottleneck. Too bad we can't create
-      // multiple entities at once... sort of like the copy method.
-      $record_id = $record->record_id;
-      $ec = entity_get_controller('TripalEntity');
-      $entity = $ec->create(array(
-        'bundle' => $bundle_name,
-        'term_id' => $bundle->term_id,
-        // Add in the Chado details for when the hook_entity_create()
-        // is called and our tripal_chado_entity_create() implementation
-        // can deal with it.
-        // @performance maybe there is something we can easily do here?
-        'chado_record' => chado_generate_var($table, array($pkey_field => $record_id)),
-        'chado_record_id' => $record_id,
-        'publish' => TRUE,
-      ));
-      $entity = $entity->save();
-      if (!$entity) {
-        throw new Exception('Could not create entity.');
-      }
-
-        // @performance remove after development: this takes 0.2-0.3s.
-        //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";
-
-      // Next save the chado entity record.
-      $entity_record = array(
-        'entity_id' => $entity->id,
-        'record_id' => $record_id,
-      );
-
-      // For the Tv2 to Tv3 migration we want to add the nid to the
-      // entity so we can associate the node with the entity.
-      if (property_exists($record, 'nid')) {
-        $entity_record['nid'] = $record->nid;
-      }
-      $result = db_insert($chado_entity_table)
-        ->fields($entity_record)
-        ->execute();
-      if(!$result){
-        throw new Exception('Could not create mapping of entity to Chado record.');
-      }
-
-      // @performance remove after development: this takes <0.001s.
-      // print 'Relate back to chado :' . (microtime(true) - $started_at) . "s.\n";
-
-      $i++;
+    // update the job status every chunk start.
+    $complete = ($total_published / $count) * 33.33333333;
+    // Currently don't support setting job progress within a transaction.
+    // if ($report_progress) { $job->setProgress(intval($complete * 3)); }
+    if ($total_published === 0) {
+      printf("%d of %d records. (%0.2f%%) Memory: %s bytes.\r",
+        $i, $count, 0, number_format(memory_get_usage()), 0);
     }
+    else {
+      printf("%d of %d records. (%0.2f%%) Memory: %s bytes; Current run time: %s minutes.\r",
+        $total_published, $count, $complete * 3, number_format(memory_get_usage()), number_format((microtime(true) - $started_at)/60, 2));
+    }
+
+    try {
+      $i = 0;
+      while($record = $records->fetchObject()) {
+
+        // @performance remove after development
+        // print 'Start current entity :' . (microtime(true) - $started_at) . "s.\n";
+
+        // First save the tripal_entity record.
+        // @performace This is likely a bottleneck. Too bad we can't create
+        // multiple entities at once... sort of like the copy method.
+        $record_id = $record->record_id;
+        $ec = entity_get_controller('TripalEntity');
+        $entity = $ec->create(array(
+          'bundle' => $bundle_name,
+          'term_id' => $bundle->term_id,
+          // Add in the Chado details for when the hook_entity_create()
+          // is called and our tripal_chado_entity_create() implementation
+          // can deal with it.
+          // @performance maybe there is something we can easily do here?
+          'chado_record' => chado_generate_var($table, array($pkey_field => $record_id)),
+          'chado_record_id' => $record_id,
+          'publish' => TRUE,
+        ));
+        $entity = $entity->save();
+        if (!$entity) {
+          throw new Exception('Could not create entity.');
+        }
+
+          // @performance remove after development: this takes 0.2-0.3s.
+          //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";
+
+        // Next save the chado entity record.
+        $entity_record = array(
+          'entity_id' => $entity->id,
+          'record_id' => $record_id,
+        );
+
+        // For the Tv2 to Tv3 migration we want to add the nid to the
+        // entity so we can associate the node with the entity.
+        if (property_exists($record, 'nid')) {
+          $entity_record['nid'] = $record->nid;
+        }
+        $result = db_insert($chado_entity_table)
+          ->fields($entity_record)
+          ->execute();
+        if(!$result){
+          throw new Exception('Could not create mapping of entity to Chado record.');
+        }
+
+        // @performance remove after development: this takes <0.001s.
+        // print 'Relate back to chado :' . (microtime(true) - $started_at) . "s.\n";
+
+        $i++;
+        $total_published++;
+      }
+    }
+    catch (Exception $e) {
+      $transaction->rollback();
+      $error = $e->getMessage();
+      tripal_report_error('tripal_chado', TRIPAL_ERROR, "Could not publish record: @error", array('@error' => $error));
+      drupal_set_message('Failed publishing record. See recent logs for more details.', 'error');
+      return FALSE;
+    }
+
+    // If we get through the loop and haven't completed 100 records, then we're done!
+    if ($i < $chunk_size) {
+      $more_records_to_publish = FALSE;
+    }
+
+    // Commit our current chunk.
+    unset($transaction);
   }
-  catch (Exception $e) {
-    $transaction->rollback();
-    $error = $e->getMessage();
-    tripal_report_error('tripal_chado', TRIPAL_ERROR, "Could not publish record: @error", array('@error' => $error));
-    drupal_set_message('Failed publishing record. See recent logs for more details.', 'error');
-    return FALSE;
-  }
+
   drupal_set_message("Succesfully published $i " . $bundle->label . " record(s).");
     // @performance remove after development
-  print 'Complete :' . (microtime(true) - $started_at) . "s.\n";
+  print 'Complete! Runtime:' . number_format(microtime(true) - $started_at) . " seconds.\n";
   return TRUE;
 }
 

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -259,21 +259,32 @@ function chado_publish_records($values, $job_id = NULL) {
         // multiple entities at once... sort of like the copy method.
         $record_id = $record->record_id;
         $ec = entity_get_controller('TripalEntity');
+
+        // @performance remove after development
+        // print 'After get controller :' . (microtime(true) - $started_at) . "s.\n";
+
         $entity = $ec->create(array(
           'bundle' => $bundle_name,
           'term_id' => $bundle->term_id,
           // Add in the Chado details for when the hook_entity_create()
           // is called and our tripal_chado_entity_create() implementation
           // can deal with it.
-          // @performance maybe there is something we can easily do here?
-          'chado_record' => chado_generate_var($table, array($pkey_field => $record_id)),
+          'chado_record' => chado_generate_var($table, array($pkey_field => $record_id), array('include_fk' => 0)),
           'chado_record_id' => $record_id,
           'publish' => TRUE,
+          'bundle_object' => $bundle,
         ));
+
+        // @performance remove after development
+        // print 'After tripal_chado_entity_create() :' . (microtime(true) - $started_at) . "s.\n";
+
         $entity = $entity->save();
         if (!$entity) {
           throw new Exception('Could not create entity.');
         }
+
+        // @performance remove after development
+        // print 'After entity save :' . (microtime(true) - $started_at) . "s.\n";
 
           // @performance remove after development: this takes 0.2-0.3s.
           //print 'Create entity itself :' . (microtime(true) - $started_at) . "s.\n";

--- a/tripal_chado/includes/tripal_chado.entity.inc
+++ b/tripal_chado/includes/tripal_chado.entity.inc
@@ -7,8 +7,15 @@
  * This hook is called when brand new entities are created, but
  * they are not loaded so the hook_entity_load() is not yet called. We
  * can use this hook to add properties to the entity before saving.
+ *
+ * @param $entity
+ *   The entity being created.
+ * @param $type
+ *   The type of entity being created.
+ * @param $bundle (OPTIONAL)
+ *   The bundle object for the current entity.
  */
-function tripal_chado_entity_create(&$entity, $type) {
+function tripal_chado_entity_create(&$entity, $type, $bundle = NULL) {
   if ($type == 'TripalEntity') {
 
     // Set some defaults on vars needed by this module.
@@ -18,7 +25,9 @@ function tripal_chado_entity_create(&$entity, $type) {
       $entity->chado_linker = NULL;
 
       // Add in the Chado table information for this entity type.
-      $bundle = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      if (!$bundle) {
+        $bundle = tripal_load_bundle_entity(array('name' => $entity->bundle));
+      }
       if ($bundle->data_table) {
         $entity->chado_table = $bundle->data_table;
         $entity->chado_column = $bundle->type_column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #530 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR optimizes the performance of Publishing Tripal Content. Specifically, I see a performance increase from 2.6 minutes to 1.17 minutes to publish 500 entities. Furthermore, publishing no longer grinds my site to a halt but instead there seems to be barely an impact to users.

Optimizations done:
- The bundle  and term objects were being loaded (4 and 1 time(s) respectively) per entity published. This is now cached by loading it once at the beginning of the publish job and then passing it to $entity->create(), $entity->save(), $entity->setAlias(), and $entity->setTitle() through a generic $cache variable. In all cases, I still load the bundle/term if it's not set in the cache making this a backwards compatible change.
- ~~There were nested transactions (publish and $entity->save) which caused unnecessary overhead. Instead I used the same $cache variable to pass the transaction through the save process.~~
- The Drupal Field cache is cleared for each entity saved to ensure new values can be loaded. However, during publish we don't attach fields so I added a conditional to ensure this cache isn't cleared during publish.
- I chunked the publishing process into 500 entity chunks to drastically speed up the select query, limit transaction time and allow reporting of progress to the jobs UI.

Additional Note: There was a comment in $entity->setAlias() implying `SELECT DISTINCT SUBSTRING_INDEX(source, '/', 1) AS path FROM url_alias` was causing performance issues during publish. I tracked this query down to drupal_path_alias_whitelist_rebuild() but didn't see it called during publish personally. We may want to look into this further.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Navigate to Admin > Tripal Content > Publish Tripal Content
2. Select a Tripal Content Type you have unpublished content for and submit the publishing job.
3. Check that the runtime reported is reasonable. NOTE: It may not be exactly the same as mine since runtime is obviously hardware dependent. Ideally you would have published the same set and timed it without the PR to allow you to compare the numbers.
4. Check that your site doesn't experience performance issues during the publish job.
5. Check that the entities published were created correctly by viewing one from Admin > Tripal Content.

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
