### PR TITLE
up mem limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ before_script:
   - drush en -y field_group, field_group_table, field_formatter_class, field_formatter_settings, ctools, date, devel,
               ds, link, entity, libraries, redirect, token uuid, jquery_update, views, webform
 
+  # up memory limit of PHP
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+
 script:
   # Link our repo to the modules directory
   - mv ../tripal sites/all/modules/tripal


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #815 

## Description

This PR modifies the PHP memory limit setting.  This prevents the test suite from running out of memory when running the OBO loader tests.
