### PR TITLE
prevent SQL error screen deleting databases in use

### DIFF
--- a/tripal_chado/includes/tripal_chado.db.inc
+++ b/tripal_chado/includes/tripal_chado.db.inc
@@ -84,7 +84,8 @@ function tripal_chado_db_edit_form($form, &$form_state) {
   ];
 
 
-  // if we don't have a db_id then we can  return the form, otherwise
+  // if 
+  we don't have a db_id then we can  return the form, otherwise
   // add in the other fields
   if ($dbid) {
     tripal_chado_add_db_form_fields($form, $form_state, $dbid);
@@ -93,11 +94,20 @@ function tripal_chado_db_edit_form($form, &$form_state) {
       '#type' => 'submit',
       '#value' => t('Update'),
     ];
-    $form['delete'] = [
-      '#type' => 'submit',
-      '#value' => t('Delete'),
-      '#attributes' => ['onclick' => 'if(!confirm("Really Delete?")){return false;}'],
-    ];
+  
+  
+    // Assert we have some configuration in our database.
+  $dbxref_count = chado_query('select count(dbxref_id) from {dbxref_id} WHERE db_id = :db_id', [':db_id'] => $dbid);  
+  
+    if ($dbxref_count == 0) {
+      $form['delete'] = [
+        '#type' => 'submit',
+        '#value' => t('Delete'),
+        '#attributes' => ['onclick' => 'if(!confirm("Really Delete?")){return false;}'],
+      ];
+    } else {
+      tripal_set_message('You cannot delete this db without first deleting the ${dbxref_count} dbxrefs associated with it.', TRIPAL_NOTICE);
+    }
   }
   else {
     // if we don't have a dbid then this is the first time the form has

--- a/tripal_chado/includes/tripal_chado.db.inc
+++ b/tripal_chado/includes/tripal_chado.db.inc
@@ -94,7 +94,6 @@ function tripal_chado_db_edit_form($form, &$form_state) {
       '#value' => t('Update'),
     ];
 
-    // Assert we have some configuration in our database.
     $dbxref_count = chado_query('select count(dbxref_id) from {dbxref} WHERE db_id = :db_id', [':db_id' => $dbid])->fetchField();
 
     if ($dbxref_count == 0) {

--- a/tripal_chado/includes/tripal_chado.db.inc
+++ b/tripal_chado/includes/tripal_chado.db.inc
@@ -84,9 +84,8 @@ function tripal_chado_db_edit_form($form, &$form_state) {
   ];
 
 
-  // if 
-  we don't have a db_id then we can  return the form, otherwise
-  // add in the other fields
+  // If we don't have a db_id then we can  return the form, otherwise
+  // add in the other fields.
   if ($dbid) {
     tripal_chado_add_db_form_fields($form, $form_state, $dbid);
 
@@ -94,19 +93,19 @@ function tripal_chado_db_edit_form($form, &$form_state) {
       '#type' => 'submit',
       '#value' => t('Update'),
     ];
-  
-  
+
     // Assert we have some configuration in our database.
-  $dbxref_count = chado_query('select count(dbxref_id) from {dbxref_id} WHERE db_id = :db_id', [':db_id'] => $dbid);  
-  
+    $dbxref_count = chado_query('select count(dbxref_id) from {dbxref} WHERE db_id = :db_id', [':db_id' => $dbid])->fetchField();
+
     if ($dbxref_count == 0) {
       $form['delete'] = [
         '#type' => 'submit',
         '#value' => t('Delete'),
         '#attributes' => ['onclick' => 'if(!confirm("Really Delete?")){return false;}'],
       ];
-    } else {
-      tripal_set_message('You cannot delete this db without first deleting the ${dbxref_count} dbxrefs associated with it.', TRIPAL_NOTICE);
+    }
+    else {
+      tripal_set_message("You cannot delete this db without first deleting the ${dbxref_count} dbxrefs associated with it.", TRIPAL_NOTICE);
     }
   }
   else {


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug fix

Issue #1005 

## Description
This is a pretty weak solution to a minor problem, i was just looking for something small to do.

The chado.database interface lets you delete a database record... but it crashes if there are linked records, since it doesnt cascade.
Cascading on delete here seems like a pretty big deal, so instead, i just block deletion (since deleting would crash anyway) and let the user know they have dbxrefs they should delete first.

## Testing?

- create a db, a cv, and a cvterm linked to the two.  You will now see a warning when trying to delete the db.

## Screenshots (if appropriate):

## Additional Notes (if any):
this is a silly PR, and definitely not a great solution, but it does blocks off a SQL crash so i figured why not submit.