### PR TITLE
Updated docs to include a tv2 link

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -1,5 +1,9 @@
-User's Guide
-============
+Tripal v3 User's Guide
+======================
+
+.. note:: 
+
+  Looking for the `Tripal v2 User's Guide <http://tripal.info/tutorials/v2.x>`_? 
 
 
 .. toctree::


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Documentation

Issue # N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is just a simple change that places a Tripal v2 User's Guide link on the home page of the Tripal v3 User's Guide to help folks find the older documentation.  The Tripal v2 User's Guide link will be removed from the man menu of the Tripal.info site.

![image](https://user-images.githubusercontent.com/1719352/58358744-0c863800-7e35-11e9-90e7-16a95371bac2.png)
