### PR TITLE
Adding TCP module

### DIFF
--- a/docs/extensions/data_input.rst
+++ b/docs/extensions/data_input.rst
@@ -54,3 +54,13 @@ This module is a collection of destination plugins to import biological data to 
 
 `Documentation <https://www.drupal.org/docs/7/modules/migrate-chado>`__
 `Repository <https://www.drupal.org/project/migrate_chado>`__
+
+Tripal Contact Profile
+----------------------
+
+[![Tripal Rating Bronze Status](https://tripal.readthedocs.io/en/7.x-3.x/_images/Tripal-Silver.png)](https://tripal.readthedocs.io/en/7.x-3.x/extensions/module_rating.html#Silver)
+
+The Tripal Contact Profile (TCP) module integrates directly into Tripal and allows users to create an extended profile that can be managed or displayed with the Colleagues Directory module (also available). It has many useful features including validation, orcid integration, better field widgets for inputting user data as well as a multi step registration feature that allows users to create both their user account as well as a TCP profile in a single registration procedure.
+
+`Documentation <https://tripal-contact-profile.readthedocs.io/en/latest/>`__
+`Repository <https://gitlab.com/TreeGenes/tripal_contact_profile>`__


### PR DESCRIPTION
TCP

Bronze:
Has a public release. |  Yes
Should install on a Tripal site appropriate for the versions it supports. |  Yes
Defines any custom tables or materialized views in the install file (if applicable). |  Not applicable
Adds any needed controlled vocabulary terms in the install file (Tripal3). |  Yes in spirit
Provides Installation and admin instructions README.md (or RTD). |  Yes
Has a license (distributed with module). | Yes

Silver:
Follows basic Drupal Coding standards; specifically, code format and API documentation. |  Yes
Uses Tripal API functions. Specifically, it should use the Chado Query API for querying chado (if using chado as the storage system). |  Yes
Tripal Jobs API for long running processes. |  Not applicable
TripalField class to add data to pages (Tripal3). |  Not applicable
Provides ways to customize the module (e.g. drush options, field/formatter settings, admin UI). |  Yes
Latest releases should follow Drupal naming best practices. e.g. first release for Drupal 7 should be: 7.x-1.x. | Yes