### PR TITLE
Fix loop error

### DIFF
--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -151,7 +151,7 @@ function tripal_chado_bundle_fields_info_base(&$info, $details, $entity_type, $b
         break;
       case 'blob':
         // not sure how to support a blob field.
-        continue;
+        continue 2;
         break;
       case 'int':
         $base_info['type'] = 'number_integer';
@@ -1013,7 +1013,7 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
         break;
       case 'blob':
         // not sure how to support a blob field.
-        continue;
+        continue 2;
         break;
       case 'int':
         $base_info['widget']['type'] = 'number';


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #870

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This issue appears on php version 7.3+. As indicated in the [PHP documentation](http://php.net/manual/en/control-structures.continue.php), the switch statement treats `continue` the same as `break`. The code is obviously intended to skip this iteration of the parent foreach loop. Therefore, switching to `continue 2` allows us to tell php we don't mean the switch statement but the foreach loop.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

Run the code in a php 7.3 environment before and after the fix.

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->

Drupal has encountered this error before and [they fixed it](https://www.drupal.org/project/drupal/issues/2989734) using the same method.

Thanks!