### PR TITLE
Update CartograTree Documentation Link

### DIFF
--- a/docs/extensions/search.rst
+++ b/docs/extensions/search.rst
@@ -6,7 +6,7 @@ CartograTree
 
 CartograTree is a web-based application that allows researchers to identify, filter, compare, and visualize geo-referenced biotic and abiotic data. Its goal is to support numerous multi-disciplinary research endeavors including: phylogenetics, population structure, and association studies.
 
-`Documentation <https://gitlab.com/TreeGenes/CartograTree/blob/master/README.md>`__
+`Documentation <https://cartogratree.readthedocs.io/en/latest/index.html>`__
 `Repository <https://gitlab.com/TreeGenes/CartograTree>`__
 
 Mainlab Chado Search


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Documentation

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
CartograTree Documentation link now points to [its documentation on readthedocs](https://cartogratree.readthedocs.io/en/latest/index.html) rather than the project README.md.

<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
