### PR TITLE
Fix #854 (empty field behaviour)

### DIFF
--- a/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_formatter.inc
+++ b/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_formatter.inc
@@ -15,7 +15,9 @@ class schema__alternate_name_formatter extends ChadoFieldFormatter {
     $list_items = array();
 
     foreach ($items as $delta => $item) {
-      $list_items[] = $item['value'];
+      if(! empty($item['value'])){
+        $list_items[] = $item['value'];
+      }
     }
     $list = 'There are no synonyms.';
     if (count($list_items) > 0) {

--- a/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_formatter.inc
+++ b/tripal_chado/includes/TripalFields/schema__alternate_name/schema__alternate_name_formatter.inc
@@ -15,9 +15,10 @@ class schema__alternate_name_formatter extends ChadoFieldFormatter {
     $list_items = array();
 
     foreach ($items as $delta => $item) {
-      if(! empty($item['value'])){
-        $list_items[] = $item['value'];
+      if(empty($item['value'])){
+        continue;
       }
+      $list_items[] = $item['value'];
     }
     $list = 'There are no synonyms.';
     if (count($list_items) > 0) {

--- a/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
+++ b/tripal_chado/includes/TripalFields/schema__publication/schema__publication_formatter.inc
@@ -21,7 +21,9 @@ class schema__publication_formatter extends ChadoFieldFormatter {
     }
 
     foreach ($items as $delta => $item) {
-
+      if(empty($item['value'])){
+        continue;
+      }
       $title = isset($item['value']['TPUB:0000039']) ? $item['value']['TPUB:0000039'] : '';
       $citation = isset($item['value']['TPUB:0000003']) ? $item['value']['TPUB:0000003'] : '';
       $entity = (is_array($item['value']) && array_key_exists('entity', $item['value'])) ? $item['value']['entity'] : '';


### PR DESCRIPTION
Fix #854 by adding a check for an empty value in $item['value].
Without it, Tripal behaves as if there was an actual value in it, and does not display properly.

![image](https://user-images.githubusercontent.com/17642511/52963322-be7a1800-339f-11e9-8848-cd8b694eda36.png)

There might be others fields with this behaviour.