### PR TITLE
749 webservices field permission

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -380,7 +380,7 @@ class TripalContentService_v0_1 extends TripalWebService {
         // TODO: handle this case.
       }
     }
-    if (isset($field['field_permissions']['type'])) {
+    if (isset($field['field_permissions']['type']) && $field['field_permissions']['type'] != 0) {
       return;
     }
 

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -44,9 +44,9 @@ class TripalContentService_v0_1 extends TripalWebService {
   public function handleRequest() {
 
     // Get the content type.
-    $ctype = (count($this->path) > 0) ? $this->path[0] : '';
+    $ctype     = (count($this->path) > 0) ? $this->path[0] : '';
     $entity_id = (count($this->path) > 1) ? $this->path[1] : '';
-    $expfield = (count($this->path) > 2) ? $this->path[2] : '';
+    $expfield  = (count($this->path) > 2) ? $this->path[2] : '';
 
     // is this a valid content type?
     if ($ctype) {
@@ -54,15 +54,15 @@ class TripalContentService_v0_1 extends TripalWebService {
       $bquery = db_select('tripal_bundle', 'tb');
       $bquery->join('tripal_term', 'tt', 'tt.id = tb.term_id');
       $bquery->join('tripal_vocab', 'tv', 'tv.id = tt.vocab_id');
-      $bquery->fields('tb', ['label']);
-      $bquery->fields('tt', ['accession']);
-      $bquery->fields('tv', ['vocabulary']);
+      $bquery->fields('tb', array('label'));
+      $bquery->fields('tt', array('accession'));
+      $bquery->fields('tv', array('vocabulary'));
       $bquery->orderBy('tb.label', 'ASC');
       $bundles = $bquery->execute();
 
       // Iterate through the terms convert the santized name to the real label.
       $i = 0;
-      $ctype_lookup = [];
+      $ctype_lookup = array();
       $found = FALSE;
       while ($bundle = $bundles->fetchObject()) {
         // Check the label by replacing non alpha-numeric characters with
@@ -90,19 +90,15 @@ class TripalContentService_v0_1 extends TripalWebService {
       $this->doEntityList($ctype);
     }
     // If we have an entity ID then build the resource for a single entity.
+    else if ($ctype and $entity_id and !$expfield) {
+      $this->doEntity($ctype, $entity_id);
+    }
+    else if ($ctype and $entity_id and $expfield) {
+      $this->doExpandedField($ctype, $entity_id, $expfield);
+    }
+    // Otherwise just list all of the available content types.
     else {
-      if ($ctype and $entity_id and !$expfield) {
-        $this->doEntity($ctype, $entity_id);
-      }
-      else {
-        if ($ctype and $entity_id and $expfield) {
-          $this->doExpandedField($ctype, $entity_id, $expfield);
-        }
-        // Otherwise just list all of the available content types.
-        else {
-          $this->doContentTypesList();
-        }
-      }
+      $this->doContentTypesList();
     }
   }
 
@@ -114,7 +110,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab for this type.
-    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
+    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
 
     // Find the field that matches the field name provided by the user.
     list($field, $instance, $term) = $this->findField($bundle, $expfield);
@@ -124,7 +120,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     }
 
     // Get the TripalEntity
-    $entity = tripal_load_entity('TripalEntity', ['id' => $entity_id], FALSE, [$field['id']]);
+    $entity = tripal_load_entity('TripalEntity', array('id' => $entity_id), FALSE, array($field['id']));
     $entity = reset($entity);
 
     // If we couldn't find the entity then fail.
@@ -143,8 +139,8 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     if (!property_exists($entity, $field['field_name'])) {
       // Attach the field and then add its values to the response.
-      field_attach_load($entity->type, [$entity->id => $entity],
-        FIELD_LOAD_CURRENT, ['field_id' => $field['id']]);
+      field_attach_load($entity->type, array($entity->id => $entity),
+          FIELD_LOAD_CURRENT, array('field_id' => $field['id']));
     }
 
     $this->addEntityField($this->resource, $term, $entity, $bundle, $field, $instance, $service_path, $expfield);
@@ -155,7 +151,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    */
   private function findField($bundle, $expfield) {
 
-    $value = [];
+    $value = array();
     $instances = field_info_instances('TripalEntity', $bundle->name);
     foreach ($instances as $instance) {
       $field_name = $instance['field_name'];
@@ -171,11 +167,11 @@ class TripalContentService_v0_1 extends TripalWebService {
       // See if the name provided matches the field name after a bit of
       // cleanup.
       if (strtolower(preg_replace('/[^\w]/', '_', $temp_term['name'])) == strtolower($expfield)) {
-        return [$field, $instance, $temp_term];
+        return array($field, $instance, $temp_term);
       }
       // Alternatively if the CV term accession matches then we're good too.
       if ($vocabulary . ':' . $accession == $expfield) {
-        return [$field, $instance, $temp_term];
+        return array($field, $instance, $temp_term);
       }
     }
   }
@@ -188,8 +184,8 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
-    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
-    $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
+    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
+    $term = entity_load('TripalTerm', array('id' => $bundle->term_id));
     $term = reset($term);
 
     // Convert the $term to a simple array
@@ -199,7 +195,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->addContextItem($term['name'], $term['url']);
 
     // Get the TripalEntity.
-    $entity = tripal_load_entity('TripalEntity', ['id' => $entity_id]);
+    $entity = tripal_load_entity('TripalEntity', array('id' => $entity_id));
     $entity = reset($entity);
 
     // If we couldn't match this field argument to a field and entity then return
@@ -216,7 +212,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->setID($entity_id);
     $this->setResourceType($this->resource, $term);
     $this->addResourceProperty($this->resource, $label, $entity->title);
-    $this->addResourceProperty($this->resource, $itemPage, url('/bio_data/' . $entity->id, ['absolute' => TRUE]));
+    $this->addResourceProperty($this->resource, $itemPage, url('/bio_data/' . $entity->id, array('absolute' => TRUE)));
 
     // Add in the entitie's fields.
     $this->addEntityFields($this->resource, $entity, $bundle, $term, $service_path);
@@ -259,7 +255,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $instances = field_info_instances('TripalEntity', $bundle->name);
 
     // Sort the instances by their weight.
-    uasort($instances, function ($a, $b) {
+    uasort($instances, function($a, $b) {
       $a_weight = (is_array($a) && isset($a['widget']['weight'])) ? $a['widget']['weight'] : 0;
       $b_weight = (is_array($b) && isset($b['widget']['weight'])) ? $b['widget']['weight'] : 0;
 
@@ -309,29 +305,23 @@ class TripalContentService_v0_1 extends TripalWebService {
       // so that the caller can get the information separately.
       $instance_settings = $instance['settings'];
       if (array_key_exists('auto_attach', $instance['settings']) and
-        $instance_settings['auto_attach'] == FALSE) {
+          $instance_settings['auto_attach'] == FALSE) {
         // Add a URL only if there are values. If there are no values then
         // don't add a URL which would make the end-user think they can get
         // that information.
         $items = field_get_items('TripalEntity', $entity, $field_name);
-        $term_key = $this->getContextTerm($term, ['lowercase', 'spacing']);
+        $term_key = $this->getContextTerm($term, array('lowercase', 'spacing'));
         $resource->addContextItem($term_key, $vocabulary . ':' . $accession);
-        $resource->addContextItem($vocabulary . ':' . $accession, [
+        $resource->addContextItem($vocabulary . ':' . $accession, array(
           '@id' => $term['url'],
-          '@type' => '@id',
-        ]);
+          '@type' => '@id'
+        ));
         if ($items and count($items) > 0 and $items[0]['value']) {
-          $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), [
-            'lowercase',
-            'spacing',
-          ]);
+          $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), array('lowercase', 'spacing'));
         }
         else {
           if ($hide_fields == FALSE) {
-            $this->addResourceProperty($resource, $term, NULL, [
-              'lowercase',
-              'spacing',
-            ]);
+            $this->addResourceProperty($resource, $term, NULL, array('lowercase', 'spacing'));
           }
         }
         continue;
@@ -346,7 +336,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Adds the field as a property of the entity resource.
    */
   private function addEntityField($resource, $term, $entity, $bundle, $field, $instance,
-                                  $service_path, $expfield = NULL) {
+      $service_path, $expfield = NULL) {
 
     // If the entity is set to hide fields that have no values then we
     // want to honor that in the web services too.
@@ -367,7 +357,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // the rules (e.g. Image field).
     drupal_alter('tripal_ws_value', $items, $field, $instance);
 
-    $values = [];
+    $values = array();
     for ($i = 0; $i < count($items); $i++) {
       if (array_key_exists('value', $items[$i])) {
         $values[$i] = $this->sanitizeFieldKeys($resource, $items[$i]['value'], $bundle, $service_path);
@@ -380,17 +370,16 @@ class TripalContentService_v0_1 extends TripalWebService {
         // TODO: handle this case.
       }
     }
+
     if (isset($field['field_permissions']['type']) && $field['field_permissions']['type'] != 0) {
       return;
     }
 
-    if ($hide_fields == TRUE and empty($values[0])) {
+      if ($hide_fields == TRUE and empty($values[0])) {
       return;
     }
 
-
-
-    // If the field cardinality is 1.
+    // If the field cardinality is 1
     if ($field['cardinality'] == 1) {
 
       // If the value is an array and this is the field page then all of those
@@ -402,19 +391,13 @@ class TripalContentService_v0_1 extends TripalWebService {
           }
         }
         else {
-          $this->addResourceProperty($resource, $term, $values[0], [
-            'lowercase',
-            'spacing',
-          ]);
+          $this->addResourceProperty($resource, $term, $values[0], array('lowercase', 'spacing'));
         }
       }
       // If the value is not an array it's a scalar so add it as is to the
       // response.
       else {
-        $this->addResourceProperty($resource, $term, $values[0], [
-          'lowercase',
-          'spacing',
-        ]);
+        $this->addResourceProperty($resource, $term, $values[0], array('lowercase', 'spacing'));
       }
     }
 
@@ -445,10 +428,7 @@ class TripalContentService_v0_1 extends TripalWebService {
       }
       else {
         //$this->resource->addProperty($key, $response);
-        $this->addResourceProperty($resource, $term, $response, [
-          'lowercase',
-          'spacing',
-        ]);
+        $this->addResourceProperty($resource, $term, $response, array('lowercase', 'spacing'));
       }
     }
   }
@@ -466,7 +446,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // If the value is an array rather than a scalar then map the sub elements
     // to controlled vocabulary terms.
     if (is_array($value)) {
-      $temp = [];
+      $temp = array();
       foreach ($value as $k => $v) {
 
         // exclude fields that have no values so we can hide them
@@ -474,15 +454,12 @@ class TripalContentService_v0_1 extends TripalWebService {
           continue;
         }
 
-        $matches = [];
+        $matches = array();
         if (preg_match('/^(.+):(.+)$/', $k, $matches)) {
           $vocabulary = $matches[1];
           $accession = $matches[2];
           $term = tripal_get_term_details($vocabulary, $accession);
-          $key = $this->addContextTerm($resource, $term, [
-            'lowercase',
-            'spacing',
-          ]);
+          $key = $this->addContextTerm($resource, $term, array('lowercase', 'spacing'));
 
           if (is_array($v)) {
             $temp[$key] = $this->sanitizeFieldKeys($resource, $v, $bundle, $service_path);
@@ -529,9 +506,9 @@ class TripalContentService_v0_1 extends TripalWebService {
       if ($key == 'entity') {
         list($item_etype, $item_eid) = explode(':', $items['entity']);
         if ($item_eid) {
-          $item_entity = tripal_load_entity($item_etype, [$item_eid]);
+          $item_entity = tripal_load_entity($item_etype, array($item_eid));
           $item_entity = reset($item_entity);
-          $bundle = tripal_load_bundle_entity(['name' => $item_entity->bundle]);
+          $bundle = tripal_load_bundle_entity(array('name' => $item_entity->bundle));
           $items['@id'] = $this->getServicePath() . '/' . urlencode($bundle->label) . '/' . $item_eid;
         }
         unset($items['entity']);
@@ -554,16 +531,16 @@ class TripalContentService_v0_1 extends TripalWebService {
     // it easier to determine which filter criteria belongs to which field. The
     // key is the label for the field and the value is the field name. This way
     // user's can use the field label or the field name to form a query.
-    $field_mapping = [];
+    $field_mapping = array();
     $fields = field_info_fields();
     foreach ($fields as $field) {
       if (array_key_exists('TripalEntity', $field['bundles'])) {
         foreach ($field['bundles']['TripalEntity'] as $bundle_name) {
           if ($bundle_name == $bundle->name) {
             $instance = field_info_instance('TripalEntity', $field['field_name'], $bundle_name);
-            if (array_key_exists('term_accession', $instance['settings'])) {
-              $vocabulary = $instance['settings']['term_vocabulary'];
-              $accession = $instance['settings']['term_accession'];
+            if (array_key_exists('term_accession', $instance['settings'])){
+                $vocabulary = $instance['settings']['term_vocabulary'];
+                $accession = $instance['settings']['term_accession'];
               $fterm = tripal_get_term_details($vocabulary, $accession);
               $key = $fterm['name'];
               $key = strtolower(preg_replace('/ /', '_', $key));
@@ -588,8 +565,8 @@ class TripalContentService_v0_1 extends TripalWebService {
    *
    * @throws Exception
    */
-  private function getOrderBy($field_mapping, $bundle) {
-    $order_by = [];
+  private function getOrderBy($field_mapping,  $bundle) {
+    $order_by = array();
 
     // Handle order separately.
     if (array_key_exists('order', $this->params)) {
@@ -603,7 +580,7 @@ class TripalContentService_v0_1 extends TripalWebService {
 
         // The user can provide a direction by separating the field key and the
         // direction with a '|' character.
-        $matches = [];
+        $matches = array();
         if (preg_match('/^(.*)\|(.*)$/', $key, $matches)) {
           $key = $matches[1];
           if ($matches[2] == 'ASC' or $matches[2] == 'DESC') {
@@ -638,10 +615,10 @@ class TripalContentService_v0_1 extends TripalWebService {
             $sortable_keys = $ws_data['sortable'];
             $criteria = implode('.', $subkeys);
             if (array_key_exists($criteria, $sortable_keys)) {
-              $order_by[$key_field_name][] = [
+              $order_by[$key_field_name][] = array(
                 'column' => $sortable_keys[$criteria],
                 'dir' => $dir,
-              ];
+              );
             }
             else {
               throw new Exception("The value, '$criteria', is not available for sorting.");
@@ -652,10 +629,10 @@ class TripalContentService_v0_1 extends TripalWebService {
           else {
             $key_field_id = $key_instance['settings']['term_vocabulary'] . ':' . $key_instance['settings']['term_accession'];
 
-            $order_by[$key_field_name][] = [
+            $order_by[$key_field_name][] = array(
               'column' => $key_field_id,
               'dir' => $dir,
-            ];
+            );
           }
 
         }
@@ -667,25 +644,19 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     // If there is no ordering that is set then set a default order.
     if (count(array_keys($order_by)) == 0) {
-      $key_field_names = [];
+      $key_field_names = array();
       if (in_array('data__identifier', $field_mapping)) {
         $key_field_names['data__identifier'][] = 'identifier';
       }
-      else {
-        if (in_array('schema__name', $field_mapping)) {
-          $key_field_names['schema__name'][] = 'name';
-        }
-        else {
-          if (in_array('rdfs_label', $field_mapping)) {
-            $key_field_names['rdfs_label'][] = 'label';
-          }
-          else {
-            if (in_array('taxrank__genus', $field_mapping)) {
-              $key_field_names['taxrank__genus'][] = 'genus';
-              $key_field_names['taxrank__species'][] = 'species';
-            }
-          }
-        }
+      else if (in_array('schema__name', $field_mapping)) {
+        $key_field_names['schema__name'][] = 'name';
+      }
+      else if (in_array('rdfs_label', $field_mapping)) {
+        $key_field_names['rdfs_label'][] = 'label';
+      }
+      else if (in_array('taxrank__genus', $field_mapping)) {
+        $key_field_names['taxrank__genus'][] = 'genus';
+        $key_field_names['taxrank__species'][] = 'species';
       }
       foreach ($key_field_names as $key_field_name => $criteria) {
         $key_field = field_info_field($key_field_name);
@@ -699,19 +670,19 @@ class TripalContentService_v0_1 extends TripalWebService {
           $ws_data = $key_field->webServicesData();
           $sortable_keys = $ws_data['sortable'];
           if (array_key_exists($criteria, $sortable_keys)) {
-            $order_by[$key_field_name][] = [
+            $order_by[$key_field_name][] = array(
               'column' => $sortable_keys[$criteria],
               'dir' => $dir,
-            ];
+            );
           }
         }
-        // If this field is not a TripalField then it should just have
-        // a simple value and we can query for that.
+       // If this field is not a TripalField then it should just have
+          // a simple value and we can query for that.
         else {
-          $order_by[$key_field_name][] = [
+          $order_by[$key_field_name][] = array(
             'column' => $key_field_id,
             'dir' => 'ASC',
-          ];
+          );
         }
       }
     }
@@ -732,21 +703,21 @@ class TripalContentService_v0_1 extends TripalWebService {
    * @throws Exception
    */
   private function getFieldFilters($field_mapping, $bundle) {
-    $filters = [];
+    $filters = array();
 
     // Iterate through the paramter list provided by user.
     foreach ($this->params as $param => $value) {
 
       // Ignore non filter parameters.
       if ($param == 'page' or $param == 'limit' or $param == 'order' or
-        $param == 'ids' or $param == 'fields') {
+          $param == 'ids' or $param == 'fields') {
         continue;
       }
 
       // Break apart any operators
       $key = $param;
       $op = '=';
-      $matches = [];
+      $matches = array();
       if (preg_match('/^(.+);(.+)$/', $key, $matches)) {
         $key = $matches[1];
         $op = $matches[2];
@@ -777,11 +748,11 @@ class TripalContentService_v0_1 extends TripalWebService {
           $searchable_keys = $ws_data['searchable'];
           $criteria = implode('.', $subkeys);
           if (array_key_exists($criteria, $searchable_keys)) {
-            $filters[$key_field_name][] = [
+            $filters[$key_field_name][] = array(
               'value' => $value,
               'op' => $op,
-              'column' => $searchable_keys[$criteria],
-            ];
+              'column' => $searchable_keys[$criteria]
+            );
           }
           else {
             throw new Exception("The filter term, '$criteria', is not available for use.");
@@ -792,11 +763,11 @@ class TripalContentService_v0_1 extends TripalWebService {
         else {
           $key_field_id = $key_instance['settings']['term_vocabulary'] . ':' . $key_instance['settings']['term_accession'];
 
-          $filters[$key_field_name][] = [
+          $filters[$key_field_name][] = array(
             'value' => $value,
             'op' => $op,
             'column' => $key_field_id,
-          ];
+          );
         }
       }
       else {
@@ -851,8 +822,8 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceCollection($service_path, $this->params);
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
-    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
-    $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
+    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
+    $term = entity_load('TripalTerm', array('id' => $bundle->term_id));
     $term = reset($term);
 
     // The type of collection is provided by our API vocabulary service.
@@ -897,10 +868,10 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Now iterate through the filters and add those.
     foreach ($filters as $key_field_name => $key_filters) {
       foreach ($key_filters as $i => $filter) {
-        $column_name = $filter['column'];
-        $value = $filter['value'];
-        $op = $filter['op'];
-        $query->fieldCondition($key_field_name, $column_name, $value, $op);
+         $column_name = $filter['column'];
+         $value = $filter['value'];
+         $op = $filter['op'];
+         $query->fieldCondition($key_field_name, $column_name, $value, $op);
       }
     }
 
@@ -939,15 +910,15 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->initPager($num_records, $limit, $page);
 
     // Check to make sure there are results.
-    $entity_ids = [];
+    $entity_ids = array();
     if (isset($results['TripalEntity']) AND is_array($results['TripalEntity'])) {
       $entity_ids = $results['TripalEntity'];
     }
 
     // If the user wants to include any fields in the list then those provided
     // names need to be converted to fields.
-    $add_fields = [];
-    $add_field_ids = [];
+    $add_fields = array();
+    $add_field_ids = array();
     if (array_key_exists('fields', $this->params)) {
       $fields = explode(',', $this->params['fields']);
       foreach ($fields as $expfield) {
@@ -959,7 +930,7 @@ class TripalContentService_v0_1 extends TripalWebService {
           $add_field_ids[] = $field['id'];
         }
         else {
-          throw new Exception(t('The field named, "!field", does not exist.', ['!field' => $expfield]));
+          throw new Exception(t('The field named, "!field", does not exist.', array('!field' => $expfield)));
         }
       }
     }
@@ -972,7 +943,7 @@ class TripalContentService_v0_1 extends TripalWebService {
       $query = db_select('tripal_entity', 'TE');
       $query->join('tripal_term', 'TT', 'TE.term_id = TT.id');
       $query->fields('TE');
-      $query->fields('TT', ['name']);
+      $query->fields('TT', array('name'));
       $query->condition('TE.id', $entity_id);
       $entity = $query->execute()->fetchObject();
 
@@ -982,16 +953,16 @@ class TripalContentService_v0_1 extends TripalWebService {
       $member->setID($entity->id);
       $this->setResourceType($member, $term);
       $this->addResourceProperty($member, $label, $entity->title);
-      $this->addResourceProperty($member, $itemPage, url('/bio_data/' . $entity->id, ['absolute' => TRUE]));
+      $this->addResourceProperty($member, $itemPage, url('/bio_data/' . $entity->id, array('absolute' => TRUE)));
 
-      $entity = tripal_load_entity('TripalEntity', [$entity_id], FALSE, $add_field_ids);
+      $entity = tripal_load_entity('TripalEntity', array($entity_id), FALSE, $add_field_ids);
       $entity = $entity[$entity_id];
 
       // Add in any requested fields
       foreach ($add_fields as $expfield => $expfield_details) {
         $this->addEntityField($member, $expfield_details['term'], $entity,
-          $bundle, $expfield_details['field'], $expfield_details['instance'],
-          $service_path);
+            $bundle, $expfield_details['field'], $expfield_details['instance'],
+            $service_path);
       }
       $this->resource->addMember($member);
     }
@@ -1020,7 +991,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Iterate through the terms and add an entry in the collection.
     $i = 0;
     while ($bundle = $bundles->fetchObject()) {
-      $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
+      $entity =  entity_load('TripalTerm', array('id' => $bundle->term_id));
       $term = reset($entity);
       $vocab = $term->vocab;
 
@@ -1058,48 +1029,47 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Adds the content collection class to the document for this service.
    */
   private function addDocContentCollectionClass() {
-    $details = [
+    $details = array(
       'id' => 'vocab:Content_Collection',
       'term' => 'vocab:Content_Collection',
       'title' => 'Content Collection',
-    ];
+    );
     $vocab = tripal_get_vocabulary_details('hydra');
-    $properties = [];
-    $properties[] = [
+    $properties = array();
+    $properties[] = array(
       'type' => $vocab['sw_url'],
       'title' => 'member',
       'description' => "The list of available content types.",
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
       "writeonly" => FALSE,
-    ];
-    $properties[] = [
+    );
+    $properties[] = array(
       "type" => $vocab['sw_url'],
       "title" => "totalItems",
       "description" => "The total number of content types.",
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
-      "writeonly" => FALSE,
-    ];
-    $properties[] = [
+      "writeonly" => FALSE
+    );
+    $properties[] = array(
       "type" => $vocab['sw_url'],
       "title" => "label",
       "description" => "The type content.",
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
-      "writeonly" => FALSE,
-    ];
+      "writeonly" => FALSE
+    );
 
-    $operations = [];
-    $operations['GET'] = [
+    $operations = array();
+    $operations['GET'] = array(
       'label' => 'Retrieves a collection (a list) of available content types.',
       'type' => '_:content_collection_retrieve',
       'expects' => NULL,
       'returns' => 'vocab:ContentCollection',
-    ];
-    $this->addDocClass($details, $operations, $properties);
+    );
+    $this->addDocClass($details,$operations, $properties);
   }
-
   /**
    * Adds classes for every content type to the documentation for this service.
    */
@@ -1116,7 +1086,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Iterate through the content types and add a class for each one.
     $i = 0;
     while ($bundle = $bundles->fetchObject()) {
-      $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
+      $entity = entity_load('TripalTerm', array('id' => $bundle->term_id));
       $term = reset($entity);
       $vocab = $term->vocab;
 
@@ -1129,24 +1099,24 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       // Create the details array for the class.
       $class_id = $this->getServicePath() . '/' . urlencode($bundle->label);
-      $details = [
+      $details = array(
         'id' => $term->getURL(),
         'term' => $term->getAccession(),
         'title' => preg_replace('/[^\w]/', '_', $bundle->label),
         'description' => $description,
-      ];
+      );
 
       // Add in the supported operations for this content type.
-      $operations = [];
+      $operations = array();
       // If the user can view this content type.
       if (user_access('view ' . $bundle->name)) {
         $label = "Retrieves the " . $bundle->label . " resource.";
-        $operations['GET'] = [
+        $operations['GET'] = array(
           'label' => $label,
           'description' => NULL,
           'returns' => $term->url,
           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_retrieve',
-        ];
+        );
       }
 
       // If the user can edit this content type.
@@ -1155,28 +1125,28 @@ class TripalContentService_v0_1 extends TripalWebService {
         if (preg_match('/^[aeiou]/i', $bundle->label)) {
           $label = "Update and replace an " . $bundle->label . " resource.";
         }
-        // TODO: add this back in when web services support this method.
-        //         $operations['PUT'] = array(
-        //           'label' => $label,
-        //           'description' => NULL,
-        //           'returns' => $term->url,
-        //           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_update',
-        //         );
+// TODO: add this back in when web services support this method.
+//         $operations['PUT'] = array(
+//           'label' => $label,
+//           'description' => NULL,
+//           'returns' => $term->url,
+//           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_update',
+//         );
       }
 
       // If the user can edit this content type.
       if (user_access('delete ' . $bundle->name)) {
-        $label = "Deletes the " . $bundle->label . " resource.";
+        $label =  "Deletes the " . $bundle->label . " resource.";
         if (preg_match('/^[aeiou]/i', $bundle->label)) {
-          $label = "Deletes an " . $bundle->label . " resource.";
+          $label =  "Deletes an " . $bundle->label . " resource.";
         }
-        // TODO: add this back in when web services support this method.
-        //         $operations['DELETE'] = array(
-        //           'label' => $label,
-        //           'description' => NULL,
-        //           'returns' => $term->url,
-        //           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_delete',
-        //         );
+// TODO: add this back in when web services support this method.
+//         $operations['DELETE'] = array(
+//           'label' => $label,
+//           'description' => NULL,
+//           'returns' => $term->url,
+//           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_delete',
+//         );
       }
 
       // Add in the properties that correspond to fields in the data.
@@ -1194,7 +1164,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Every content type (bundle) has fields that need to be set as properties.
    */
   private function addDocBundleFieldProperties($bundle, $bundle_term) {
-    $properties = [];
+    $properties = array();
 
     $content_type_accession = $bundle_term->vocab->vocabulary . ':' . $bundle_term->accession;
 
@@ -1229,14 +1199,14 @@ class TripalContentService_v0_1 extends TripalWebService {
         $link = new TripalWebServiceResource($this->base_path);
         $link->setID($accession);
         $link->setType('hydra:Link');
-        $link->addContextItem('domain', [
+        $link->addContextItem('domain', array(
           "@id" => "rdfs:domain",
-          "@type" => "@id",
-        ]);
-        $link->addContextItem('range', [
+          "@type" => "@id"
+        ));
+        $link->addContextItem('range', array(
           "@id" => "rdfs:range",
-          "@type" => "@id",
-        ]);
+          "@type" => "@id"
+        ));
         $link->addContextItem('readable', 'hydra:readable');
         $link->addContextItem('writeable', 'hydra:writeable');
         $link->addContextItem('required', 'hydra:required');
@@ -1247,7 +1217,7 @@ class TripalContentService_v0_1 extends TripalWebService {
         //       $link->addProperty('domain', $service_path . '#EntryPoint');
         //       $link->addProperty('range', $service_class::$label);
 
-        $ops = [];
+        $ops = array();
         $op = new TripalWebServiceResource($this->base_path);
 
         $op->setID('_:' . $field_name . '_retrieve');
@@ -1255,21 +1225,21 @@ class TripalContentService_v0_1 extends TripalWebService {
         $op->addContextItem('method', 'hydra:method');
         $op->addContextItem('label', 'rdfs:label');
         $op->addContextItem('description', 'rdfs:comment');
-        $op->addContextItem('expects', [
+        $op->addContextItem('expects', array(
           "@id" => "hydra:expects",
-          "@type" => "@id",
-        ]);
-        $op->addContextItem('returns', [
+          "@type" => "@id"
+        ));
+        $op->addContextItem('returns', array(
           "@id" => "hydra:returns",
-          "@type" => "@id",
-        ]);
+          "@type" => "@id"
+        ));
         $op->addContextItem('statusCodes', 'hydra:statusCodes');
         $op->addProperty('method', "GET");
         $op->addProperty('label', 'Retrieves the ' . $instance['label'] . ' resource.');
         $op->addProperty('description', $instance['description']);
         $op->addProperty('expects', NULL);
         $op->addProperty('returns', $accession);
-        $op->addProperty('statusCodes', []);
+        $op->addProperty('statusCodes', array());
         $ops[] = $op;
         $link->addContextItem('supportedOperation', 'hydra:supportedOperation');
         $link->addProperty('supportedOperation', $ops);
@@ -1278,7 +1248,7 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       $formatters = tripal_get_field_field_formatters($field, $instance);
 
-      $property = [
+      $property = array(
         'type' => $proptype,
         'title' => $instance['label'],
         'description' => $instance['description'],
@@ -1286,12 +1256,11 @@ class TripalContentService_v0_1 extends TripalWebService {
         "readonly" => FALSE,
         "writeonly" => TRUE,
         "tripal_formatters" => $formatters,
-      ];
+      );
       $properties[] = $property;
     }
     return $properties;
   }
-
   /**
    * Every content type (bundle) needs a collection class in the documentation.
    */
@@ -1299,49 +1268,49 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     $accession = preg_replace('/[^\w]/', '_', $bundle->label . ' Collection');
 
-    $details = [
+    $details = array(
       'id' => 'vocab:' . $accession,
       'term' => 'vocab:' . $accession,
       'title' => $bundle->label . ' Collection',
       'subClassOf' => 'hydra:Collection',
       'description' => 'A collection (or list) of ' . $bundle->label . ' resources.',
-    ];
+    );
     $vocab = tripal_get_vocabulary_details('hydra');
-    $properties = [];
-    $properties[] = [
+    $properties = array();
+    $properties[] = array(
       'type' => $vocab['sw_url'],
       'title' => 'member',
       'description' => "The list of available " . $bundle->label . '(s).',
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
       "writeonly" => FALSE,
-    ];
-    $properties[] = [
+    );
+    $properties[] = array(
       "type" => $vocab['sw_url'],
       "title" => "totalItems",
       "description" => "The total number of resources.",
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
-      "writeonly" => FALSE,
-    ];
-    $properties[] = [
+      "writeonly" => FALSE
+    );
+    $properties[] = array(
       "type" => $vocab['sw_url'],
       "title" => "label",
       "description" => "A label or name for the resource.",
-      "required" => NULL,
+      "required" => null,
       "readonly" => FALSE,
-      "writeonly" => FALSE,
-    ];
+      "writeonly" => FALSE
+    );
 
     $class_id = $this->getServicePath() . '/' . urlencode($bundle->label);
-    $operations = [];
-    $operations['GET'] = [
+    $operations = array();
+    $operations['GET'] = array(
       'label' => 'Retrieves a list of all ' . $bundle->label . ' resources.',
       'description' => NULL,
       'expects' => NULL,
       'returns' => $term->url,
       'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_collection_retrieve',
-    ];
+    );
 
     // If the user can create this content type then we allow a POST on the
     // collection type.
@@ -1350,20 +1319,20 @@ class TripalContentService_v0_1 extends TripalWebService {
       if (preg_match('/^[aeiou]/i', $bundle->label)) {
         $label = "Creates an " . $bundle->label;
       }
-      // TODO: add this back in when web services support this method.
-      //       $operations['POST'] = array(
-      //         'label' => $label,
-      //         'description' => NULL,
-      //         'expects' => $term->url,
-      //         'returns' => $term->url,
-      //         'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_create',
-      //         'statusCodes' => array(
-      //           array(
-      //             "code" => 201,
-      //             "description" => "If the " . $bundle->label . " was created successfully."
-      //           ),
-      //         ),
-      //       );
+// TODO: add this back in when web services support this method.
+//       $operations['POST'] = array(
+//         'label' => $label,
+//         'description' => NULL,
+//         'expects' => $term->url,
+//         'returns' => $term->url,
+//         'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_create',
+//         'statusCodes' => array(
+//           array(
+//             "code" => 201,
+//             "description" => "If the " . $bundle->label . " was created successfully."
+//           ),
+//         ),
+//       );
     }
     $this->addDocClass($details, $operations, $properties);
   }

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -44,9 +44,9 @@ class TripalContentService_v0_1 extends TripalWebService {
   public function handleRequest() {
 
     // Get the content type.
-    $ctype     = (count($this->path) > 0) ? $this->path[0] : '';
+    $ctype = (count($this->path) > 0) ? $this->path[0] : '';
     $entity_id = (count($this->path) > 1) ? $this->path[1] : '';
-    $expfield  = (count($this->path) > 2) ? $this->path[2] : '';
+    $expfield = (count($this->path) > 2) ? $this->path[2] : '';
 
     // is this a valid content type?
     if ($ctype) {
@@ -54,15 +54,15 @@ class TripalContentService_v0_1 extends TripalWebService {
       $bquery = db_select('tripal_bundle', 'tb');
       $bquery->join('tripal_term', 'tt', 'tt.id = tb.term_id');
       $bquery->join('tripal_vocab', 'tv', 'tv.id = tt.vocab_id');
-      $bquery->fields('tb', array('label'));
-      $bquery->fields('tt', array('accession'));
-      $bquery->fields('tv', array('vocabulary'));
+      $bquery->fields('tb', ['label']);
+      $bquery->fields('tt', ['accession']);
+      $bquery->fields('tv', ['vocabulary']);
       $bquery->orderBy('tb.label', 'ASC');
       $bundles = $bquery->execute();
 
       // Iterate through the terms convert the santized name to the real label.
       $i = 0;
-      $ctype_lookup = array();
+      $ctype_lookup = [];
       $found = FALSE;
       while ($bundle = $bundles->fetchObject()) {
         // Check the label by replacing non alpha-numeric characters with
@@ -90,15 +90,19 @@ class TripalContentService_v0_1 extends TripalWebService {
       $this->doEntityList($ctype);
     }
     // If we have an entity ID then build the resource for a single entity.
-    else if ($ctype and $entity_id and !$expfield) {
-      $this->doEntity($ctype, $entity_id);
-    }
-    else if ($ctype and $entity_id and $expfield) {
-      $this->doExpandedField($ctype, $entity_id, $expfield);
-    }
-    // Otherwise just list all of the available content types.
     else {
-      $this->doContentTypesList();
+      if ($ctype and $entity_id and !$expfield) {
+        $this->doEntity($ctype, $entity_id);
+      }
+      else {
+        if ($ctype and $entity_id and $expfield) {
+          $this->doExpandedField($ctype, $entity_id, $expfield);
+        }
+        // Otherwise just list all of the available content types.
+        else {
+          $this->doContentTypesList();
+        }
+      }
     }
   }
 
@@ -110,7 +114,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab for this type.
-    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
+    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
 
     // Find the field that matches the field name provided by the user.
     list($field, $instance, $term) = $this->findField($bundle, $expfield);
@@ -120,7 +124,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     }
 
     // Get the TripalEntity
-    $entity = tripal_load_entity('TripalEntity', array('id' => $entity_id), FALSE, array($field['id']));
+    $entity = tripal_load_entity('TripalEntity', ['id' => $entity_id], FALSE, [$field['id']]);
     $entity = reset($entity);
 
     // If we couldn't find the entity then fail.
@@ -139,8 +143,8 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     if (!property_exists($entity, $field['field_name'])) {
       // Attach the field and then add its values to the response.
-      field_attach_load($entity->type, array($entity->id => $entity),
-          FIELD_LOAD_CURRENT, array('field_id' => $field['id']));
+      field_attach_load($entity->type, [$entity->id => $entity],
+        FIELD_LOAD_CURRENT, ['field_id' => $field['id']]);
     }
 
     $this->addEntityField($this->resource, $term, $entity, $bundle, $field, $instance, $service_path, $expfield);
@@ -151,7 +155,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    */
   private function findField($bundle, $expfield) {
 
-    $value = array();
+    $value = [];
     $instances = field_info_instances('TripalEntity', $bundle->name);
     foreach ($instances as $instance) {
       $field_name = $instance['field_name'];
@@ -167,11 +171,11 @@ class TripalContentService_v0_1 extends TripalWebService {
       // See if the name provided matches the field name after a bit of
       // cleanup.
       if (strtolower(preg_replace('/[^\w]/', '_', $temp_term['name'])) == strtolower($expfield)) {
-        return array($field, $instance, $temp_term);
+        return [$field, $instance, $temp_term];
       }
       // Alternatively if the CV term accession matches then we're good too.
       if ($vocabulary . ':' . $accession == $expfield) {
-        return array($field, $instance, $temp_term);
+        return [$field, $instance, $temp_term];
       }
     }
   }
@@ -184,8 +188,8 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
-    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
-    $term = entity_load('TripalTerm', array('id' => $bundle->term_id));
+    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
+    $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
     $term = reset($term);
 
     // Convert the $term to a simple array
@@ -195,7 +199,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->addContextItem($term['name'], $term['url']);
 
     // Get the TripalEntity.
-    $entity = tripal_load_entity('TripalEntity', array('id' => $entity_id));
+    $entity = tripal_load_entity('TripalEntity', ['id' => $entity_id]);
     $entity = reset($entity);
 
     // If we couldn't match this field argument to a field and entity then return
@@ -212,7 +216,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->setID($entity_id);
     $this->setResourceType($this->resource, $term);
     $this->addResourceProperty($this->resource, $label, $entity->title);
-    $this->addResourceProperty($this->resource, $itemPage, url('/bio_data/' . $entity->id, array('absolute' => TRUE)));
+    $this->addResourceProperty($this->resource, $itemPage, url('/bio_data/' . $entity->id, ['absolute' => TRUE]));
 
     // Add in the entitie's fields.
     $this->addEntityFields($this->resource, $entity, $bundle, $term, $service_path);
@@ -255,7 +259,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     $instances = field_info_instances('TripalEntity', $bundle->name);
 
     // Sort the instances by their weight.
-    uasort($instances, function($a, $b) {
+    uasort($instances, function ($a, $b) {
       $a_weight = (is_array($a) && isset($a['widget']['weight'])) ? $a['widget']['weight'] : 0;
       $b_weight = (is_array($b) && isset($b['widget']['weight'])) ? $b['widget']['weight'] : 0;
 
@@ -305,23 +309,29 @@ class TripalContentService_v0_1 extends TripalWebService {
       // so that the caller can get the information separately.
       $instance_settings = $instance['settings'];
       if (array_key_exists('auto_attach', $instance['settings']) and
-          $instance_settings['auto_attach'] == FALSE) {
+        $instance_settings['auto_attach'] == FALSE) {
         // Add a URL only if there are values. If there are no values then
         // don't add a URL which would make the end-user think they can get
         // that information.
         $items = field_get_items('TripalEntity', $entity, $field_name);
-        $term_key = $this->getContextTerm($term, array('lowercase', 'spacing'));
+        $term_key = $this->getContextTerm($term, ['lowercase', 'spacing']);
         $resource->addContextItem($term_key, $vocabulary . ':' . $accession);
-        $resource->addContextItem($vocabulary . ':' . $accession, array(
+        $resource->addContextItem($vocabulary . ':' . $accession, [
           '@id' => $term['url'],
-          '@type' => '@id'
-        ));
+          '@type' => '@id',
+        ]);
         if ($items and count($items) > 0 and $items[0]['value']) {
-          $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), array('lowercase', 'spacing'));
+          $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), [
+            'lowercase',
+            'spacing',
+          ]);
         }
         else {
           if ($hide_fields == FALSE) {
-            $this->addResourceProperty($resource, $term, NULL, array('lowercase', 'spacing'));
+            $this->addResourceProperty($resource, $term, NULL, [
+              'lowercase',
+              'spacing',
+            ]);
           }
         }
         continue;
@@ -336,7 +346,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Adds the field as a property of the entity resource.
    */
   private function addEntityField($resource, $term, $entity, $bundle, $field, $instance,
-      $service_path, $expfield = NULL) {
+                                  $service_path, $expfield = NULL) {
 
     // If the entity is set to hide fields that have no values then we
     // want to honor that in the web services too.
@@ -357,7 +367,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // the rules (e.g. Image field).
     drupal_alter('tripal_ws_value', $items, $field, $instance);
 
-    $values = array();
+    $values = [];
     for ($i = 0; $i < count($items); $i++) {
       if (array_key_exists('value', $items[$i])) {
         $values[$i] = $this->sanitizeFieldKeys($resource, $items[$i]['value'], $bundle, $service_path);
@@ -370,13 +380,15 @@ class TripalContentService_v0_1 extends TripalWebService {
         // TODO: handle this case.
       }
     }
-    // Field specific permissions can result in an empty $values.
-    if (empty($values)) {
+    if (isset($field['field_permissions']['type'])) {
       return;
     }
+
     if ($hide_fields == TRUE and empty($values[0])) {
       return;
     }
+
+
 
     // If the field cardinality is 1.
     if ($field['cardinality'] == 1) {
@@ -390,13 +402,19 @@ class TripalContentService_v0_1 extends TripalWebService {
           }
         }
         else {
-          $this->addResourceProperty($resource, $term, $values[0], array('lowercase', 'spacing'));
+          $this->addResourceProperty($resource, $term, $values[0], [
+            'lowercase',
+            'spacing',
+          ]);
         }
       }
       // If the value is not an array it's a scalar so add it as is to the
       // response.
       else {
-        $this->addResourceProperty($resource, $term, $values[0], array('lowercase', 'spacing'));
+        $this->addResourceProperty($resource, $term, $values[0], [
+          'lowercase',
+          'spacing',
+        ]);
       }
     }
 
@@ -427,7 +445,10 @@ class TripalContentService_v0_1 extends TripalWebService {
       }
       else {
         //$this->resource->addProperty($key, $response);
-        $this->addResourceProperty($resource, $term, $response, array('lowercase', 'spacing'));
+        $this->addResourceProperty($resource, $term, $response, [
+          'lowercase',
+          'spacing',
+        ]);
       }
     }
   }
@@ -445,7 +466,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // If the value is an array rather than a scalar then map the sub elements
     // to controlled vocabulary terms.
     if (is_array($value)) {
-      $temp = array();
+      $temp = [];
       foreach ($value as $k => $v) {
 
         // exclude fields that have no values so we can hide them
@@ -453,12 +474,15 @@ class TripalContentService_v0_1 extends TripalWebService {
           continue;
         }
 
-        $matches = array();
+        $matches = [];
         if (preg_match('/^(.+):(.+)$/', $k, $matches)) {
           $vocabulary = $matches[1];
           $accession = $matches[2];
           $term = tripal_get_term_details($vocabulary, $accession);
-          $key = $this->addContextTerm($resource, $term, array('lowercase', 'spacing'));
+          $key = $this->addContextTerm($resource, $term, [
+            'lowercase',
+            'spacing',
+          ]);
 
           if (is_array($v)) {
             $temp[$key] = $this->sanitizeFieldKeys($resource, $v, $bundle, $service_path);
@@ -505,9 +529,9 @@ class TripalContentService_v0_1 extends TripalWebService {
       if ($key == 'entity') {
         list($item_etype, $item_eid) = explode(':', $items['entity']);
         if ($item_eid) {
-          $item_entity = tripal_load_entity($item_etype, array($item_eid));
+          $item_entity = tripal_load_entity($item_etype, [$item_eid]);
           $item_entity = reset($item_entity);
-          $bundle = tripal_load_bundle_entity(array('name' => $item_entity->bundle));
+          $bundle = tripal_load_bundle_entity(['name' => $item_entity->bundle]);
           $items['@id'] = $this->getServicePath() . '/' . urlencode($bundle->label) . '/' . $item_eid;
         }
         unset($items['entity']);
@@ -530,16 +554,16 @@ class TripalContentService_v0_1 extends TripalWebService {
     // it easier to determine which filter criteria belongs to which field. The
     // key is the label for the field and the value is the field name. This way
     // user's can use the field label or the field name to form a query.
-    $field_mapping = array();
+    $field_mapping = [];
     $fields = field_info_fields();
     foreach ($fields as $field) {
       if (array_key_exists('TripalEntity', $field['bundles'])) {
         foreach ($field['bundles']['TripalEntity'] as $bundle_name) {
           if ($bundle_name == $bundle->name) {
             $instance = field_info_instance('TripalEntity', $field['field_name'], $bundle_name);
-            if (array_key_exists('term_accession', $instance['settings'])){
-                $vocabulary = $instance['settings']['term_vocabulary'];
-                $accession = $instance['settings']['term_accession'];
+            if (array_key_exists('term_accession', $instance['settings'])) {
+              $vocabulary = $instance['settings']['term_vocabulary'];
+              $accession = $instance['settings']['term_accession'];
               $fterm = tripal_get_term_details($vocabulary, $accession);
               $key = $fterm['name'];
               $key = strtolower(preg_replace('/ /', '_', $key));
@@ -564,8 +588,8 @@ class TripalContentService_v0_1 extends TripalWebService {
    *
    * @throws Exception
    */
-  private function getOrderBy($field_mapping,  $bundle) {
-    $order_by = array();
+  private function getOrderBy($field_mapping, $bundle) {
+    $order_by = [];
 
     // Handle order separately.
     if (array_key_exists('order', $this->params)) {
@@ -579,7 +603,7 @@ class TripalContentService_v0_1 extends TripalWebService {
 
         // The user can provide a direction by separating the field key and the
         // direction with a '|' character.
-        $matches = array();
+        $matches = [];
         if (preg_match('/^(.*)\|(.*)$/', $key, $matches)) {
           $key = $matches[1];
           if ($matches[2] == 'ASC' or $matches[2] == 'DESC') {
@@ -614,10 +638,10 @@ class TripalContentService_v0_1 extends TripalWebService {
             $sortable_keys = $ws_data['sortable'];
             $criteria = implode('.', $subkeys);
             if (array_key_exists($criteria, $sortable_keys)) {
-              $order_by[$key_field_name][] = array(
+              $order_by[$key_field_name][] = [
                 'column' => $sortable_keys[$criteria],
                 'dir' => $dir,
-              );
+              ];
             }
             else {
               throw new Exception("The value, '$criteria', is not available for sorting.");
@@ -628,10 +652,10 @@ class TripalContentService_v0_1 extends TripalWebService {
           else {
             $key_field_id = $key_instance['settings']['term_vocabulary'] . ':' . $key_instance['settings']['term_accession'];
 
-            $order_by[$key_field_name][] = array(
+            $order_by[$key_field_name][] = [
               'column' => $key_field_id,
               'dir' => $dir,
-            );
+            ];
           }
 
         }
@@ -643,19 +667,25 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     // If there is no ordering that is set then set a default order.
     if (count(array_keys($order_by)) == 0) {
-      $key_field_names = array();
+      $key_field_names = [];
       if (in_array('data__identifier', $field_mapping)) {
         $key_field_names['data__identifier'][] = 'identifier';
       }
-      else if (in_array('schema__name', $field_mapping)) {
-        $key_field_names['schema__name'][] = 'name';
-      }
-      else if (in_array('rdfs_label', $field_mapping)) {
-        $key_field_names['rdfs_label'][] = 'label';
-      }
-      else if (in_array('taxrank__genus', $field_mapping)) {
-        $key_field_names['taxrank__genus'][] = 'genus';
-        $key_field_names['taxrank__species'][] = 'species';
+      else {
+        if (in_array('schema__name', $field_mapping)) {
+          $key_field_names['schema__name'][] = 'name';
+        }
+        else {
+          if (in_array('rdfs_label', $field_mapping)) {
+            $key_field_names['rdfs_label'][] = 'label';
+          }
+          else {
+            if (in_array('taxrank__genus', $field_mapping)) {
+              $key_field_names['taxrank__genus'][] = 'genus';
+              $key_field_names['taxrank__species'][] = 'species';
+            }
+          }
+        }
       }
       foreach ($key_field_names as $key_field_name => $criteria) {
         $key_field = field_info_field($key_field_name);
@@ -669,19 +699,19 @@ class TripalContentService_v0_1 extends TripalWebService {
           $ws_data = $key_field->webServicesData();
           $sortable_keys = $ws_data['sortable'];
           if (array_key_exists($criteria, $sortable_keys)) {
-            $order_by[$key_field_name][] = array(
+            $order_by[$key_field_name][] = [
               'column' => $sortable_keys[$criteria],
               'dir' => $dir,
-            );
+            ];
           }
         }
-       // If this field is not a TripalField then it should just have
-          // a simple value and we can query for that.
+        // If this field is not a TripalField then it should just have
+        // a simple value and we can query for that.
         else {
-          $order_by[$key_field_name][] = array(
+          $order_by[$key_field_name][] = [
             'column' => $key_field_id,
             'dir' => 'ASC',
-          );
+          ];
         }
       }
     }
@@ -702,21 +732,21 @@ class TripalContentService_v0_1 extends TripalWebService {
    * @throws Exception
    */
   private function getFieldFilters($field_mapping, $bundle) {
-    $filters = array();
+    $filters = [];
 
     // Iterate through the paramter list provided by user.
     foreach ($this->params as $param => $value) {
 
       // Ignore non filter parameters.
       if ($param == 'page' or $param == 'limit' or $param == 'order' or
-          $param == 'ids' or $param == 'fields') {
+        $param == 'ids' or $param == 'fields') {
         continue;
       }
 
       // Break apart any operators
       $key = $param;
       $op = '=';
-      $matches = array();
+      $matches = [];
       if (preg_match('/^(.+);(.+)$/', $key, $matches)) {
         $key = $matches[1];
         $op = $matches[2];
@@ -747,11 +777,11 @@ class TripalContentService_v0_1 extends TripalWebService {
           $searchable_keys = $ws_data['searchable'];
           $criteria = implode('.', $subkeys);
           if (array_key_exists($criteria, $searchable_keys)) {
-            $filters[$key_field_name][] = array(
+            $filters[$key_field_name][] = [
               'value' => $value,
               'op' => $op,
-              'column' => $searchable_keys[$criteria]
-            );
+              'column' => $searchable_keys[$criteria],
+            ];
           }
           else {
             throw new Exception("The filter term, '$criteria', is not available for use.");
@@ -762,11 +792,11 @@ class TripalContentService_v0_1 extends TripalWebService {
         else {
           $key_field_id = $key_instance['settings']['term_vocabulary'] . ':' . $key_instance['settings']['term_accession'];
 
-          $filters[$key_field_name][] = array(
+          $filters[$key_field_name][] = [
             'value' => $value,
             'op' => $op,
             'column' => $key_field_id,
-          );
+          ];
         }
       }
       else {
@@ -821,8 +851,8 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource = new TripalWebServiceCollection($service_path, $this->params);
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
-    $bundle = tripal_load_bundle_entity(array('label' => $ctype));
-    $term = entity_load('TripalTerm', array('id' => $bundle->term_id));
+    $bundle = tripal_load_bundle_entity(['label' => $ctype]);
+    $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
     $term = reset($term);
 
     // The type of collection is provided by our API vocabulary service.
@@ -867,10 +897,10 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Now iterate through the filters and add those.
     foreach ($filters as $key_field_name => $key_filters) {
       foreach ($key_filters as $i => $filter) {
-         $column_name = $filter['column'];
-         $value = $filter['value'];
-         $op = $filter['op'];
-         $query->fieldCondition($key_field_name, $column_name, $value, $op);
+        $column_name = $filter['column'];
+        $value = $filter['value'];
+        $op = $filter['op'];
+        $query->fieldCondition($key_field_name, $column_name, $value, $op);
       }
     }
 
@@ -909,15 +939,15 @@ class TripalContentService_v0_1 extends TripalWebService {
     $this->resource->initPager($num_records, $limit, $page);
 
     // Check to make sure there are results.
-    $entity_ids = array();
+    $entity_ids = [];
     if (isset($results['TripalEntity']) AND is_array($results['TripalEntity'])) {
       $entity_ids = $results['TripalEntity'];
     }
 
     // If the user wants to include any fields in the list then those provided
     // names need to be converted to fields.
-    $add_fields = array();
-    $add_field_ids = array();
+    $add_fields = [];
+    $add_field_ids = [];
     if (array_key_exists('fields', $this->params)) {
       $fields = explode(',', $this->params['fields']);
       foreach ($fields as $expfield) {
@@ -929,7 +959,7 @@ class TripalContentService_v0_1 extends TripalWebService {
           $add_field_ids[] = $field['id'];
         }
         else {
-          throw new Exception(t('The field named, "!field", does not exist.', array('!field' => $expfield)));
+          throw new Exception(t('The field named, "!field", does not exist.', ['!field' => $expfield]));
         }
       }
     }
@@ -942,7 +972,7 @@ class TripalContentService_v0_1 extends TripalWebService {
       $query = db_select('tripal_entity', 'TE');
       $query->join('tripal_term', 'TT', 'TE.term_id = TT.id');
       $query->fields('TE');
-      $query->fields('TT', array('name'));
+      $query->fields('TT', ['name']);
       $query->condition('TE.id', $entity_id);
       $entity = $query->execute()->fetchObject();
 
@@ -952,16 +982,16 @@ class TripalContentService_v0_1 extends TripalWebService {
       $member->setID($entity->id);
       $this->setResourceType($member, $term);
       $this->addResourceProperty($member, $label, $entity->title);
-      $this->addResourceProperty($member, $itemPage, url('/bio_data/' . $entity->id, array('absolute' => TRUE)));
+      $this->addResourceProperty($member, $itemPage, url('/bio_data/' . $entity->id, ['absolute' => TRUE]));
 
-      $entity = tripal_load_entity('TripalEntity', array($entity_id), FALSE, $add_field_ids);
+      $entity = tripal_load_entity('TripalEntity', [$entity_id], FALSE, $add_field_ids);
       $entity = $entity[$entity_id];
 
       // Add in any requested fields
       foreach ($add_fields as $expfield => $expfield_details) {
         $this->addEntityField($member, $expfield_details['term'], $entity,
-            $bundle, $expfield_details['field'], $expfield_details['instance'],
-            $service_path);
+          $bundle, $expfield_details['field'], $expfield_details['instance'],
+          $service_path);
       }
       $this->resource->addMember($member);
     }
@@ -990,7 +1020,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Iterate through the terms and add an entry in the collection.
     $i = 0;
     while ($bundle = $bundles->fetchObject()) {
-      $entity =  entity_load('TripalTerm', array('id' => $bundle->term_id));
+      $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
       $term = reset($entity);
       $vocab = $term->vocab;
 
@@ -1028,47 +1058,48 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Adds the content collection class to the document for this service.
    */
   private function addDocContentCollectionClass() {
-    $details = array(
+    $details = [
       'id' => 'vocab:Content_Collection',
       'term' => 'vocab:Content_Collection',
       'title' => 'Content Collection',
-    );
+    ];
     $vocab = tripal_get_vocabulary_details('hydra');
-    $properties = array();
-    $properties[] = array(
+    $properties = [];
+    $properties[] = [
       'type' => $vocab['sw_url'],
       'title' => 'member',
       'description' => "The list of available content types.",
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
       "writeonly" => FALSE,
-    );
-    $properties[] = array(
+    ];
+    $properties[] = [
       "type" => $vocab['sw_url'],
       "title" => "totalItems",
       "description" => "The total number of content types.",
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
-      "writeonly" => FALSE
-    );
-    $properties[] = array(
+      "writeonly" => FALSE,
+    ];
+    $properties[] = [
       "type" => $vocab['sw_url'],
       "title" => "label",
       "description" => "The type content.",
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
-      "writeonly" => FALSE
-    );
+      "writeonly" => FALSE,
+    ];
 
-    $operations = array();
-    $operations['GET'] = array(
+    $operations = [];
+    $operations['GET'] = [
       'label' => 'Retrieves a collection (a list) of available content types.',
       'type' => '_:content_collection_retrieve',
       'expects' => NULL,
       'returns' => 'vocab:ContentCollection',
-    );
-    $this->addDocClass($details,$operations, $properties);
+    ];
+    $this->addDocClass($details, $operations, $properties);
   }
+
   /**
    * Adds classes for every content type to the documentation for this service.
    */
@@ -1085,7 +1116,7 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Iterate through the content types and add a class for each one.
     $i = 0;
     while ($bundle = $bundles->fetchObject()) {
-      $entity = entity_load('TripalTerm', array('id' => $bundle->term_id));
+      $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
       $term = reset($entity);
       $vocab = $term->vocab;
 
@@ -1098,24 +1129,24 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       // Create the details array for the class.
       $class_id = $this->getServicePath() . '/' . urlencode($bundle->label);
-      $details = array(
+      $details = [
         'id' => $term->getURL(),
         'term' => $term->getAccession(),
         'title' => preg_replace('/[^\w]/', '_', $bundle->label),
         'description' => $description,
-      );
+      ];
 
       // Add in the supported operations for this content type.
-      $operations = array();
+      $operations = [];
       // If the user can view this content type.
       if (user_access('view ' . $bundle->name)) {
         $label = "Retrieves the " . $bundle->label . " resource.";
-        $operations['GET'] = array(
+        $operations['GET'] = [
           'label' => $label,
           'description' => NULL,
           'returns' => $term->url,
           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_retrieve',
-        );
+        ];
       }
 
       // If the user can edit this content type.
@@ -1124,28 +1155,28 @@ class TripalContentService_v0_1 extends TripalWebService {
         if (preg_match('/^[aeiou]/i', $bundle->label)) {
           $label = "Update and replace an " . $bundle->label . " resource.";
         }
-// TODO: add this back in when web services support this method.
-//         $operations['PUT'] = array(
-//           'label' => $label,
-//           'description' => NULL,
-//           'returns' => $term->url,
-//           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_update',
-//         );
+        // TODO: add this back in when web services support this method.
+        //         $operations['PUT'] = array(
+        //           'label' => $label,
+        //           'description' => NULL,
+        //           'returns' => $term->url,
+        //           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_update',
+        //         );
       }
 
       // If the user can edit this content type.
       if (user_access('delete ' . $bundle->name)) {
-        $label =  "Deletes the " . $bundle->label . " resource.";
+        $label = "Deletes the " . $bundle->label . " resource.";
         if (preg_match('/^[aeiou]/i', $bundle->label)) {
-          $label =  "Deletes an " . $bundle->label . " resource.";
+          $label = "Deletes an " . $bundle->label . " resource.";
         }
-// TODO: add this back in when web services support this method.
-//         $operations['DELETE'] = array(
-//           'label' => $label,
-//           'description' => NULL,
-//           'returns' => $term->url,
-//           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_delete',
-//         );
+        // TODO: add this back in when web services support this method.
+        //         $operations['DELETE'] = array(
+        //           'label' => $label,
+        //           'description' => NULL,
+        //           'returns' => $term->url,
+        //           'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_delete',
+        //         );
       }
 
       // Add in the properties that correspond to fields in the data.
@@ -1163,7 +1194,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Every content type (bundle) has fields that need to be set as properties.
    */
   private function addDocBundleFieldProperties($bundle, $bundle_term) {
-    $properties = array();
+    $properties = [];
 
     $content_type_accession = $bundle_term->vocab->vocabulary . ':' . $bundle_term->accession;
 
@@ -1198,14 +1229,14 @@ class TripalContentService_v0_1 extends TripalWebService {
         $link = new TripalWebServiceResource($this->base_path);
         $link->setID($accession);
         $link->setType('hydra:Link');
-        $link->addContextItem('domain', array(
+        $link->addContextItem('domain', [
           "@id" => "rdfs:domain",
-          "@type" => "@id"
-        ));
-        $link->addContextItem('range', array(
+          "@type" => "@id",
+        ]);
+        $link->addContextItem('range', [
           "@id" => "rdfs:range",
-          "@type" => "@id"
-        ));
+          "@type" => "@id",
+        ]);
         $link->addContextItem('readable', 'hydra:readable');
         $link->addContextItem('writeable', 'hydra:writeable');
         $link->addContextItem('required', 'hydra:required');
@@ -1216,7 +1247,7 @@ class TripalContentService_v0_1 extends TripalWebService {
         //       $link->addProperty('domain', $service_path . '#EntryPoint');
         //       $link->addProperty('range', $service_class::$label);
 
-        $ops = array();
+        $ops = [];
         $op = new TripalWebServiceResource($this->base_path);
 
         $op->setID('_:' . $field_name . '_retrieve');
@@ -1224,21 +1255,21 @@ class TripalContentService_v0_1 extends TripalWebService {
         $op->addContextItem('method', 'hydra:method');
         $op->addContextItem('label', 'rdfs:label');
         $op->addContextItem('description', 'rdfs:comment');
-        $op->addContextItem('expects', array(
+        $op->addContextItem('expects', [
           "@id" => "hydra:expects",
-          "@type" => "@id"
-        ));
-        $op->addContextItem('returns', array(
+          "@type" => "@id",
+        ]);
+        $op->addContextItem('returns', [
           "@id" => "hydra:returns",
-          "@type" => "@id"
-        ));
+          "@type" => "@id",
+        ]);
         $op->addContextItem('statusCodes', 'hydra:statusCodes');
         $op->addProperty('method', "GET");
         $op->addProperty('label', 'Retrieves the ' . $instance['label'] . ' resource.');
         $op->addProperty('description', $instance['description']);
         $op->addProperty('expects', NULL);
         $op->addProperty('returns', $accession);
-        $op->addProperty('statusCodes', array());
+        $op->addProperty('statusCodes', []);
         $ops[] = $op;
         $link->addContextItem('supportedOperation', 'hydra:supportedOperation');
         $link->addProperty('supportedOperation', $ops);
@@ -1247,7 +1278,7 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       $formatters = tripal_get_field_field_formatters($field, $instance);
 
-      $property = array(
+      $property = [
         'type' => $proptype,
         'title' => $instance['label'],
         'description' => $instance['description'],
@@ -1255,11 +1286,12 @@ class TripalContentService_v0_1 extends TripalWebService {
         "readonly" => FALSE,
         "writeonly" => TRUE,
         "tripal_formatters" => $formatters,
-      );
+      ];
       $properties[] = $property;
     }
     return $properties;
   }
+
   /**
    * Every content type (bundle) needs a collection class in the documentation.
    */
@@ -1267,49 +1299,49 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     $accession = preg_replace('/[^\w]/', '_', $bundle->label . ' Collection');
 
-    $details = array(
+    $details = [
       'id' => 'vocab:' . $accession,
       'term' => 'vocab:' . $accession,
       'title' => $bundle->label . ' Collection',
       'subClassOf' => 'hydra:Collection',
       'description' => 'A collection (or list) of ' . $bundle->label . ' resources.',
-    );
+    ];
     $vocab = tripal_get_vocabulary_details('hydra');
-    $properties = array();
-    $properties[] = array(
+    $properties = [];
+    $properties[] = [
       'type' => $vocab['sw_url'],
       'title' => 'member',
       'description' => "The list of available " . $bundle->label . '(s).',
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
       "writeonly" => FALSE,
-    );
-    $properties[] = array(
+    ];
+    $properties[] = [
       "type" => $vocab['sw_url'],
       "title" => "totalItems",
       "description" => "The total number of resources.",
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
-      "writeonly" => FALSE
-    );
-    $properties[] = array(
+      "writeonly" => FALSE,
+    ];
+    $properties[] = [
       "type" => $vocab['sw_url'],
       "title" => "label",
       "description" => "A label or name for the resource.",
-      "required" => null,
+      "required" => NULL,
       "readonly" => FALSE,
-      "writeonly" => FALSE
-    );
+      "writeonly" => FALSE,
+    ];
 
     $class_id = $this->getServicePath() . '/' . urlencode($bundle->label);
-    $operations = array();
-    $operations['GET'] = array(
+    $operations = [];
+    $operations['GET'] = [
       'label' => 'Retrieves a list of all ' . $bundle->label . ' resources.',
       'description' => NULL,
       'expects' => NULL,
       'returns' => $term->url,
       'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_collection_retrieve',
-    );
+    ];
 
     // If the user can create this content type then we allow a POST on the
     // collection type.
@@ -1318,20 +1350,20 @@ class TripalContentService_v0_1 extends TripalWebService {
       if (preg_match('/^[aeiou]/i', $bundle->label)) {
         $label = "Creates an " . $bundle->label;
       }
-// TODO: add this back in when web services support this method.
-//       $operations['POST'] = array(
-//         'label' => $label,
-//         'description' => NULL,
-//         'expects' => $term->url,
-//         'returns' => $term->url,
-//         'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_create',
-//         'statusCodes' => array(
-//           array(
-//             "code" => 201,
-//             "description" => "If the " . $bundle->label . " was created successfully."
-//           ),
-//         ),
-//       );
+      // TODO: add this back in when web services support this method.
+      //       $operations['POST'] = array(
+      //         'label' => $label,
+      //         'description' => NULL,
+      //         'expects' => $term->url,
+      //         'returns' => $term->url,
+      //         'type' => '_:' . preg_replace('/[^\w]/', '_', strtolower($bundle->label)) . '_create',
+      //         'statusCodes' => array(
+      //           array(
+      //             "code" => 201,
+      //             "description" => "If the " . $bundle->label . " was created successfully."
+      //           ),
+      //         ),
+      //       );
     }
     $this->addDocClass($details, $operations, $properties);
   }

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -370,12 +370,15 @@ class TripalContentService_v0_1 extends TripalWebService {
         // TODO: handle this case.
       }
     }
-
+    // Field specific permissions can result in an empty $values.
+    if (empty($values)) {
+      return;
+    }
     if ($hide_fields == TRUE and empty($values[0])) {
       return;
     }
 
-    // If the field cardinality is 1
+    // If the field cardinality is 1.
     if ($field['cardinality'] == 1) {
 
       // If the value is an array and this is the field page then all of those


### PR DESCRIPTION

# Bug fix

Issue #749 

## Description
I added a guide for using field-specific permissions, to hide some fields from certain user types on input and on display.
https://tripal.readthedocs.io/en/latest/user_guide/content_types/field_permissions.html

However web services still displayed content that was hidden.  This PR should resolve that.

## Testing?


Follow the guide to hide a particular field (uncheck all boxes except for admin). You can visit the page as anon/admin to verify the field is hidden to anonymous users.  Then visit that content with web services: the field should display.

If you then checkout this branch and view via web services, th field should no longer display.
