### PR TITLE
Fix undefined index in search tool

### DIFF
--- a/tripal/includes/TripalFieldQuery.inc
+++ b/tripal/includes/TripalFieldQuery.inc
@@ -124,7 +124,10 @@ class TripalFieldQuery extends EntityFieldQuery {
       if (is_numeric($results)) {
         return $results;
       }
-      return count($results['TripalEntity']);
+      if (array_key_exists('TripalEntity', $results)) {
+        return count($results['TripalEntity']);
+      }
+      return 0;
     }
     return $results;
   }


### PR DESCRIPTION
# Bug Fix

Issue #734 

## Description
Added a test for a key existence in array. This key was not set when there was no results, such bringing up a warning. If there are no results, it just return 0.

## Testing?
Use any of the search tool (ex: /data_search/mrna) and use any query that will not return any results.
(Might need to be logged as admin to see the warning without the fix)

