### PR TITLE
Fixed a bug for the API function chado_query()

### DIFF
--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1671,7 +1671,7 @@ function chado_query($sql, $args = array()) {
   // names with 'chado'.
   if ($is_local) {
     // Remove carriage returns from the SQL.
-    $sql = preg_replace('/\n/', '', $sql);
+    $sql = preg_replace('/\n/', ' ', $sql);
 
     // Prefix the tables with their correct schema.
     // Chado tables should be enclosed in curly brackets (ie: {feature} )


### PR DESCRIPTION
Fixed a bug that when an SQL statement spans multiple lines, chado_query() messed up the SQL by removing the carriage returns and caused error. The carriage return should be replaced by at least one space when joining lines.
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
