### PR TITLE
Type Hinting problems with PHP 5.6: WSOD

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -1733,8 +1733,8 @@ function hook_bundle_delete_orphans(TripalBundle $bundle, array $ids, TripalJob 
  *  If $count == FALSE then an array of all entity IDs that are orphaned. If
  *  $count == TRUE then a single integer count value is returned.
  */
-function hook_bundle_find_orphans(TripalBundle $bundle, bool $count = FALSE, 
-  int $offset = 0, int $limit = 10) {
+function hook_bundle_find_orphans(TripalBundle $bundle, $count = FALSE,
+  $offset = 0, $limit = 10) {
   
     // See the tripal_chado_bundle_find_orphans() function for an example.  
   

--- a/tripal/includes/TripalBundleController.inc
+++ b/tripal/includes/TripalBundleController.inc
@@ -140,7 +140,7 @@ class TripalBundleController extends EntityAPIControllerExportable {
    *  If $count == FALSE then an array of all entity IDs that are orphaned. If
    *  $count == TRUE then a single integer count value is returned.
    */
-  public function findOrphans(int $id, bool $count = FALSE, int $offset = 0, int $limit = 0) {
+  public function findOrphans($id, $count = FALSE, $offset = 0, $limit = 0) {
     
     // Call the hook for modules to find their orphans
     $bundle = tripal_load_bundle_entity(['id' => $id]);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->

# Bug Fix

## Description
PHP 5.6 only supports type hinting for objects and arrays. However there were a couple of places where it was used for int and bool, which caused WSOD on PHP 5.6 sites. Although we are moving on from supporting 5.6 since PHP will soon cease support, we don't want site maintainers struggling to upgrade to be met with a WSOD.

Since this PR only changes type hinting in function parameters, it should only require a single review.

## Testing?

Pull this branch and refresh your site. You should not see a WSOD ;-P 