### PR TITLE
update the NCBI taxon db to not go to purl but to NCBI

### DIFF
--- a/tripal_chado/includes/tripal_chado.semweb.inc
+++ b/tripal_chado/includes/tripal_chado.semweb.inc
@@ -2135,7 +2135,7 @@ function tripal_chado_populate_vocab_NCBITAXON() {
     'name' => 'NCBITaxon',
     'description' => 'NCBI organismal classification.',
     'url' => 'http://www.berkeleybop.org/ontologies/ncbitaxon/',
-    'urlprefix' => 'http://purl.obolibrary.org/obo/ncbitaxon#',
+    'urlprefix' => 'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={accession}',
   ));
   chado_insert_cv(
     'ncbitaxon',

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1854,3 +1854,16 @@ function tripal_chado_update_7336() {
     }
   }
 }
+
+/**
+ * Update the NCBITaxon DB entry.
+ */
+function tripal_chado_update_7337(){
+
+  chado_insert_db(array(
+    'name' => 'NCBITaxon',
+    'description' => 'NCBI organismal classification.',
+    'url' => 'http://www.berkeleybop.org/ontologies/ncbitaxon/',
+    'urlprefix' => 'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={accession}',
+  ));
+}


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bux Fix
# Documentation  --->

# Bug fix

Issue #724 
see also #722 for user encountering this problem.

## Description

the NCBI taxon db linked out to PURL.  This isn't ideal, because if you have a dbxref using NCBI taxon you probably want to link out to NCBI taxon, not the "ontology" itself.

ie visit https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=7004 not http://purl.obolibrary.org/obo/ncbitaxon#%7B720%7D