### PR TITLE
dont include ontology relationships in tree viewer

### DIFF
--- a/tripal_chado/includes/setup/tripal_chado.chado_vx_x.inc
+++ b/tripal_chado/includes/setup/tripal_chado.chado_vx_x.inc
@@ -512,6 +512,7 @@ function tripal_chado_add_cv_root_mview_mview() {
       INNER JOIN cv CV on CV.cv_id = CVT.cv_id
     WHERE CVTR.object_id not in
       (SELECT subject_id FROM cvterm_relationship)
+    AND CVT.is_relationshiptype = 0
   ";
 
   // Create the MView

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1568,4 +1568,23 @@ function tripal_chado_update_7327() {
   }
 }
 
+/**
+ * Don't count relationship cvterms as ontology roots.
+ */
+function tripal_chado_update_7328() {
+  try {
+    $mv_name = 'cv_root_mview';
+    // Remove the old mview.
+    $mview_id = chado_get_mview_id($mv_name);
+    chado_delete_mview($mview_id);
+    module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.chado_vx_x');
+    // Re-add the mview.
+    tripal_chado_add_cv_root_mview_mview();
+    $mview_id = chado_get_mview_id($mv_name);
+    chado_populate_mview($mview_id);
+  } catch (\PDOException $e) {
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not perform update: '. $error);
+  }
+}
 


### PR DESCRIPTION
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #526

## Type(s) of Change(s)
DO NOT RUN THIS WITHOUT #570  merged.  If you're looking at this PR, go to #570 first. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
DO NOT RUN THIS WITHOUT #570  merged.  If you're looking at this PR, go to #570 first. 

relationship terms have no parent, and therefore show up at the root of the cvterm browsers.  I use this browser for cv_xray and having relationships show up at the root of GO or other ontologies is annoying/distracting.

This PR modifies the MVIEW to ignore relationship cvterms.



## Testing?
DO NOT RUN THIS WITHOUT #570  merged.  If you're looking at this PR, go to #570 first. 

* run `drush updatedb`.  Visit an ontology with relationships showing up in the root (ie GO)

EDIT: at @spficklin 's suggestion, you should probably run the command explicitly to prevent changing your tripal version in the db, at least until this is merged into master.  to do so:  `drush eval "module_load_install('tripal_chado'); tripal_chado_update_7328();"`

## Screenshots (if appropriate):

before

![screen shot 2018-08-22 at 4 57 48 pm](https://user-images.githubusercontent.com/7063154/44490538-8b431000-a62c-11e8-9afc-35019bcd1550.png)


after the relationship terms are gone.  You can see that a user doesnt want t osee these terms.  probably.