### PR TITLE
 remove extra comma and thus extra column from  creating content guide table

### DIFF
--- a/docs/user_guide/creating_content.rst
+++ b/docs/user_guide/creating_content.rst
@@ -17,7 +17,7 @@ Tripal v3 comes with some pre-defined content types, however you have the abilit
 Find a Controlled Vocabulary (CV) Term
 ---------------------------------------
 
-Before creating a new content type for your site you must identify a CV term that best matches the content type you would like to create.  CVs are plentiful and at times selection of the correct term from the right vocabulary can be challenging. If there is any doubt about what term to use, then it is best practice to reach out to others to confirm your selection. The Tripal User community is a great place to do this by posting a description of your content type and your proposed term on the `Tripal Issue Queue <https://github.com/tripal/tripal/issues>`_.  Confirming your term with others will also encourage re-use across Tripal sites and improve data exchagnge capabilities.
+Before creating a new content type for your site you must identify a CV term that best matches the content type you would like to create.  CVs are plentiful and at times selection of the correct term from the right vocabulary can be challenging. If there is any doubt about what term to use, then it is best practice to reach out to others to confirm your selection. The Tripal User community is a great place to do this by posting a description of your content type and your proposed term on the `Tripal Issue Queue <https://github.com/tripal/tripal/issues>`_.  Confirming your term with others will also encourage re-use across Tripal sites and improve data exchange capabilities.
 
 The `EBI's Ontology Lookup Service <http://www.ebi.ac.uk/ols/index>`_ is a great place to locate terms from public vocabularies. At this site you can search for terms for your content type.  If you can not find an appropriate term in a public vocabulary or via discussion with others then you create a new **local** term within the **local** vocabulary that comes with Tripal.
 
@@ -85,15 +85,15 @@ Perhaps we want to be more specific with our genetic marker pages and create pag
 To accomplish this we can walk through the content type creation form and set the following values:
 
 .. csv-table::
-  :header: 'Field', 'Value'
+  :header: Field, Value
 
   "Content Type", "SNP (SO:0000694)"
   "Storage Backend", "Chado"
   "Chado Table", "feature"
-  "Are all records in the 'feature' table of type 'genetic_marker'?", "No"
-  "Type column", "--None--",
-  "Do you want to use the 'featureprop' table to distinguish between content types?", "Yes"
-  "Base Type", "genetic_marker (SO:0001645)"
+  "Are all records in the ``feature`` table of type 'genetic_marker'?", "No"
+  "Type column", "--None--"
+  "Do you want to use the ``featureprop`` table to distinguish between content types?", "Yes"
+  "Base Type", "'genetic_marker' (SO:0001645)"
   "Property Type", "type (rdfs:type)"
   "Property Value", "SNP"
 


### PR DESCRIPTION
<!--- If it fixes an open issue, please add the issue link below. -->
Issue # NA

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [x] Updates documentation (inline or markdown files)

## Description
There was an extra column in a table in the creating content types guide.  In fixing I also fixed a couple of typos.

## Screenshots (if appropriate):

before:
<img width="812" alt="screen shot 2018-09-15 at 12 50 47 pm" src="https://user-images.githubusercontent.com/7063154/45589132-2191eb00-b8e6-11e8-9a09-c11128ead0dd.png">

after:
<img width="830" alt="screen shot 2018-09-15 at 12 50 43 pm" src="https://user-images.githubusercontent.com/7063154/45589133-25257200-b8e6-11e8-96da-49318eb35ae9.png">
