### PR TITLE
resolve various warnings for unset variables in TaxonomyImporter

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.phylotree.api.inc
@@ -303,11 +303,12 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings) {
 function chado_insert_phylotree(&$options, &$errors, &$warnings) {
   global $user;
 
-  $options['name_re'] = trim($options['name_re']);
+  $options['name_re'] = $options['name_re'] ? trim($options['name_re']) : NULL;
   $options['leaf_type'] = trim($options['leaf_type']);
   $options['name'] = trim($options['name']);
   $options['format'] = trim($options['format']);
   $options['tree_file'] = trim($options['tree_file']);
+  $options['analysis_id'] = $options['analysis_id'] ? $options['analysis_id'] : NULL;
 
   // Validate the incoming options.
   $success = chado_validate_phylotree('insert', $options, $errors, $warnings);

--- a/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
+++ b/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
@@ -236,7 +236,7 @@ class TaxonomyImporter extends TripalImporter {
     if (!$taxonomy_ids and $import_existing) {
       $this->setTotalItems(count($this->all_orgs));
     }
-    $this->setItemsHandled($num_handled);
+    $this->setItemsHandled(0);
 
     // If the user wants to import new taxonomy IDs then do that.
     if ($taxonomy_ids){
@@ -272,6 +272,7 @@ class TaxonomyImporter extends TripalImporter {
   private function initTree() {
     // Add the taxonomy tree record into the phylotree table. If the tree
     // already exists then don't insert it again.
+    $site_name = variable_get('site_name');
     $tree_name = $site_name . 'Taxonomy Tree';
     $phylotree = chado_select_record('phylotree', array('*'), array('name' => $tree_name));
     if (count($phylotree) == 0) {
@@ -514,7 +515,7 @@ class TaxonomyImporter extends TripalImporter {
     // organism already.
     $values = array(
       'db_id' => array(
-        'name' => NCBITaxon
+        'name' => 'NCBITaxon'
       ),
       'accession' => $taxid,
     );
@@ -548,8 +549,8 @@ class TaxonomyImporter extends TripalImporter {
           WHERE concat(genus, ' ', species) = :sci_name
         ";
       $results = chado_query($sql, array(':sci_name' => $sci_name));
-      if ($results) {
-        $item = $results->fetchObject();
+      $item = $results->fetchObject();
+      if ($item) {
         $columns = array('*');
         $values = array('organism_id' => $item->organism_id);
         $organism = chado_select_record('organism', $columns, $values);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

# Bug fix

Issue #791 

## Description
When I run the TaxonomyImporter via Drupal (ie NOT via a job) I get various warnings.  This PR should be entirely eye-ball level obvious fixes to resolve those warnings.

## Testing?
Unfortunately the job doesnt complain about these PHP warnings so you can't test by running hte importer.  If you'd like to test, you can

-download and enable the [tripal_eutils module](https://github.com/NAL-i5K/tripal_eutils), which does require the [tripal_manage_analyses module](https://github.com/statonlab/tripal_manage_analyses)
-go to the importer, located at `admin/tripal/tripal_eutils/import`.  Enter any valid BioSample accession ID, such as `744358`.  
- Press submit at the bottom of the screen.

You will get several warnings from the TaxonomyImporter on master, and this PR will resolve them all.


Because this PR only fixes obvious typos and adds some additional checks for keys existing, this is a 1 review only PR.