### PR TITLE
Fixes node sync error issue due to missing $transaction variable.

### DIFF
--- a/tripal_core/api/tripal_core.chado_nodes.api.inc
+++ b/tripal_core/api/tripal_core.chado_nodes.api.inc
@@ -911,7 +911,7 @@ function chado_node_sync_records($base_table, $max_sync = FALSE,
   print "\n$count $base_table records found.\n";
 
   $i = 0;
-  //$transaction = db_transaction();
+  $transaction = db_transaction();
   print "\nNOTE: Syncing is performed using a database transaction. \n" .
       "If the sync fails or is terminated prematurely then the entire set of \n" .
       "synced items is rolled back and will not be found in the database\n\n";
@@ -970,7 +970,7 @@ function chado_node_sync_records($base_table, $max_sync = FALSE,
   }
 
   catch (Exception $e) {
-    // $transaction->rollback();
+    $transaction->rollback();
     print "\n"; // make sure we start errors on new line
     watchdog_exception('trp-fsync', $e);
     print "FAILED: Rolling back database changes...\n";

--- a/tripal_core/api/tripal_core.chado_nodes.api.inc
+++ b/tripal_core/api/tripal_core.chado_nodes.api.inc
@@ -970,7 +970,7 @@ function chado_node_sync_records($base_table, $max_sync = FALSE,
   }
 
   catch (Exception $e) {
-    $transaction->rollback();
+    // $transaction->rollback();
     print "\n"; // make sure we start errors on new line
     watchdog_exception('trp-fsync', $e);
     print "FAILED: Rolling back database changes...\n";


### PR DESCRIPTION
In function chado_node_sync_records(), the $transaction variable has been commented line 914 but not line 973 which prevents error from being displayed correctly.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

#

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->