### PR TITLE
Fix for Issue #996

### DIFF
--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -224,6 +224,8 @@ function chado_publish_records($values, $job = NULL) {
   // Perform the query in chunks.
   $sql = $select . $from . $where . ' LIMIT ' . $chunk_size;
   $more_records_to_publish = TRUE;
+  $num_actually_published = 0; // the full number of records published.
+  $i = 0; //reset on each chunk.
   while ($more_records_to_publish) {
 
     $records = chado_query($sql, $args);
@@ -236,6 +238,9 @@ function chado_publish_records($values, $job = NULL) {
     // are already in one.
     $transaction = db_transaction();
     try {
+      // Keep track of how many we've published so far
+      // before clearing our chunk,
+      $num_actually_published = $num_actually_published + $i;
       $i = 0;
       while ($record = $records->fetchObject()) {
 
@@ -293,7 +298,7 @@ function chado_publish_records($values, $job = NULL) {
       return FALSE;
     }
 
-    // If we get through the loop and haven't completed 100 records, then 
+    // If we get through the loop and haven't completed 100 records, then
     // we're done!
     if ($i < $chunk_size) {
       $more_records_to_publish = FALSE;
@@ -303,9 +308,12 @@ function chado_publish_records($values, $job = NULL) {
     unset($transaction);
   }
 
+  // Add the last number published to our total.
+  $num_actually_published = $num_actually_published + $i;
+
   tripal_report_error($message_type, TRIPAL_INFO,
     "Successfully published !count !type record(s).",
-    ['!count' => $i, '!type' => $bundle->label], $message_opts);
+    ['!count' => $num_actually_published, '!type' => $bundle->label], $message_opts);
 
   return TRUE;
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #996 

## Description
Originally the publish was reporting only the last chunk sync'd as the total number published 😞  This PR fixes that ensuring that the full actual number published is reported.

## Testing?
1. Create an organism, analysis and base chromosome: `chr1` specifically.
2. Use the GFF3 loader to load this file: [Mt4.0v2_genes_20140818_1100.chr1.1505genes.gff3.txt](https://github.com/tripal/tripal/files/3776277/Mt4.0v2_genes_20140818_1100.chr1.1505genes.gff3.txt)
3. Publish Genes. You expect 1505 genes published.
```
2019-10-27 13:39:07: Calling: chado_publish_records(Array)
INFO (PUBLISH_RECORDS): There are 1505 records to publish.
There are 1505 records to publish.
INFO (PUBLISH_RECORDS): Successfully published 1505 Gene record(s).
Successfully published 1505 Gene record(s).
```