### PR TITLE
Bug in update function 7336

### DIFF
--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1846,11 +1846,12 @@ function tripal_chado_update_7336() {
       $field_name = $base . '_contact';
       $instance_info = field_info_instance('TripalEntity', $field_name, $bundle_name);
 
-      $instance_info['type'] = 'chado_linker__contact';
-      $instance_info['widget']['type'] = 'chado_linker__contact_widget';
-      $instance_info['formatter']['type'] = 'chado_linker__contact_widget';
-      field_update_instance($instance_info);
-      
+      if ($instance_info) {
+        $instance_info['type'] = 'chado_linker__contact';
+        $instance_info['widget']['type'] = 'chado_linker__contact_widget';
+        $instance_info['formatter']['type'] = 'chado_linker__contact_widget';
+        field_update_instance($instance_info);
+      }
     }
   }
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue # N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The update function `tripal_chado_update_7336` fails if I don't have any contact linker field instances for my bundles.  This is just a simple fix to make sure the instance exists before trying to update it.  
## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
This changes just wraps an if statement around the update.  I don't think it needs a functional test. Just one code review.