### PR TITLE
ReadTheDoc instructions for custom module

### DIFF
--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -15,5 +15,6 @@ Developer's Guide
    dev_guide/exporting_field_settings
    dev_guide/custom_data_loader
    dev_guide/custom_web_services
+   dev_guide/rtd
    dev_guide/contributing
    dev_guide/tutorials

--- a/docs/dev_guide/contributing/documentation.rst
+++ b/docs/dev_guide/contributing/documentation.rst
@@ -1,3 +1,5 @@
+.. _tripal_rtd:
+
 Contributing to the Documentation
 ==================================
 

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -1,0 +1,37 @@
+Using ReadTheDocs
+=================
+
+.. note::
+
+  For Tripal's own ReadTheDocs guidelines: :ref:`tripal_rtd`
+
+
+What is ReadTheDocs?
+--------------------
+
+Documentation is important. It tells users how to use our product, and developers how to read our code.  We recommend hosting documentation for your custom module somewhere easily accessible, like ReadTheDocs.
+
+`ReadTheDocs <https://readthedocs.org/>`_ uses the `Sphinx <http://www.sphinx-doc.org/en/master/>`_ framework to build a website in a Continuous Integration setup. When new code is pushed to GitHub, the documentation website as defined by sphinx is built, and the "live" documentation website is updated.
+
+- Code changes can include documentation updates **in the same pull request**.
+- Changes to the documentation is **subject to review, just like code changes**.
+- Documentation changes are under **version control**.
+
+How do I add ReadTheDocs to My Project?
+---------------------------------------
+
+- Set up your ReadeTheDocs account and add your project integration
+- Install Sphinx
+- Run the quickstart command: ``sphinx-quickstart``
+- Write your documentation (we're using RST format)
+- run ``make html`` in the docs folder to build your site for testing purposes
+- Push your changes to GitHub
+
+For a detailed walkthrough, please see the `official ReadTheDocs getting started guide <https://docs.readthedocs.io/en/latest/getting_started.html>`_.
+
+We use RST format to write our documentation. It might seem a little more complicated than markdown (and it is), but it's also more powerful.  The choice is yours for which format to use.
+
+Link documents to your ``index.rst`` and Sphinx will build you a searchable site with nicely formatted navigation.
+
+
+ReadTheDocs also provides some really awesome **versioning** tools, allowing you to post releases of the documentation so users can go back and find older documentation with almost no effort on your part.

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -3,7 +3,7 @@ Using ReadTheDocs
 
 .. note::
 
-  For Tripal's own ReadTheDocs guidelines: :ref:`tripal_rtd`
+  For Tripal's own ReadTheDocs guidelines: :ref:`tripal_rtd`.
 
 
 What is ReadTheDocs?

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -11,7 +11,9 @@ What is ReadTheDocs?
 
 Documentation is important. It tells users how to use our product, and developers how to read our code.  We recommend hosting documentation for your custom module somewhere easily accessible, like ReadTheDocs.
 
-`ReadTheDocs <https://readthedocs.org/>`_ uses the `Sphinx <http://www.sphinx-doc.org/en/master/>`_ framework to build a website in a Continuous Integration setup. When new code is pushed to GitHub, the documentation website as defined by sphinx is built, and the "live" documentation website is updated.
+`ReadTheDocs <https://readthedocs.org/>`_ (RTD) uses the `Sphinx <http://www.sphinx-doc.org/en/master/>`_ framework to build a website in a Continuous Integration setup. Your RTD-compatible documentation is added directly to your module and when code changes are pushed to GitHub, the documentation website as defined by sphinx is built, and the "live" documentation website is updated.
+
+Benefits to housing documentation inside of your module code are:
 
 - Code changes can include documentation updates **in the same pull request**.
 - Changes to the documentation is **subject to review, just like code changes**.
@@ -19,21 +21,22 @@ Documentation is important. It tells users how to use our product, and developer
 
 How do I add ReadTheDocs to my project?
 ---------------------------------------
+Below is a quick overview of steps for integrating your module's documentation with RTD:
 
-- Set up your ReadeTheDocs account and add your project integration
+- Set up your ReadTheDocs account and import your project.
 - Install Sphinx
 - Run the quickstart command: ``sphinx-quickstart``
-- Write your documentation (we're using RST format)
-- run ``make html`` in the docs folder to build your site for testing purposes
+- Write your documentation (we're using reStructuredText (RST) format)
+  - Create an ``index.rst`` as the home page
+  ` Link other RST documents in your ``index.rst`` 
+- run ``make html`` in the docs folder to build your site for testing purposes. Sphinx will build you a searchable site with nicely formatted navigation.
 - Push your changes to GitHub
 
 For a detailed walkthrough, please see the `official ReadTheDocs getting started guide <https://docs.readthedocs.io/en/latest/getting_started.html>`_.
 
-We use RST format to write our documentation. It might seem a little more complicated than markdown (and it is), but it's also more powerful.  The choice is yours for which format to use.
+For RTD integration we recommend using reStructuredText (RST) to write your documentation. It might seem a little more complicated than markdown (and it is), but it's also more powerful.  The choice is yours for which format to use.
 
-Link documents to your ``index.rst`` and Sphinx will build you a searchable site with nicely formatted navigation.
-
-ReadTheDocs also provides some really awesome **versioning** tools, allowing you to post releases of the documentation so users can go back and find older documentation with almost no effort on your part.
+ReadTheDocs also provides **versioning** tools, allowing you to post releases of the documentation so users can go back and find older documentation with almost no effort on your part.
 
 What should my documentation include?
 -------------------------------------

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -24,13 +24,14 @@ How do I add ReadTheDocs to my project?
 Below is a quick overview of steps for integrating your module's documentation with RTD:
 
 - Set up your ReadTheDocs account and import your project.
-- Install Sphinx
-- Run the quickstart command: ``sphinx-quickstart``
-- Write your documentation (we're using reStructuredText (RST) format)
-  - Create an ``index.rst`` as the home page
-  - Link other RST documents in your ``index.rst`` 
-- run ``make html`` in the docs folder to build your site for testing purposes. Sphinx will build you a searchable site with nicely formatted navigation.
-- Push your changes to GitHub
+- Install Sphinx.
+- Create a ``docs`` folder at the root of your project and navigate into it.
+- Run the quickstart command: ``sphinx-quickstart``.
+  - This creates necessary site configuration files (``conf.py``) as well as the make script to build your site.
+- Write your documentation (we're using reStructuredText (RST) format):
+  - Create an ``index.rst`` as the home page.
+  - Link other RST documents in your ``index.rst``.
+- Once the guide is on your master branch on GitHub, ReadTheDocs will handle the rest!
 
 For a detailed walkthrough, please see the `official ReadTheDocs getting started guide <https://docs.readthedocs.io/en/latest/getting_started.html>`_.
 

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -17,7 +17,7 @@ Documentation is important. It tells users how to use our product, and developer
 - Changes to the documentation is **subject to review, just like code changes**.
 - Documentation changes are under **version control**.
 
-How do I add ReadTheDocs to My Project?
+How do I add ReadTheDocs to my project?
 ---------------------------------------
 
 - Set up your ReadeTheDocs account and add your project integration
@@ -33,5 +33,19 @@ We use RST format to write our documentation. It might seem a little more compli
 
 Link documents to your ``index.rst`` and Sphinx will build you a searchable site with nicely formatted navigation.
 
-
 ReadTheDocs also provides some really awesome **versioning** tools, allowing you to post releases of the documentation so users can go back and find older documentation with almost no effort on your part.
+
+What should my documentation include?
+-------------------------------------
+
+We suggest that your module include the following sections:
+
+- Overview
+- Installation and Setup Guide
+- User's Manual
+
+The Overview section should describe what features your module offers.
+
+The Installation and setup section should guide a site administrator through installing and setting up your module.  Any site-wide settings that need to be configured, environmental variables set, or anything else not handled by the automated Drupal install should be covered.
+
+The User's guide should walk through the day-to-day usage of your module.  This may include using custom importers, dashboards, or simply summaries of the new content this module provides.

--- a/docs/dev_guide/rtd.rst
+++ b/docs/dev_guide/rtd.rst
@@ -28,7 +28,7 @@ Below is a quick overview of steps for integrating your module's documentation w
 - Run the quickstart command: ``sphinx-quickstart``
 - Write your documentation (we're using reStructuredText (RST) format)
   - Create an ``index.rst`` as the home page
-  ` Link other RST documents in your ``index.rst`` 
+  - Link other RST documents in your ``index.rst`` 
 - run ``make html`` in the docs folder to build your site for testing purposes. Sphinx will build you a searchable site with nicely formatted navigation.
 - Push your changes to GitHub
 


### PR DESCRIPTION

# Documentation 

Issue #785

This PR provides a brief guide for setting up a RTD site for your custom module.

I've intentionally left the instructions abbreviated, as RTD may change, and its redundant with the instructions provided by RTD themselves.

However I realized we probably want to offer some guidelines/suggestions for "good" documentation so I elaborated on that.