### PR TITLE
Stop loading the entire entity to check user access

### DIFF
--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -60,7 +60,7 @@ class TripalEntityUIController extends EntityDefaultUIController {
     }
 
     // Link for viewing a tripal data type.
-    $items['bio_data/' . $wildcard] = array(
+    $items['bio_data/%'] = array(
       'title callback' => 'tripal_entity_title',
       'title arguments' => array(1),
       'page callback' => 'tripal_view_entity',
@@ -71,7 +71,7 @@ class TripalEntityUIController extends EntityDefaultUIController {
     );
 
     // 'View' tab for an individual entity page.
-    $items['bio_data/' . $wildcard . '/view'] = array(
+    $items['bio_data/%/view'] = array(
       'title' => 'View',
       'page callback' => 'tripal_view_entity',
       'page arguments' => array(1),
@@ -115,7 +115,20 @@ class TripalEntityUIController extends EntityDefaultUIController {
  * @see hook_entity_view_alter()
  */
 function tripal_view_entity($entity, $view_mode = 'full') {
-   $content = '';
+   if(!is_object($entity)) {
+     $id = intval($entity);
+     if($id === 0) {
+       return drupal_not_found();
+     }
+
+     $entities = tripal_load_entity('TripalEntity', [$id]);
+     if(empty($entities)) {
+       return drupal_not_found();
+     }
+
+     $entity = reset($entities);
+   }
+
    $controller = entity_get_controller($entity->type);
    $content = $controller->view(array($entity->id => $entity));
    drupal_set_title($entity->title);

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -443,7 +443,10 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
   }
   elseif (intval($entity) !== 0) {
     if (!isset($cache)) {
-      $cache = cache_get("tripal_entity_access_cache")->data;
+      $cache = cache_get("tripal_entity_access_cache");
+      if (isset($cache->data)) {
+        $cache = $cache->data;
+      }
     }
 
     if (empty($cache)) {

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -432,20 +432,27 @@ function tripal_field_property_get($entity, array $options, $field_name, $entity
  */
 function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type = NULL) {
   global $user;
+  $cache = &drupal_static(__FUNCTION__, NULL);
+
+  if (!isset($account)) {
+    $account = $user;
+  }
 
   if (is_object($entity)) {
     $bundle_name = $entity->bundle;
   }
   elseif (intval($entity) !== 0) {
-    $sql = 'SELECT {bundle} FROM tripal_entity WHERE id = :id';
-    $bundle_name = db_query($sql, [':id' => $entity])->fetchField();
+    if (!isset($cache) && ($cache = cache_get("tripal_entity_access:$entity")) && !empty($cache->data)) {
+      $bundle_name = $cache->data;
+    }
+    else {
+      $sql = 'SELECT {bundle} FROM tripal_entity WHERE id = :id';
+      $bundle_name = db_query($sql, [':id' => $entity])->fetchField();
+      cache_set("tripal_entity_access:$entity", $bundle_name);
+    }
   }
   else {
     return FALSE;
-  }
-
-  if (!isset($account)) {
-    $account = $user;
   }
 
   if(!$entity_type) {

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -443,7 +443,7 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
   }
   elseif (intval($entity) !== 0) {
     if (!isset($cache)) {
-      $cache = cache_get("tripal_entity_access")->data;
+      $cache = cache_get("tripal_entity_access_cache")->data;
     }
 
     if (empty($cache)) {
@@ -457,7 +457,7 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
       $sql = 'SELECT {bundle} FROM tripal_entity WHERE id = :id';
       $bundle_name = db_query($sql, [':id' => $entity])->fetchField();
       $cache[$entity] = $bundle_name;
-      cache_set("tripal_entity_access", $cache);
+      cache_set("tripal_entity_access_cache", $cache);
     }
   }
   else {

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -433,8 +433,12 @@ function tripal_field_property_get($entity, array $options, $field_name, $entity
 function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type = NULL) {
   global $user;
 
-  if ($entity) {
+  if (is_object($entity)) {
     $bundle_name = $entity->bundle;
+  }
+  elseif (intval($entity) !== 0) {
+    $sql = 'SELECT {bundle} FROM tripal_entity WHERE id = :id';
+    $bundle_name = db_query($sql, [':id' => $entity])->fetchField();
   }
   else {
     return FALSE;
@@ -444,8 +448,12 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
     $account = $user;
   }
 
-  if (!$entity_type) {
-    $entity_type = $entity->type;
+  if(!$entity_type) {
+    if(is_object($entity)) {
+      $entity_type = $entity->type;
+    } else {
+      $entity_type = 'TripalEntity';
+    }
   }
 
   // See if other modules want to adust permissions.

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -442,23 +442,33 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
     $bundle_name = $entity->bundle;
   }
   elseif (intval($entity) !== 0) {
-    if (!isset($cache) && ($cache = cache_get("tripal_entity_access:$entity")) && !empty($cache->data)) {
-      $bundle_name = $cache->data;
+    if (!isset($cache)) {
+      $cache = cache_get("tripal_entity_access")->data;
+    }
+
+    if (empty($cache)) {
+      $cache = [];
+    }
+
+    if (isset($cache[$entity])) {
+      $bundle_name = $cache[$entity];
     }
     else {
       $sql = 'SELECT {bundle} FROM tripal_entity WHERE id = :id';
       $bundle_name = db_query($sql, [':id' => $entity])->fetchField();
-      cache_set("tripal_entity_access:$entity", $bundle_name);
+      $cache[$entity] = $bundle_name;
+      cache_set("tripal_entity_access", $cache);
     }
   }
   else {
     return FALSE;
   }
 
-  if(!$entity_type) {
-    if(is_object($entity)) {
+  if (!$entity_type) {
+    if (is_object($entity)) {
       $entity_type = $entity->type;
-    } else {
+    }
+    else {
       $entity_type = 'TripalEntity';
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #538

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
See issue #538 

This fix preserves backwards compatibility by applying the fix only when an integer is passed to the function instead of an object as expected by the old behavior.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. add `bio_data/#` links to your main menu (structure -> menus -> main menu -> add link)
1. measure the speed of the page (you can use chrome dev tools. The network tab can show waterfall chart detailing how long a page takes to load)
1. the more links added, the slower the page.

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Using this fix we managed to speed up our site loading by 500%. Cache rebuilding used to take 1.2 minutes while with this fix it only takes 13.35 seconds. Visiting the home page before this fix takes 5.55 seconds after the cache has been repopulated, now it takes 813 milliseconds. This data was collected from testing the fix on our [live site](https://hardwoodgenomics.org). 