### PR TITLE
657 fix broken chado property API calls and add unit tests for each

### DIFF
--- a/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
+++ b/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
@@ -4,25 +4,31 @@ namespace Tests;
 
 use StatonLab\TripalTestSuite\DBTransaction;
 use StatonLab\TripalTestSuite\TripalTestCase;
+use StatonLab\TripalTestSuite\Database\Factory;
 
 class TripalChadoPropertyAPITest extends TripalTestCase {
 
   use DBTransaction;
 
   /**
+   * Tests chado_insert_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
-   *
+   * @group chado-property
    */
-  public function test_chado_insert_property() {
+  public function test_chado_insert_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -30,9 +36,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     chado_insert_property($record, $property);
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -45,19 +51,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
 
   /**
+   * Tests chado_get_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
-   *
+   * @group chado-property
    */
-  public function test_chado_get_property() {
+  public function test_chado_get_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -68,7 +79,7 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertNotFalse($retrieved);
     $this->assertEquals($value, $retrieved->value);
 
-    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    $record = ['prop_id' => $prop[$prop_table.'_id'], 'table' => $base_table];
     $retrieved = chado_get_property($record, $property);
 
     $this->assertNotNull($retrieved);
@@ -76,18 +87,25 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
   }
 
   /**
+   * Tests chado_update_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  public function test_chado_update_property() {
-    $feature = factory('chado.feature')->create();
+  public function test_chado_update_property($prop_table, $base_table) {
+
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
     $new_value = 'chado_API_new';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -100,9 +118,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     chado_update_property($record, $property);
 
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -114,17 +132,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
   }
 
   /**
+   * Tests chado_delete_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  public function test_chado_delete_property() {
-    $feature = factory('chado.feature')->create();
+  public function test_chado_delete_property($prop_table, $base_table) {
+
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -134,9 +159,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     chado_delete_property($record, $property);
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -145,25 +170,33 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     $prop = chado_insert_property($record, $property);
 
-    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    $record = ['prop_id' => $prop[$prop_table.'_id'], 'table' => $base_table];
     chado_delete_property($record, $property);
   }
 
 
   /**
+   * Tests chado_get_record_with_property() with all prop tables.
+   *
+   * Note: chado_get_record_with_property() gets all records in the base table 
+   *   assigned one or more properties.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  function test_chado_get_record_with_property() {
-    //  * Get all records in the base table assigned one or more properties.
+  function test_chado_get_record_with_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -177,8 +210,8 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertNotEmpty($records);
     $this->assertEquals(1, count($records));
 
-    $feature = factory('chado.feature')->create();
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $base_record = factory('chado.'.$base_table)->create();
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     chado_insert_property($record, $property);
     $records = chado_get_record_with_property($record, $property);
 
@@ -186,5 +219,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertEquals(2, count($records));
   }
 
+  /**
+   * Data Provider: All base tables with associated property tables.
+   *
+   * @return
+   *   An array where each item specifies the property table
+   *   and it's associated base table.
+   */
+  function propTableProvider() {
+    $prop_tables = [];
 
+    $base_tables = chado_get_base_tables();
+    foreach ($base_tables as $base) {
+      $prop = $base . 'prop';
+      if (chado_table_exists($prop) AND Factory::exists('chado.'.$base)) {
+        $prop_tables[] = [$prop, $base];
+      }
+    }
+
+    return $prop_tables;
+  }
 }

--- a/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
+++ b/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
@@ -71,7 +71,8 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
     $retrieved = chado_get_property($record, $property);
-    $this->assertNotFalse($retrieved);
+
+    $this->assertNotNull($retrieved);
     $this->assertEquals($value, $retrieved->value);
   }
 

--- a/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
+++ b/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Tests;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+class TripalChadoPropertyAPITest extends TripalTestCase {
+
+  use DBTransaction;
+
+  /**
+   * @group chado
+   * @group api
+   *
+   */
+  public function test_chado_insert_property() {
+
+    $feature = factory('chado.feature')->create();
+    $term = factory('chado.cvterm')->create();
+
+    $value = 'chado_API_test_value';
+
+    // Linker column
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $property = [
+      'type_id' => $term->cvterm_id,
+      'value' => $value,
+    ];
+
+    chado_insert_property($record, $property);
+
+    $result = db_select('chado.featureprop', 'f')
+      ->fields('f')
+      ->condition('f.feature_id', $feature->feature_id)
+      ->execute()
+      ->fetchObject();
+
+    $this->assertNotEmpty($result);
+    $this->assertEquals($value, $result->value);
+    $this->assertEquals($term->cvterm_id, $result->type_id);
+    $this->assertEquals('0', $result->rank);
+
+  }
+
+
+  /**
+   * @group chado
+   * @group api
+   * @group wip
+   *
+   */
+  public function test_chado_get_property() {
+
+    $feature = factory('chado.feature')->create();
+    $term = factory('chado.cvterm')->create();
+
+    $value = 'chado_API_test_value';
+
+    // Linker column
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $property = [
+      'type_id' => $term->cvterm_id,
+      'value' => $value,
+    ];
+
+    $prop = chado_insert_property($record, $property);
+    $retrieved = chado_get_property($record, $property);
+    $this->assertNotFalse($retrieved);
+    $this->assertEquals($value, $retrieved->value);
+
+    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    $retrieved = chado_get_property($record, $property);
+    $this->assertNotFalse($retrieved);
+    $this->assertEquals($value, $retrieved->value);
+  }
+
+  /**
+   * @group chado
+   * @group api
+   */
+  public function test_chado_update_property() {
+    $feature = factory('chado.feature')->create();
+    $term = factory('chado.cvterm')->create();
+
+    $value = 'chado_API_test_value';
+    $new_value = 'chado_API_new';
+
+    // Linker column
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $property = [
+      'type_id' => $term->cvterm_id,
+      'value' => $value,
+    ];
+
+    chado_insert_property($record, $property);
+
+    $property['value'] = $new_value;
+
+    chado_update_property($record, $property);
+
+
+    $result = db_select('chado.featureprop', 'f')
+      ->fields('f')
+      ->condition('f.feature_id', $feature->feature_id)
+      ->execute()
+      ->fetchObject();
+
+    $this->assertNotEmpty($result);
+    $this->assertEquals($new_value, $result->value);
+    $this->assertEquals($term->cvterm_id, $result->type_id);
+    $this->assertEquals('0', $result->rank);
+
+  }
+
+  /**
+   * @group chado
+   * @group api
+   */
+  public function test_chado_delete_property() {
+    $feature = factory('chado.feature')->create();
+    $term = factory('chado.cvterm')->create();
+
+    $value = 'chado_API_test_value';
+
+    // Linker column
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $property = [
+      'type_id' => $term->cvterm_id,
+      'value' => $value,
+    ];
+
+    chado_insert_property($record, $property);
+
+    chado_delete_property($record, $property);
+
+    $result = db_select('chado.featureprop', 'f')
+      ->fields('f')
+      ->condition('f.feature_id', $feature->feature_id)
+      ->execute()
+      ->fetchObject();
+
+    $this->assertFalse($result);
+
+
+    $prop = chado_insert_property($record, $property);
+
+    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    chado_delete_property($record, $property);
+  }
+
+
+  /**
+   * @group wip
+   * @group chado
+   * @group api
+   */
+  function test_chado_get_record_with_property() {
+    //  * Get all records in the base table assigned one or more properties.
+
+    $feature = factory('chado.feature')->create();
+    $term = factory('chado.cvterm')->create();
+
+    $value = 'chado_API_test_value';
+
+    // Linker column
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $property = [
+      'type_id' => $term->cvterm_id,
+      'value' => $value,
+    ];
+
+    chado_insert_property($record, $property);
+
+    unset($record['id']);
+    $records = chado_get_record_with_property($record, $property);
+
+    $this->assertNotEmpty($records);
+    $this->assertEquals(1, count($records));
+
+    $feature = factory('chado.feature')->create();
+    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    chado_insert_property($record, $property);
+    $records = chado_get_record_with_property($record, $property);
+
+    $this->assertNotEmpty($records);
+    $this->assertEquals(2, count($records));
+  }
+
+
+}

--- a/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
+++ b/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
@@ -47,7 +47,6 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
   /**
    * @group chado
    * @group api
-   * @group wip
    *
    */
   public function test_chado_get_property() {
@@ -152,7 +151,6 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
 
   /**
-   * @group wip
    * @group chado
    * @group api
    */

--- a/tripal_chado/api/tripal_chado.property.api.inc
+++ b/tripal_chado/api/tripal_chado.property.api.inc
@@ -333,9 +333,11 @@ function chado_update_property($record, $property, $options = array()) {
 
   $insert_if_missing = array_key_exists('insert_if_missing', $options) ? $options['insert_if_missing'] : FALSE;
 
+
   // First see if the property is missing (we can't update a missing property.
   $prop = chado_get_property($record, $property);
-  if (!is_array($prop) or count($prop) == 0) {
+
+  if (empty($prop)) {
     if ($insert_if_missing) {
       return chado_insert_property($record, $property);
     }
@@ -343,6 +345,7 @@ function chado_update_property($record, $property, $options = array()) {
       return FALSE;
     }
   }
+
 
   // Build the values array for checking if the CVterm exists.
   $type = array();
@@ -360,6 +363,7 @@ function chado_update_property($record, $property, $options = array()) {
   if ($type_id) {
     $type['cvterm_id'] = $type_id;
   }
+
 
   // Make sure the CV term exists.
   $options = array();
@@ -437,7 +441,7 @@ function chado_update_property($record, $property, $options = array()) {
  *     -id: The primary key value of the base table. The property will be
  *         deleted from the record that matches this id.
  *     -prop_id: The primary key in the [table]prop table to be deleted.  If
- *         this value is supplied then the 'table' and 'id' keys are not needed.
+ *         this value is supplied then the  'id' key is not needed.
  * @param $property
  *   An associative array used to specify the property to be updated.  It can
  *   contain the following keys. The keys must be specified to uniquely identify
@@ -518,7 +522,7 @@ function chado_delete_property($record, $property) {
   // Construct the array that will match the exact record to update.
   else {
     $match = array(
-      $fkcol => $record_id,
+      $fkcol => $base_id,
       'type_id' => $type,
     );
   }

--- a/tripal_chado/api/tripal_chado.property.api.inc
+++ b/tripal_chado/api/tripal_chado.property.api.inc
@@ -24,7 +24,7 @@
  *     -id: The primary key value of the base table. The property will be
  *         associated with the record that matches this id.
  *     -prop_id: The primary key in the [table]prop table.  If this value
- *         is supplied then the 'table' and 'id' keys are not needed.
+ *         is supplied then the 'id' key is not needed.
  * @param $property
  *   An associative array used to specify the property to be selected.  It can
  *   contain the following keys. The keys must be specified to uniquely identify
@@ -98,15 +98,20 @@ function chado_get_property($record, $property) {
 
   // Construct the array of values to be selected.
   $values = array(
-    $fkcol => $base_id,
     'type_id' => $type,
   );
+
+  //Can supply either base_id or prop_id.
+  if ($base_id){
+    $values[$fkcol] = $base_id;
+  }
 
   // If we have the unique property_id make sure to add that to the values.
   if ($prop_id) {
     $property_pkey = $table_desc['primary key'][0];
     $values[$property_pkey] = $prop_id;
   }
+
   $results = chado_generate_var($base_table . 'prop', $values);
   if ($results) {
     $results = chado_expand_var($results, 'field', $base_table . 'prop.value');


### PR DESCRIPTION
   
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #657 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API-specific change (fix or addition to an API function)
- [x] Updates documentation (inline or markdown files)

## Description
There were several bugs with the chado properties API.  Although issue #657 was created for a specific one, I made a simple unit test for each base function: this PR includes those tests and also the necessary fixes to get them to pass.

The following issues were addressed:

* `chado_get_property` and `chado_update_property` say that if `prop_id` is supplied, then table and id keys are not needed. However, it still needs the table key.
* `chado_get_property` fails if a prop_id and table are supplied.  This is because the base key was added regardless of if it was passed in or not.
* `chado_update_property` failed.  This was because it expected an array returned from `chado_get_property`.  However, that function returns an object if theres only one match (which one would generally expect for this call.)
* `chado_delete_property` used an unitialized variable, causing it to always fail.


## Testing?

The easiest way I can think of to test this is to pull this branch, then run `phpunit --group api`.  All tests will pass.  Next, revert the `tripal_chado/api/tripal_chado.property.api.inc` file to the copy on `7.x-3.x`, and rerun the tests.  You should now have 3 failing tests: `chado_get_property`, `chado_update_property`, and `chado_delete_property`.  So:

```
phpunit --group api
git checkout 7.x-3.x tripal_chado/api/tripal_chado.property.api.inc
phpunit --group api
```

Theres no way I'm aware of to test these changes via the GUI.


### Test Cases

Because test are the main way to confirm this functionality, I describe my test cases below:

#### test_chado_insert_property

Create a feature and cvterm: use chado_insert_property to add them.  Confirm via SQL that the property was added.

#### test_chado_get_property

Create a feature and cvterm: use chado_insert_property to add them.  Then use `chado_get_property` to retrieve them.  Test cases where the `$record` provided is table/id, and table/prop_id.

#### test_chado_update_property

Insert a feature property, then provide a new value and run `chado_update_property`.  Confirm that the property value was updated but that other values stayed the same.

#### test_chado_delete_property

Insert a featureprop, and use chado_delete_property to remove.

### test_chado_get_record_with_property 
insert a single featureprop, and use chado_get_record_with property to retrieve it, given the property type_id and value.
Then, insert a second feature and featureprop with the same type_id and value, confirm that both featureprops are returned.


## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
