### PR TITLE
Auto search on default views.

### DIFF
--- a/tripal/tripal.views_default.inc
+++ b/tripal/tripal.views_default.inc
@@ -61,7 +61,9 @@ function tripal_bundle_default_views(&$views) {
     $handler->display->display_options['access']['perm'] = 'view ' . $bundle->name;
     $handler->display->display_options['cache']['type'] = 'none';
     $handler->display->display_options['query']['type'] = 'views_query';
-    $handler->display->display_options['exposed_form']['type'] = 'basic';
+    $handler->display->display_options['exposed_form']['type'] = 'input_required';
+    $handler->display->display_options['exposed_form']['options']['submit_button'] = 'Search';
+    $handler->display->display_options['exposed_form']['options']['text_input_required_format'] = 'filtered_html';
     $handler->display->display_options['pager']['type'] = 'full';
     $handler->display->display_options['pager']['options']['items_per_page'] = '10';
     $handler->display->display_options['pager']['options']['offset'] = '0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #578 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Default search views for each Tripal content type were searching automatically.  This is not what the searches did in Tv2.  They should not search unless the user pushes the 'Search' button.  

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Pull the branch, clear the cache and navigate to any of the default Tripal content type search views.  They should come up relatively quickly and with no search results.  The button should say 'Search' rather than 'Apply.  

If you have already customized any of these views then the PR won't fix it. It only works for non customized views.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
