### PR TITLE
Data Collections Show for Anonymous Users

### DIFF
--- a/tripal/views_handlers/tripal_views_handler_area_collections.inc
+++ b/tripal/views_handlers/tripal_views_handler_area_collections.inc
@@ -16,6 +16,10 @@ class tripal_views_handler_area_collections extends views_handler_area_result {
     if (!$collections_enabled) {
       return '';
     }
+    
+    if (user_is_anonymous()) {
+      return '';
+    }
 
     // We need a specific form to work with Tripal content types and the tripal_views_query plugin.
     if ($this->query->plugin_name == 'tripal_views_query') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #591

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The data collection form shows up on the default Tripal views even if no one is logged in. We have a request #343 to support anonymous users, but at least for the Tripal v3 stable release we need to fix this bug.

For example, check out this page on the demo site: http://demo.tripal.info/3.x/data_search/gene

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
Pull the PR. Log out of your Tripal site and go to one of the default Tripal search views (you must have permissions set to use them).  You should not see the Data Collections form.  If you log in and go back to the view you'll see it.

This is such a simple fix it only needs 1 review.

## Screenshots (if appropriate):

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
