### PR TITLE
remove php tag and fix site build to use php syntax highlighting prop…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,16 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+
+#PHP stuff
+#see: https://www.sitepoint.com/using-sphinx-for-php-project-documentation/
+
+from sphinx.highlighting import lexers
+from pygments.lexers.web import PhpLexer
+lexers["php"] = PhpLexer(startinline=True, linenos=1)
+lexers["php-annotations"] = PhpLexer(startinline=True, linenos=1)
+
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/dev_guide/custom_field/manual_field_creation.rst
+++ b/docs/dev_guide/custom_field/manual_field_creation.rst
@@ -36,7 +36,7 @@ The following describes a ChadoField class from top to bottom. The code for the 
 
 .. code-block:: php
 
-  <?php
+  
 
   class obi__organism extends ChadoField {
 
@@ -51,7 +51,7 @@ Next, the TripalField/ChadoField class has a section of public static variables.
 
 .. code-block:: php
 
-  <?php
+  
 
   // The default label for this field.
   public static $default_label = 'Organism';
@@ -64,7 +64,7 @@ As described in the section titled Tripal Data Structures, fields that are attac
 
 .. code-block:: php
 
-  <?php
+  
   // Provide a list of instance specific settings. These can be access within
   // the instanceSettingsForm.  When the instanceSettingsForm is submitted
   // then Drupal with automatically change these settings for the instance.
@@ -93,7 +93,7 @@ As you may have noticed, a field requires a widget and a formatter.  This is why
 
 .. code-block:: php
 
-  <?php
+  
   // The default widget for this field.
   public static $default_widget = 'obi__organism_widget';
 
@@ -104,7 +104,7 @@ Drupal allows new instances of fields to be attached to any Bundle.  This is rea
 
 .. code-block:: php
 
-  <?php
+  
   // A boolean specifying that users should not be allowed to create
   // fields and instances of this field type through the UI. Such
   // fields can only be created programmatically with field_create_field()
@@ -116,7 +116,7 @@ Sometimes a field is meant to provide a visualization or some other functionalit
 
 .. code-block:: php
 
-  <?php
+  
   // A boolean specifying that the field will not contain any data. This
   // should exclude the field from web serivces or downloads.  An example
   // could be a quick search field that appears on the page that redirects
@@ -133,7 +133,7 @@ Finally, the last item in our Class variables is the **download_formatters**.  T
 
 .. .. code-block::
 
-  <?php
+  
 
   // Indicates the download formats for this field.  The list must be the
   // name of a child class of the TripalFieldDownloader.
@@ -237,7 +237,7 @@ We can easily get all of the values we need from this organism object.   We can 
 
 .. code-block:: php
 
-  <?php
+  
 
       $label = tripal_replace_chado_tokens($string, $organism);
       $entity->{$field_name}['und'][0]['value'] = array(
@@ -280,7 +280,7 @@ Notice, though, that we did not add this value inside the 'value' key like we di
 
 .. code-block:: php
 
-  <?php
+  
 
   $entity->{$field_name}['und'][0]['value'])
 
@@ -288,7 +288,7 @@ Instead, we put it in at the same level as 'value':
 
 .. code-block:: php
 
-  <?php
+  
 
   $entity->{$field_name}['und'][0][$linker_field]
 
@@ -314,7 +314,7 @@ The elementInfo() function is necessary to integrate your new field with Drupal 
 
 .. code-block:: php
 
-  <?php
+  
 
   /**
    * @see TripalField::elementInfo()
@@ -393,7 +393,7 @@ The code above generates and returns an associative array that provides metadata
 
 .. code-block:: php
 
-  <?php
+  
 
     $field_term = $this->getFieldTermID();
 
@@ -416,7 +416,7 @@ The array keys just mentioned fully describe our field to Drupal and Tripal.  Ne
 
 .. code-block:: php
 
-  <?php
+  
 
 
         'elements' => array(
@@ -434,7 +434,7 @@ Notice that our field will allow searching, provides a variety of search filter 
 
 .. code-block:: php
 
-  <?php
+  
 
          $genus_term => array(
             'searchable' => TRUE,
@@ -466,7 +466,7 @@ As described above in the elementInfo function section, some fields and elements
 
 .. code-block:: php
 
-  <?php
+  
 
   public function query($query, $condition) {
       $alias = $this->field['field_name'];
@@ -517,7 +517,7 @@ The code above is how the field tells Drupal and Tripal how to find and filter t
 
 .. code-block:: php
 
-  <?php
+  
 
     $alias = $this->field['field_name'];
     $operator = $condition['operator'];

--- a/docs/dev_guide/custom_field/select_vocab_terms.rst
+++ b/docs/dev_guide/custom_field/select_vocab_terms.rst
@@ -31,7 +31,7 @@ Notice how the teal box (the **short name**) is OBI, and the orange box contains
 
 .. code-block:: php
 
-	<?php
+	
 
    $term= tripal_insert_cvterm([
             'id' => 'OBI:0100026',
@@ -49,7 +49,7 @@ Note that in the code above the namespace is provided as the **cv_name** element
 
 .. code-block:: php
 
-  <?php
+  
   tripal_insert_db(array(
     'name' => 'obi',
     'description' => 'The Ontology for Biomedical Investigation.',
@@ -66,7 +66,7 @@ Second, we insert the record for the controlled vocabulary.
 
 .. code-block:: php
 
-  <?php
+  
  	tripal_insert_cv(
     	'OBI',
     	'Ontology for Biomedical Investigation. The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific.'
@@ -86,7 +86,7 @@ Notice that in the Term Info box on the right there is the term **has_obo_namesp
 
 .. code-block:: php
 
-  <?php
+  
     $term= tripal_insert_cvterm([
             'id' => 'SO:0000316',
             'name' => 'CDS',
@@ -117,7 +117,7 @@ For this case, the **namespace** is EDAM, the short name is **data**, and the ac
 
 .. code-block:: php
 
-  <?php
+  
 	$term= tripal_insert_cvterm([
 	  'id' => 'data:2044',
 	  'name' => 'sequence',
@@ -146,7 +146,7 @@ Sometimes a good CVterm just doesn't exist for what you want to describe. If you
 
 .. code-block:: php
 
-	<?php
+	
 	$term= tripal_insert_cvterm([
 	   'id' => 'local:shame_on_you',
 	   'name' => 'shame_on_you',

--- a/docs/dev_guide/custom_web_services.rst
+++ b/docs/dev_guide/custom_web_services.rst
@@ -46,7 +46,7 @@ Within this file we will implement our class with the following structure:
 
 .. code-block:: php
 
-	<?php
+	
 	class TripalJobService_v0_1 extends TripalWebService {
 
 	  /**
@@ -146,7 +146,7 @@ For our services we need to provide the information to Tripal so that it can gen
 
 .. code-block:: php
 
-	<?php
+	
 
  	public function getDocumentation() {
         $term = tripal_get_term_details('local', 'computational_jobs');
@@ -219,7 +219,7 @@ in the code above need to determine if the resource is a job collection or a job
 
 .. code-block:: php
 
-	<?php
+	
 
     /**
      * Generates the job collection resource.
@@ -294,7 +294,7 @@ Lastly, we need to add our "members" of the collection.  These are the jobs from
 
 .. code-block:: php
 
-	<?php
+	
 
         foreach ($jobs as $job) {
             $member = new TripalWebServiceResource($service_path);


### PR DESCRIPTION
…erly

<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue N/A

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [x] Updates documentation (inline or markdown files)

## Description

This is a minor pR only requiring one reviewer.

It's a big Quality of Life fix for the documentation, though.  What I did was update the build `conf.py` to fetch the correct PHP Lexer.  Previously, if you wanted the PHP syntax highlighting to show up right, you needed to add `<?php` to the head of EVERY PHP block.  Not only was this annoying, but it also messed up my IDE, making it think the whole document was in PHP.

By changing the conf.py we can just use the ``.. code-block php`` directive and the highlighting will be correct (albeit ugly: fixing the theme is on my wish list).

This PR also removes the unnecessary `<?php` tags from the codeblocks.

## Screenshots:

### Before
![screen shot 2018-09-12 at 2 24 41 pm](https://user-images.githubusercontent.com/7063154/45445341-f3b76700-b697-11e8-94cc-49b8c019c008.png)
### After
![screen shot 2018-09-12 at 2 24 25 pm](https://user-images.githubusercontent.com/7063154/45445345-f4e89400-b697-11e8-8835-ebf96ef3ccf4.png)

please notice in the first code block, there is no syntax highlighting.  In the second, we have the `<?php` tag which is unnecessary and can mess up your IDE.

In the after, both blocks have syntax highlighting without a `<?php` tag.