### PR TITLE
Fix issue with aliases token not filled (#790)

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -1324,10 +1324,10 @@ function tripal_replace_entity_tokens($string, &$entity, $bundle_entity = NULL) 
 
   // If we have any fields that need attaching, then do so now.
   if (count(array_keys($attach_fields)) > 0) {
+    $field_ids = array();
     foreach ($attach_fields as $storage_type => $details) {
       $storage = $details['storage'];
       $fields = $details['fields'];
-      $field_ids = array();
       foreach ($fields as $field) {
         $field_ids[$field['id']] = array($entity->id);
       }

--- a/tripal/includes/tripal.field_storage.inc
+++ b/tripal/includes/tripal.field_storage.inc
@@ -38,6 +38,8 @@ function tripal_field_storage_load($entity_type, $entities, $age,
     // Iterate through the entity's fields so we can get the column names
     // that need to be selected from each of the tables represented.
     $tables = array();
+    $record = $entity->chado_record;
+
     foreach ($fields as $field_id => $ids) {
 
       // By the time this hook runs, the relevant field definitions have been
@@ -48,7 +50,6 @@ function tripal_field_storage_load($entity_type, $entities, $age,
       $field_name = $field['field_name'];
       $field_type = $field['type'];
       $field_module = $field['module'];
-      $record = $entity->chado_record;
       // Get the instnace for this field
       $instance = field_info_instance($entity_type, $field_name, $entity->bundle);
 

--- a/tripal/includes/tripal.field_storage.inc
+++ b/tripal/includes/tripal.field_storage.inc
@@ -48,7 +48,7 @@ function tripal_field_storage_load($entity_type, $entities, $age,
       $field_name = $field['field_name'];
       $field_type = $field['type'];
       $field_module = $field['module'];
-
+      $record = $entity->chado_record;
       // Get the instnace for this field
       $instance = field_info_instance($entity_type, $field_name, $entity->bundle);
 
@@ -59,8 +59,23 @@ function tripal_field_storage_load($entity_type, $entities, $age,
       if (class_exists($field_type)) {
         $tfield = new $field_type($field, $instance);
         $tfield->load($entity);
+      } 
+      else {
+        if ($field_type == 'text') {
+          $field_table = $instance['settings']['chado_table'];
+          $field_column = $instance['settings']['chado_column'];
+          $record = chado_expand_var($record, 'field', "$field_table.$field_column");
+          $entity->{$field_name}['und'][0]['value'] = $record->$field_column;
+          // Text fields that have a text_processing == 1 setting need a
+          // special 'format' element too:
+          if (array(key_exists('text_processing', $instance['settings']) and
+            $instance['settings']['text_processing'] == 1)) {
+          // TODO: we need a way to write the format back to the
+          // instance settings if the user changes it when using the form.
+            $entity->{$field_name}['und'][0]['format'] = array_key_exists('format', $instance['settings']) ? $instance['settings']['format'] : 'full_html';
+          }
+        }
       }
-
     } // end: foreach ($fields as $field_id => $ids) {
   } // end: foreach ($entities as $id => $entity) {
 }


### PR DESCRIPTION
# Bux Fix

Issue #790 

## Description
1) Put the $field_ids definition outside the loop to avoid a reset.

2) Fixed token management for text fields (based on implementation in tripal_chado_field_storage_load)
