### PR TITLE
Sink chad.db creation link to match chado.cv

### DIFF
--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -701,6 +701,7 @@ function tripal_chado_menu() {
     'file' => 'includes/tripal_chado.db.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_NORMAL_ITEM,
+    'weight' => 7,
   );
   $items['admin/tripal/loaders/chado_db/edit/%'] = array(
     'title' => 'Edit a Database Reference',


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Minor improvement

Issue # N/A

## Description


Another minor frustration resolution- @almasaeed2010 and myself couldn't find the GUI to add a database.  

I think weighting it to be immediately after the CV loader stuff (which is weighted at 6) will make it easier to find by grouping them together:

### before

![Screen Shot 2019-03-19 at 12 14 04 PM](https://user-images.githubusercontent.com/7063154/54622761-84ed0900-4a40-11e9-8ff9-cd9f36860432.png)


### after 

![Screen Shot 2019-03-19 at 12 10 53 PM](https://user-images.githubusercontent.com/7063154/54622496-0f813880-4a40-11e9-8bfe-213802a2d881.png)
