### PR TITLE
Fixed instructions for the field

### DIFF
--- a/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
+++ b/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
@@ -320,7 +320,7 @@ class remote__data extends WebServicesField {
       ->execute()->fetchAll();
 
     foreach ($sites as $site) {
-      $rows[$site->id] =$site->name;
+      $rows[$site->id] = $site->name;
     }
 
     $element['data_info']['remote_site'] = array(
@@ -333,8 +333,15 @@ class remote__data extends WebServicesField {
     $element['data_info']['query'] = array(
       '#type' => 'textarea',
       '#title' => 'Query to Execute',
-      '#description' => 'Enter the query that will retreive the remote records. ' .
-        'If the full URL to the content web service is ' .
+      '#description' => 'Enter the query that will retreive the remote records. ',
+      '#default_value' => $this->instance['settings']['data_info']['query'],
+      '#rows' => 3,
+      '#required' => TRUE
+    );
+    $element['data_info']['query_instructions'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Query to Execute Instructions',
+      '#description' => 'If the full URL to the content web service is ' .
         'https://[tripal_site]/web-services/content/v0.1/. Then this field should ' .
         'contain the text immediately after the content/v0.1 portion of the URL. ' .
         'For information about building web services queries see the ' .
@@ -347,29 +354,19 @@ class remote__data extends WebServicesField {
         'use tokens to do this (see the "Available Tokesn" fieldset below). ' .
         'For this example, the query text should be ' .
         'Organism?genus=[taxrank__genus]&species=[taxrank__species].',
-      '#default_value' => $this->instance['settings']['data_info']['query'],
-      '#rows' => 5,
-      '#required' => TRUE
-    );
-    $element['data_info']['rd_field_name'] = array(
-      '#type' => 'textfield',
-      '#title' => 'Field to Display',
-      '#description' => 'The results returned by the query should match
-        entities (or records) from the selected remote site.  That entity
-        will have multiple fields. Only one remote field can be shown by
-        this field. Please enter the name of the field you would like
-        to display.  Some fields have "subfields".  You can display a subfield
-        rather than the entire field by entering a comma-separated sequence
-        of subfields.  For example, for relationships, you may only want to
-        show the "clause", therefore, the entry here would be: realtionship,clause.',
-      '#default_value' => $this->instance['settings']['data_info']['rd_field_name'],
-      '#required' => TRUE
-    );
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE
+    ];
+    $element['data_info']['query_instructions']['instructions'] = [
+      '#type' => 'markup',
+      '#markup' => '',      
+    ];
+    
     $element['data_info']['token_display']['tokens'] = array(
       '#type' => 'hidden',
       '#value' => serialize($tokens)
     );
-
+    
     $element['data_info']['token_display'] = array(
       '#type' => 'fieldset',
       '#title' => 'Available Tokens',
@@ -377,11 +374,57 @@ class remote__data extends WebServicesField {
       '#collapsible' => TRUE,
       '#collapsed' => TRUE
     );
-
+    
     $element['data_info']['token_display']['content'] = array(
       '#type' => 'item',
       '#markup' => theme_token_list($tokens),
     );
+    
+    $element['data_info']['rd_field_name'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Field to Display',
+      '#description' => 'Enter the key from the results returned by the "Query to Execute" that should be displayed. See the example below for more details.',
+      '#default_value' => $this->instance['settings']['data_info']['rd_field_name'],
+      '#required' => TRUE
+    );
+    
+    $element['data_info']['rd_field_name_instructions'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Field to Display Instructions',
+      '#description' => '',
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE
+    ];
+    $element['data_info']['rd_field_name_instructions']['insructions'] = [
+      '#type' => 'markup',
+      '#markup' => 'The query from a Tripal web service response is always
+       in JSON array arranged in key/value pairs.  The key is the name of a
+       controlled vocabulary term.  
+       <br><br>Suppose you want to query details about an organism.
+       Consider the following JSON result 
+       <pre style="height: 200px; overflow: auto;">   
+        "@type": "organism",
+        "label": "Anopheles gambiae",
+        "ItemPage": "http://demo.tripal.info/3.x/bio_data/642",
+        "type": "Organism",
+        "abbreviation": "A.gambiae",
+        "genus": "Anopheles",
+        "species": "gambiae",
+        "common_name": "mosquito",
+        "database_cross_reference": "http://demo.tripal.info/3.x/web-services/content/v0.1/Organism/642/database+cross+reference",
+        "equivalent_name": "Anopheles gambiae sensu stricto",
+        "division": "Invertebrates",
+        "mitochondrial_genetic_code_name": "Invertebrate Mitochondrial",
+        "synonym": "Anopheles gambiae S",
+        "genetic_code": "1",
+        "lineage": "cellular organisms; Eukaryota; Opisthokonta; Metazoa; Eumetazoa; Bilateria; Protostomia; Ecdysozoa; Panarthropoda; Arthropoda; Mandibulata; Pancrustacea; Hexapoda; Insecta; Dicondylia; Pterygota; Neoptera; Holometabola; Diptera; Nematocera; Culicomorpha; Culicoidea; Culicidae; Anophelinae; Anopheles; Cellia; Pyretophorus; gambiae species complex",
+        "genetic_code_name": "Standard",
+        "genbank_common_name": "African malaria mosquito"
+       </pre> 
+       To display the "lineage" from the JSON above you would enter the word 
+       "lineage" in the Field to Display textbox.   
+      ',
+    ];
 
     $element['data_info']['description'] = array(
       '#type' => 'textarea',

--- a/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
+++ b/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
@@ -341,19 +341,23 @@ class remote__data extends WebServicesField {
     $element['data_info']['query_instructions'] = [
       '#type' => 'fieldset',
       '#title' => 'Query to Execute Instructions',
-      '#description' => 'If the full URL to the content web service is ' .
-        'https://[tripal_site]/web-services/content/v0.1/. Then this field should ' .
-        'contain the text immediately after the content/v0.1 portion of the URL. ' .
-        'For information about building web services queries see the ' .
-        'online documentation at ' . l('The Tripal v3 User\'s Guide', 'http://tripal.info/tutorials/v3.x/web-services') . '. ' .
-        'For example, suppose this field is attached to an ' .
-        'Organism content type on the local site, and you want to retrieve a ' .
-        'field for the same organism on a remote Tripal site then you will ' .
-        'want to query on the genus and species. Also, you want the genus and ' .
-        'species to match the organism that this field is attached to. You can ' .
-        'use tokens to do this (see the "Available Tokesn" fieldset below). ' .
-        'For this example, the query text should be ' .
-        'Organism?genus=[taxrank__genus]&species=[taxrank__species].',
+      '#description' => 'If the full URL to the remote tripal content web '.
+        'service is "https://[tripal_site]/web-services/content/v0.1/". Then '.
+        'this field should contain the text immediately after the '.
+        '"content/v0.1" portion of the URL. For information about building '.
+        'web services queries see the online documentation at '.
+        l('The Tripal v3 User\'s Guide', 'http://tripal.info/tutorials/v3.x/web-services').
+        '. For example, suppose this field is attached to an Organism content '.
+        'type on the local site, and you want to retrieve a field for the '.
+        'same organism on a remote Tripal site. To retrieve the matching '.
+        'record, you will want to query on the genus and species, since it '.
+        'is unique and, you want them to match the organism for each specific '.
+        'local organism page. You can use tokens to do this (see the '.
+        '"Available Tokens" fieldset below). For this example, the full '.
+        'remote web service endpoint would be '.
+        '"https://[tripal_site]/web-services/content/v0.1/Organism" '.
+        'and the query text should be '.
+        '"Organism?genus=[taxrank__genus]&species=[taxrank__species]".',
       '#collapsible' => TRUE,
       '#collapsed' => TRUE
     ];
@@ -421,8 +425,8 @@ class remote__data extends WebServicesField {
         "genetic_code_name": "Standard",
         "genbank_common_name": "African malaria mosquito"
        </pre> 
-       To display the "lineage" from the JSON above you would enter the word 
-       "lineage" in the Field to Display textbox.   
+       To display the "common_name" from the JSON above you would enter the word
+       "common_name" in the Field to Display textbox.
       ',
     ];
 

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -420,7 +420,7 @@ class TripalContentService_v0_1 extends TripalWebService {
         $i++;
       }
       if ($expfield) {
-        $resource = $response;
+        $this->resource = $response;
       }
       else {
         //$this->resource->addProperty($key, $response);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #625 and discovered bug.

## Type(s) of Change(s)
<!--- What types of changes does your code introduce? 
         Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API-specific change (fix or addition to an API function)
- [ ] Updates documentation (inline or markdown files)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This addresses issue #625 where the instructions for setting field values for the remote__data field were not clear enough.  The problem was that the `Available Tokens` fieldset appeared below the field named `Field to Display` and it implied that tokens could be used.  This is not the case.  To fix this I

1) Moved the `Available Tokens` fieldset below the `Query to Execute` field.
2) The instructions needed more details and were becoming too long so I added fieldsets to contain the instructions for both fields.  

Also, there was a 1-line bug fix in web services that I included in this PR. You can see it in the code review. It was so minor I decided to include it here rather than create it's on PR.  It fixes the problem when browsing web services.  For fields that are not auto attached the web services gives a link.  If the user follows that link it takes them to another web service result that then provides the values.  This result was not complete.  This fixes it.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
There is no need to test the fixes to the remote__data field unless you want to see the changes yourself. Otherwise a code review and looking at the screenshots should suffice.  

To test the web services fix, pull the branch, navigate through web services to any entity that has relationships and follow the relationships link. You should see all of the relationships.

## Screenshots (if appropriate):
Screenshot of new remote__data form page with described fixes:

![image](https://user-images.githubusercontent.com/1719352/46239267-50c74400-c34b-11e8-8e2a-69074cc40b0e.png)

Screenshot of web services for a gene with non-attached fields shown as links:

![image](https://user-images.githubusercontent.com/1719352/46239332-435e8980-c34c-11e8-991d-5c4a25435f9b.png)

Screenshot of web services when looking at relationships, before the fix.

![image](https://user-images.githubusercontent.com/1719352/46239348-69842980-c34c-11e8-86ae-0a6a71f52e00.png)

And after the fix:

![image](https://user-images.githubusercontent.com/1719352/46239340-5b360d80-c34c-11e8-9d9b-c88efa3fae13.png)


## Additional Notes (if any):
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
