### PR TITLE
Remove default empty record in cross reference field

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
@@ -136,16 +136,6 @@ class sbo__database_cross_reference extends ChadoField {
       return;
     }
 
-    // Set some defaults for the empty record.
-    $entity->{$field_name}['und'][0] = [
-      'value' => '',
-      'chado-' . $field_table . '__' . $pkey => '',
-      'chado-' . $field_table . '__' . $fkey_lcolumn => $record->$fkey_rcolumn,
-      'chado-' . $field_table . '__dbxref_id' => '',
-      'db_id' => '',
-      'accession' => '',
-    ];
-
     $linker_table = $base_table . '_dbxref';
     $options = ['return_array' => 1];
     $record = chado_expand_var($record, 'table', $linker_table, $options);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #884 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Simply removed extra code.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
Using this branch:
- Visit an entity that does not have cross reference data
- When the `hide empty fields` option is enabled, the field should disappear. Otherwise, the message `There are no cross references` should appear.