### PR TITLE
Add support to override the default button on Tripal importers.

### DIFF
--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -70,6 +70,13 @@ class TripalImporter {
   public static $button_text = 'Import File';
 
   /**
+   * If the loader should provide a submit button using $button_text above.
+   * Set this to FALSE to exclude the default button. This is useful for
+   * multi-page forms which need to change the button text.
+   */
+  public static $use_button;
+
+  /**
    * Indicates the methods that the file uploader will support.
    */
   public static $methods = [

--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -74,7 +74,7 @@ class TripalImporter {
    * Set this to FALSE to exclude the default button. This is useful for
    * multi-page forms which need to change the button text.
    */
-  public static $use_button;
+  public static $use_button = TRUE;
 
   /**
    * Indicates the methods that the file uploader will support.

--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -111,7 +111,7 @@ function tripal_get_importer_form($form, &$form_state, $class) {
   // to change the order of their elements in reference to the default ones.
   $form = array_merge($form, $element_form);
 
-  if (array_key_exists($class, 'use_button') and $class::$use_button] == TRUE) {
+  if ($class::$use_button == TRUE) {
     $form['button'] = [
       '#type' => 'submit',
       '#value' => t($class::$button_text),

--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -111,11 +111,13 @@ function tripal_get_importer_form($form, &$form_state, $class) {
   // to change the order of their elements in reference to the default ones.
   $form = array_merge($form, $element_form);
 
-  $form['button'] = [
-    '#type' => 'submit',
-    '#value' => t($class::$button_text),
-    '#weight' => 10,
-  ];
+  if (array_key_exists('use_button', $class::$methods) and $class::$methods['use_button'] == TRUE) {
+    $form['button'] = [
+      '#type' => 'submit',
+      '#value' => t($class::$button_text),
+      '#weight' => 10,
+    ];
+  }
   return $form;
 }
 

--- a/tripal/includes/tripal.importer.inc
+++ b/tripal/includes/tripal.importer.inc
@@ -111,7 +111,7 @@ function tripal_get_importer_form($form, &$form_state, $class) {
   // to change the order of their elements in reference to the default ones.
   $form = array_merge($form, $element_form);
 
-  if (array_key_exists('use_button', $class::$methods) and $class::$methods['use_button'] == TRUE) {
+  if (array_key_exists($class, 'use_button') and $class::$use_button] == TRUE) {
     $form['button'] = [
       '#type' => 'submit',
       '#value' => t($class::$button_text),


### PR DESCRIPTION
# New Feature

Issue n/a

## Description
When creating a multi-page Tripal Importer, you need the ability to override the submit button. Specifically, I needed to ensure the button said "Next" on the first pages and "Import" on the last page. At @spficklin recommendation, this PR adds a `$use_button` static property to the TripalImporter base class which allows the button to be excluded from the default form when it's set to FALSE. This is a backwards compatible change that matches the current conventions of the TripalImporter class.

TripalImporters to not have access to the default form in their TripalImporter::form() function. This protects default functionality but also means we can't just alter the text of the button using the form array. Especially in the case of the submit button which is added to the form after the developer loses control of it.

NOTE: A guide for how to make multi-page importers is started and will be available in a 2nd PR.

## Testing?
I have developed an example multi-page form to test this functionality. It's included in the [Tripal Examples module](https://github.com/tripa/tripal_example).
1. Clone the Tripal Example module and enable Tripal Example > Example Importers (`trpexp_importers`).
2. Before switching to this branch, check `Admin > Tripal > Data Importers > Example Multi-Page Importer`. Notice that the `Import File` button is mistakenly shown on the first page.
3. Switch to the branch and notice that the importer now performs as expected (no Import File button on the first page).
Alternatively, I've added screenshots to show the mutli-page form in action using the changes in this branch.

## Screenshots (if appropriate):
<img width="724" alt="Screen Shot 2019-06-20 at 9 34 38 AM" src="https://user-images.githubusercontent.com/1566301/59861843-cf7f6980-933e-11e9-9893-9d153582a67c.png">
<img width="732" alt="Screen Shot 2019-06-20 at 9 34 48 AM" src="https://user-images.githubusercontent.com/1566301/59861852-d27a5a00-933e-11e9-83f5-0d99a564d4c3.png">
<img width="727" alt="Screen Shot 2019-06-20 at 9 35 01 AM" src="https://user-images.githubusercontent.com/1566301/59861859-d5754a80-933e-11e9-930d-f96ff081b0c0.png">

