### PR TITLE
Fix for disappearing fields in tables that are ajax loaded.

### DIFF
--- a/tripal/api/tripal.fields.api.inc
+++ b/tripal/api/tripal.fields.api.inc
@@ -4,7 +4,7 @@
  * @file
  * Provides an application programming interface (API) for working with
  * fields attached to TripalEntity content types (bundles).
- * 
+ *
  */
 
 /**
@@ -13,31 +13,31 @@
  * @{
  * Provides an application programming interface (API) for working with
  * fields attached to TripalEntity content types (bundles).
- * 
+ *
  * Fields:
- * A field is a reusable "data container" that is attached to a Bundle. 
- * Programmatically, each field provides one or more primitive data types, with 
- * validators and widgets for editing and formatters for display. Each field 
- * independently manages the data to which it assigned.  Just like with Bundles, 
- * Fields are also described using controlled vocabulary terms.  For example, a 
- * gene Bundle has a field attached that provides the name of the gene.   
- * This field only provides the name and nothing more.  Tripal uses the 
- * schema:name vocabulary term to describe the field.  
+ * A field is a reusable "data container" that is attached to a Bundle.
+ * Programmatically, each field provides one or more primitive data types, with
+ * validators and widgets for editing and formatters for display. Each field
+ * independently manages the data to which it assigned.  Just like with Bundles,
+ * Fields are also described using controlled vocabulary terms.  For example, a
+ * gene Bundle has a field attached that provides the name of the gene.
+ * This field only provides the name and nothing more.  Tripal uses the
+ * schema:name vocabulary term to describe the field.
  *
  * Field Instances:
- * Fields describe "atomic" units of data that are associated with an entity.  
- * For example, a "name" is an atomic unit of data about a Gene or Organism 
- * entity. Fields can be reused for multiple Bundles. For example, gene, mRNA, 
- * genetic markers and variants all have name data.  Despite that all of these 
+ * Fields describe "atomic" units of data that are associated with an entity.
+ * For example, a "name" is an atomic unit of data about a Gene or Organism
+ * entity. Fields can be reused for multiple Bundles. For example, gene, mRNA,
+ * genetic markers and variants all have name data.  Despite that all of these
  * Bundles provides a "name", we only need one field to describe that this data
- * is a "name".  However, we may want to customize a field specific to each 
- * bundle.  Therefore, an Instance of a field is attached to a bundle, and 
- * field instances can then be customized differently.  The most important 
- * customization is the one that defines the Chado table from which the data 
- * for a field is retrieved.   Despite that field instances are attached to 
- * bundles, they become visible with Entities.  When an entity is loaded for 
- * display, Drupal examines all of the fields that are attached to the entity's 
- * bundle, and then populates the fields instances with data specific to the 
+ * is a "name".  However, we may want to customize a field specific to each
+ * bundle.  Therefore, an Instance of a field is attached to a bundle, and
+ * field instances can then be customized differently.  The most important
+ * customization is the one that defines the Chado table from which the data
+ * for a field is retrieved.   Despite that field instances are attached to
+ * bundles, they become visible with Entities.  When an entity is loaded for
+ * display, Drupal examines all of the fields that are attached to the entity's
+ * bundle, and then populates the fields instances with data specific to the
  * entity being loaded.
  * @}
  *
@@ -81,8 +81,8 @@ function hook_field_storage_tquery($conditions, $orderBy) {
 }
 
 /**
- * Allows a module to return a bundles field info. 
- * 
+ * Allows a module to return a bundles field info.
+ *
  * @param $entity_type
  *  The name of the entity, like 'TripalEntity'.
  * @param $bundle
@@ -100,7 +100,7 @@ function hook_bundle_fields_info($entity_type, $bundle) {
  *  The name of the entity, most likely 'TripalEntity'.
  * @param $bundle
  *  The bundle object.
- * 
+ *
  * @ingroup tripal_fields_api
  */
 function hook_bundle_instances_info($entity_type, $bundle) {
@@ -111,11 +111,11 @@ function hook_bundle_instances_info($entity_type, $bundle) {
  * Indicate if a field has an empty value.
  *
  * By default, all field values are attached to an entity in the form
- * $entity->{field_name}[{language}][{delta}].   Tyipcally a field witll then
+ * $entity->{field_name}[{language}][{delta}].   Typically a field will then
  * have a 'value' element:  $entity->{field_name}[{language}][{delta}]['value']
  * and if that value is empty then the field is considered empty by Tripal.
- * By default the tripal_field-is_empty() function is used to check all
- * fields to see if they are empty. However, this fhook can be implemented by
+ * By default the tripal_field_is_empty() function is used to check all
+ * fields to see if they are empty. However, this hook can be implemented by
  * any module to override that behavior.
  *
  * @param $field
@@ -130,32 +130,32 @@ function hook_bundle_instances_info($entity_type, $bundle) {
  * @return
  *   TRUE if the field value is empty for the given delta, and FALSE if not
  *   empty.
- *   
+ *
  * @ingroup tripal_fields_api
  */
 function tripal_field_is_empty($field, $items, $delta = 0) {
-  
+
   // If the $items argument is empty then return TRUE.
   if (!$items) {
     return TRUE;
   }
-  
+
   // If the field is a tripal field storage API field and there
   // is no value field then the field is empty.
-  if (array_key_exists('storage', $field) and 
-      array_key_exists('tripal_storage_api', $field['storage']['settings']) and 
+  if (array_key_exists('storage', $field) and
+      array_key_exists('tripal_storage_api', $field['storage']['settings']) and
       !array_key_exists('value', $items[$delta])) {
     return TRUE;
   }
-  
+
   // If there is a value field but there's nothing in it, the the field is
   // empty.
-  if (array_key_exists($delta, $items) and 
-      array_key_exists('value', $items[$delta]) and 
+  if (array_key_exists($delta, $items) and
+      array_key_exists('value', $items[$delta]) and
       empty($items[$delta]['value'])) {
     return TRUE;
   }
-  
+
   // Otherwise, the field is not empty.
   return FALSE;
 }

--- a/tripal/includes/TripalEntityController.inc
+++ b/tripal/includes/TripalEntityController.inc
@@ -101,7 +101,7 @@ class TripalEntityController extends EntityAPIController {
 
     return TRUE;
   }
-  
+
   /**
    * Sets the title for an entity.
    *
@@ -649,7 +649,7 @@ class TripalEntityController extends EntityAPIController {
 
           // Add this field to the entity with default value.
           if (!isset($queried_entities[$id]->{$field_name})) {
-            $queried_entities[$id]->{$field_name} = array();
+            $queried_entities[$id]->{$field_name} = [];
           }
 
           // Options used for the field_attach_load function.
@@ -688,14 +688,19 @@ class TripalEntityController extends EntityAPIController {
           // attach then we will ignore it. It can only be set by providing
           // the id in the $field_id array handled previously.
           else {
-            
+
+            // Does the field instance have an 'auto_attach' setting?
+            $auto_attach = FALSE;
+            if (array_key_exists('settings', $instance) and
+                array_key_exists('auto_attach', $instance['settings']) and
+                $instance['settings']['auto_attach'] == TRUE) {
+              $auto_attach = TRUE;
+            }
+
             // Do not load fields that are not auto attached.  Instead set
             // their value to an empty string and set the #processed key to
             // FALSE.
-            if (array_key_exists('settings', $instance) and
-                array_key_exists('auto_attach', $instance['settings']) and
-                $instance['settings']['auto_attach'] == FALSE) {
-
+            if (!$auto_attach) {
                // Add an empty value. This will allow the tripal_entity_view()
                // hook to add the necessary prefixes to the field for ajax
                // loading.

--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -475,10 +475,15 @@ function tripal_entity_reload($entity) {
 
   $sql = "SELECT count(*) FROM cache_field WHERE cid like :cid";
   $count = db_query($sql, [':cid' => $cid . '%'])->fetchField();
+
   if (!isset($count) or $count > 0) {
     drupal_set_message('Failed to clear the cache for this entity.');
   }
   else {
+    // We must reload the entity.  If we don't then other processes that
+    // depended on a fully loaded entity object will mess up.
+    $entity = tripal_load_entity('TripalEntity', [$entity->id]);
+
     drupal_set_message('Cache cleared, entity reloaded');
   }
   drupal_goto('bio_data/' . $entity_id);

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -498,18 +498,18 @@ function tripal_entity_access($op, $entity = NULL, $account = NULL, $entity_type
 
 /**
  * Implements hook_entity_prepare_view
- * 
+ *
  * This function is called before building the content array for an entity. It
  * allows us to load any unattached fields if AJAX is turned off.
  */
 function tripal_entity_prepare_view($entities, $type, $langcode) {
-  
+
   // This is for only TripalEntity content types.
   if ($type != 'TripalEntity') {
     return;
   }
 
-  // Iterate through the entities and instancesa and if AJAX loading is turned
+  // Iterate through the entities and instances and if AJAX loading is turned
   // off then we need to load those fields that were not auto attached.
   foreach ($entities as $entity_id => &$entity) {
     $bundle = tripal_load_bundle_entity(['name' => $entity->bundle]);
@@ -518,17 +518,17 @@ function tripal_entity_prepare_view($entities, $type, $langcode) {
     foreach ($instances as $instance) {
       $field_name = $instance['field_name'];
       $field = field_info_field($field_name);
-      
+
       $auto_attach = array_key_exists('auto_attach', $instance['settings']) ? $instance['settings']['auto_attach'] : TRUE;
       $processed = $entity->{$field_name}['#processed'];
-      
+
       // If the field is not ajax loadable and the field is not auto attached
       // then we need to add the value.
       if (!$use_ajax and $auto_attach == FALSE and $processed == FALSE) {
         $temp = tripal_load_entity('TripalEntity', [$entity_id], TRUE, [$field['id']]);
         reset($temp);
         $entity->{$field_name} = $temp[$entity_id]->{$field_name};
-        $items = field_get_items('TripalEntity', $entity, $field_name);        
+        $items = field_get_items('TripalEntity', $entity, $field_name);
       }
     }
   }
@@ -537,7 +537,7 @@ function tripal_entity_prepare_view($entities, $type, $langcode) {
 /**
  * Implements hook_entity_view.
  *
- * Here we want to overwite unattached fields with a div box that will be
+ * Here we want to overwrite unattached fields with a div box that will be
  * recognized by JavaScript that will then use AJAX to load the field.
  * The tripal_ajax_attach_field() function is called by an AJAX call to
  * retrieve the field.  We also remove empty fields that were auto attached.
@@ -548,13 +548,13 @@ function tripal_entity_view($entity, $type, $view_mode, $langcode) {
   if ($type != 'TripalEntity') {
     return;
   }
-    
+
   $bundle = tripal_load_bundle_entity(['name' => $entity->bundle]);
   $hide_empty = tripal_get_bundle_variable('hide_empty_field', $bundle->id);
   $use_ajax = tripal_get_bundle_variable('ajax_field', $bundle->id);
 
   // Iterate through the fields attached to this entity and add IDs to them
-  // as well as some classe for ajax loading.
+  // as well as some classes for ajax loading.
   foreach (element_children($entity->content) as $child_name) {
 
     // Surround the field with a <div> box for AJAX loading if this
@@ -565,7 +565,7 @@ function tripal_entity_view($entity, $type, $view_mode, $langcode) {
       continue;
     }
     $field = field_info_field($instance['field_name']);
-     
+
     // Check if this is an AJAX loadable field, and if so set the class.
     $class = '';
     $auto_attach = array_key_exists('auto_attach', $instance['settings']) ? $instance['settings']['auto_attach'] : TRUE;
@@ -573,7 +573,7 @@ function tripal_entity_view($entity, $type, $view_mode, $langcode) {
     if ($use_ajax and $auto_attach == FALSE and $processed == FALSE) {
       $class = 'class="tripal-entity-unattached"';
     }
-    
+
     // Set the prefix and suffix.
     if (!array_key_exists('#prefix', $entity->content[$child_name])) {
       $entity->content[$child_name]['#prefix'] = '';
@@ -583,7 +583,7 @@ function tripal_entity_view($entity, $type, $view_mode, $langcode) {
     }
     $entity->content[$child_name]['#prefix'] .= '<div id="tripal-entity-' . $entity->id . '--' . $child_name . '" ' . $class . '>';
     $entity->content[$child_name]['#suffix'] .= '</div>';
-    
+
     // Remove any auto attached fields if they are empty.
     if ($hide_empty and $processed) {
       $items = field_get_items('TripalEntity', $entity, $child_name);
@@ -592,8 +592,7 @@ function tripal_entity_view($entity, $type, $view_mode, $langcode) {
       }
     }
   }
-  
-  //dpm($entity->content);
+
   // Add some settings for AJAX to deal with fields.
   $settings = [
     'tripal_display' => [

--- a/tripal/includes/tripal.fields.inc
+++ b/tripal/includes/tripal.fields.inc
@@ -188,7 +188,6 @@ function tripal_field_formatter_view($entity_type, $entity, $field,
     $formatter = new $formatter_class($field, $instance);
     $formatter->view($element, $entity_type, $entity, $langcode, $items, $display);
   }
-
   return $element;
 }
 
@@ -216,7 +215,7 @@ function tripal_field_no_delete() {
  * the table to let the user know where fields are storing their data.
  */
 function tripal_form_field_ui_field_overview_form_alter(&$form, &$form_state, $form_id) {
-  
+
   $used_terms = [];
 
   // If this isn't a TripalEntity content type then skip this form.
@@ -234,9 +233,9 @@ function tripal_form_field_ui_field_overview_form_alter(&$form, &$form_state, $f
 
     $field = field_info_field($field_name);
     $instance = field_info_instance('TripalEntity', $field_name, $form['#bundle']);
-    
+
     // Warn users if a field is missing a term.
-    if ($instance and $instance['entity_type'] == 'TripalEntity' and 
+    if ($instance and $instance['entity_type'] == 'TripalEntity' and
         array_key_exists('settings', $instance) and is_array($instance['settings']) and
         (!array_key_exists('term_vocabulary', $instance['settings']) or !$instance['settings']['term_vocabulary'])) {
       tripal_report_error('tripal_fields', TRIPAL_WARNING,
@@ -245,22 +244,22 @@ function tripal_form_field_ui_field_overview_form_alter(&$form, &$form_state, $f
           ['drupal_set_message' => TRUE]);
     }
     // Warn users if any of the terms are not unique.
-    if ($instance and array_key_exists('settings', $instance) and is_array($instance['settings']) and 
+    if ($instance and array_key_exists('settings', $instance) and is_array($instance['settings']) and
         array_key_exists('term_vocabulary', $instance['settings'])) {
       $term = $instance['settings']['term_vocabulary'] . ':' . $instance['settings']['term_accession'];
       if (array_key_exists($term, $used_terms)) {
         $used_terms[$term][] = $field_name;
         tripal_report_error('tripal_fields', TRIPAL_WARNING,
           'The term !term is in use by multiple fields: !fields. ' .
-          'This is not allowed. Every field must have a different controlled vocabulary term. ' . 
+          'This is not allowed. Every field must have a different controlled vocabulary term. ' .
           'Please correct the term assignments.',
-          ['!term' => $term, '!fields' => implode(', ', $used_terms[$term])], 
+          ['!term' => $term, '!fields' => implode(', ', $used_terms[$term])],
           ['drupal_set_message' => TRUE]);
       }
       $used_terms[$term][] = $field_name;
     }
-    
-    
+
+
     // For rows in the tables that aren't fields, just add an empty value
     // for the storage column.
     if (!$field) {
@@ -715,15 +714,15 @@ function tripal_field_instance_settings_form_alter_validate($form, &$form_state)
         }
       }
     }
-    
-    // Make sure this term is not already used.    
+
+    // Make sure this term is not already used.
     $bundle_name = $form_state['values']['instance']['bundle'];
     $existing_instances = field_info_instances('TripalEntity', $bundle_name);
     $field_term_id = $form_state['values']['instance']['settings']['term_vocabulary'] . ':' . $form_state['values']['instance']['settings']['term_accession'];
-    $field_name = $form_state['values']['instance']['field_name'];  
+    $field_name = $form_state['values']['instance']['field_name'];
     foreach ($existing_instances as $existing_name => $existing_instance) {
       $existing_term_id = $existing_instance['settings']['term_vocabulary'] . ':' . $existing_instance['settings']['term_accession'];
-      if ($existing_term_id == $field_term_id and $field_name != $existing_name) {       
+      if ($existing_term_id == $field_term_id and $field_name != $existing_name) {
         form_set_error('term-', t('The term, !term, is already in use on this content type.  A term can only be used once per content type. Please choose a different term.',
           ['!term' => $field_term_id]));
       }
@@ -765,7 +764,7 @@ function tripal_field_widget_form_validate($element, &$form_state, $form) {
   tripal_load_include_field_class($widget_class);
   if (class_exists($widget_class)) {
     $widget = new $widget_class($field, $instance);
-    
+
     // Set the validation function for this field widget depending on the
     // form displaying the widget.
     if ($form['#form_id'] == 'field_ui_field_edit_form') {

--- a/tripal/includes/tripal.user.inc
+++ b/tripal/includes/tripal.user.inc
@@ -3,7 +3,7 @@
 
 function tripal_user_get_files($uid){
   $directory = [];
-  
+
   // Get all of the files that have been uploaded by the user.
   $sql = "
      SELECT FM.fid, FM.filename, FM.uri, FM.uid, FM.filesize, TGEF.expiration_date
@@ -11,39 +11,39 @@ function tripal_user_get_files($uid){
        INNER JOIN {file_usage} FU on FM.fid = FU.fid and FM.uid = :user_id
        LEFT JOIN {tripal_expiration_files} TGEF on TGEF.fid = FU.fid
      WHERE FU.module = 'tripal'
-     ORDER BY FM.filename
+     ORDER BY FM.uri
    ";
   $files = db_query($sql, array(':user_id' => $uid));
   $rows = array();
   While ($file = $files->fetchObject()) {
-    
+
     // Don't list files that don't exist on the file system.
     if (!file_exists($file->uri)) {
       continue;
     }
-    
+
     // Files have to be in the User's directory.
     if (!preg_match('/^public:\/\/tripal\/users\//', $file->uri)) {
       continue;
     }
-    
+
     // If the expiration date is somehow not set, then set it.
     if (!$file->expiration_date) {
       $file->expiration_date = tripal_reset_file_expiration($file->fid);
     }
-    
+
     // Organize the file into it's directory structure.
-    $rpath = preg_replace('/^public:\/\/tripal\/users\/'. $uid . '\//', '', $file->uri); 
+    $rpath = preg_replace('/^public:\/\/tripal\/users\/'. $uid . '\//', '', $file->uri);
     $paths = explode('/', $rpath);
-    _tripal_user_build_files_dir($directory, $paths, $file); 
+    _tripal_user_build_files_dir($directory, $paths, $file);
   }
-  
+
   return $directory;
 }
 
-/** 
+/**
  * A recursive helper function for building the directory file tree.
- * 
+ *
  * @param $directory
  *   The $directory array into which the file will be placed.
  * @param $paths
@@ -62,21 +62,21 @@ function _tripal_user_build_files_dir(&$directory, $paths, $file) {
   }
 }
 
-/** 
+/**
  * Generates an item list of the files.
- * 
+ *
  * The results from this function can be passed to the theme_item_list function
  * and then themed as a file tree..
- * 
+ *
  * @param $files_list
  *   The array as returned by tripal_user_get_files().
- * 
- * @return 
+ *
+ * @return
  *   An item list.
  */
 function tripal_user_get_files_item_list($files_list, &$i = 0) {
   $items = [];
-  
+
   // Add a header row
   if ($i == 0) {
     $items[] = [
@@ -85,7 +85,7 @@ function tripal_user_get_files_item_list($files_list, &$i = 0) {
       '<span class="file-size"><b>Size</b></span>' ,
     ];
   }
-  
+
   // Iterate through each file and recursively add it to our items array.
   foreach ($files_list as $filename => $file) {
     $i++;
@@ -106,8 +106,8 @@ function tripal_user_get_files_item_list($files_list, &$i = 0) {
       }
       $expiration = $file->expiration_date ? date('Y-m-d', $file->expiration_date) : '';
       $items[] = [
-        'data' => '<span class="file-details"><span class="file-name">' . $filename . '</span>' . 
-          '<span class="file-expires">' . $dayleft . ' days</span>' . 
+        'data' => '<span class="file-details"><span class="file-name">' . $filename . '</span>' .
+          '<span class="file-expires">' . $dayleft . ' days</span>' .
           '<span class="file-size">' . tripal_format_bytes($file->filesize) . '</span></span>' ,
         'class' => ['tree-node-file', ($i % 2 == 0) ? 'even' : 'odd'],
         'fid' => $file->fid,
@@ -115,18 +115,18 @@ function tripal_user_get_files_item_list($files_list, &$i = 0) {
       ];
     }
   }
-  
+
   return $items;
 }
 
 /**
  * Gets the list of collections that have not yet generated files.
- * 
+ *
  * @param $uid
  *   The ID of the user.
  */
 function tripal_user_files_get_pending_collections_table($uid) {
-  
+
   $collections = db_select('tripal_collection', 'tc')
     ->fields('tc', array('collection_id'))
     ->condition('uid', $uid)
@@ -135,21 +135,21 @@ function tripal_user_files_get_pending_collections_table($uid) {
 
   $headers = array('Name', 'Download Formats', 'Actions');
   $rows = array();
-  
+
   while ($collection_id = $collections->fetchField()) {
     $collection = new TripalEntityCollection();
     $collection->load($collection_id);
-    
+
     $downloads = array();
     $formatters = $collection->getFormatters();
     $formatter_labels = [];
-    
+
     $status = 'complete';
     foreach ($formatters as $class_name => $label) {
       $formatter_labels[] = $label;
-      
+
       $outfile = $collection->getOutfilePath($class_name);
-      
+
       if (file_exists($outfile)) {
         continue;
       }
@@ -157,8 +157,8 @@ function tripal_user_files_get_pending_collections_table($uid) {
         $status = 'pending';
       }
     }
-    
-    if ($status == 'pending') {    
+
+    if ($status == 'pending') {
       $rows[] = array(
         'data' => array(
           $collection->getName(),
@@ -193,9 +193,9 @@ function tripal_user_files_get_pending_collections_table($uid) {
 
   drupal_add_css(drupal_get_path('module', 'tripal') . '/theme/css/tripal_user_files.css');
   drupal_add_js(drupal_get_path('module', 'tripal') . '/theme/js/tripal.user_files.js', 'file');
-   
+
   $user_files = tripal_user_get_files($uid);
-  $items = tripal_user_get_files_item_list($user_files);  
+  $items = tripal_user_get_files_item_list($user_files);
   $theme_files = theme_item_list([
     'items' => $items,
     'title' => '',
@@ -204,7 +204,7 @@ function tripal_user_files_get_pending_collections_table($uid) {
       'id' => 'tripal-user-file-tree'
     ],
   ]);
-   
+
   $data_collections = tripal_user_files_get_pending_collections_table($uid);
 
   // Get the user quota settings.
@@ -243,7 +243,7 @@ function tripal_user_files_get_pending_collections_table($uid) {
       '#title' => 'Pending Data Collections',
       '#markup' => $data_collections,
       '#description' =>  t('Data collections allow you to store custom sets of data
-       for use on this site.  Typically data collections are created using search 
+       for use on this site.  Typically data collections are created using search
        tools.  The above data collections are waiting to be generated. You must
        generate the files before you can use them.'),
     ),
@@ -376,8 +376,8 @@ function tripal_delete_file_form_submit($form, &$form_state) {
 function tripal_view_file($uid, $fid) {
   $file = file_load($fid);
   $usage = file_usage_list($file);
-  
-  // Check to see if this is a data collection.  
+
+  // Check to see if this is a data collection.
   $collection = NULL;
   $collection_ctypes = [];
   $collection_field_list = [];
@@ -388,23 +388,23 @@ function tripal_view_file($uid, $fid) {
       $collection_id = array_keys($usage['tripal']['data_collection'])[0];
       $collection = new TripalEntityCollection();
       $collection->load($collection_id);
-      
+
       // Get the content types for this data collection.
-      $cbundles = $collection->getBundles();     
+      $cbundles = $collection->getBundles();
       foreach ($cbundles as $cbundle) {
         $eids = $collection->getEntityIDs($cbundle->bundle_name);
         $fields = $collection->getFieldIDs($cbundle->bundle_name);
-        
+
         // Convert local field IDs to their names.
         if (!$cbundle->site_id) {
           $bundle = tripal_load_bundle_entity(array('name' => $cbundle->bundle_name));
           $collection_ctypes[] = $bundle->label;
-          
+
           foreach ($fields as $field_id) {
             $field = field_info_field_by_id($field_id);
             $instance = field_info_instance('TripalEntity', $field['field_name'], $bundle->name);
             $collection_field_list[] = $instance['label'];
-            
+
             $field_formatters = tripal_get_field_field_formatters($field, $instance);
             foreach ($field_formatters as $class_name => $label) {
               tripal_load_include_downloader_class($class_name);
@@ -414,11 +414,11 @@ function tripal_view_file($uid, $fid) {
         }
         // Convert remote field IDs to their names.
         // TODO: add in retrieval of remote details.
-        
-        
+
+
         $collection_entities += count($eids);
       }
-      
+
     }
   }
 
@@ -463,7 +463,7 @@ function tripal_view_file($uid, $fid) {
     ),
     $expiration
   );
-  
+
   $md5_file = $file->uri . '.md5';
   if (file_exists($md5_file)) {
     $rows[] = array(
@@ -474,7 +474,7 @@ function tripal_view_file($uid, $fid) {
       ),
       file_get_contents($md5_file),
     );
-  } 
+  }
   $rows[] = array(
     array(
       'data' => 'Actions',
@@ -493,8 +493,8 @@ function tripal_view_file($uid, $fid) {
     'colgroups' => [],
     'empty' => '',
   ]);
-  
-  
+
+
   $collection_content = '';
   if ($collection) {
     $rows = [];
@@ -514,7 +514,7 @@ function tripal_view_file($uid, $fid) {
       ),
       join(', ', $collection_ctypes),
     );
-    
+
     $rows[] = array(
       array(
         'data' => 'Fields',
@@ -547,7 +547,7 @@ function tripal_view_file($uid, $fid) {
       ),
       l('Delete', 'user/' . $uid . '/data-collections/' . $collection->getCollectionID() . '/delete')
     );
-    
+
     $collection_content = '<b>Collection Details</b>' . theme_table([
       'header' => $headers,
       'rows' => $rows,
@@ -558,7 +558,7 @@ function tripal_view_file($uid, $fid) {
       'empty' => '',
     ]);
   }
-  
+
   drupal_json_output($file_content . $collection_content);
 }
 

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -120,7 +120,7 @@ function tripal_menu() {
     'type' => MENU_LOCAL_ACTION,
     'weight' => 3
   ];
-  
+
   /**
    * Tripal Extensions
    */
@@ -1530,21 +1530,7 @@ function tripal_html5_file_value($element, $input = FALSE, &$form_state) {
  * @param $context
  */
 function tripal_field_display_TripalEntity_alter(&$display, $context){
-/*   $field = $context['field'];
-  $field_name = $context['field']['field_name'];
-  $bundle = $context['entity']->bundle;
-  $bundle_info = tripal_load_bundle_entity(array('name' => $bundle));
 
-  // Hide fields that are empty, but only if the hide_empty_field variable
-  // is set to TRUE for this bundle and ajax load is turned off.
-  $hide_empty = tripal_get_bundle_variable('hide_empty_field', $bundle_info->id);
-  if ($hide_empty == TRUE) {
-    $items = field_get_items('TripalEntity', $context['entity'], $field_name);
-    if (tripal_field_is_empty($field, $items)) {
-      // Stop the right rail element from rendering.
-      drupal_add_css('.' . $field_name.' {display: none;}', 'inline');
-    }
-  }  */
 }
 
 /**
@@ -1565,18 +1551,18 @@ function tripal_field_group_table_rows_alter(&$element, &$children) {
       $bundle = $element[$child]['#bundle'];
       $bundle_info = tripal_load_bundle_entity(array('name' => $bundle));
 
+      $processed = FALSE;
+      if (array_key_exists('#processed', $element[$child]['#object']->$child)) {
+        $processed = $element[$child]['#object']->$child['#processed'];
+      }
+
       // If the hide empty variable is turned on and ajax load is turned off
       // then remove fields from the field group.
       $hide_variable = tripal_get_bundle_variable('hide_empty_field', $bundle_info->id);
-      if($hide_variable == TRUE){
+      if ($hide_variable == TRUE and $processed == TRUE) {
         $items = $element[$child]['#items'];
-        // Case #1: there are no items.
-        if (count($items) == 0) {
-          unset($children[$index]);
-          unset($element[$child]);
-        }
-        // Case #2: there is one item but the value is empty.
-        if (count($items) == 1 and array_key_exists('value', $items[0]) and empty($items[0]['value'])) {
+        $field = field_info_field($child);
+        if ($field and tripal_field_is_empty($field, $items)) {
           unset($children[$index]);
           unset($element[$child]);
         }

--- a/tripal_chado/includes/TripalFields/data__sequence/data__sequence_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence/data__sequence_formatter.inc
@@ -12,13 +12,19 @@ class data__sequence_formatter extends ChadoFieldFormatter {
    */
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
 
-    $content = 'There is no sequence.';
-    if (count($items) > 0 and $items[0]['value']) {
-      $num_bases = 50;
-      $content = '<pre class="residues-formatter">';
-      $content .= wordwrap($items[0]['value'], $num_bases, "<br>", TRUE);
-      $content .= '</pre>';
+    // If there are no items, we don't want to return any markup.
+    if (count($items) == 0 or (count($items) == 1 and empty($items[0]['value']))) {
+      $element[0] = array(
+        '#type' => 'markup',
+        '#markup' => 'No sequence is available.',
+      );
+      return;
     }
+
+    $num_bases = 50;
+    $content = '<pre class="residues-formatter">';
+    $content .= wordwrap($items[0]['value'], $num_bases, "<br>", TRUE);
+    $content .= '</pre>';
     $element[0] = array(
       // We create a render array to produce the desired markup,
       '#type' => 'markup',

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
@@ -103,7 +103,7 @@ class sbo__relationship_formatter extends ChadoFieldFormatter {
 
       $rows[][] = array(
         'data' => $phrase,
-        'class' => array('tripal-entity-unattached field-items')
+        //'class' => array('tripal-entity-unattached field-items')
       );
     }
 

--- a/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
+++ b/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
@@ -16,7 +16,11 @@ class schema__publication_formatter extends ChadoFieldFormatter {
     $chado_table = $this->instance['settings']['chado_table'];
 
     // If there are no items, we don't want to return any markup.
-    if (empty($items)) {
+    if (count($items) == 0 or (count($items) == 1 and empty($items[0]['value']))) {
+      $element[0] = array(
+        '#type' => 'markup',
+        '#markup' => 'There are no publications associated with this record.',
+      );
       return;
     }
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #805 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

When hiding of empty fields for a content type is turned on, then fields that are marked to not auto attach (meaning they should be loaded via AJAX) are automatically removed from the Tripal Pane table. This is because they are technically "empty" as data has not yet been added to them (it gets added via AJAX). This is incorrect behavior. They should not be removed from the table until after their data is loaded. The tripal_field_group_table_rows_alter function is the culprit.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
To test that there is a problem
1.  Do not pull this branch just yet
2.  Make sure you have checked from the mRNA content type the hide empty fields and the load via ajax settings.
3. Go to any mRNA page that has a sequence.  I use the Citrus sinensis data from the Tripal tutorial.  
4. Click the 'Reload' tab and the page should reload.  The mRNA sequence is missing!
5. Turn off the 'hide empty fields' setting for the mRNA content type, return to the mRNA page and then click the 'Reload' tab. You should now see the sequence.

To test the fix:
1.  Pull the branch
2.  Perform steps 1-4 above.  This time however, the mRNA sequence is present.

