### PR TITLE
Add term check when retrieving term details.

### DIFF
--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -361,7 +361,7 @@ function tripal_get_term_details($vocabulary, $accession) {
         tripal_report_error(
           'tripal',
           TRIPAL_ERROR,
-          "Unable to find term for :vocab, :accession.",
+          "Unable to find term for :vocab, :accession using :function.",
           [':vocab' => $vocabulary, ':accession' => $accession, ':function' => $function]
         );
         return FALSE;

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -355,7 +355,17 @@ function tripal_get_term_details($vocabulary, $accession) {
     $module = $stores[$keys[0]]['module'];
     $function = $module . '_vocab_get_term';
     if (function_exists($function)) {
+
       $term = $function($vocabulary, $accession);
+      if (!$term) {
+        tripal_report_error(
+          'tripal',
+          TRIPAL_ERROR,
+          "Unable to find term for :vocab, :accession.",
+          [':vocab' => $vocabulary, ':accession' => $accession]
+        );
+        return FALSE;
+      }
 
       // If the vocabulary is missing then we have a problem.
       if (!array_key_exists('vocabulary', $term)) {

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -362,7 +362,7 @@ function tripal_get_term_details($vocabulary, $accession) {
           'tripal',
           TRIPAL_ERROR,
           "Unable to find term for :vocab, :accession.",
-          [':vocab' => $vocabulary, ':accession' => $accession]
+          [':vocab' => $vocabulary, ':accession' => $accession, ':function' => $function]
         );
         return FALSE;
       }


### PR DESCRIPTION
# Bug Fix
Issue #561 

## Description
This PR adds a simple check to function `tripal_get_term_details()` to ensure we don't try to access array keys without first checking to see if we have a term.

## Testing?
I'm not able to duplicate the original problem. However you can prove the function still works as follows:
```php
// Works.
$details = tripal_get_term_details('EFO','0000269');
dpm($details, 'details');

// Should not work but no errors.
$details = tripal_get_term_details('UFO','0000269');
dpm($details, 'details');
```