### PR TITLE
Case sensitive chado_query function

### DIFF
--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1741,8 +1741,7 @@ function chado_query($sql, $args = []) {
       $matches = $matches[1];
       $chado_tables = array_unique(array_keys(chado_get_table_names(TRUE)));
       foreach ($matches as $match) {
-        $match = strtolower($match);
-        if (in_array($match, $chado_tables)) {
+        if (in_array(strtolower($match), $chado_tables)) {
           $sql = preg_replace("/\{$match\}/", $chado_schema_name . '.' . $match, $sql);
         }
       }
@@ -1753,8 +1752,7 @@ function chado_query($sql, $args = []) {
       $matches = $matches[1];
       $drupal_tables = array_unique(array_keys(drupal_get_schema()));
       foreach ($matches as $match) {
-        $match = strtolower($match);
-        if (in_array($match, $drupal_tables)) {
+        if (in_array(strtolower($match), $drupal_tables)) {
           $sql = preg_replace("/\[$match\]/", $drupal_schema_name . '.' . $match, $sql);
         }
       }

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1740,7 +1740,7 @@ function chado_query($sql, $args = []) {
     if (preg_match_all('/\{(.*?)\}/', $sql, $matches)) {
       $matches = $matches[1];
       $chado_tables = array_unique(array_keys(chado_get_table_names(TRUE)));
-      foreach ($matches as $match) {
+      foreach ($matches as strtolower($match)) {
         if (in_array($match, $chado_tables)) {
           $sql = preg_replace("/\{$match\}/", $chado_schema_name . '.' . $match, $sql);
         }
@@ -1751,7 +1751,7 @@ function chado_query($sql, $args = []) {
     if (preg_match_all('/\[(.*?)\]/', $sql, $matches)) {
       $matches = $matches[1];
       $drupal_tables = array_unique(array_keys(drupal_get_schema()));
-      foreach ($matches as $match) {
+      foreach ($matches as strtolower($match)) {
         if (in_array($match, $drupal_tables)) {
           $sql = preg_replace("/\[$match\]/", $drupal_schema_name . '.' . $match, $sql);
         }

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1740,7 +1740,8 @@ function chado_query($sql, $args = []) {
     if (preg_match_all('/\{(.*?)\}/', $sql, $matches)) {
       $matches = $matches[1];
       $chado_tables = array_unique(array_keys(chado_get_table_names(TRUE)));
-      foreach ($matches as strtolower($match)) {
+      foreach ($matches as $match) {
+        $match = strtolower($match);
         if (in_array($match, $chado_tables)) {
           $sql = preg_replace("/\{$match\}/", $chado_schema_name . '.' . $match, $sql);
         }
@@ -1751,7 +1752,8 @@ function chado_query($sql, $args = []) {
     if (preg_match_all('/\[(.*?)\]/', $sql, $matches)) {
       $matches = $matches[1];
       $drupal_tables = array_unique(array_keys(drupal_get_schema()));
-      foreach ($matches as strtolower($match)) {
+      foreach ($matches as $match) {
+        $match = strtolower($match);
         if (in_array($match, $drupal_tables)) {
           $sql = preg_replace("/\[$match\]/", $drupal_schema_name . '.' . $match, $sql);
         }

--- a/tripal_chado/includes/ChadoPrefixExtender.inc
+++ b/tripal_chado/includes/ChadoPrefixExtender.inc
@@ -189,7 +189,7 @@ class ChadoPrefixExtender extends SelectQueryExtender {
       static::$chado_tables = chado_get_table_names(TRUE);
     }
 
-    return in_array($table, static::$chado_tables);
+    return in_array(strtolower($table), static::$chado_tables);
   }
 
   /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #971

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
If someone uses the `chado_query` API function and uses a case other than lower-case to name a table (e.g. `{CV}` rather than '{cv}`) then the `chado_query` function doesn't recognize the table and doesn't add the `chado.` prefix to it.  The problem occurs in the Tripal Biomaterial module as described in this issue:  #971.


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
As this problem is specific to the Tripal Biomaterial module and @martacds has a biomaterial XML file to load. I am requesting that she (or her group) test this fix.  If it fixes it for here and we get one code review from the PMC I think we can merge.
