### PR TITLE
Fix #790 (+ revert #799) : Alias issues

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -1324,17 +1324,17 @@ function tripal_replace_entity_tokens($string, &$entity, $bundle_entity = NULL) 
 
   // If we have any fields that need attaching, then do so now.
   if (count(array_keys($attach_fields)) > 0) {
-    $field_ids = array();
     foreach ($attach_fields as $storage_type => $details) {
+      $field_ids = array();
       $storage = $details['storage'];
       $fields = $details['fields'];
       foreach ($fields as $field) {
         $field_ids[$field['id']] = array($entity->id);
       }
       $entities = array($entity->id => $entity);
+      module_invoke($storage['module'], 'field_storage_load', 'TripalEntity',
+          $entities, FIELD_LOAD_CURRENT, $field_ids, array());
     }
-    module_invoke($storage['module'], 'field_storage_load', 'TripalEntity',
-        $entities, FIELD_LOAD_CURRENT, $field_ids, array());
   }
 
   // Now that all necessary fields are attached process the tokens.


### PR DESCRIPTION
# Bug Fix

Issue #790
## Description
When writing #799, I misread the logic behind the loops.
The issue was not that the array was reset every loop, it was that 

`module_invoke($storage['module'], 'field_storage_load', 'TripalEntity',
          $entities, FIELD_LOAD_CURRENT, $field_ids, array());`

was **not** called every loop

Before #799, it meant that only one storage type was properly loaded (the last one in the loop).
After #799, one storage type is properly loaded (the last one), but we try to load fields not belonging in that storage type (and fail silently).

I think the intended logic was to have one loop per storage type, select all the fields belonging in that storage type, and load them. This PR fixes that.

## Additional Notes (if any):

It fixes #790 because the two missing fields (text) are properly loaded by tripal_chado_field_storage_load (with the else clause)
