### PR TITLE
Delete removed entity from chado_bio_data_x

### DIFF
--- a/tripal_chado/includes/tripal_chado.entity.inc
+++ b/tripal_chado/includes/tripal_chado.entity.inc
@@ -148,7 +148,7 @@ function tripal_chado_entity_delete($entity, $type) {
 
   // Delete the removed entity from the corresponding chado_bio_data_x table
   $bundle = $entity->bundle;
-  db_delete("chado_{$bundle}")->condition('entity_id', $entity->id);
+  db_delete("chado_{$bundle}")->condition('entity_id', $entity->id)->execute();
 }
 
 /**

--- a/tripal_chado/includes/tripal_chado.entity.inc
+++ b/tripal_chado/includes/tripal_chado.entity.inc
@@ -142,9 +142,13 @@ function tripal_chado_entity_update($entity, $type) {
  * Implements hook_entity_delete().
  */
 function tripal_chado_entity_delete($entity, $type) {
-  if ($type == 'TripalEntity') {
-
+  if ($type !== 'TripalEntity') {
+    return;
   }
+
+  // Delete the removed entity from the corresponding chado_bio_data_x table
+  $bundle = $entity->bundle;
+  db_delete("chado_{$bundle}")->condition('entity_id', $entity->id);
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #652 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

As detailed in issue #652, deleting an entity using the GUI (or the `entity_delete` function), does not delete the corresponding record in the `chado_bio_data_x` table. This PR uses the `hook_entity_delete` hook to act on the deletion and remove the record from the other  table as well.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
1. Before pulling this branch, create an organism entity and find the new record in `chado_bio_data_x`, where `x` is the `bundle_id` for `organism`
1. Delete the newly created organism using the GUI and you'll notice that the record still exists in the `chado_bio_data_x` table but does not exist in `tripal_entity`.
1. Now pull this branch and repeat the steps.
1. The record should no longer exist in the bundle table.

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
