### PR TITLE
Added our current syntax to the guide.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,34 @@ http://www.sphinx-doc.org/en/master/usage/quickstart.html
 For more extensive edits, or when contributing new guides, you should build the documentation locally. From the `docs` root (eg `/var/www/html/sites/all/modules/tripal/docs/`, execute `make html`.  The built site will be in `docs/_build/html/index.html`.
 
 ### Tripal conventions
+Please follow these guidelines when updating our docs. Let us know if you have any questions or something isn't clear.
 
 Please place images in the same folder as the guide text file, following the convention [file_name].[n].[optional description].[extension].  For example, `configuring_page_display.3.rearrange.png` or `configuring_page_display.1.png` are both located in `docs/user_guide/` and are part of the `configuring_page_display.rst` guide.
 
-More guidelines coming soon...
+We currently use the following syntax:
+```
+Title of File (using title case)
+=================================
+
+Introduction text.
+
+Section Title
+-------------
+
+We use double backticks to indicate ``inline-code`` including file names, function and method names, paths, etc.
+
+Longer code-blocks should begin with the ``.. code-block:: [type]`` directive and should be indented at least one 
+level. There should also be a blank line before and after it as shown below.
+
+.. code-block:: sql
+  if ($needs_documentation) {
+      use $these_guidelines;
+      $contribute_docs = $appreciated;
+  }
+
+Section 1.1 Title
+^^^^^^^^^^^^^^^^^
+
+The use of appropriate sections makes reading documentation and later specific details easier. Sub sections such 
+as this one will be hidden unless the main section is already selected.
+```


### PR DESCRIPTION
## This PR Extends @bradfordcondon's existing PR thus only requires his review

I added our current syntax to the guide... As per #672, we may want to change our current guidelines to match ReadtheDocs conventions. **I'm including them here anyway to give people guidance in the meantime and ensure our documentation remains consistent.**

Note: I know the code example could be found elsewhere but none of the documentation I found made it clear that you had to indent the code block. This is something I struggled with when first contributing documentation. The importance of example code blocks makes me feel the couple of lines to make this clear is worth it.