### PR TITLE
add menu item for creating Tripal content

### DIFF
--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -927,8 +927,6 @@ function tripal_entity_delete_form_submit($form, &$form_state) {
  */
 function _tripal_entity_add_access() {
   global $user;
-
-
   $types = tripal_get_content_types();
   foreach ($types as $type) {
     if (user_access('create ' . $type->name, $user)) {

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -109,6 +109,21 @@ function tripal_menu() {
     'file path' => drupal_get_path('module', 'system'),
   );
 
+
+
+  $items['admin/content/bio_data/add'] = [
+    'title' => 'Add Tripal Content',
+    'description' => t('Create new Tripal Content.'),
+    'page callback' => 'tripal_add_page',
+    //'page arguments' => [''],
+    'access arguments' => ['administer tripal'],
+    'file' => 'includes/TripalEntityUIController.inc',
+    'file path' => drupal_get_path('module', 'tripal'),
+    'type' => MENU_LOCAL_ACTION,
+  ];
+
+
+
   $items['admin/content/bio_data/unpublish'] = [
     'title' => 'Unpublish Orphaned Content',
     'description' => t('Unpublish content that has no associated records in the data store.'),

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -109,20 +109,15 @@ function tripal_menu() {
     'file path' => drupal_get_path('module', 'system'),
   );
 
-
-
   $items['admin/content/bio_data/add'] = [
     'title' => 'Add Tripal Content',
     'description' => t('Create new Tripal Content.'),
     'page callback' => 'tripal_add_page',
-    //'page arguments' => [''],
     'access arguments' => ['administer tripal'],
     'file' => 'includes/TripalEntityUIController.inc',
     'file path' => drupal_get_path('module', 'tripal'),
     'type' => MENU_LOCAL_ACTION,
   ];
-
-
 
   $items['admin/content/bio_data/unpublish'] = [
     'title' => 'Unpublish Orphaned Content',


### PR DESCRIPTION
<!--- Thank you for contributing! -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# New (Minor) feature

Issue #894

## Description
It drove me crazy that i had to click on Content -> Tripal Content and wait for that page to load to add content.

I just add a menu hook item for the "add tripal content" page at `admin/content/bio_data/add`

## Testing?

using the `menu` or `devel_menu` module, you'll see a new menu item at content -> tripal content for add tripal content. 
Be sure to clear your cache first!

## Screenshots (if appropriate):
Before:
![Screen Shot 2019-03-18 at 12 12 44 PM](https://user-images.githubusercontent.com/7063154/54549890-66740880-4981-11e9-9c3e-96826df5d65d.png)
After:
![Screen Shot 2019-03-18 at 1 25 06 PM](https://user-images.githubusercontent.com/7063154/54549882-62e08180-4981-11e9-8618-3d9d21e2e9f6.png)


## Additional Notes (if any):

The `tripal_add_page` function seems way too generic for its function, considering its not a local method to the EntityController....

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
