### PR TITLE
Web Services field causing problems

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -161,18 +161,27 @@ class TripalContentService_v0_1 extends TripalWebService {
       $field_name = $instance['field_name'];
       $field = field_info_field($field_name);
       $field_type = $field['type'];
+
       // Skip fields of remote data.
       if ($field_type == 'remote__data') {
         continue;
       }
+
       $vocabulary = $instance['settings']['term_vocabulary'];
       $accession = $instance['settings']['term_accession'];
       $temp_term = tripal_get_term_details($vocabulary, $accession);
+
+      // See if the name matches perfectly.
+      if (strtolower($temp_term['name']) == strtolower($expfield)) {
+        return [$field, $instance, $temp_term];
+      }
+
       // See if the name provided matches the field name after a bit of
       // cleanup.
       if (strtolower(preg_replace('/[^\w]/', '_', $temp_term['name'])) == strtolower($expfield)) {
         return [$field, $instance, $temp_term];
       }
+
       // Alternatively if the CV term accession matches then we're good too.
       if ($vocabulary . ':' . $accession == $expfield) {
         return [$field, $instance, $temp_term];


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug

Issue #928

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
If you are using web services and you want to expand a field that has a link (expandable field) and if that field name has a space in it, then web services breaks.


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

Use the default Citrus data from the Tripal User's Guide tutorial.  Be sure that the `mRNA` content type is published.   Prior to pulling this PR, open web services, find an `mRNA` record follow the `sequence_coordinate` link.  It should give you the following error:

```
error: "Could not find a matching field for the name: Sequence coordinates"
```
Pull the code for this PR and try following the link again.

Alternatively, you can test with any web services field that has a space in it.

## Screenshots (if appropriate):

Here are before and after screenshots:
![ws_before](https://user-images.githubusercontent.com/1719352/56776114-4fde7f80-677f-11e9-9a5a-bcc19683d35a.png)
![ws_after](https://user-images.githubusercontent.com/1719352/56776116-51a84300-677f-11e9-93f9-5254f741486d.png)



## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
