### PR TITLE
For Bradford: Update Property Tests PR

### DIFF
--- a/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
+++ b/tests/tripal_chado/api/TripalChadoPropertyAPITest.php
@@ -4,25 +4,31 @@ namespace Tests;
 
 use StatonLab\TripalTestSuite\DBTransaction;
 use StatonLab\TripalTestSuite\TripalTestCase;
+use StatonLab\TripalTestSuite\Database\Factory;
 
 class TripalChadoPropertyAPITest extends TripalTestCase {
 
   use DBTransaction;
 
   /**
+   * Tests chado_insert_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
-   *
+   * @group chado-property
    */
-  public function test_chado_insert_property() {
+  public function test_chado_insert_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -30,9 +36,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     chado_insert_property($record, $property);
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -45,19 +51,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
 
   /**
+   * Tests chado_get_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
-   *
+   * @group chado-property
    */
-  public function test_chado_get_property() {
+  public function test_chado_get_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -68,7 +79,7 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertNotFalse($retrieved);
     $this->assertEquals($value, $retrieved->value);
 
-    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    $record = ['prop_id' => $prop[$prop_table.'_id'], 'table' => $base_table];
     $retrieved = chado_get_property($record, $property);
 
     $this->assertNotNull($retrieved);
@@ -76,18 +87,25 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
   }
 
   /**
+   * Tests chado_update_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  public function test_chado_update_property() {
-    $feature = factory('chado.feature')->create();
+  public function test_chado_update_property($prop_table, $base_table) {
+
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
     $new_value = 'chado_API_new';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -100,9 +118,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     chado_update_property($record, $property);
 
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -114,17 +132,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
   }
 
   /**
+   * Tests chado_delete_property() with all prop tables.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  public function test_chado_delete_property() {
-    $feature = factory('chado.feature')->create();
+  public function test_chado_delete_property($prop_table, $base_table) {
+
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -134,9 +159,9 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     chado_delete_property($record, $property);
 
-    $result = db_select('chado.featureprop', 'f')
-      ->fields('f')
-      ->condition('f.feature_id', $feature->feature_id)
+    $result = db_select('chado.'.$prop_table, 'p')
+      ->fields('p')
+      ->condition('p.'.$base_pkey, $base_record->{$base_pkey})
       ->execute()
       ->fetchObject();
 
@@ -145,25 +170,33 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
 
     $prop = chado_insert_property($record, $property);
 
-    $record = ['prop_id' => $prop['featureprop_id'], 'table' => 'feature'];
+    $record = ['prop_id' => $prop[$prop_table.'_id'], 'table' => $base_table];
     chado_delete_property($record, $property);
   }
 
 
   /**
+   * Tests chado_get_record_with_property() with all prop tables.
+   *
+   * Note: chado_get_record_with_property() gets all records in the base table 
+   *   assigned one or more properties.
+   *
+   * @dataProvider propTableProvider
+   *
    * @group chado
    * @group api
+   * @group chado-property
    */
-  function test_chado_get_record_with_property() {
-    //  * Get all records in the base table assigned one or more properties.
+  function test_chado_get_record_with_property($prop_table, $base_table) {
 
-    $feature = factory('chado.feature')->create();
+    $base_record = factory('chado.'.$base_table)->create();
+    $base_pkey = $base_table.'_id';
     $term = factory('chado.cvterm')->create();
 
     $value = 'chado_API_test_value';
 
     // Linker column
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     $property = [
       'type_id' => $term->cvterm_id,
       'value' => $value,
@@ -177,8 +210,8 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertNotEmpty($records);
     $this->assertEquals(1, count($records));
 
-    $feature = factory('chado.feature')->create();
-    $record = ['table' => 'feature', 'id' => $feature->feature_id];
+    $base_record = factory('chado.'.$base_table)->create();
+    $record = ['table' => $base_table, 'id' => $base_record->{$base_pkey}];
     chado_insert_property($record, $property);
     $records = chado_get_record_with_property($record, $property);
 
@@ -186,5 +219,24 @@ class TripalChadoPropertyAPITest extends TripalTestCase {
     $this->assertEquals(2, count($records));
   }
 
+  /**
+   * Data Provider: All base tables with associated property tables.
+   *
+   * @return
+   *   An array where each item specifies the property table
+   *   and it's associated base table.
+   */
+  function propTableProvider() {
+    $prop_tables = [];
 
+    $base_tables = chado_get_base_tables();
+    foreach ($base_tables as $base) {
+      $prop = $base . 'prop';
+      if (chado_table_exists($prop) AND Factory::exists('chado.'.$base)) {
+        $prop_tables[] = [$prop, $base];
+      }
+    }
+
+    return $prop_tables;
+  }
 }


### PR DESCRIPTION
## Not a Typical PR as it's for @bradfordcondon branch. As such it is only subject to his review.

PR #659 

The main thing this PR does is extend your unit tests to all property tables in Chado. I did this by using the chado_get_base_tables() API function (so this is NOT dependent on #641). For each base table, I check if there is an associated prop table and that there is a TripalTestSuite Factory available.

Feel free to modify as you see fit :-)