### PR TITLE
Remove undefined menu callback (tripal 2)

### DIFF
--- a/tripal_pub/tripal_pub.module
+++ b/tripal_pub/tripal_pub.module
@@ -188,12 +188,6 @@ function tripal_pub_menu() {
     'access arguments' => array('administer tripal pub'),
     'type ' => MENU_CALLBACK,
   );
-  $items['admin/tripal/chado/tripal_pub/import/changedb'] = array(
-    'page callback' => 'tripal_pub_importer_setup_page_update_remotedb',
-    'page arguments' => array(),
-    'access arguments' => array('administer tripal pub'),
-    'type ' => MENU_CALLBACK,
-  );
 
   $items['admin/tripal/chado/tripal_pub/import/criteria/%/%'] = array(
     'page callback' => 'tripal_pub_importer_setup_page_update_criteria',


### PR DESCRIPTION
# Bux Fix

Issue #640 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

As discussed in the issue (#640), this PR removes an undefined menu callback. This is the same as #715 but for tripal 2.

Thanks!