### PR TITLE
Allow complex filtering when only one level is set

### DIFF
--- a/tests/tripal_chado/api/ChadoQueryTest.php
+++ b/tests/tripal_chado/api/ChadoQueryTest.php
@@ -37,7 +37,7 @@ class ChadoQueryTest extends TripalTestCase {
       'uniquename' => array(
         array(
           'op' => 'LIKE',
-          'data' => '01%',
+          'data' => 'octopus%',
         ),
       ),
     );
@@ -49,7 +49,7 @@ class ChadoQueryTest extends TripalTestCase {
 
     // Test 3 Pass an array of filters with multiple items.
     $selector = array(
-      'uniquename' => array(
+      'type_id' => array(
         array(
           'op' => '>',
           'data' => ($stock->type_id - 1),
@@ -60,7 +60,8 @@ class ChadoQueryTest extends TripalTestCase {
         ),
       ),
     );
-    $object = chado_generate_var('stock',[], $selector);
+
+    $object = chado_generate_var('stock', $selector);
     $this->assertNotNull($object->stock_id);
     $this->assertEquals($stock->stock_id, $object->stock_id);
 

--- a/tests/tripal_chado/api/ChadoQueryTest.php
+++ b/tests/tripal_chado/api/ChadoQueryTest.php
@@ -24,10 +24,11 @@ class ChadoQueryTest extends TripalTestCase {
         'data' => '01%',
       ),
     );
-    $object = chado_generate_var('stock', $selector);
 
+    $object = chado_generate_var('stock',[], $selector);
 
     $this->assertNotNull($object);
+    $this->assertEquals($stock->stock_id, $object->stock_id);
 
     // Test 2 Pass an array of filters with a single item.
     $selector = array(
@@ -39,9 +40,11 @@ class ChadoQueryTest extends TripalTestCase {
         ),
       ),
     );
-    $object = chado_generate_var('stock', $selector);
+    $object = chado_generate_var('stock',[], $selector);
 
     $this->assertNotNull($object);
+    $this->assertEquals($stock->stock_id, $object->stock_id);
+
 
     // Test 3 Pass an array of filters with multiple items.
     $selector = array(
@@ -56,8 +59,10 @@ class ChadoQueryTest extends TripalTestCase {
         ),
       ),
     );
-    $object = chado_generate_var('stock', $selector);
+    $object = chado_generate_var('stock',[], $selector);
     $this->assertNotNull($object);
+    $this->assertEquals($stock->stock_id, $object->stock_id);
+
   }
 
 }

--- a/tests/tripal_chado/api/ChadoQueryTest.php
+++ b/tests/tripal_chado/api/ChadoQueryTest.php
@@ -18,21 +18,22 @@ class ChadoQueryTest extends TripalTestCase {
 
     // Test 1. Pass a single filter.
     $selector = array(
-      'stock_id' => 1085,
+      'stock_id' => $stock->stock_id,
       'uniquename' => array(
         'op' => 'LIKE',
-        'data' => '01%',
+        'data' => 'octopus%',
       ),
     );
 
-    $object = chado_generate_var('stock',[], $selector);
+    $object = chado_generate_var('stock', $selector);
 
-    $this->assertNotNull($object);
+    $this->assertNotNull($object->stock_id);
     $this->assertEquals($stock->stock_id, $object->stock_id);
+
 
     // Test 2 Pass an array of filters with a single item.
     $selector = array(
-      'stock_id' => 1085,
+      'stock_id' => $stock->stock_id,
       'uniquename' => array(
         array(
           'op' => 'LIKE',
@@ -40,9 +41,9 @@ class ChadoQueryTest extends TripalTestCase {
         ),
       ),
     );
-    $object = chado_generate_var('stock',[], $selector);
+    $object = chado_generate_var('stock', $selector);
 
-    $this->assertNotNull($object);
+    $this->assertNotNull($object->stock_id);
     $this->assertEquals($stock->stock_id, $object->stock_id);
 
 
@@ -60,7 +61,7 @@ class ChadoQueryTest extends TripalTestCase {
       ),
     );
     $object = chado_generate_var('stock',[], $selector);
-    $this->assertNotNull($object);
+    $this->assertNotNull($object->stock_id);
     $this->assertEquals($stock->stock_id, $object->stock_id);
 
   }

--- a/tests/tripal_chado/api/ChadoQueryTest.php
+++ b/tests/tripal_chado/api/ChadoQueryTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Tests;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+class ChadoQueryTest extends TripalTestCase {
+  // Uncomment to auto start and rollback db transactions per test method.
+  use DBTransaction;
+
+  /**
+   * @group filter
+   * See PR 827.
+   */
+  public function test_filter_level(){
+
+    $stock = factory('chado.stock')->create(['uniquename' => 'octopus_core_test_name']);
+
+    // Test 1. Pass a single filter.
+    $selector = array(
+      'stock_id' => 1085,
+      'uniquename' => array(
+        'op' => 'LIKE',
+        'data' => '01%',
+      ),
+    );
+    $object = chado_generate_var('stock', $selector);
+
+
+    $this->assertNotNull($object);
+
+    // Test 2 Pass an array of filters with a single item.
+    $selector = array(
+      'stock_id' => 1085,
+      'uniquename' => array(
+        array(
+          'op' => 'LIKE',
+          'data' => '01%',
+        ),
+      ),
+    );
+    $object = chado_generate_var('stock', $selector);
+
+    $this->assertNotNull($object);
+
+    // Test 3 Pass an array of filters with multiple items.
+    $selector = array(
+      'uniquename' => array(
+        array(
+          'op' => '>',
+          'data' => ($stock->type_id - 1),
+        ),
+        array(
+          'op' => '<',
+          'data' => ($stock->type_id + 1),
+        ),
+      ),
+    );
+    $object = chado_generate_var('stock', $selector);
+    $this->assertNotNull($object);
+  }
+
+}

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1368,7 +1368,7 @@ function chado_select_record($table, $columns, $values, $options = NULL) {
       // CASE 1a: If there is only one element in the array, treat it the same
       // as a non-array value.
       if (count($value) == 1 AND is_int(key($value))
-          AND !(isset($value[0]['op']) && isset($value[0]['op']))) {
+          AND !(isset($value[0]['op']) && isset($value[0]['data']))) {
 
         $value = array_pop($value);
         $op = '=';

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1367,7 +1367,8 @@ function chado_select_record($table, $columns, $values, $options = NULL) {
 
       // CASE 1a: If there is only one element in the array, treat it the same
       // as a non-array value.
-      if (count($value) == 1 AND is_int(key($value))) {
+      if (count($value) == 1 AND is_int(key($value))
+          AND !(isset($value[0]['op']) && isset($value[0]['op']))) {
 
         $value = array_pop($value);
         $op = '=';


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#

Issue #

## Description
When using complex filtering, one could use as filter argument ($values):
```
array(
  'fieldname' => array(
    'op' => 'someop',
    'data' => 'somevalue',
  ),
);
```
or
```
array(
  'fieldname' => array(
    array(
      'op' => 'someop',
      'data' => 'somevalue',
    ),
    array(
      'op' => 'someop2',
      'data' => 'somevalue2',
    ),
  ),
);
```

but the following syntax was not supported:
```
array(
  'fieldname' => array(
    array(
      'op' => 'someop',
      'data' => 'somevalue',
    ),
  ),
);
```
This last syntax should be supported as complex filters might be auto-generated by some process that should not have to worry, in the end, if they provide just one or several complex filters for a field.
This patch does the trick.

## Testing?
Tested with the 3 case of complex filter above and also with a simple filter with multiple values like:
```
array(
  'fieldname' => array(
    array(
      'test' => '1',
    ),
  ),
);
```


## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
