### PR TITLE
Minor typo in module rating instructions

### DIFF
--- a/docs/extensions/module_rating.rst
+++ b/docs/extensions/module_rating.rst
@@ -28,7 +28,7 @@ Silver
     - TripalField class to add data to pages (Tripal3). (:doc:`Tutorial <../dev_guide/custom_field>`)
 - Provides ways to customize the module (e.g. drush options, field/formatter settings, admin UI).
 - Latest releases should follow Drupal naming best practices.
-    - e.g. first release for Drupal 7 should be: ``7.x-1.x``.
+    - e.g. first release for Drupal 7 should be: ``7.x-1.0``.
 
 Gold
 -----


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Documentation

Issue NA

## Description

Minor typo fix.  first release should be 7.x-1.0 not 7.x-1.x right?
