### PR TITLE
resolve SO based bundles using wrong term name

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -433,6 +433,9 @@ function tripal_add_notification($title, $details, $type, $actions, $submitter_i
  *     - term_name: A human-readable name for this term.  This will became
  *       the name that appears for the content type.  In practice, this
  *       should be the name of the term. (E.g. the name for SO:0000704 is gene).
+ *     - label: An alternative bundle label.  This will be used instead of the
+ *       term name, for cases where the vocabulary term is not human readable.
+ *
  * @param $job
  *  The job ID if this is launched via a job.
  *
@@ -446,6 +449,7 @@ function tripal_create_bundle($args, $job = NULL) {
   $accession = $args['accession'];
   $term_name = $args['term_name'];
   $storage_args = $args['storage_args'];
+  $label = $args['label'];
 
   $message_args = [
     'job' => $job,
@@ -505,9 +509,11 @@ function tripal_create_bundle($args, $job = NULL) {
     if (!in_array($bundle_name, array_keys($einfo['bundles']))) {
       // Make the label for the content type have capitalized words.  The
       // exception is 'mRNA' which we know should not be uppercased.
-      $label = ucwords(preg_replace('/_/', ' ', $term_name));
-      if ($term_name == 'mRNA') {
-        $label = $term_name;
+      if (!$label) {
+        $label = ucwords(preg_replace('/_/', ' ', $term_name));
+        if ($term_name == 'mRNA') {
+          $label = $term_name;
+        }
       }
       // Insert the bundle.
       db_insert('tripal_bundle')

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -728,7 +728,8 @@ function tripal_chado_prepare_genetic_types($job) {
   $args = [
     'vocabulary' => 'SO',
     'accession' => '0001060',
-    'term_name' => 'Sequence Variant',
+    'label' => "Sequence Variant",
+    'term_name' => 'sequence_variant',
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',
@@ -743,7 +744,8 @@ function tripal_chado_prepare_genetic_types($job) {
   $args = [
     'vocabulary' => 'SO',
     'accession' => '0001645',
-    'term_name' => 'Genetic Marker',
+    'term_name' => 'genetic_marker',
+    'label' => "Genetic Marker",
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',
@@ -759,7 +761,9 @@ function tripal_chado_prepare_genetic_types($job) {
   $args = [
     'vocabulary' => 'SO',
     'accession' => '0001500',
-    'term_name' => 'Heritable Phenotypic Marker',
+    'term_name' => 'heritable_phenotypic_marker',
+    'label' => "Heritable Phenotypic Marker",
+
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -348,7 +348,8 @@ function tripal_chado_prepare_general_types($job) {
   $args = [
     'vocabulary' => 'SIO',
     'accession' => '001066',
-    'term_name' => 'Study',
+    'term_name' => 'study',
+    'label' => 'Study',
     'storage_args' => [
       'data_table' => 'study',
     ],
@@ -501,7 +502,8 @@ function tripal_chado_prepare_genomic_types($job) {
   $args = [
     'vocabulary' => 'operation',
     'accession' => '0525',
-    'term_name' => 'Genome Assembly',
+    'term_name' => 'Genome assembly',
+    'label' => 'Genome Assembly',
     'storage_args' => [
       'data_table' => 'analysis',
       'type_linker_table' => 'analysisprop',
@@ -518,7 +520,8 @@ function tripal_chado_prepare_genomic_types($job) {
   $args = [
     'vocabulary' => 'operation',
     'accession' => '0362',
-    'term_name' => 'Genome Annotation',
+    'term_name' => 'Genome annotation',
+    'label' => 'Genome Annotation',
     'storage_args' => [
       'data_table' => 'analysis',
       'type_linker_table' => 'analysisprop',
@@ -574,7 +577,8 @@ function tripal_chado_prepare_expression_types($job) {
   $args = [
     'vocabulary' => 'OBI',
     'accession' => '0000070',
-    'term_name' => 'Assay',
+    'term_name' => 'assay',
+    'label' => 'Assay',
     'storage_args' => [
       'data_table' => 'assay',
     ],
@@ -628,7 +632,8 @@ function tripal_chado_prepare_germplasm_types($job) {
   $args = [
     'vocabulary' => 'CO_010',
     'accession' => '0000044',
-    'term_name' => 'Germplasm Accession',
+    'term_name' => 'accession',
+    'label' => 'Germplasm Accession',
     'storage_args' => [
       'data_table' => 'stock',
       'type_column' => 'type_id',
@@ -643,7 +648,8 @@ function tripal_chado_prepare_germplasm_types($job) {
   $args = [
     'vocabulary' => 'CO_010',
     'accession' => '0000255',
-    'term_name' => 'Generated germplasm (breeding cross)',
+    'label' => 'Generated Germplasm (Breeding Cross)',
+    'term_name' => 'generated germplasm',
     'storage_args' => [
       'data_table' => 'stock',
       'type_column' => 'type_id',
@@ -658,7 +664,8 @@ function tripal_chado_prepare_germplasm_types($job) {
   $args = [
     'vocabulary' => 'CO_010',
     'accession' => '0000029',
-    'term_name' => 'Cultivar (germplasm variety)',
+    'label' => 'Cultivar (Germplasm Variety)',
+    'term_name' => 'cultivar',
     'storage_args' => [
       'data_table' => 'stock',
       'type_column' => 'type_id',
@@ -673,7 +680,8 @@ function tripal_chado_prepare_germplasm_types($job) {
   $args = [
     'vocabulary' => 'CO_010',
     'accession' => '0000162',
-    'term_name' => 'Recombinant Inbred Line',
+    'label' => 'Recombinant Inbred Line',
+    'term_name' => '414 inbred line',
     'storage_args' => [
       'data_table' => 'stock',
       'type_column' => 'type_id',
@@ -695,7 +703,8 @@ function tripal_chado_prepare_genetic_types($job) {
   $args = [
     'vocabulary' => 'data',
     'accession' => '1278',
-    'term_name' => 'Genetic Map',
+    'label' => 'Genetic Map',
+    'term_name' => 'Genetic map',
     'storage_args' => [
       'data_table' => 'featuremap',
       'type_linker_table' => 'featuremapprop',

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1948,9 +1948,97 @@ function tripal_chado_update_7337(){
 function tripal_chado_update_7338() {
 
   $terms = [
-    ['label' => 'Sequence Variant', 'term' => 'sequence_variant', 'accession' => '0001060'],
-    ['label' => 'Genetic Marker', 'term' => 'genetic_marker', 'accession' => '0001645'],
-    ['label' => 'Heritable Phenotypic Marker', 'term' => 'heritable_phenotypic_marker', 'accession' => '0001500']
+    [
+      'vocabulary' => 'SO',
+      'label' => 'Sequence Variant',
+      'term' => 'sequence_variant',
+      'accession' => '0001060',
+    ],
+    [
+      'vocabulary' => 'SO',
+      'label' => 'Genetic Marker',
+      'term' => 'genetic_marker',
+      'accession' => '0001645',
+    ],
+    [
+      'vocabulary' => 'SO',
+      'label' => 'Heritable Phenotypic Marker',
+      'term' => 'heritable_phenotypic_marker',
+      'accession' => '0001500',
+    ],
+    [
+      'vocabulary' => 'SIO',
+      'label' => 'Study',
+      'term' => 'study',
+      'accession' => '001066',
+    ],
+    [
+      'vocabulary' => 'sep',
+      'label' => 'Biological Sample',
+      'term' => '	biological sample',
+      'accession' => '00195',
+    ],
+    [
+      'vocabulary' => 'OBI',
+      'label' => 'Assay',
+      'term' => 'assay',
+      'accession' => '0000070',
+    ],
+    [
+      'vocabulary' => 'data',
+      'label' => 'Genetic Map',
+      'term' => 'Genetic map',
+      'accession' => '1278',
+    ],
+    [
+      'vocabulary' => 'operation',
+      'label' => 'Genome Annotation',
+      'term' => 'Genome annotation',
+      'accession' => '0362',
+    ],
+    [
+      'vocabulary' => 'operation',
+      'label' => 'Genome Assembly',
+      'term' => 'Genome assembly',
+      'accession' => '0525',
+    ],
+    [
+      'vocabulary' => 'CO_010',
+      'label' => 'Generated Germplasm (Breeding Cross)',
+      'term' => 'generated germplasm',
+      'accession' => '0000255',
+    ],
+    [
+      'vocabulary' => 'CO_010',
+      'label' => 'Cultivar (Germplasm Variety)',
+      'term' => 'cultivar',
+      'accession' => '0000029',
+    ],
+
+    [
+      'vocabulary' => 'CO_010',
+      'label' => 'Germplasm Accession',
+      'term' => 'accession',
+      'accession' => '0000044',
+    ],
+    [
+      'vocabulary' => 'data',
+      'label' => 'Physical Map',
+      'term' => 'Physical map',
+      'accession' => '1280',
+    ],
+    [
+      'vocabulary' => 'sep',
+      'label' => 'Protocol',
+      'term' => '	protocol',
+      'accession' => '00101',
+    ],
+    [
+      'vocabulary' => 'CO_010',
+      'label' => 'Recombinant Inbred Line',
+      'term' => '414 inbred line',
+      'accession' => '0000162',
+    ],
   ];
 
   try {
@@ -1959,9 +2047,9 @@ function tripal_chado_update_7338() {
       $label = $term['label'];
       $termName = $term['term'];
       $accession = $term['accession'];
-
+      $vocabulary = $term['vocabulary']; #shortname, ie, chado.db
       $term = tripal_load_term_entity([
-        'vocabulary' => 'SO',
+        'vocabulary' => $vocabulary,
         'accession' => $accession
       ]);
 

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1940,3 +1940,50 @@ function tripal_chado_update_7337(){
     throw new DrupalUpdateException('Could not perform update: '. $error);
   }
 }
+
+
+/**
+ * Modify the term name for Sequence Variant, Genetic Marker, and Heritable Phenotypic Marker to match the corresponding SO term.
+ */
+function tripal_chado_update_7338() {
+
+  $terms = [
+    ['label' => 'Sequence Variant', 'term' => 'sequence_variant', 'accession' => '0001060'],
+    ['label' => 'Genetic Marker', 'term' => 'genetic_marker', 'accession' => '0001645'],
+    ['label' => 'Heritable Phenotypic Marker', 'term' => 'heritable_phenotypic_marker', 'accession' => '0001500']
+  ];
+
+  try {
+    foreach ($terms as $term) {
+
+      $label = $term['label'];
+      $termName = $term['term'];
+      $accession = $term['accession'];
+
+      $term = tripal_load_term_entity([
+        'vocabulary' => 'SO',
+        'accession' => $accession
+      ]);
+
+      if (!$term) {
+        continue;
+      }
+      $term->name = $termName;
+      $term->save();
+
+      $bundle = tripal_load_bundle_entity(['term_id' => $term->id]);
+
+      if (!$bundle) {
+        continue;
+      }
+      $bundle->label = $label;
+      $bundle->save();
+
+
+    }
+  } catch (\PDOException $e) {
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not perform update: '. $error);
+  }
+
+}


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #938

## Description

Some SO bundles were added using the human readable names instead of the machine readable names. 
These were Sequence Variant, Genetic Marker, and Heritable Phenotypic Marker ie instead of `sequence_variant`.  This is problematic not just because using bad terms is bad, but other modules looking for these bundles wont find them if they look by term name.

This PR changes the term name to match the SO term while setting the label to remain the human readable label. 

## Testing?

Note your bundle names and terms at`/admin/structure/bio_data` for the above terms.  The term column will be the human readable name instead of the machine name.  Run `updatedb` and confirm the term names have been fixed.
Additionally/alternatively build a new site with this branch and confirm bundles have the correct terms.
