### PR TITLE
Powered by Tripal block not displayed correctly on pages with existin…

### DIFF
--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -1144,7 +1144,7 @@ function tripal_block_view($delta = ''){
 
       $block['title'] = '';
       $block['content'] = array(
-        '#markup' => '<a href="http://tripal.info"><img border="0" src="' . $base_path . drupal_get_path('module', 'tripal') . '/theme/images/' . $image . '"></a>',
+        '#markup' => '<a href="http://tripal.info"><img border="0" src="/' . $base_path . drupal_get_path('module', 'tripal') . '/theme/images/' . $image . '"></a>',
       );
       break;
     case 'content_type_barchart':


### PR DESCRIPTION
Changed "Powered by Tripal" logo image path to absolute.

Changed image path of the Tripal logo to absolute to allow it to be displayed correctly on all pages.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:

# Bug Fix
 --->

# Bug Fix

Issue #918 

## Description
<!--- Describe your changes in detail -->
Changed the path of the image html tag to aboslute path, starting with '/' in the 
Powered by Tripal block defined in tripal/tripal.module.


<!--- Why is this change required? What problem does it solve? -->

The image did not display correctly on many pages and would cause a hanging block thread in some cases.


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):


![image](https://user-images.githubusercontent.com/893151/55384350-cf838080-552a-11e9-9261-b21102ebf583.png)
# Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
