### PR TITLE
remove synonyms from autocomplete options

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.cv.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.cv.api.inc
@@ -1276,11 +1276,6 @@ function chado_autocomplete_cvterm($cv_id, $string = '') {
       SELECT CVT.cvterm_id, CVT.name
       FROM {cvterm} CVT
       WHERE CVT.cv_id = :cv_id and lower(CVT.name) like lower(:name)
-      UNION
-      SELECT CVT2.cvterm_id, CVTS.synonym as name
-      FROM {cvterm} CVT2
-        INNER JOIN {cvtermsynonym} CVTS ON CVTS.cvterm_id = CVT2.cvterm_id
-      WHERE CVT2.cv_id = :cv_id and lower(CVTS.synonym) like lower(:name)
       ORDER by name
       LIMIT 25 OFFSET 0
     ";
@@ -1298,12 +1293,6 @@ function chado_autocomplete_cvterm($cv_id, $string = '') {
       FROM {cvterm} CVT
         INNER JOIN {cv} CV on CVT.cv_id = CV.cv_id
       WHERE lower(CVT.name) like lower(:name)
-      UNION
-      SELECT CVT2.cvterm_id, CVTS.synonym as name, CV2.name as cvname, CVT2.cv_id
-      FROM {cvterm} CVT2
-        INNER JOIN {cv} CV2 on CVT2.cv_id = CV2.cv_id
-        INNER JOIN {cvtermsynonym} CVTS ON CVTS.cvterm_id = CVT2.cvterm_id
-      WHERE lower(CVTS.synonym) like lower(:name)
       ORDER by name
       LIMIT 25 OFFSET 0
     ";


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #801 

## Description

Autocomplete fetches synonyms and offers them to users.  However, forms then use that value and assume it's a valid cvterm, when, in fact, it might not be.  See, for example, #762 where stephen tried to add a relationship with "I-box promoter motif" and got an error, because thats a synonym for another term.

 @laceysanderson and myself think the best solution is removing autocomplete support for synonyms, because it's used so pervasively and there might be cases where the term name changing to the synonym's name would be problematic.

## Testing?
### to recreate the problem
On master, create any content type with the annotation field (most have it, for example analysis).  Use i-box promoter motif.  it should give you an error upon submission.
### to view the resolution
search for i-box on this branch.  there should only be the base i-box term, not the promoter motif synonym.


## Screenshots (if appropriate):

before pr 

![screen shot 2019-01-03 at 5 39 56 pm](https://user-images.githubusercontent.com/7063154/50665445-b9dbda80-0f7e-11e9-9c25-4e61e704623b.png)

after pr
![screen shot 2019-01-03 at 5 38 47 pm](https://user-images.githubusercontent.com/7063154/50665373-71242180-0f7e-11e9-883a-4d6d2a2e5948.png)
