### PR TITLE
Remove php 5.6 support from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ sudo: required
 php:
   - 7.0
   - 7.1
-  - 7.2
 
 env:
   - BASE_URL="http://127.0.0.1:8080"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ services:
 sudo: required
 
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - BASE_URL="http://127.0.0.1:8080"


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR adds support for php7.2 and remove 5.6 on Travis.

PHP 5.6 is nearing end-of-life. Our PRs have already dropped support for 5.6. For example, PR #678 uses type declarations that are only supported on php 7.0+. Therefore, many of our PRs will fail on travis if we don't remove 5.6 support and instead add 7.2.


## Screenshots (if appropriate):
<img width="846" alt="screen shot 2018-12-10 at 10 12 21 am" src="https://user-images.githubusercontent.com/1512664/49741369-43d8a200-fc64-11e8-8c55-a2980297569e.png">