### PR TITLE
Fix invalid type in foreach loop

### DIFF
--- a/tripal_chado/includes/TripalFields/so__cds/so__cds.inc
+++ b/tripal_chado/includes/TripalFields/so__cds/so__cds.inc
@@ -79,6 +79,11 @@ class so__cds extends ChadoField {
     $feature = chado_expand_var($feature, 'table', 'featureloc', $options);
     $featurelocs = $feature->featureloc->feature_id;
 
+    // Verify that we have featurelocs before entering the loop
+    if(!is_array($featurelocs)) {
+      return;
+    }
+
     foreach($featurelocs as $featureloc){
       // Generate a CDS sequence if one exsits for this feature alignment.
       $cds_sequence = chado_get_feature_sequences(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #608 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR fixes an error in the so__cds field where an non-array variable gets passed to the foreach loop.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
I think the test can be done by inspecting the code directly since it's a very simple fix. However, to fully test:
1. You must have CDS without associated featurelocs
1. Publish and visit the CDS feature page
1. The error described in #608 should not appear

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
