### PR TITLE
Accidentally merged incorrect fix for issue #565. Here is a fix...

### DIFF
--- a/tripal/includes/TripalFieldQuery.inc
+++ b/tripal/includes/TripalFieldQuery.inc
@@ -120,6 +120,9 @@ class TripalFieldQuery extends EntityFieldQuery {
       $results = $this->_intersectResults($results, $st_results);
     }
 
+    if ($this->count == TRUE) {
+      return count($results['TripalEntity']);
+    }
     return $results;
   }
   

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -885,7 +885,8 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     // Perform the query just as a count first to get the number of records.
     $cquery = clone $query;
-    $num_records = $cquery->count();
+    $cquery->count();
+    $num_records = $cquery->execute();
 
     if (!$num_records) {
       $num_records = 0;

--- a/tripal_ws/includes/TripalWebServiceResource.inc
+++ b/tripal_ws/includes/TripalWebServiceResource.inc
@@ -43,10 +43,6 @@ class TripalWebServiceResource {
 
     // First, add the RDFS and Hydra vocabularies to the context.  All Tripal
     // web services should use these.
-    $vocab = tripal_get_vocabulary_details('rdf');
-
-    $this->addContextItem('rdf', $vocab['sw_url']);
-
     $vocab = tripal_get_vocabulary_details('rdfs');
     $this->addContextItem('rdfs', $vocab['sw_url']);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #565 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Please see issue #565 and PR #567.  The fix that I approved for PR #567 was incorrect.   I went through it too fast. It did fix the problem with the web services not showing up due to an error, but it accidentally added in to the totalItems field the entire TripalEntity query object!  This PR fixes that and adds the fix properly to the TripalFieldQuery->execute() function.

This fix only touches a few lines of code and I think only need 1 review.  I also took advantage of the opportunity to remove the 'rdf' vocabulary from the web services context as it was causing error log messages. It's not needed.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->

Just pull this PR and test that web services works and that the totalItems for the organism listing (at web-services/content/v0.1/Organism) is a number.


## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
