### PR TITLE
unset global mview variable when deleting if set

### DIFF
--- a/tripal_chado/api/tripal_chado.mviews.api.inc
+++ b/tripal_chado/api/tripal_chado.mviews.api.inc
@@ -355,6 +355,13 @@ function chado_delete_mview($mview_id) {
       $sql = "DROP TABLE {" . $mview->mv_table . "}";
       $success = chado_query($sql);
       if ($success) {
+        //unset the variable
+        global $databases;
+        $default_db = $databases['default']['default']['database'];
+        $chado_schema = chado_get_schema_name('chado');
+        if (isset($GLOBALS["chado_tables"][$default_db][$chado_schema][$mview->mv_table])){
+          unset($GLOBALS["chado_tables"][$default_db][$chado_schema][$mview->mv_table]);
+        }
         drupal_set_message(t("Materialized view, %name, deleted.", array('%name' => $mview->name)));
         return TRUE;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #569 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The `chado_delete_mview` function does not unset the global variable that the table exists.  This means that trying to delete, and then re-add an mview, causes problems because tripal will think a table exists via the global variable even after its been deleted.

## Testing?

the below update function is what i was using to test: you can add to your chado.install and run it manually like so: `drush eval "module_load_install('tripal_chado'); tripal_chado_update_7328();"`


```php

/**
 * Don't count relationship cvterms as ontology roots.
 */
function tripal_chado_update_7328() {
  try {
    $mv_name = 'cv_root_mview';
    // Remove the old mview.
    $mview_id = chado_get_mview_id($mv_name);
      chado_delete_mview($mview_id);

    module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.chado_vx_x');
    // Re-add the mview.

    tripal_chado_add_cv_root_mview_mview();

    $mview_id = chado_get_mview_id($mv_name);
    chado_populate_mview($mview_id);
  } catch (\PDOException $e) {
    $error = $e->getMessage();
    throw new DrupalUpdateException('Could not perform update: ' . $error);
  }

}

```



## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
