### PR TITLE
Fix Issue #1007

### DIFF
--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -2495,6 +2495,9 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
   $prop_table = $table_name . 'prop';
   if (chado_table_exists($prop_table)) {
 
+    $schema = chado_get_schema($prop_table);
+    $pkey = $schema['primary key'][0];
+
     $props = tripal_chado_bundle_get_properties($table_name, $prop_table, $type_table, $type_column, $cvterm_id, $type_value);
     foreach ($props as $term) {
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1007

## Description
Error encountered when adding property fields.
```
Notice: Undefined variable: pkey in tripal_chado_bundle_instances_info_linker() (line 2524 of /var/www/html/sites/all/modules/tripal/tripal_chado/includes/tripal_chado.fields.inc).
```

## Testing?
1. Use the following code to add a property on your site. I execute this in the devel "Execute PHP"
```
$record = array('table' => 'contact', 'id' => 1);
$status = chado_insert_property(
    $record, [
        'type_name' =>'sequence_variant',
        'cv_name' => 'sequence', 
        'value' => 'anything',  
]);
```
2. Go to Admin > Structure > Tripal Content Types > Contact > Manage Fields and click "    Check for new fields"

On 7.x-3.x you receive the error mentioned and on this branch you do not.
