### PR TITLE
fix variable passed in hook menu for views integration

### DIFF
--- a/tripal_chado_views/tripal_chado_views.module
+++ b/tripal_chado_views/tripal_chado_views.module
@@ -82,7 +82,7 @@ function tripal_chado_views_menu() {
   $items['admin/tripal/storage/chado/views-integration/delete/%'] = array(
     'title' => 'Delete Views Integration',
     'page callback' => 'tripal_chado_views_integration_delete',
-    'page arguments' => array(4),
+    'page arguments' => array(6),
     'access arguments' => array('manage tripal_views_integration'),
     'type' => MENU_CALLBACK,
   );
@@ -105,21 +105,11 @@ function tripal_chado_views_menu() {
     'weight' => 2,
   );
 
-  $items['admin/tripal/storage/chado/views-integration/export'] = array(
-    'title' => 'Export Views Integration',
-    'description' => 'Export a Chado Views Integration for use in another Tripal site',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('tripal_chado_views_integration_export_form', 4),
-    'access arguments' => array('manage tripal_views_integration'),
-    'type' => MENU_CALLBACK,
-    'weight' => 3,
-  );
-
   $items['admin/tripal/storage/chado/views-integration/export/%'] = array(
     'title' => 'Export Views Integration',
     'description' => 'Export a Chado Views Integration for use in another Tripal site',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('tripal_chado_views_integration_export_form', 4),
+    'page arguments' => array('tripal_chado_views_integration_export_form', 6),
     'access arguments' => array('manage tripal_views_integration'),
     'type' => MENU_CALLBACK,
   );


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

# Bug Fix

Issue #712

## Description
The tripal views integration module passes the wrong part of the url as the 
`access arguments` probably left over from changing the menu structure.

As a result, from `admin/tripal/storage/chado/views-integration` clicking on export or delete will give a PDO error and crash.  Edit was not effected.

thank you @risharde for identifying the issue.



## Testing?
Visit `admin/tripal/storage/chado/views-integration` and click export/delete on any view.  it will crash.

Pull this branch, and clear your cache, the links will now work.


## Additional Notes (if any):

I deleted teh menu callback for `admin/tripal/storage/chado/views-integration/export` since i dont see it used: `admin/tripal/storage/chado/views-integration/export/%` exports a specific view, and the menu is at `admin/tripal/storage/chado/views-integration`, so `admin/tripal/storage/chado/views-integration/export` doesnt make any sense, and also would pass null in the code which isnt handled, so im pretty sure its safe to delete.
