### PR TITLE
Added fix for TOC auto hide

### DIFF
--- a/tripal/theme/js/tripal.js
+++ b/tripal/theme/js/tripal.js
@@ -73,7 +73,7 @@
     pane.remove();
     
     // Remove the pane's title from the TOC.
-    $('#' + this.id).hide(0);
+    $('#' + this.id).parents('.views-row').remove();
   }
   
   /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

# Bug Fix

Issue # NA

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a very simple 1 line of code change to the JavaScript that fixes a bug when removing the row from the sidebar TOC when a panel is empty.  Previously it just removed the `<a>` tag but left the surrounding `<span>` and that left uneven spacing between links.  This fixes that problem.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
It's hard to test depending on your CSS and the spacing between your links.  Just pull the branch and load a page to makes sure nothing breaks. You have to have 'Hide Empty fields' checked for the content type.

This is just a simple code fix and only needs one review. It's so simple you can probably just review the code itself. I'd like to get this into the Tv3 release if possible.

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/1719352/46322193-62535a80-c59c-11e8-81e3-fec739666cbf.png)

After:
![image](https://user-images.githubusercontent.com/1719352/46322183-510a4e00-c59c-11e8-8c27-6b5d6d3b736f.png)


## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->