### PR TITLE
Setting admin permissions on content creation

### DIFF
--- a/tripal/includes/TripalBundleUIController.inc
+++ b/tripal/includes/TripalBundleUIController.inc
@@ -878,10 +878,29 @@ function tripal_admin_access($entity) {
     return FALSE;
   }
 
-  // Identify the administrative user roles.
-  $admin_rid = variable_get('user_admin_role');  
-  $admin_role = user_role_load($admin_rid);
-  $roles = array($admin_role->rid => $admin_role->name);
+  // Get the administrative user roles.
+  $admin_role = NULL;
+  $admin_rid = variable_get('user_admin_role'); 
+  if (!$admin_rid) {
+    // If we couldn't identify a single role from the 'user_admin_role' variable
+    // then let's get the role that is currently set to administer tripal. If
+    // there is more than one then we don't really know which to choose unless
+    // the default rid of '3' is present.
+    $admin_roles = user_roles(FALSE, 'administer tripal');
+    if (count(array_keys($admin_roles)) == 1) {
+      $admin_rid = key($admin_roles);
+    }
+    // The rid 3 is Drupal's default for the admin user.
+    else if (in_array(3, array_keys($admin_roles))) {
+      $admin_rid = 3;
+    }
+  }
+  
+  // If we can't find a unique admin role then just don't add one and
+  // the user will be forced to manually set permissions for the admin.
+  if (!$admin_rid) {
+    return FALSE;
+  }
   
   // Define the permissions.
   $permission_for_role = array(
@@ -890,11 +909,9 @@ function tripal_admin_access($entity) {
     'edit ' . $bundle->name => TRUE,
     'delete ' . $bundle->name => TRUE,
   );
-
+  
   // Assign the permissions
-  foreach($roles as $role => $value){
-    user_role_change_permissions($role, $permission_for_role);
-  }
+  user_role_change_permissions($admin_rid, $permission_for_role);
 
   return TRUE;
 }

--- a/tripal/includes/TripalBundleUIController.inc
+++ b/tripal/includes/TripalBundleUIController.inc
@@ -879,8 +879,10 @@ function tripal_admin_access($entity) {
   }
 
   // Identify the administrative user roles.
-  $admin_role = user_role_load_by_name('administrator');
+  $admin_rid = variable_get('user_admin_role');  
+  $admin_role = user_role_load($admin_rid);
   $roles = array($admin_role->rid => $admin_role->name);
+  
   // Define the permissions.
   $permission_for_role = array(
     'create ' . $bundle->name => TRUE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #562

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
See Issue #562 for a full description of the problem.  But in short, if your admin role is not named 'administrator' then you got errors when trying to create a new content type.  This fixes that problem.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
There is only two lines of code changes for this fix.  It retrieves the admin role from a Drupal variable rather than using a hardcoded 'administrator' role name.  To test it, make sure your administrator role is named something other than 'administrator', then try to create a content type.  It should fail.  Then pull this branch, try to create another content type and it should succeed with no errors.

As this is a small code change I think only 1 review is required.  As @almasaeed2010 reported the problem I request that he review it as I think he can check it quickly.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
