### PR TITLE
Bundle Category not set correctly

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -542,7 +542,7 @@ function tripal_create_bundle($args, $job = NULL) {
     }
 
     // Set the bundle category
-    $category = array_key_exists('bundle_category', $args) ? $args['bundle_category'] : 'Other';
+    $category = array_key_exists('category', $args) ? $args['category'] : 'Other';
     tripal_set_bundle_variable('bundle_category', $bundle->id, $category);
 
     // Attache the bundle fields.

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -782,6 +782,11 @@ function _tripal_chado_prepare_create_bundle($args, $job) {
     }
   }
   else {
+
+    // Update the bundle category in case it was set incorrectly.
+    $category = array_key_exists('category', $args) ? $args['category'] : 'Other';
+    tripal_set_bundle_variable('bundle_category', $bundle->id, $category);
+
     drush_print("Content type already created (skipping): " . $args['term_name'] . "...");
   }
 }


### PR DESCRIPTION
# Bux Fix
Issue #744 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
All content types are being grouped into the other category rather then set as they should be.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
Test the "Fix categories" commit:
1. Create a new Tripal site on 7.x-3.x
2. Navigate to Content > Create Tripal Content and notice all content types are in the other category
3. Switch to branch and re-prepare chado.
4. Navigate to Content > Create Tripal Content and notice all content types are correctly categorized.

Test the "Categorize" commit:
1. Create a new Tripal site on this branch 
2. Navigate to Content > Create Tripal Content and notice all content types are correctly categorized.
