### PR TITLE
URGENT: Fix Tripal 2 => 3 upgrade

### DIFF
--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -118,6 +118,18 @@ function tripal_enable() {
     db_rename_table('tripal_variables2', 'tripal_variables');
   }
 
+  if (db_table_exists('tripal_custom_quota2')) {
+    $sql = "DROP TABLE tripal_custom_quota";
+    db_query($sql);
+    db_rename_table('tripal_custom_quota2', 'tripal_custom_quota');
+  }
+
+  if (db_table_exists('tripal_expiration_files2')) {
+    $sql = "DROP TABLE tripal_expiration_files";
+    db_query($sql);
+    db_rename_table('tripal_expiration_files2', 'tripal_expiration_files');
+  }
+
   // schema change
   if (!db_field_exists('tripal_jobs', 'includes')) {
     $sql = "ALTER TABLE tripal_jobs ADD COLUMN includes text";
@@ -151,6 +163,14 @@ function tripal_schema() {
     if (db_table_exists('tripal_variables')) {
       db_rename_table('tripal_variables', 'tripal_variables2');
     }
+
+    if (db_table_exists('tripal_custom_quota')) {
+      db_rename_table('tripal_custom_quota', 'tripal_custom_quota2');
+    }
+    if (db_table_exists('tripal_expiration_files')) {
+      db_rename_table('tripal_expiration_files', 'tripal_expiration_files2');
+    }
+
     variable_set ('tripal_v2_upgrade_v3_check', TRUE);
   }
   $schema = array();
@@ -159,12 +179,7 @@ function tripal_schema() {
   $schema['tripal_token_formats'] = tripal_tripal_token_formats_schema();
   $schema['tripal_variables'] = tripal_tripal_variables_schema();
   $schema['tripal_expiration_files'] = tripal_tripal_expiration_files_schema();
-  // Only create the quota table if it doesn't already exist.
-  // This is needed b/c the module defining this table changed from tripal_core to tripal
-  // and this confuses the Drupal Schema API.
-  if (!db_table_exists('tripal_custom_quota')) {
-    $schema['tripal_custom_quota'] = tripal_tripal_custom_quota_schema();
-  }
+  $schema['tripal_custom_quota'] = tripal_tripal_custom_quota_schema();
   
   // Adds a table for managing TripalEntity entities.
   $schema['tripal_vocab'] = tripal_tripal_vocab_schema();

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -158,10 +158,14 @@ function tripal_schema() {
   $schema['tripal_jobs'] = tripal_tripal_jobs_schema();
   $schema['tripal_token_formats'] = tripal_tripal_token_formats_schema();
   $schema['tripal_variables'] = tripal_tripal_variables_schema();
-  $schema['tripal_custom_quota'] = tripal_tripal_custom_quota_schema();
   $schema['tripal_expiration_files'] = tripal_tripal_expiration_files_schema();
-
-
+  // Only create the quota table if it doesn't already exist.
+  // This is needed b/c the module defining this table changed from tripal_core to tripal
+  // and this confuses the Drupal Schema API.
+  if (!db_table_exists('tripal_custom_quota')) {
+    $schema['tripal_custom_quota'] = tripal_tripal_custom_quota_schema();
+  }
+  
   // Adds a table for managing TripalEntity entities.
   $schema['tripal_vocab'] = tripal_tripal_vocab_schema();
   $schema['tripal_term'] = tripal_tripal_term_schema();


### PR DESCRIPTION
# Bug Fix

Issue #904 

## Description
Due to backport of the user file quota system to Tripal 2, the upgrade process now fails since the `tripal_custom_quota` and `tripal_expiration_files` tables already exist. This PR uses the typical Tripal3 method of moving the original tables out of the way, allowing Drupal to create the new one and then replacing it with the original table.

**NOTE: In order for tests to pass the Tripal2 docker needs to be updated. This is due to another commit on 7.x-2.x that fixes a change to views (i.e. views automagically disables views when module is disabled and doesn't allow suppressing of error if tripal tries to re-disable them).**

## Testing?
In this case, Travis will do the testing for you. **As long as the tests now pass, 👍**. 

Excerpt from Travis:
(note the following failed without this PR)
```
$ docker exec -it tripal2 bash -c "rm -rf /modules/tripal && ln -s /tripal /modules/tripal"
The command "docker exec -it tripal2 bash -c "rm -rf /modules/tripal && ln -s /tripal /modules/tripal"" exited with 0.
2.31s

$ docker exec -it tripal2 drush en -y tripal
The following extensions will be enabled: tripal
Do you really want to continue? (y/n): y
tripal was enabled successfully.                                     [ok]
tripal defines the following permissions: administer tripal, access tripal content overview, manage tripal content types, publish tripal content, upload files, view dev helps
The command "docker exec -it tripal2 drush en -y tripal" exited with 0.
```

If you would like to be **extra diligent**:
1. test Tripal2: tripal core can be disabled without error on most recent 7.x-2.x
2. Test upgrade (disable tripal2 and enable tripal3) works without error.
3. Check the tripal file quota system still works after upgrade.
