### PR TITLE
Issue #702: Fix Location on Map field undefined error.

### DIFF
--- a/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
+++ b/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
@@ -322,10 +322,11 @@ class ogi__location_on_map extends ChadoField {
       }
     }
 
+
     // If there are no map positions expanded above then remove the stub.
     // This is needed to ensure this field isn't displayed when there are no locations.
     if (!isset($feature->featurepos->feature_id) OR (sizeof($feature->featurepos->feature_id) == 0)) {
-      unset($entity->{$field_name});
+      $entity->{$field_name}['und'][0]['value'] = array();
     }
   }
 


### PR DESCRIPTION
# Bug Fix

Issue #702 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
@abretaud saw this notice while displaying an mRNA (with data from the Citrus demo from tripal 2.x) and I say it on gene pages created using Tripal DevSeed:

```
Notice: Undefined property: TripalEntity::$ogi__location_on_map in TripalEntityController->attachLoad() (line 681 of /var/www/html/sites/all/modules/tripal/tripal/includes/TripalEntityController.inc).
```

It was caused because the ogi__location_on_map field unset itself when it was empty rather then just returning a non-true value. This PR fixes this behavior.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
### Warning is gone
1. Go to an existing Gene page (before pulling this branch) and click the "Reload" tab. You should see the above warning.
2. Pull the PR, go to the same page and click the "Reload" tab. The message should be gone :-)

### feature location field still works.
Ideally also test a page with a location on a map to ensure the field still works as it's supposed to. To test this, 
1. create a fake map feature (or use an existing feature),
2. insert a fake featuremap record 
3. add a `featurepos` pointing to the map feature, fake featuremap and your gene. 
4. Check that the on "Reload" the featuremap field now displays the record you just inserted.

The following screenshot shows the field still works with this PR ;-p
![screen shot 2018-10-03 at 10 20 14 am](https://user-images.githubusercontent.com/1566301/46424401-44017200-c6f6-11e8-8e9f-fcc4e8fd4ecd.png)