### PR TITLE
check field permissions explicitly if configured

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -377,7 +377,9 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       if ($field['field_permissions']['type'] === '1') {
         // Field is private.
-        return;
+           if (!user_access('view ' . $field_name, $user)) {
+          return;
+        }
       }
       if ($field['field_permissions']['type'] === '2') {
         // Field is custom permissions: Check

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -371,9 +371,21 @@ class TripalContentService_v0_1 extends TripalWebService {
       }
     }
 
-    if (isset($field['field_permissions']['type']) && $field['field_permissions']['type'] != 0) {
-      return;
-    }
+    if (isset($field['field_permissions']['type'])) {
+
+      global $user;
+
+      if ($field['field_permissions']['type'] === '1') {
+        // Field is private.
+        return;
+      }
+      if ($field['field_permissions']['type'] === '2') {
+        // Field is custom permissions: Check
+        // if user has access to view this field in any entity.
+        if (!user_access('view ' . $field_name, $user)) {
+          return;
+        }
+      }
 
       if ($hide_fields == TRUE and empty($values[0])) {
       return;

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -386,6 +386,7 @@ class TripalContentService_v0_1 extends TripalWebService {
           return;
         }
       }
+    }
 
       if ($hide_fields == TRUE and empty($values[0])) {
       return;


### PR DESCRIPTION
finish resolving #749 , after #794

this PR deals with custom field permission cases properly, by using `global $user` and checking permissions for that user.
This PR assumes that it makes sense for web services to have a user associated with them (rather than needing to assume that the user is anonymous).

to check if the user accessing web services has permission for the field, in the event of custom field permissions.
