### PR TITLE
Cache terms to improve the performance of page load

### DIFF
--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -575,8 +575,11 @@ class OBOImporter extends TripalImporter {
    *
    */
   public function postRun() {
+    
+    // Clear the cached terms
+    cache_clear_all('tripal_chado:term:*', 'cache', TRUE);
 
-    // Update the cv_root_mview materiailzed view.
+    // Update the cv_root_mview materialized view.
     $this->logMessage("Updating the cv_root_mview materialized view...");
     $mview_id = tripal_get_mview_id('cv_root_mview');
     tripal_populate_mview($mview_id);
@@ -585,7 +588,7 @@ class OBOImporter extends TripalImporter {
     $mview_id = tripal_get_mview_id('db2cv_mview');
     tripal_populate_mview($mview_id);
 
-    // Upate the cvtermpath table for each newly added CV.
+    // Update the cvtermpath table for each newly added CV.
     $this->logMessage("Updating cvtermpath table.  This may take a while...");
     foreach ($this->obo_namespaces as $namespace => $cv_id) {
       $this->logMessage("- Loading paths for vocabulary: @vocab", array('@vocab' => $namespace));

--- a/tripal_chado/includes/tripal_chado.cv.inc
+++ b/tripal_chado/includes/tripal_chado.cv.inc
@@ -154,6 +154,10 @@ function tripal_cv_cv_edit_form_submit($form, &$form_state) {
   if (strcmp($op, 'Update')==0) {
     $match = array('cv_id' => $cv_id);
     $success = chado_update_record('cv', $match, $values);
+    
+    // Clear the cached terms
+    cache_clear_all('tripal_chado:term:*', 'cache', TRUE);
+    
     if ($success) {
       drupal_set_message(t("Controlled vocabulary updated"));
       drupal_goto('admin/tripal/loaders/chado_vocabs/chado_cvs');

--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -257,9 +257,11 @@ function tripal_chado_vocab_get_term_children($vocabulary, $accession) {
  * This hook is created by the Tripal module and is not a Drupal hook.
  */
 function tripal_chado_vocab_get_term($vocabulary, $accession) {
+  // Cache ID for this term:
+  $cid = 'tripal_chado:term:' . $vocabulary . ':' . $accession;
   
-  // Check the cache fisrt. Get the term from cache if it's available
-  $cache = cache_get('tripal_chado:term:' . $vocabulary . ':' . $accession);
+  // Check the cache first. Get the term from cache if it's available
+  $cache = cache_get($cid, 'cache');
   if (isset($cache->data)) {
     return $cache->data;
   }
@@ -292,7 +294,7 @@ function tripal_chado_vocab_get_term($vocabulary, $accession) {
 
   // Cache the term to reduce the amount of queries sent to the database
   $term =  _tripal_chado_format_term_description($cvterm);
-  cache_set('tripal_chado:term:' . $vocabulary . ':' . $accession, $term);
+  cache_set($cid, $term, 'cache', CACHE_TEMPORARY);
   return $term;
 }
 

--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -257,7 +257,12 @@ function tripal_chado_vocab_get_term_children($vocabulary, $accession) {
  * This hook is created by the Tripal module and is not a Drupal hook.
  */
 function tripal_chado_vocab_get_term($vocabulary, $accession) {
-
+  
+  // Check the cache fisrt. Get the term from cache if it's available
+  $cache = cache_get('tripal_chado:term:' . $vocabulary . ':' . $accession);
+  if (isset($cache->data)) {
+    return $cache->data;
+  }
   // It's possible that Chado is not available (i.e. it gets renamed
   // for copying) but Tripal has already been prepared and the
   // entities exist.  If this is the case we don't want to run the
@@ -285,7 +290,10 @@ function tripal_chado_vocab_get_term($vocabulary, $accession) {
   $cvterm = chado_expand_var($cvterm, 'table', 'cvterm_relationship', $options);
   $cvterm = chado_expand_var($cvterm, 'table', 'cvtermprop', $options);
 
-  return _tripal_chado_format_term_description($cvterm);
+  // Cache the term to reduce the amount of queries sent to the database
+  $term =  _tripal_chado_format_term_description($cvterm);
+  cache_set('tripal_chado:term:' . $vocabulary . ':' . $accession, $term);
+  return $term;
 }
 
 /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->


<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

#

Issue # n/a

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Cache terms to improve the performance of page load. Since Tripal 3 is now ontology based, it sends a lot of queries to retrieve the definition of terms. This PR caches the terms to reduce the number of SQL sent to the server and thus improves the performance. 

The cached terms will be cleared when an OBO lmporter job finishes, or a cvterm gets updated using the GUI interface.
## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
Time the page load before and after the fix. You should notice the difference. This PR improves the performance the second time a page of same type (not just the exact same page) is loaded. It also improves the single page load when a page tries to load the same term multiple times.

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->