### PR TITLE
Allows query object to be dumped as a string.

### DIFF
--- a/tripal/includes/TripalFieldQuery.inc
+++ b/tripal/includes/TripalFieldQuery.inc
@@ -243,4 +243,11 @@ class TripalFieldQuery extends EntityFieldQuery {
       throw new EntityFieldQueryException(t("Field storage engine not found."));
     }
   }
+
+  /**
+   * Allows query object to be dumped as a string.
+   */
+  public function __toString() {
+    return print_r($this, TRUE);
+  }
 }


### PR DESCRIPTION
This is one way to solve #881

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
