### PR TITLE
Bug Fix for bulk setting of URL Aliases

### DIFF
--- a/tripal/includes/TripalBundleUIController.inc
+++ b/tripal/includes/TripalBundleUIController.inc
@@ -447,17 +447,18 @@ function tripal_tripal_bundle_form_validate($form, $form_state) {
 
   // PART 2: URL Alias'
   if ($form_state['values']['url']['url_pattern']) {
+    $url_pattern = trim($form_state['values']['url']['url_pattern']);    
     $tokens_available = unserialize($form_state['values']['url']['tokens']);
     
     // For backwards compatibility we should warn uses if they use the word 
     // 'feature' as this conflicts with the feature lookup tool. 
-    if (preg_match('/^feature\//', $form_state['values']['url']['url_pattern'])) {
+    if (preg_match('/^feature\//', $url_pattern)) {
       $msg = t('The word "feature" should not be used first in the pattern as it conflicts with the feature lookup tool provided by Tripal');
       form_set_error('url][url_pattern', $msg);
     }
     
     // Now make sure the tokens are valid.
-    if (preg_match_all('/(\[\w+\])/', $form_state['values']['url']['url_pattern'], $matches)) {
+    if (preg_match_all('/(\[\w+\])/', $url_pattern, $matches)) {
 
       // The matches of the first and only pattern will be our tokens.
       $tokens_used = $matches[1];
@@ -510,7 +511,8 @@ function tripal_tripal_bundle_form_submit($form, &$form_state) {
 
     // Save the URL alias pattern if it's set.
     if ($form_state['values']['url']['url_pattern']) {
-      tripal_set_bundle_variable('url_format', $bundle->id, $form_state['values']['url']['url_pattern']);
+      $url_pattern = trim($form_state['values']['url']['url_pattern']);
+      tripal_set_bundle_variable('url_format', $bundle->id, $url_pattern);
     }
 
     // There are two submit buttons for this either updating the paths or the
@@ -530,7 +532,7 @@ function tripal_tripal_bundle_form_submit($form, &$form_state) {
         'tripal_update_all_urls_and_titles', $args, $user->uid, 10, $includes);
     }
     elseif ($trigger == 'Bulk update all aliases'){
-      $update = $form_state['input']['url']['url_pattern'];
+      $update = $url_pattern;
       $type = 'alias';
       $args = array(
         'bundle_id' => $bundle->name,

--- a/tripal/includes/TripalBundleUIController.inc
+++ b/tripal/includes/TripalBundleUIController.inc
@@ -448,6 +448,15 @@ function tripal_tripal_bundle_form_validate($form, $form_state) {
   // PART 2: URL Alias'
   if ($form_state['values']['url']['url_pattern']) {
     $tokens_available = unserialize($form_state['values']['url']['tokens']);
+    
+    // For backwards compatibility we should warn uses if they use the word 
+    // 'feature' as this conflicts with the feature lookup tool. 
+    if (preg_match('/^feature\//', $form_state['values']['url']['url_pattern'])) {
+      $msg = t('The word "feature" should not be used first in the pattern as it conflicts with the feature lookup tool provided by Tripal');
+      form_set_error('url][url_pattern', $msg);
+    }
+    
+    // Now make sure the tokens are valid.
     if (preg_match_all('/(\[\w+\])/', $form_state['values']['url']['url_pattern'], $matches)) {
 
       // The matches of the first and only pattern will be our tokens.

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -18,11 +18,12 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
   $num_entities = $entities->rowCount();
   
   // Parse the $update variable for tokens and load those tokens.
-  preg_match_all("'/\[.*?\]/'", $update, $bundle_tokens);
+  preg_match_all("/\[.*?\]/", $update, $bundle_tokens);
 
   $fields = array();
+  print_r($bundle_tokens);
   foreach ($bundle_tokens as $bundle_token) {
-    $elements = explode(',', $token);
+    $elements = explode(',', $bundle_token[0]);
     $field_name = array_shift($elements);
     $field_array = field_info_field($field_name);
     $fields[] = $field_array['id'];

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -42,6 +42,9 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
         $ec->setAlias($ent, $update);
         $ec->resetCache();
       }
+      // To speed up bulk alias updating the following function was skipped
+      // over. We'll add it back here to complete the process.
+      drupal_path_alias_whitelist_rebuild();
     }
     elseif ($type == 'title') {
       if (!empty($arg)) {

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -21,7 +21,6 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
   preg_match_all("/\[.*?\]/", $update, $bundle_tokens);
 
   $fields = array();
-  print_r($bundle_tokens);
   foreach ($bundle_tokens as $bundle_token) {
     $elements = explode(',', $bundle_token[0]);
     $field_name = array_shift($elements);

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -42,16 +42,12 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
         $ec->setAlias($ent, $update);
         $ec->resetCache();
       }
-      // To speed up bulk alias updating the following function was skipped
-      // over. We'll add it back here to complete the process.
-      drupal_path_alias_whitelist_rebuild();
     }
     elseif ($type == 'title') {
       if (!empty($arg)) {
         if (is_array($arg)) {
           $ent = reset($arg);
         }
-
         $ec = entity_get_controller('TripalEntity');
         $ec->setTitle($ent, $update);
         $ec->resetCache();
@@ -63,6 +59,12 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
       print $i . "/" . $num_entities . " entities have been updated. Memory usage: $mem bytes.\r";
     }
     $i++;
+  }
+  
+  // To speed up bulk alias updating the following function was skipped
+  // over. We'll add it back here to complete the process.
+  if ($type == 'alias') {
+    drupal_path_alias_whitelist_rebuild();
   }
 
   print "\nDone.";


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type: -->
# Bux Fix

Issue #727

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are two problems when updating URL alias.  
1)  Somehow in the code below the `$bundle_tokens` didn't get used properly in the for loop causing errors when updating.
https://github.com/tripal/tripal/blob/3f134c3030d4b6e8ff834ecef05626ed0eb311ab/tripal/includes/tripal.bulk_update.inc#L19-L30
2)  If the user uses the word `feature` as the first word in the URL it conflicts with Tripal's feature lookup tool that already uses that URL.
3)  In issue #727 it was reported that the URL wouldn't work on the first attempt if manually typing the URL into the browser. I think this may be related to number 2 above, as I can only reproduce the problem in that case. But we will test for it here to be sure.

This PR fixes the code in issue #1 and adds a warning that user's should not use `feature` as the first word.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
1) First pull the branch.

2) Go to Admin > Structure > Tripal Content Types and select a content type that is mapped to the Chado feature table (e.g. Gene).   Edit the content type and scroll to the bottom and click the `URL Path Options`   Set the URL to this:
```
feature/[obi__organism,TAXRANK:0000005]/[obi__organism,TAXRANK:0000006]/[rdfs__type]/[data__identifier]
```
Then click the button to `Bulk Update all aliases`   You should get an error notice that the word 'feature' should not be used as the first word in the URL alias string.    

2)  Next, replace the word `feature` with something else (e.g. 'gene') and click the button 'Bulk Upload all aliases'.  it should add a job.

3)  Run the job

4)  To test problem 3 above, do not load a gene page via the GUI, but rather try to type the URL into a browser. If you have sample data from the Tripal tutorial then this URL should work:  http://localhost/blah/Citrus/sinensis/Gene/orange1.1g015632m.g

