### PR TITLE
A small typo fix that caused all importers to fail

### DIFF
--- a/tripal_chado/includes/tripal_chado.mapping.inc
+++ b/tripal_chado/includes/tripal_chado.mapping.inc
@@ -24,7 +24,7 @@ function tripal_chado_map_cvterms() {
         // Get the list of cvterm_ids from existing records in the table.
         $sql = "
           SELECT $local_id
-          FROM { " . $tablename . "}
+          FROM {" . $tablename . "}
           GROUP BY $local_id
         ";
         $results = chado_query($sql);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This is a small typo fix. I would mark this as an urgent issue since it causes all importers to fail at the end of the job. I am not sure if the transaction gets rolled back because of this error or not.

This is the error that showed up when using the FASTA importer:

```
Step 1: Finding sequences...
Step 2: Importing sequences...
Found 200 sequence(s).
Percent complete: 100.00 %. Memory: 37,557,224 bytes.
Done.

Remapping Chado Controlled vocabularies to Tripal Terms...
WD tripal_chado: PDOException: SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "arraydesign" does not exist                          [error]
LINE 1:            SELECT platformtype_id           FROM  arraydesig...
                                                          ^:            SELECT platformtype_id           FROM { arraydesign}          
GROUP BY platformtype_id         ; Array
(
)
 in chado_query() (line 1790 of
/Users/Almsaeed/Work/DevSites/Tripal/sites/all/modules/tripal/tripal_chado/api/tripal_chado.query.api.inc).
FAILED: Rolling back database changes...

Done.
```

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
1. Try loading a fasta file using the main 7.x-3.x branch
   - you should see an error as shown above
1. Switch to `t3_fix-typo` and try to load again.
   - the error disappears

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
