### PR TITLE
PHP Undefined Property Notice in TripalEntityController

### DIFF
--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -647,6 +647,7 @@ class TripalEntityController extends EntityAPIController {
           // Add this field to the entity with default value.
           if (!isset($queried_entities[$id]->{$field_name})) {
             $queried_entities[$id]->{$field_name} = array();
+            $entity->{$field_name} = array();
           }
 
           // Options used for the field_attach_load function.

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -645,8 +645,8 @@ class TripalEntityController extends EntityAPIController {
           $field_id = $field['id'];
 
           // Add this field to the entity with default value.
-          if (!isset($queried_entities[$id]->$field_name)) {
-            $queried_entities[$id]->$field_name = array();
+          if (!isset($queried_entities[$id]->{$field_name})) {
+            $queried_entities[$id]->{$field_name} = array();
           }
 
           // Options used for the field_attach_load function.
@@ -661,7 +661,7 @@ class TripalEntityController extends EntityAPIController {
           if ($field_cache) {
             $cache_data = cache_get($cfid, 'cache_field');
             if (!empty($cache_data)) {
-              $queried_entities[$id]->$field_name = $cache_data->data;
+              $queried_entities[$id]->{$field_name} = $cache_data->data;
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;
               continue;
             }
@@ -675,7 +675,7 @@ class TripalEntityController extends EntityAPIController {
                   FIELD_LOAD_CURRENT, $options);
               // Cache the field.
               if ($field_cache) {
-                cache_set($cfid, $entity->$field_name, 'cache_field');
+                cache_set($cfid, $entity->{$field_name}, 'cache_field');
               }
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;
             }
@@ -696,7 +696,7 @@ class TripalEntityController extends EntityAPIController {
                // Add an empty value. This will allow the tripal_entity_view()
                // hook to add the necessary prefixes to the field for ajax
                // loading.
-               $queried_entities[$id]->$field_name['und'][0]['value'] = '';
+               $queried_entities[$id]->{$field_name}['und'][0]['value'] = '';
                $queried_entities[$id]->{$field_name}['#processed'] = FALSE;
             }
             else {
@@ -705,7 +705,7 @@ class TripalEntityController extends EntityAPIController {
               // Cache the field.
               if ($field_cache) {
                 if (property_exists($entity, $field_name)) {
-                  cache_set($cfid, $entity->$field_name, 'cache_field');
+                  cache_set($cfid, $entity->{$field_name}, 'cache_field');
                 }
               }
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -631,9 +631,9 @@ class TripalEntityController extends EntityAPIController {
         $function = 'field_attach_load';
       }
       foreach ($queried_entities as $id => $entity) {
-        $info = entity_get_info($entity->type);
+        $info = entity_get_info($queried_entities[$id]->type);
         $field_cache = array_key_exists('field cache', $info) ? $info['field cache'] : FALSE;
-        $bundle_name = $entity->bundle;
+        $bundle_name = $queried_entities[$id]->bundle;
 
         // Iterate through the field instances and find those that are set to
         // 'auto_attach' and which are attached to this bundle. Add all
@@ -647,7 +647,6 @@ class TripalEntityController extends EntityAPIController {
           // Add this field to the entity with default value.
           if (!isset($queried_entities[$id]->{$field_name})) {
             $queried_entities[$id]->{$field_name} = array();
-            $entity->{$field_name} = array();
           }
 
           // Options used for the field_attach_load function.
@@ -672,11 +671,11 @@ class TripalEntityController extends EntityAPIController {
           // to only load the  fields specified.
           if (count($field_ids) > 0) {
             if (in_array($field_id, $field_ids)) {
-              $function($this->entityType, array($entity->id => $queried_entities[$id]),
+              $function($this->entityType, array($id => $queried_entities[$id]),
                   FIELD_LOAD_CURRENT, $options);
               // Cache the field.
               if ($field_cache) {
-                cache_set($cfid, $entity->{$field_name}, 'cache_field');
+                cache_set($cfid, $queried_entities[$id]->{$field_name}, 'cache_field');
               }
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;
             }
@@ -701,12 +700,12 @@ class TripalEntityController extends EntityAPIController {
                $queried_entities[$id]->{$field_name}['#processed'] = FALSE;
             }
             else {
-              $function($this->entityType, array($entity->id => $queried_entities[$id]),
+              $function($this->entityType, array($id => $queried_entities[$id]),
                   FIELD_LOAD_CURRENT, $options);
               // Cache the field.
               if ($field_cache) {
-                if (property_exists($entity, $field_name)) {
-                  cache_set($cfid, $entity->{$field_name}, 'cache_field');
+                if (property_exists($queried_entities[$id], $field_name)) {
+                  cache_set($cfid, $queried_entities[$id]->{$field_name}, 'cache_field');
                 }
               }
               $queried_entities[$id]->{$field_name}['#processed'] = TRUE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #618

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
PHP is throwing notices because some fields are not defined on the entity.
This fix simply initializes the field in the (not passed by reference) `$entity` as an empty array.

## Testing?

1. Clear the cache
2. Make sure entities load without the php notice described in #618 

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
