### PR TITLE
Fix so__genotype->load($entity)

### DIFF
--- a/tripal_chado/includes/TripalFields/so__genotype/so__genotype.inc
+++ b/tripal_chado/includes/TripalFields/so__genotype/so__genotype.inc
@@ -144,7 +144,7 @@ class so__genotype extends ChadoField {
       ],
     ];
     $record = chado_expand_var($record, 'table', $linker_table, $options);
-    $genotype_linkers = isset($record->$linker_table->$fkey_rcolumn) ? $record->$linker_table->$fkey_rcolumn : '';
+    $genotype_linkers = $record->$linker_table;
     if ($genotype_linkers) {
       foreach ($genotype_linkers as $i => $genotype_linker) {
         $genotype = $genotype_linker->genotype_id;


### PR DESCRIPTION
Implement the fix to so__genotype->load($entity) as described in #980.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #980

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
so__genotype->load($entity) was not properly loading entities. This fix resolves that problem and is based on the functionality of the sbo__phenotype class [here](https://github.com/tripal/tripal/blob/a18b5002e3d1af91c1762809c8ab7aff531401ed/tripal_chado/includes/TripalFields/sbo__phenotype/sbo__phenotype.inc#L120)

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
 - Add and configure the so__genotype Tripal Field to any Tripal Content.
 - Populate chado with data that should associate a genotype with your existing Tripal Content.
 - Publish the Tripal Content.
 - See that no genotypes are found, despite the data existing in chado.

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
