### PR TITLE
Check that the field name exists before continuing

### DIFF
--- a/tripal/includes/TripalFieldDownloaders/TripalCSVDownloader.inc
+++ b/tripal/includes/TripalFieldDownloaders/TripalCSVDownloader.inc
@@ -80,6 +80,10 @@ class TripalCSVDownloader extends TripalFieldDownloader {
           // TODO: What to do with fields that are arrays?
         }
       }
+      // Report the misconfigured field
+      elseif(!$field_name) {
+        tripal_report_error('tripal', TRIPAL_ERROR, 'Unable to find field name for field id: '.$field_id);
+      }
       // If we have multiple items then deal with that.
       else {
         $col[] = '';

--- a/tripal/includes/TripalFieldDownloaders/TripalCSVDownloader.inc
+++ b/tripal/includes/TripalFieldDownloaders/TripalCSVDownloader.inc
@@ -54,7 +54,7 @@ class TripalCSVDownloader extends TripalFieldDownloader {
       $field_name = $field['field_name'];
 
       // If we only have one item for this value then add it.
-      if (is_array($entity->{$field_name}['und']) and count($entity->{$field_name}['und']) == 1) {
+      if ($field_name and is_array($entity->{$field_name}['und']) and count($entity->{$field_name}['und']) == 1) {
         $value = $entity->{$field_name}['und'][0]['value'];
 
         // If the single element is not an array then this is good.

--- a/tripal/includes/TripalFieldDownloaders/TripalTabDownloader.inc
+++ b/tripal/includes/TripalFieldDownloaders/TripalTabDownloader.inc
@@ -54,7 +54,7 @@ class TripalTabDownloader extends TripalFieldDownloader {
        $field_name = $field['field_name'];
 
        // If we only have one item for this value then add it.
-       if (is_array($entity->{$field_name}['und']) and count($entity->{$field_name}['und']) == 1) {
+       if ($field_name and is_array($entity->{$field_name}['und']) and count($entity->{$field_name}['und']) == 1) {
          $value = $entity->{$field_name}['und'][0]['value'];
 
          // If the single element is not an array then this is good.

--- a/tripal/includes/TripalFieldDownloaders/TripalTabDownloader.inc
+++ b/tripal/includes/TripalFieldDownloaders/TripalTabDownloader.inc
@@ -76,6 +76,10 @@ class TripalTabDownloader extends TripalFieldDownloader {
            // TODO: What to do with fields that are arrays?
          }
        }
+       // Report the misconfigured field
+       elseif(!$field_name) {
+         tripal_report_error('tripal', TRIPAL_ERROR, 'Unable to find field name for field id: '.$field_id);
+       }
        // If we have multiple items then deal with that.
        else {
          $col[] = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #478 

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As described in issue #478, Tripal's CSV and TSV downloaders fail in some cases. This PR mitigates that issue by checking that `$field_name` is not null/undefined. It also reports the error instead of failing fatally.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
I am not sure which field is triggering this error yet. It's currently happening on our live server and this simple fix works for us.

## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
