### PR TITLE
 Unable to create cvterm-based content type

### DIFF
--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -1148,6 +1148,11 @@ function tripal_chado_field_storage_bundle_mapping_form_summary(&$form, &$form_s
     ];
   }
 
+  //
+  // Add the row for cvterm options
+  //
+  // @todo @lacey
+
   $table = array(
     'header' => $headers,
     'rows' => $rows,
@@ -1808,8 +1813,13 @@ function tripal_chado_field_storage_bundle_mapping_form_validate($form, &$form_s
   if ($clicked_button == 'chado-cvterm-settings-continue') {
     // If the user chose to differentiate type based on cv_id and supplied a cv_id
     // then we're done!
-    if (($form_state['values']['chado_type_use_cv'] == 'cv') AND ($form_state['values']['chado_type_cv_id'] > 0)) {
-      $form_state['chado-stage'] = 'complete';
+    if ($form_state['values']['chado_type_use_cv'] == 'cv') {
+      if ($form_state['values']['chado_type_cv_id'] > 0) {
+        $form_state['chado-stage'] = 'complete';
+      }
+      else {
+        form_set_error('chado_type_cv_id', 'Please select a controlled vocabulary which contains records for this content type.');
+      }
     }
 
     // If the user chose to diffentiate type based on the current term,
@@ -1883,7 +1893,8 @@ function tripal_chado_field_storage_bundle_mapping_form_submit($form,
   // If the user indicated they want to use a cv_id to control which cvterm
   // records become pages then we'll set the stroage args and return.
   elseif ($default['use_cvterm'] == 'cv' AND $default['cv_id']) {
-    $storage_args['data_table'] = $default['table'];
+    // @debug dpm($form_state, 'form state');
+    $storage_args['data_table'] = 'cvterm';
     $storage_args['type_id'] = $form_state['values']['selected_cvterm_id'];
     $storage_args['type_value'] = $default['cv_id'];
   }

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -1010,6 +1010,14 @@ function tripal_chado_field_storage_bundle_mapping_form_summary(&$form, &$form_s
     '#type' => 'value',
     '#value' => $default['use_linker'],
   ];
+  $form['chado_type_use_cv'] = [
+    '#type' => 'value',
+    '#value' => $default['use_cvterm'],
+  ];
+  $form['chado_type_cv_id'] = [
+    '#type' => 'value',
+    '#value' => $default['cv_id'],
+  ];
 
   //
   // Add the base table row.
@@ -1151,7 +1159,34 @@ function tripal_chado_field_storage_bundle_mapping_form_summary(&$form, &$form_s
   //
   // Add the row for cvterm options
   //
-  // @todo @lacey
+  if ($default['use_cvterm']) {
+    $message = 'No. All records belong to a single controlled vocabulary.';
+    if ($default['use_cvterm'] == 'parent') {
+      $message = 'Yes. Records should include all child records of the specified term.';
+    }
+    $rows[] = [
+      [
+        'data' => 'Use a Parent Chado cvterm?',
+        'header' => TRUE,
+        'width' => '20%',
+      ],
+      $message,
+    ];
+
+    // Add the cv if needed
+    if ($default['cv_id'] > 0) {
+      $cv_name = chado_query('SELECT name FROM chado.cv WHERE cv_id=:id',
+        [':id' => $default['cv_id']])->fetchField();
+        $rows[] = [
+          [
+            'data' => 'Restrict to Vocabulary',
+            'header' => TRUE,
+            'width' => '20%',
+          ],
+          $cv_name,
+        ];
+    }
+  }
 
   $table = array(
     'header' => $headers,
@@ -1814,17 +1849,19 @@ function tripal_chado_field_storage_bundle_mapping_form_validate($form, &$form_s
     // If the user chose to differentiate type based on cv_id and supplied a cv_id
     // then we're done!
     if ($form_state['values']['chado_type_use_cv'] == 'cv') {
-      if ($form_state['values']['chado_type_cv_id'] > 0) {
+      if (isset($form_state['values']['chado_type_cv_id']) AND ($form_state['values']['chado_type_cv_id'] > 0)) {
         $form_state['chado-stage'] = 'complete';
       }
-      else {
+      else if (isset($form['chado_type_cv_id'])) {
         form_set_error('chado_type_cv_id', 'Please select a controlled vocabulary which contains records for this content type.');
       }
     }
 
     // If the user chose to diffentiate type based on the current term,
     // then we're done!
-    // @todo @lacey handle this case.
+    if ($form_state['values']['chado_type_use_cv'] == 'parent') {
+      $form_state['chado-stage'] = 'complete';
+    }
   }
 
   //
@@ -1892,8 +1929,7 @@ function tripal_chado_field_storage_bundle_mapping_form_submit($form,
 
   // If the user indicated they want to use a cv_id to control which cvterm
   // records become pages then we'll set the stroage args and return.
-  elseif ($default['use_cvterm'] == 'cv' AND $default['cv_id']) {
-    // @debug dpm($form_state, 'form state');
+  else if (($default['use_cvterm'] == 'cv') AND ($default['cv_id'])) {
     $storage_args['data_table'] = 'cvterm';
     $storage_args['type_id'] = $form_state['values']['selected_cvterm_id'];
     $storage_args['type_value'] = $default['cv_id'];
@@ -1907,4 +1943,3 @@ function tripal_chado_field_storage_bundle_mapping_form_submit($form,
   }
 
 }
-

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -1612,17 +1612,17 @@ function tripal_chado_field_storage_bundle_mapping_form_add_cvterm(&$form,
       within the cvterm table?',
     '#options' => array(
       'cv' => 'All records that belong to a single controlled vocabulary?',
-      'parent' => 'All child records of the specified term?'
+      //  SPF: Commenting out until we can write the code to deal with
+      //  using a parent term to indicate child elements that belong to the
+      //  content type.
+      // 'parent' => 'All child records of the specified term?'
     ),
     '#description' => t('Records in the cvterm table are often not used for content
         types. The records in the cvterm table are meant to be vocabulary terms.
-        However, there are times when records in the cvterm table can be
+        However, there are times when records in the cvterm table may be
         used for a content type. One example is for trait "pages" that
-        use phenotype values stored in the phenotype table.  Because records in
-        the cvterm table are vocabulary terms they do not have "types" so the
-        only ways to distinguish them are 1) to use the controlled vocabulary to
-        distinguish the records or 2) to use all children records of the
-        selected term.  Please select the appropriate value for this case.'),
+        use phenotype values stored in the phenotype table. The vocabulary that
+        contains the "trait" terms should then be provided.'),
     '#default_value' => $default['use_cvterm'],
   );
   if ($default['use_cvterm'] == 'cv') {

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -845,6 +845,8 @@ function tripal_chado_field_storage_bundle_mapping_form_get_defaults($form, $for
     'has_all' => '',
     'use_linker' => '',
     'use_prop' => '',
+    'use_cvterm' => '',
+    'cv_id' => '',
     'type_column' => '',
     'base_selected_term' => '',
     'prop_selected_term' => '',
@@ -892,7 +894,14 @@ function tripal_chado_field_storage_bundle_mapping_form_get_defaults($form, $for
   if (array_key_exists('term_name2', $form_state['values'])) {
     $default['prop_selected_term'] = tripal_get_term_lookup_form_result($form, $form_state, '', 2);
   }
-
+  if (array_key_exists('chado_type_use_cv', $form_state['values'])
+    and $form_state['values']['chado_type_use_cv']) {
+    $default['use_cvterm'] = $form_state['values']['chado_type_use_cv'];
+  }
+  if (array_key_exists('chado_type_cv_id', $form_state['values'])
+    and $form_state['values']['chado_type_cv_id']) {
+    $default['cv_id'] = $form_state['values']['chado_type_cv_id'];
+  }
   return $default;
 }
 /**
@@ -1529,6 +1538,7 @@ function tripal_chado_field_storage_bundle_mapping_form_get_type_fks_options($ta
   }
   return $column_options;
 }
+
 /**
  *
  */
@@ -1548,6 +1558,53 @@ function tripal_chado_field_storage_bundle_mapping_form_get_base_type_column($ta
     }
   }
   return $base_type_column;
+}
+
+/**
+ * Provides the option form needed for a cvterm-based content type.
+ */
+function tripal_chado_field_storage_bundle_mapping_form_add_cvterm(&$form,
+    &$form_state, $term, &$default){
+
+  $form['chado_type_use_cv'] = array(
+    '#type' => 'radios',
+    '#title' => 'How do you want to distinguish the "' . $term->name . '" records
+      within the cvterm table?',
+    '#options' => array(
+      'cv' => 'All records that belong to a single controlled vocabulary?',
+      'parent' => 'All child records of the specified term?'
+    ),
+    '#description' => t('Records in the cvterm table are often not used for content
+        types. The records in the cvterm table are meant to be vocabulary terms.
+        However, there are times when records in the cvterm table can be
+        used for a content type. One example is for trait "pages" that
+        use phenotype values stored in the phenotype table.  Because records in
+        the cvterm table are vocabulary terms they do not have "types" so the
+        only ways to distinguish them are 1) to use the controlled vocabulary to
+        distinguish the records or 2) to use all children records of the
+        selected term.  Please select the appropriate value for this case.'),
+    '#default_value' => $default['use_cvterm'],
+  );
+  if ($default['use_cvterm'] == 'cv') {
+    $cvs = chado_get_cv_select_options();
+    $form['chado_type_cv_id'] = array(
+      '#type' => 'select',
+      '#options' => $cvs,
+      '#title' => t('Select a controlled vocabulary'),
+      '#default_value' => $default['cv_id'],
+    );
+  }
+
+  $form['chado-cvterm-settings-continue'] = array(
+    '#type' => 'submit',
+    '#value' => t('Continue'),
+    '#name' => 'chado-cvterm-settings-continue',
+    '#validate' => [
+      'tripal_chado_field_storage_bundle_mapping_form_validate',
+      'tripal_admin_add_type_form_validate'
+    ],
+  );
+
 }
 
 /**
@@ -1743,10 +1800,22 @@ function tripal_chado_field_storage_bundle_mapping_form_validate($form, &$form_s
     if (!$valid) {
       return;
     }
+
     // If we're here then alll validations passed and we are good to go!
     $form_state['chado-stage'] = 'complete';
   }
 
+  if ($clicked_button == 'chado-cvterm-settings-continue') {
+    // If the user chose to differentiate type based on cv_id and supplied a cv_id
+    // then we're done!
+    if (($form_state['values']['chado_type_use_cv'] == 'cv') AND ($form_state['values']['chado_type_cv_id'] > 0)) {
+      $form_state['chado-stage'] = 'complete';
+    }
+
+    // If the user chose to diffentiate type based on the current term,
+    // then we're done!
+    // @todo @lacey handle this case.
+  }
 
   //
   // Check for a reset.
@@ -1757,6 +1826,7 @@ function tripal_chado_field_storage_bundle_mapping_form_validate($form, &$form_s
   }
 
 }
+
 /**
  * Implements hook_field_stoage_bundle_mapping_form_submit().
  *
@@ -1809,5 +1879,21 @@ function tripal_chado_field_storage_bundle_mapping_form_submit($form,
       $storage_args['base_type_id'] = $form_state['values']['base_term'][0]->cvterm_id;
     }
   }
+
+  // If the user indicated they want to use a cv_id to control which cvterm
+  // records become pages then we'll set the stroage args and return.
+  elseif ($default['use_cvterm'] == 'cv' AND $default['cv_id']) {
+    $storage_args['data_table'] = $default['table'];
+    $storage_args['type_id'] = $form_state['values']['selected_cvterm_id'];
+    $storage_args['type_value'] = $default['cv_id'];
+  }
+
+  //  If the user indicated they want to use a cvterm_id to control which cvterm
+  // records become pages then we'll set the stroage args and return.
+  elseif ($default['use_cvterm'] == 'cvterm') {
+    // @todo @lacey implement this case
+    drupal_set_message('This case currently is not supported.', 'warning');
+  }
+
 }
 

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -227,10 +227,10 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
   $schema = chado_get_schema($table_name);
 
   // Add the additional_type field to all tables with a type_id that is not used
-  // as the type column nor has a $base_type_id (i.e. the content type uses a 
+  // as the type column nor has a $base_type_id (i.e. the content type uses a
   // prop or linker table to resolve the type).
-  if (array_key_exists('type_id', $schema['fields']) and 'type_id' != $type_column and 
-      !$base_type_id and $table_name != 'organism') {    
+  if (array_key_exists('type_id', $schema['fields']) and 'type_id' != $type_column and
+      !$base_type_id and $table_name != 'organism') {
 
     $field_name = 'schema__additional_type';
     $field_type = 'schema__additional_type';
@@ -244,7 +244,7 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
       ),
     );
   }
-  
+
   // BASE ARRAYDESIGN TABLE
   if ($table_name == 'arraydesign') {
     $field_name = 'ncit__technology_platform';
@@ -258,7 +258,7 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
         'type' => 'field_chado_storage',
       ),
     );
-    
+
     $field_name = 'efo__substrate_type';
     $field_type = 'schema__additional_type';
     $info[$field_name] = array(
@@ -511,7 +511,7 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
   }
 
   // Protocol.
-  if ($table_name != 'protocol' and 
+  if ($table_name != 'protocol' and
       array_key_exists('protocol_id', $schema['fields'])) {
     $field_name = 'sep__protocol';
     $field_type = 'sep__protocol';
@@ -525,7 +525,7 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
       ),
     );
   }
-  
+
   // Assay operator.
   if ($table_name == 'assay') {
       $field_name = 'assay__operator_id';
@@ -551,15 +551,15 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
         ),
       );
     }
-  
+
   // For the pub_id field in the base table.
   $schema = chado_get_schema($table_name);
   if (array_key_exists('pub_id', $schema['fields']) and $table_name != 'pub') {
-    
+
     // Remove the schema__publication added by the
     // tripal_chado_bunde_instnaces_info_base function.
     unset($info['schema__publication']);
-    
+
     $field_name = 'schema__publication_single';
     $field_type = 'schema__publication';
     $info[$field_name] = array(
@@ -571,7 +571,7 @@ function tripal_chado_bundle_fields_info_custom(&$info, $details, $entity_type, 
         'type' => 'field_chado_storage',
       ),
     );
-  } 
+  }
 
   // Analysis Id
   if (array_key_exists('analysis_id', $schema['fields']) and $table_name != 'analysis') {
@@ -717,24 +717,24 @@ function tripal_chado_bundle_fields_info_linker(&$info, $details, $entity_type, 
   // PROPERTIES
   $prop_table = $table_name . 'prop';
   if (chado_table_exists($prop_table)) {
-    
-    $props = tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id);
+
+    $props = tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id, $type_value);
     foreach ($props as $term) {
-          
+
       $field_name = strtolower(preg_replace('/[^\w]/','_', $term->dbxref_id->db_id->name . '__' . $term->name));
 
       // The field name can only be 32 chars, but if our name is longer we need
-      // to add some random chars to ensure we don't have naming conflicts 
-      // with other terms (e.g. mitochondrial_genetic_code and 
+      // to add some random chars to ensure we don't have naming conflicts
+      // with other terms (e.g. mitochondrial_genetic_code and
       // mitochondrial_genetic_code_name)
       if (strlen($field_name) >= 32) {
         $field_name = substr($field_name, 0, 20) . '_' . $term->cvterm_id;
       }
       $field_type = 'chado_linker__prop';
-      
+
       // Don't try to add a property that uses the same term as another field.
       if (array_key_exists($field_name, $info)) {
-        tripal_report_error('chado_fields', TRIPAL_WARNING, 
+        tripal_report_error('chado_fields', TRIPAL_WARNING,
           'A field of type !type already exists, yet a property wants to use the same term. The property cannot be added.',
          ['!type' => $field_name],
          ['drupal_set_message' => TRUE]);
@@ -1250,7 +1250,7 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
     // ARRAYDESIGN TABLE
     //
     if ($table_name == 'arraydesign') {
-      if ($column_name == 'name' or $column_name == 'version' or 
+      if ($column_name == 'name' or $column_name == 'version' or
           $column_name == 'array_dimensions' or $column_name == 'element_dimensions') {
         $base_info['widget']['type'] = 'text_textfield';
         $base_info['settings']['text_processing'] = '0';
@@ -1264,7 +1264,7 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
       if ($column_name == 'manufacturer_id') {
         $base_info['label'] = 'Manufacturer';
       }
-      
+
     }
 
     $info[$field_name] = $base_info;
@@ -1287,14 +1287,14 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
   $type_column = $details['chado_type_column'];
   $cvterm_id  = $details['chado_cvterm_id'];
   $type_value = $details['chado_type_value'];
-  $base_type_id = $details['chado_base_type_id'];  
+  $base_type_id = $details['chado_base_type_id'];
   $schema = chado_get_schema($table_name);
 
   // Add the additional_type field to all tables with a type_id that is not used
   // as the type column nor has a $base_type_id (i.e. the content type uses a
   // prop or linker table to resolve the type).
   if (array_key_exists('type_id', $schema['fields']) and 'type_id' != $type_column and
-      !$base_type_id and $table_name != 'organism') { 
+      !$base_type_id and $table_name != 'organism') {
     $field_name = 'schema__additional_type';
     $is_required = FALSE;
     if (array_key_exists('not null', $schema['fields']['type_id']) and
@@ -1354,7 +1354,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
       ),
     );
   }
-  
+
   if ($table_name == 'arraydesign') {
     $field_name = 'ncit__technology_platform';
     $default_vocab = '';
@@ -1392,7 +1392,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-    
+
     $field_name = 'efo__substrate_type';
     $default_vocab = '';
     $parent_term = '';
@@ -2051,15 +2051,15 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-  } 
+  }
   // pub_id field in table.
   $schema = chado_get_schema($table_name);
   if (array_key_exists('pub_id', $schema['fields']) and $table_name != 'pub') {
-    
-    // Remove the schema__publication added by the 
+
+    // Remove the schema__publication added by the
     // tripal_chado_bunde_instnaces_info_base function.
     unset($info['schema__publication']);
-      
+
     $field_name = 'schema__publication_single';
     $info[$field_name] =  array(
       'field_name' => $field_name,
@@ -2091,13 +2091,13 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-  } 
-  
-  if ($table_name == 'assay') {      
+  }
+
+  if ($table_name == 'assay') {
     // Remove the ncit__operator added by the
     // tripal_chado_bunde_instnaces_info_base function.
     unset($info['ncit__operator']);
-    
+
     $field_name = 'assay__operator_id';
     $info[$field_name] =  array(
       'field_name' => $field_name,
@@ -2114,7 +2114,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'term_vocabulary' => 'NCIT',
         'term_name' => 'Operator',
         'term_accession' => 'C48036',
-        
+
       ),
       'widget' => array(
         'type' => 'local__contact_widget',
@@ -2130,7 +2130,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-    
+
     $field_name = 'efo__array_design';
     $info[$field_name] =  array(
       'field_name' => $field_name,
@@ -2147,7 +2147,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'term_vocabulary' => 'EFO',
         'term_name' => 'array design',
         'term_accession' => '0000269',
-        
+
       ),
       'widget' => array(
         'type' => 'efo__array_design_widget',
@@ -2163,7 +2163,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         ),
       ),
     );
-  } 
+  }
   // Analysis Id
   if (array_key_exists('analysis_id', $schema['fields']) and $table_name != 'analysis') {
     $field_name = 'operation__analysis';
@@ -2187,7 +2187,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
         'term_vocabulary' => 'operation',
         'term_name' => 'Analysis',
         'term_accession' => '2945',
-        
+
       ),
       'widget' => array(
         'type' => 'operation__analysis_widget',
@@ -2489,11 +2489,11 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
   $prop_table = $table_name . 'prop';
   if (chado_table_exists($prop_table)) {
 
-    $props = tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id);
-    foreach ($props as $term) {     
+    $props = tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id, $type_value);
+    foreach ($props as $term) {
 
        $field_name = strtolower(preg_replace('/[^\w]/','_', $term->dbxref_id->db_id->name . '__' . $term->name));
-       
+
        // The field name can only be 32 chars, but if our name is longer we need
        // to add some random chars to ensure we don't have naming conflicts
        // with other terms (e.g. mitochondrial_genetic_code and
@@ -2708,7 +2708,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
       ),
     );
   }
-
+  return;
   // SYNONYMS
   $syn_table = $table_name . '_synonym';
   if (chado_table_exists($syn_table)) {
@@ -2751,7 +2751,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
 
 /**
  * Used to find all of the properties for a given table.
- *  
+ *
  * @param $table_name
  *   The name of the base table.
  * @param unknown $prop_table
@@ -2760,33 +2760,46 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
  *   The name of the table that contains the type specifier.
  * @param $type_column
  *   The name of the column that contains the type specifier.
- *   
+ *
  * @return
  *   An array of cvterm objects for the properties to be added as fields.
  */
-function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id) {
-  
+function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id, $type_value) {
+
   $tschema = chado_get_schema($table_name);
   $schema = chado_get_schema($prop_table);
   $tpkey = $tschema['primary key'][0];
   $pkey = $schema['primary key'][0];
-  
+
   $props = NULL;
-  
+
   // Property tables can be a bit tricky because not all property types
   // in the prop table are appropriate for each type of data.  Also som
   // bundle types are resolved via a property.  So, we have to distinguish
   // between these two cases.
   $sql = '';
   $args = array();
-  
-  // First, is this the case where all of the records in the table are
+
+  // First, If this is the case where the base table is 'cvterm' then we are wanting
+  // to get properties from the cvterm table using the cv_id as the
+  // differentiator.
+  if ($prop_table == 'cvtermprop') {
+    $sql = "
+        SELECT DISTINCT P.type_id
+        FROM {" . db_escape_table($prop_table) . "} P
+          INNER JOIN {" . db_escape_table($table_name) . "} T on T.$tpkey = P.$tpkey
+        WHERE T.cv_id = :cv_id
+      ";
+    $args[':cv_id'] = $type_value;
+    $props = chado_query($sql, $args);
+  }
+  // Second, is this the case where all of the records in the table are
   // of this type?  If so, then all properties apply
-  if (!$type_column) {
+  else if (!$type_column) {
     $sql = 'SELECT DISTINCT type_id FROM {' . db_escape_table($prop_table) . '}';
     $props = chado_query($sql, $args);
   }
-  // Second, if this is the case where a content type is uniquely identified
+  // Third, if this is the case where a content type is uniquely identified
   // by a type_id value in the base table, then only properties associated
   // with that type ID should be used.
   else if ($type_column and !$type_table) {
@@ -2799,7 +2812,7 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
     $args[':cvterm_id'] = $cvterm_id;
     $props = chado_query($sql, $args);
   }
-  // Third, if this is the case where a content type is uniquely identified
+  // Fourth, if this is the case where a content type is uniquely identified
   // via a term/value pair in the prop table.
   else if ($type_column and $type_table == $prop_table and !empty($type_value)) {
     $sql = "
@@ -2814,7 +2827,7 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
     $args[':prop_value'] = $type_value;
     $props = chado_query($sql, $args);
   }
-  // Fourth, if this is the case where the content type is uinquely identifed
+  // Fifth, if this is the case where the content type is uniquely identified
   // via another table (e.g. cvterm linking table) and not this prop table.
   else if ($type_column and $type_table != $prop_table and empty($type_value)) {
     $sql = "
@@ -2830,7 +2843,7 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
   if (!$props) {
     return [];
   }
-  
+
   // Iterate through all of the properties and do some final checks to see
   // which ones should be added.
   $prop_arr = [];
@@ -2840,8 +2853,8 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
   while ($prop = $props->fetchObject()) {
     $term = chado_generate_var('cvterm', array('cvterm_id' => $prop->type_id));
     $term = chado_expand_var($term, 'field', 'cvterm.definition');
-    
-   
+
+
     // The tripal_analysis_KEGG, tripal_analysis_blast, and
     // tripal_analysis_interpro modules store results in the analysisprop
     // table which is probably not the best place, but we don't want to
@@ -2851,7 +2864,7 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
          $term->dbxref_id->db_id->name == 'tripal')) {
       continue;
     }
-    
+
     // The Tripal publication importer adds properties to publications that
     // are also represented in the table fields.  We want editing of pub
     // related fields to always go back to the pub table, so we do not
@@ -2870,7 +2883,7 @@ function tripal_chado_bundle_get_properties($table_name, $prop_table, $type_tabl
         continue;
       }
     }
-    
+
     // Add the term to our list!
     $prop_arr[] = $term;
   }


### PR DESCRIPTION
# Bug Fix

Issue #813 

## Description
Originally I got a WSOD when I trying to create a content type where the base table is cvterm. This was caused by a missing function (`tripal_chado_field_storage_bundle_mapping_form_add_cvterm`) which generates the options for a cvterm content type. Additionally, cvterm logic had been removed from the whole process. This PR brings back this functionality.

## Testing?

Attempt to create as content type where the base table is cvterm and...
### All records in a cv become pages of the selected type.
1. Go to Admin > Structure > Tripal Content Types > Add Tripal Content Type
2. **Step 1:** choose any term (e.g. "Trait")
3. **Step 2:** storage method is chado
4. **Step 3:** 
        - chado table: cvterm; 
        - Select "All records that belong to a single controlled vocabulary "
        - Select any cv with terms.
5. Click "Create content type"

On 7.x-3.x you would see a blank screen after clicking continue with "cvterm" chosen as the chado table. On this branch you will be able to create the content type.

## Known Limitations
Choosing "All child records of the specified term" is still not supported as I do not know the storage arguments needed for this. @spficklin do you know what they should be?