### PR TITLE
Trigger a window resize event when the tripal_ds animation is complete

### DIFF
--- a/tripal_ds/theme/js/tripal_ds.js
+++ b/tripal_ds/theme/js/tripal_ds.js
@@ -34,7 +34,7 @@
           }
         });
       });
-      
+
       // Move the tripal pane to the first position when its TOC item is clicked.
       $('.tripal_pane-toc-list-item-link').each(function (i) {
         var id = '.tripal_pane-fieldset-' + $(this).attr('id');
@@ -63,6 +63,18 @@
             // Trigger expansion event to allow the pane content
             // to react to the size change
             $(id).trigger($.Event('tripal_ds_pane_expanded', {id: id}));
+            
+            // Trigger a window resize event to notify charting modules that
+            // the container dimensions has changed
+            if (typeof Event !== 'undefined') {
+              window.dispatchEvent(new Event('resize'));
+            }
+            else {
+              // Support IE
+              var event = window.document.createEvent('UIEvents');
+              event.initUIEvent('resize', true, false, window, 0);
+              window.dispatchEvent(event);
+            }
           });
           return false;
         });


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


# Bug Fix

Issue #824

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Fixes an issue with charting modules as described in #824.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

The easiest way to test is to use tripal_analysis_interpro or tripal_analysis_blast modules to try to display a chart.

Thanks!