### PR TITLE
call fgets on open file instead of path

### DIFF
--- a/docs/dev_guide/custom_data_loader.rst
+++ b/docs/dev_guide/custom_data_loader.rst
@@ -343,8 +343,9 @@ To import data into Chado we will use the Tripal API. After splitting each line 
     // to load the entire file into memory but rather to iterate over each
     // line separately.
     $bytes_read = 0;
-    while ($line = fgets($file_path)) {
-
+    $in_fh = fopen($file_path, "r");
+    while ($line = fgets($in_fh)) {
+  
       // Calculate how many bytes we have read from the file and let the
       // importer know how many have been processed so it can provide a
       // progress indicator.


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Minor Documentation Fix

Issue #861 

## Description
A user was confused by this example, and rightfully so as it called `fgets` on a file path instead of on an open file.  This patch resolves this.