### PR TITLE
Create dbxref record if not present

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
@@ -99,7 +99,7 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
       '#disabled' => $db_id ? FALSE : TRUE,
     );
   }
-    
+
   /**
    * @see TripalFieldWidget::validate()
    */
@@ -111,7 +111,7 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     $field_table = $this->instance['settings']['chado_table'];
     $field_column = $this->instance['settings']['chado_column'];
     $base_table = $this->instance['settings']['base_table'];
-    
+
     $schema = chado_get_schema($table_name);
     $pkey = $schema['primary key'][0];
     $fkeys = array_values($schema['foreign keys'][$base_table]['columns']);
@@ -121,6 +121,8 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     $dbxref_id = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'];
     $db_id = $form_state['values'][$field_name]['und'][$delta]['db_id'];
     $accession = $form_state['values'][$field_name]['und'][$delta]['accession'];
+
+    dpm('HERE: '.$db_id);
 
     // If user did not select a database, we want to remove the dbxref record.
     // We do this by setting all values to empty except the value and the
@@ -139,6 +141,26 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
         $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'] = $dbxref->dbxref_id;
         $form_state['values'][$field_name]['und'][$delta]['value'] = $dbxref->dbxref_id;
       }
+    }
+  }
+
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+    $field_name = $this->field['field_name'];
+    $field_table = $this->instance['settings']['chado_table'];
+
+    $dbxref_id = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'];
+    $db_id = $form_state['values'][$field_name]['und'][$delta]['db_id'];
+    $accession = $form_state['values'][$field_name]['und'][$delta]['accession'];
+
+    dpm($db_id);
+
+    if($db_id and !$dbxref_id) {
+      $dbxref = chado_insert_dbxref([
+        'db_id' => $db_id,
+        'accession' => $accession
+      ]);
+      $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'] = $dbxref->dbxref_id;
+      $form_state['values'][$field_name]['und'][$delta]['value'] = $dbxref->dbxref_id;
     }
   }
 

--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
@@ -122,8 +122,6 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     $db_id = $form_state['values'][$field_name]['und'][$delta]['db_id'];
     $accession = $form_state['values'][$field_name]['und'][$delta]['accession'];
 
-    dpm('HERE: '.$db_id);
-
     // If user did not select a database, we want to remove the dbxref record.
     // We do this by setting all values to empty except the value and the
     // primary key.
@@ -144,6 +142,9 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     }
   }
 
+  /**
+   * @see TripalFieldWidget::submit()
+   */
   public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
     $field_name = $this->field['field_name'];
     $field_table = $this->instance['settings']['chado_table'];
@@ -151,8 +152,6 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
     $dbxref_id = $form_state['values'][$field_name]['und'][$delta]['chado-' . $field_table . '__dbxref_id'];
     $db_id = $form_state['values'][$field_name]['und'][$delta]['db_id'];
     $accession = $form_state['values'][$field_name]['und'][$delta]['accession'];
-
-    dpm($db_id);
 
     if($db_id and !$dbxref_id) {
       $dbxref = chado_insert_dbxref([


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


# New Feature / Bug Fix



issue #770 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Create a dbxref record if one is not present in the sbo__database_cross field. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
- Create a new `Cross Reference` entry for an accession that does not exist by editing an existing entity or creating a new one:
- The new record should exist in `chado.dbxref` and become available on the entity page

## Screenshots (if appropriate):

### Form Screenshot
<img width="755" alt="screen shot 2018-12-04 at 9 58 24 am" src="https://user-images.githubusercontent.com/1512664/49450515-2b234480-f7ab-11e8-9f7a-a213aab80fbe.png">

### Result Screenshot
<img width="737" alt="screen shot 2018-12-04 at 10 00 49 am" src="https://user-images.githubusercontent.com/1512664/49450695-8b19eb00-f7ab-11e8-8a82-91481b17367d.png">


## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->