### PR TITLE
Proposed change for issue #1010

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -110,7 +110,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Creates a resource for an expanded field of an entity.
    */
   private function doExpandedField($ctype, $entity_id, $expfield) {
-    $service_path = $this->getServicePath() . '/' . urlencode($ctype) . '/' . $entity_id;
+    $service_path = $this->getServicePath() . '/' . preg_replace('/[^\w]/', '_', $ctype) . '/' . $entity_id;
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab for this type.

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -193,7 +193,7 @@ class TripalContentService_v0_1 extends TripalWebService {
    * Creates a resource for a single entity.
    */
   private function doEntity($ctype, $entity_id) {
-    $service_path = $this->getServicePath() . '/' . urlencode($ctype);
+    $service_path = $this->getServicePath() . '/' . preg_replace('/[^\w]/', '_', $ctype);
     $this->resource = new TripalWebServiceResource($service_path);
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.


### PR DESCRIPTION
Apply the same treatment to service path and or content type name as seen in doEntityList method.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#Issue #1010 Web Services: Invalid Content Type.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The use of urlencode() replaces any white spaces into plus symbol (+) causing field label to mismatch and trigger an invalid content type error. This proposal makes it consistent to apply the same treatment (as seen in other sections) to content type labels when used in constructing the field url.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
After implementing this proposal, access /web-services/content/v0.1 in your site and click on @id link of a content type that contains multiple words (ie. Genetic Marker, F1 Breeding Crosses etc), keep accessing @id while observing that the string url should now not contain any plus symbol to concatenate words in content type name/label. Do this until you reach content resource.

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
