### PR TITLE
resolve Phylotree TripalImporter errors

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
@@ -198,11 +198,29 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings) {
       ),
     );
     $dbxref = chado_generate_var('dbxref', $values);
+
     if (!$dbxref) {
-      $errors['dbxref'] = t('The dbxref provided does not exist in the database: %dbxref.', array('%dbxref' => $dbxref));
-      return FALSE;
+
+      $db = chado_generate_var('db', array( 'name' => $db_name));
+
+      if (!$db){
+              $errors['dbxref'] = t('
+              dbxref could not be created for db: %dbxref.', array('%dbxref' => $dbxref));
+              return FALSE;
+      }
+    $dbxref =  chado_insert_record('dbxref', $values);
+
+    if (!$dbxref){
+            $errors['dbxref'] = t('
+            dbxref could not be created for db: %dbxref.', array('%dbxref' => $dbxref));
+            return FALSE;
     }
+  }
+  if (is_array($dbxref)){
+    $options['dbxref_id'] = $dbxref['dbxref_id'];
+    }else {
     $options['dbxref_id'] = $dbxref->dbxref_id;
+  }
   }
 
   // Make sure the tree name is unique.

--- a/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
@@ -3,7 +3,7 @@
 /**
  * @file
  * Provides API functions specificially for managing phylogenetic and taxonomic
- * tree records in Chado.  
+ * tree records in Chado.
  */
 
 /**
@@ -11,8 +11,8 @@
  * @ingroup tripal_chado_api
  * @{
  * Provides API functions specificially for managing phylogenetic and taxonomic
- * tree records in Chado.  The API consists of functions for creation, 
- * retrieval, update and deltion (CRUD) for phylogenetic tree records as 
+ * tree records in Chado.  The API consists of functions for creation,
+ * retrieval, update and deltion (CRUD) for phylogenetic tree records as
  * well as importing of trees in the newick file format.
  * @}
  */
@@ -83,10 +83,6 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings) {
     }
     if (!array_key_exists('description', $options)) {
       $errors['description'] = t('Please provide a description for this tree.');
-      return FALSE;
-    }
-    if (!array_key_exists('tree_file', $options)) {
-      $errors['tree_file'] = t('Please provide either the full path to the tree_file or a Drupal managed file ID number.');
       return FALSE;
     }
     if (!array_key_exists('format', $options) or !$options['format']) {
@@ -254,7 +250,7 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings) {
  *     'tree_file':  The path of the file containing the phylogenetic tree to
  *                   import or a Drupal managed_file numeric ID.
  *     'format':     The file format. Currently only 'newick is supported'.
- * 
+ *
  *  Optional keys:
  *     'dbxref':     A database cross-reference of the form DB:ACCESSION.
  *                   Where DB is the database name, which is already present
@@ -312,6 +308,7 @@ function chado_insert_phylotree(&$options, &$errors, &$warnings) {
     'comment' => $options['description'],
     'type_id' => $options['type_id'],
   );
+
   $phylotree = chado_insert_record('phylotree', $values);
   if (!$phylotree) {
     drupal_set_message(t('Unable to add phylotree.'), 'warning');
@@ -675,7 +672,7 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = arra
       if (!empty($tree['name']) and $tree['name'] != '') {
         if (!$options['taxonomy']) {
 
-          // This is a sequence-based tree. Try to match leaf nodes with 
+          // This is a sequence-based tree. Try to match leaf nodes with
           // features.
           // First, Get the Name and uniquename for the feature.
           $matches = array();
@@ -751,9 +748,9 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = arra
 /**
  * Get the vocabulary terms used to describe nodes in the tree.
  *
- * @return 
+ * @return
  *  Array of vocab info or FALSE on failure.
- * 
+ *
  * @ingroup tripal_phylotree_api
  */
 function chado_phylogeny_get_node_types_vocab() {

--- a/tripal_chado/includes/TripalImporter/NewickImporter.inc
+++ b/tripal_chado/includes/TripalImporter/NewickImporter.inc
@@ -125,7 +125,7 @@ class NewickImporter extends TripalImporter {
         tree. In this case, the word 'taxonomy' should be used."),
       '#required' => TRUE,
       '#default_value' => $leaf_type,
-      '#autocomplete_path' => "admin/tripal/legacy/tripal_cv/cvterm/auto_name/$cv_id",
+      '#autocomplete_path' => "admin/tripal/storage/chado/auto_name/cvterm/$cv_id",
     ];
 
     $form['dbxref'] = [
@@ -173,13 +173,11 @@ class NewickImporter extends TripalImporter {
   public function formValidate($form, &$form_state) {
 
     $values = $form_state['values'];
-
     $options = [
       'name' => trim($values["tree_name"]),
       'description' => trim($values["description"]),
       'analysis_id' => $values["analysis_id"],
       'leaf_type' => $values["leaf_type"],
-      'tree_file'    => $this->arguments['files'][0]['file_path'],
       'format' => 'newick',
       'dbxref' => trim($values["dbxref"]),
       'match' => $values["match"],
@@ -216,15 +214,15 @@ class NewickImporter extends TripalImporter {
     $arguments = $this->arguments['run_args'];
 
     $options = array(
-      'name'         => $this->arguments["tree_name"],
-      'description'  => $this->arguments["description"],
-      'analysis_id'  => $this->arguments["analysis_id"],
-      'leaf_type'    => $this->arguments["leaf_type"],
+      'name'         => $arguments["tree_name"],
+      'description'  => $arguments["description"],
+      'analysis_id'  => $arguments["analysis_id"],
+      'leaf_type'    => $arguments["leaf_type"],
       'tree_file'    => $this->arguments['files'][0]['file_path'],
       'format'       => 'newick',
-      'dbxref'       => $this->arguments["dbxref"],
-      'match'        => $this->arguments["match"],
-      'name_re'      => $this->arguments["name_re"],
+      'dbxref'       => $arguments["dbxref"],
+      'match'        => $arguments["match"],
+      'name_re'      => $arguments["name_re"],
     );
     $errors = array();
     $warnings = array();

--- a/tripal_chado/includes/TripalImporter/NewickImporter.inc
+++ b/tripal_chado/includes/TripalImporter/NewickImporter.inc
@@ -29,7 +29,7 @@ class NewickImporter extends TripalImporter {
    * Provides information to the user about the file upload.  Typically this
    * may include a description of the file types allowed.
    */
-  public static $upload_description = 'Please provide the Newick formatted tree file.  The file must have a .txt or .tree extension.';
+  public static $upload_description = 'Please provide the Newick formatted tree file (one tree per file only).  The file must have a .txt or .tree extension.';
 
   /**
    * The title that should appear above the file upload section.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Issue #290 

## Type(s) of Change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
* The Newick Importer cvterm lookup gave ajax errors if you did not have the legacy tripal_cv module enabled
* the Newick Importer ended up nulling all arguments in the form by accident.  This means that trees were created with no name, and with the default type only (polypeptide)  We fix that.
* Importer incorrectly validated file itself.  The base class handles that.
* add note to importer that we expect one tree per file.

additionally
* The Database Cross-Reference says it will create an accession for an entry if it doesnt exist but the db doesnt.  However, supply a db:accession that doesnt exist results in a validation error.

## Testing?
Run the importer to test.  If you have a newick file, thats great.  If not, you can use devseed:

https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/sequences/mrna_mini.fasta.tree
and the corresponding fasta file:

https://github.com/statonlab/tripal_dev_seed/blob/master/Fexcel_mini/sequences/mrna_mini.fasta

(edit: replaced above link with link of the "raw" fasta not the aligned)


on master, look for the imported trees not having the SO type you selected (it will always be polypeptide) and publishing with no name.  This branch will resolve that.

Edit: you can also test the dbxref error.  Try creating a dbxref that isnt in your database  but where the db is(local:pigstailsarecurly for example).  On master you will get a validation error, whereas this branch it will insert the accession.