### PR TITLE
Fix multiple close icons with ajax calls

### DIFF
--- a/tripal_ds/theme/js/tripal_ds.js
+++ b/tripal_ds/theme/js/tripal_ds.js
@@ -3,6 +3,9 @@
     attach: function (context, settings){
       // Add a close button for each pane except for the te_base
       $('div.tripal_pane').each(function (i) {
+        if($(this).find('.tripal_pane-fieldset-buttons').length > 0) {
+          return;
+        }
         $(this).prepend(
           '<div class="tripal_pane-fieldset-buttons">' +
             '<div id="tripal-pane-close-button" class="tripal-pane-button">' +


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #838 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

It seems that Drupal executes all JS code that's registeres as a Drupal.behavors module whenever an AJAX call is made in a form. Tripal DS adds the `x` icon to panes on page load. Checking to make sure the `x` doesn't already exist before adding it fixes the issue.

```
if($(this).find('.tripal_pane-fieldset-buttons').length > 0) {
  return;
}
```

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

See issue #838 for a full example.

## Screenshots (if appropriate):

Screenshots have been posted by @mboudet 

![screenshot "screenshot"](https://user-images.githubusercontent.com/17642511/51840655-ea5c2d80-230c-11e9-985d-6f7ad165efa5.png)

Thanks!
