### PR TITLE
PHP 7.2 migration displays a "Countable" error

### DIFF
--- a/tripal_stock/theme/templates/tripal_stock_collections.tpl.php
+++ b/tripal_stock/theme/templates/tripal_stock_collections.tpl.php
@@ -6,6 +6,13 @@ $options = array('return_array' => 1);
 $stock = chado_expand_var($stock, 'table', 'stockcollection_stock', $options);
 $collections = $stock->stockcollection_stock;
 
+if (!$collections) {
+  $collections = array();
+}
+elseif (!is_array($collections)) {
+  $collections = array($collections);
+}
+
 if (count($collections) > 0) {?>
   <div class="tripal_stock-data-block-desc tripal-data-block-desc">This stock is found in the following collections.</div> <?php 
   

--- a/tripal_stock/theme/templates/tripal_stock_publications.tpl.php
+++ b/tripal_stock/theme/templates/tripal_stock_publications.tpl.php
@@ -5,7 +5,12 @@ $stock = $variables['node']->stock;
 $options = array('return_array' => 1);
 $stock = chado_expand_var($stock, 'table', 'stock_pub', $options);
 $stock_pubs = $stock->stock_pub; 
-
+if (!$stock_pubs) {
+  $stock_pubs = array();
+}
+elseif (!is_array($stock_pubs)) {
+  $stock_pubs = array($stock_pubs);
+}
 
 if (count($stock_pubs) > 0) { ?>
   <div class="tripal_stock_pub-data-block-desc tripal-data-block-desc"></div> <?php 


### PR DESCRIPTION
Solves "Warning: count(): Parameter must be an array or an object that implements Countable in include() (line 9 of .../modules/tripal/tripal_stock/theme/templates/tripal_stock_collections.tpl.php)." (and issues at line 25 after when $collections is not a non-empty array). This issue appears in PHP 7 because "count()" behavior changed and does not return "1" when a scalar is provided as argument.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
