### PR TITLE
Update job_management.rst

### DIFF
--- a/docs/user_guide/job_management.rst
+++ b/docs/user_guide/job_management.rst
@@ -25,8 +25,8 @@ The Tripal Daemon requires the `Libraries API <https://www.drupal.org/project/li
 
 .. code-block:: shell
 
-  drush pm-download Libraries
-  drush pm-enable Libraries
+  drush pm-download libraries
+  drush pm-enable libraries
 
 Next, we need the `PHP-Daemon Library version 2.0 <https://github.com/shaneharter/PHP-Daemon>`_. You must download the PHP-Daemon Library and extract it in your ``sites/all/libraries`` directory. The folder must be named "PHP-Daemon".  The following commands can be used to do this:
 


### PR DESCRIPTION
# Documentation 

Issue #387 

## Description
There was a very small typo in the Tripal Daemon installation docs. This PR fixes it.

## Testing?
This change is so small you should be able to test by simply looking at the change. It turns out that Drush commands are case-sensistive 😝 
