### PR TITLE
fix bug for names of tables without type_id.  Fix bug where names wit…

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -239,34 +239,29 @@ class sbo__relationship extends ChadoField {
     $this->base_type_column = 'table_name';
     switch ($instance['settings']['chado_table']) {
 
+      // TODO: note that Chado 1.4 will add types to, at least,
+      // project and analysis, at which point you should use the default instead.
       case 'acquisition_relationship':
       case 'analysis_relationship':
       case 'biomaterial_relationship':
       case 'cell_line_relationship':
       case 'quantification_relationship':
-        $this->base_type_column = 'table_name';
-        break;
       case 'element_relationship':
-        // RELATIONSHIP->subject_id_key->feature_id->name;
-        $this->base_name_columns = ['name'];
+      case 'project_relationship':
+      case 'pub_relationship':
         $this->base_type_column = 'table_name';
-        break;
+        $this->base_name_columns = ['name'];
+      break;
+
       case 'organism_relationship':
         $this->base_name_columns = ['genus', 'species'];
-        $this->base_type_column = 'table_name';
-        break;
-      case 'project_relationship':
-        $this->base_name_columns = ['name'];
         $this->base_type_column = 'table_name';
         break;
       case 'phylonode_relationship':
         $this->base_name_columns = ['label'];
         $this->base_type_column = 'table_name';
         break;
-      case 'pub_relationship':
-        $this->base_name_columns = ['name'];
-        $this->base_type_column = 'table_name';
-        break;
+
       case 'contact':
         $this->base_name_columns = ['name'];
         $this->base_type_column = 'type_id';

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
@@ -96,16 +96,17 @@ class sbo__relationship_formatter extends ChadoFieldFormatter {
       // Convert the object/subject to a link if an entity exists for it.
       if (array_key_exists('entity', $item['value']['local:relationship_object'])) {
         list($entity_type, $object_entity_id) = explode(':', $item['value']['local:relationship_object']['entity']);
+
         if ($object_entity_id != $entity->id) {
           $link = l($object_name, 'bio_data/' . $object_entity_id);
-          $phrase = preg_replace("/$object_name/", $link, $phrase);
+          $phrase = str_replace($object_name, $link, $phrase);
         }
       }
       if (array_key_exists('entity', $item['value']['local:relationship_subject'])) {
         list($entity_type, $subject_entity_id) = explode(':', $item['value']['local:relationship_subject']['entity']);
         if ($subject_entity_id != $entity->id) {
           $link = l($subject_name, 'bio_data/' . $subject_entity_id);
-          $phrase = preg_replace("/$subject_name/", $link, $phrase);
+          $phrase = str_replace($subject_name, $link, $phrase);
         }
       }
 


### PR DESCRIPTION
…h regexp characters wouldnt replace with the link.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #911

## Description

### Bug

Analysis relationships did not have the name:

![Screen Shot 2019-03-27 at 1 06 32 PM](https://user-images.githubusercontent.com/7063154/55100198-aa5cc100-5097-11e9-97b2-a6fc5aed7f98.png)

Relationships between entities whose names have regexp characters (`*` `.` for example) didnt have their title replaced with the link properly.

![Screen Shot 2019-03-27 at 1 24 20 PM](https://user-images.githubusercontent.com/7063154/55100240-c52f3580-5097-11e9-9dc4-91f7cc2c2687.png)


### Resolution

* The relationship base accidentally didnt set the "type" for some type-less columns. I compile all said columns into the same case in this PR (and add a note that chado 1.4 will introduce a type for sure...)

* we used `preg_replace` to replace the entity title with the linked entity title.   I dont think we have a need for `preg_replace` so `str_replace` is the better choice and wont break when titles have odd characters in them.


## Testing?

Create an `analysis._A` and `analysis._B` (note regexp characters).  Make sure your relationship formatter is set to display for analysis. 
 Create a relationship between the two with the relationship widget.  You should see the relationship listed in the relationship widget, but without the names.

## Screenshots (if appropriate):

With this PR

![Screen Shot 2019-03-27 at 1 49 01 PM](https://user-images.githubusercontent.com/7063154/55100244-cb251680-5097-11e9-981a-c6d5928d0a1c.png)

