### PR TITLE
resolve content creation bug w/ contact field: attach linker contact field instead of base field 

### DIFF
--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -2241,7 +2241,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
         'term_name' => 'contact',
       ),
       'widget' => array(
-        'type' => 'local__contact_widget',
+        'type' => 'chado_linker__contact_widget',
         'settings' => array(
           'display_label' => 1,
         ),
@@ -2249,7 +2249,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
       'display' => array(
         'default' => array(
           'label' => 'hidden',
-          'type' => 'local__contact_formatter',
+          'type' => 'chado_linker__contact_formatter',
           'settings' => array(),
         ),
       ),

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1825,3 +1825,39 @@ function tripal_chado_update_7335() {
     throw new DrupalUpdateException('Could not perform update: '. $error);
   }
 }
+
+
+/**
+ * Use correct contact field when linked via linker table.
+ */
+function tripal_chado_update_7336() {
+
+  $bases = [
+    'feature',
+    'featuremap',
+    'library',
+    'nd_experiment',
+    'project',
+    'pubauthor',
+  ];
+
+  $bundles = field_info_instances('TripalEntity');
+
+  foreach ($bundles as $bundle_name => $fields) {
+
+    $bundle = tripal_load_bundle_entity(['name' => $bundle_name]);
+    $base = $bundle->data_table;
+
+    if (in_array($base, $bases)) {
+
+      $field_name = $base . '_contact';
+      $instance_info = field_info_instance('TripalEntity', $field_name, $bundle_name);
+
+      $instance_info['type'] = 'chado_linker__contact';
+      $instance_info['widget']['type'] = 'chado_linker__contact_widget';
+      $instance_info['formatter']['type'] = 'chado_linker__contact_widget';
+      field_update_instance($instance_info);
+
+    }
+  }
+}

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1827,19 +1827,11 @@ function tripal_chado_update_7335() {
 }
 
 
+
 /**
  * Use correct contact field when linked via linker table.
  */
 function tripal_chado_update_7336() {
-
-  $bases = [
-    'feature',
-    'featuremap',
-    'library',
-    'nd_experiment',
-    'project',
-    'pubauthor',
-  ];
 
   $bundles = field_info_instances('TripalEntity');
 
@@ -1848,7 +1840,8 @@ function tripal_chado_update_7336() {
     $bundle = tripal_load_bundle_entity(['name' => $bundle_name]);
     $base = $bundle->data_table;
 
-    if (in_array($base, $bases)) {
+    $contact_table = $base . '_contact';
+    if (chado_table_exists($contact_table)) {
 
       $field_name = $base . '_contact';
       $instance_info = field_info_instance('TripalEntity', $field_name, $bundle_name);
@@ -1857,7 +1850,7 @@ function tripal_chado_update_7336() {
       $instance_info['widget']['type'] = 'chado_linker__contact_widget';
       $instance_info['formatter']['type'] = 'chado_linker__contact_widget';
       field_update_instance($instance_info);
-
+      
     }
   }
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

# bug fix 

Issue #717

## Description
per @laceysanderson 's report:

When trying to create a project:

```
Could not save the TripalEntity: SQLSTATE[23502]: Not null violation: 7 ERROR: null value in column "contact_id" violates not-null constraint DETAIL: Failing row contains (1, 1, null).
Cannot save entity
```
and the form is reset without creating the project.

after examining the bug, the same should be true for other content with a contact linker field instead of a base contact field, for example, library.

## Testing?
create a project and/or library on 7.x-3.x with NULL for contact, it should fail.  

switch to this branch.  **clear the cache**.  remove the contact field, and then press the check for new fields button.  You should now be able to create the content.

(note: how do I delete and re-add the field as an `updatedb`?)
## Screenshots (if appropriate):

## Additional Notes (if any):
