### PR TITLE
Added 'legacy' to the old Tv2 content types

### DIFF
--- a/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
+++ b/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
@@ -17,7 +17,7 @@
 function tripal_analysis_node_info() {
   $nodes = array();
   $nodes['chado_analysis'] = array(
-    'name'        => t('Analysis'),
+    'name'        => t('Analysis (Tripal v2 legacy)'),
     'base'        => 'chado_analysis',
     'description' => t('An analysis'),
     'has_title'   => TRUE,

--- a/legacy/tripal_contact/includes/tripal_contact.chado_node.inc
+++ b/legacy/tripal_contact/includes/tripal_contact.chado_node.inc
@@ -16,7 +16,7 @@ function tripal_contact_node_info() {
 
   return array(
     'chado_contact' => array(
-      'name'        => t('Contact'),
+      'name'        => t('Contact (Tripal v2 legacy)'),
       'base'        => 'chado_contact',
       'description' => t('A contact from the Chado database'),
       'has_title'   => TRUE,

--- a/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
+++ b/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
@@ -16,7 +16,7 @@ function tripal_feature_node_info() {
   $nodes = array();
 
   $nodes['chado_feature'] = array(
-    'name'        => t('Feature'),
+    'name'        => t('Feature (Tripal v2 legacy)'),
     'base'        => 'chado_feature',
     'description' => t('A feature from the chado database'),
     'has_title'   => TRUE,

--- a/legacy/tripal_featuremap/includes/tripal_featuremap.chado_node.inc
+++ b/legacy/tripal_featuremap/includes/tripal_featuremap.chado_node.inc
@@ -15,7 +15,7 @@
 function tripal_featuremap_node_info() {
   $nodes = array();
   $nodes['chado_featuremap'] = array(
-    'name'        => t('Feature Map'),
+    'name'        => t('Feature Map (Tripal v2 legacy)'),
     'base'        => 'chado_featuremap',
     'description' => t('A map of features from the chado database (e.g. genetic map)'),
     'has_title'   => TRUE,

--- a/legacy/tripal_library/includes/tripal_library.chado_node.inc
+++ b/legacy/tripal_library/includes/tripal_library.chado_node.inc
@@ -15,7 +15,7 @@
 function tripal_library_node_info() {
   $nodes = array();
   $nodes['chado_library'] = array(
-    'name'        => t('Library'),
+    'name'        => t('Library (Tripal v2 legacy)'),
     'base'        => 'chado_library',
     'description' => t('A library from the chado database'),
     'has_title'   => TRUE,

--- a/legacy/tripal_organism/includes/tripal_organism.chado_node.inc
+++ b/legacy/tripal_organism/includes/tripal_organism.chado_node.inc
@@ -15,7 +15,7 @@
 function tripal_organism_node_info() {
   $nodes = array();
   $nodes['chado_organism'] = array(
-    'name'        => t('Organism'),
+    'name'        => t('Organism (Tripal v2 legacy)'),
     'base'        => 'chado_organism',
     'description' => t('An organism'),
     'has_title'   => TRUE,

--- a/legacy/tripal_phylogeny/includes/tripal_phylogeny.chado_node.inc
+++ b/legacy/tripal_phylogeny/includes/tripal_phylogeny.chado_node.inc
@@ -16,7 +16,7 @@
 function tripal_phylogeny_node_info() {
   $nodes = array();
   $nodes['chado_phylotree'] = array(
-    'name'        => t('Phylotree'),
+    'name'        => t('Phylotree (Tripal v2 legacy)'),
     'base'        => 'chado_phylotree',
     'description' => t('A phylotree from the chado database'),
     'has_title'   => TRUE,

--- a/legacy/tripal_project/includes/tripal_project.chado_node.inc
+++ b/legacy/tripal_project/includes/tripal_project.chado_node.inc
@@ -16,7 +16,7 @@
 function tripal_project_node_info() {
   return array(
     'chado_project' => array(
-      'name'        => t('Project'),
+      'name'        => t('Project (Tripal v2 legacy)'),
       'base'        => 'chado_project',
       'description' => t('A project from the Chado database'),
       'has_title'   => TRUE,

--- a/legacy/tripal_pub/includes/tripal_pub.chado_node.inc
+++ b/legacy/tripal_pub/includes/tripal_pub.chado_node.inc
@@ -17,7 +17,7 @@
 function tripal_pub_node_info() {
   $nodes = array();
   $nodes['chado_pub'] = array(
-    'name'        => t('Publication'),
+    'name'        => t('Publication (Tripal v2 legacy)'),
     'base'        => 'chado_pub',
     'description' => t('A publication from the Chado database'),
     'has_title'   => TRUE,

--- a/legacy/tripal_stock/includes/tripal_stock.chado_node.inc
+++ b/legacy/tripal_stock/includes/tripal_stock.chado_node.inc
@@ -15,7 +15,7 @@
 function tripal_stock_node_info() {
   return array(
     'chado_stock' => array(
-      'name'        => t('Stock'),
+      'name'        => t('Stock (Tripal v2 legacy)'),
       'base'        => 'chado_stock',
       'description' => t('A Chado Stock is a collection of material that can be sampled and have experiments performed on it.'),
       'has_title'   => TRUE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #568 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The Tripal v2 node types that appear when users click the 'Add Content' link might confuse folks who are using Tripal v3 in legacy mode.  This is because there will be "biological" content types as nodes and as new entities.  This PR adds "Tripal v2 legacy" to each node content type when looking at the 'Add Content' page, and the 'Structure > Content Types' page.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Just pull the branch, make sure you have some legacy modules enabled, clear the cache and check out the "Add Content Page".

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
