### PR TITLE
Proposed Fix to Issue #1019 - Hydra:member empty

### DIFF
--- a/tests/tripal_ws/http/TripalWebServicesContentTest.php
+++ b/tests/tripal_ws/http/TripalWebServicesContentTest.php
@@ -58,4 +58,105 @@ class TripalWebServicesContentTest extends TripalTestCase {
     $json = $response->json();
     $this->assertEquals($json['label'], "$label Collection");
   }
+
+  /**
+   * Tests the sanitizeFieldKeys() method.
+   * @group tripal_ws
+   * @group tripalWS-ServiceResource
+   */
+  public function testSanitizeFieldKeys() {
+
+    // We need a bundle in order to determine a valid base path.
+    $label = db_query('SELECT label FROM tripal_bundle LIMIT 1')->fetchField();
+    $bundle = tripal_load_bundle_entity(['label' => $label]);
+    $this->assertNotNull($bundle,
+      "Unable to load the associated bundle object.");
+
+    // We need a resource to add context to.
+    $base_path = "web-services/content/v0.1/$label";
+    $resource = new \TripalWebServiceResource($base_path);
+    $this->assertNotNull($resource,
+      "Unable to create a Tripal Web Service Resource for testing.");
+
+    // We need a ContentService object to call sanitizeFieldKeys().
+    module_load_include('inc', 'tripal_ws', 'includes/TripalWebService/TripalContentService_v0_1');
+    $web_service = new \TripalContentService_v0_1($base_path);
+    $this->assertNotNull($web_service,
+      "Unable to create a TripalContentService_v0_1 object for testing.");
+
+    // Now finally, we try to test it!
+    // - Associative array where keys are valid terms.
+    $value = [
+      'rdfs:type' => 'fake',
+    ];
+    $sanitized_value = $this->invokeMethod($web_service, 'sanitizeFieldKeys', [
+      $resource,
+      $value,
+      $bundle,
+      $base_path
+    ]);
+    $this->assertNotNull($sanitized_value,
+      "You should be able to sanitize a term-indexed array if terms are valid.");
+
+    // - Numeric keys to direct values.
+    $value = [
+      'fake',
+      'none',
+      5
+    ];
+    $sanitized_value = $this->invokeMethod($web_service, 'sanitizeFieldKeys', [
+      $resource,
+      $value,
+      $bundle,
+      $base_path
+    ]);
+    $this->assertNotNull($sanitized_value,
+      "You should be able to sanitize a numeric-indexed array if sub-elements are direct values.");
+
+    // - Numeric keys where value is an array with term keys.
+    $value = [
+      ['rdfs:type' => 'fake'],
+      ['rdfs:type' => 'none'],
+    ];
+    $sanitized_value = $this->invokeMethod($web_service, 'sanitizeFieldKeys', [
+      $resource,
+      $value,
+      $bundle,
+      $base_path
+    ]);
+    $this->assertNotNull($sanitized_value,
+      "You should be able to sanitize a numeric-indexed array if sub-elements are also arrays.");
+
+    // - Numeric keys where value is an array with random keys.
+    //   (random keys should be removed.)
+    $value = [
+      ['randomnotterm' => 'fake'],
+    ];
+    $sanitized_value = $this->invokeMethod($web_service, 'sanitizeFieldKeys', [
+      $resource,
+      $value,
+      $bundle,
+      $base_path
+    ]);
+    $this->assertEmpty($sanitized_value[0],
+      "You should be able to sanitize a numeric-indexed array if sub-elements arrays are not keyed with valid terms.");
+
+  }
+
+  /**
+   * Call protected/private method of a class.
+   *
+   * @param object &$object    Instantiated object that we will run method on.
+   * @param string $methodName Method name to call
+   * @param array  $parameters Array of parameters to pass into method.
+   *
+   * @return mixed Method return.
+   */
+  public function invokeMethod(&$object, $methodName, array $parameters = array()) {
+      $reflection = new \ReflectionClass(get_class($object));
+      $method = $reflection->getMethod($methodName);
+      $method->setAccessible(true);
+
+      return $method->invokeArgs($object, $parameters);
+  }
 }

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -514,7 +514,11 @@ class TripalContentService_v0_1 extends TripalWebService {
             $temp[$key] = $v;
           }
           $term['name'] = $key;
-
+        }
+        elseif (is_numeric($k)) {
+          // Key is non-vocabulary term:
+          // Index number (0, 1, 2...) of a hydra:member array.
+          $temp[$k] = $this->sanitizeFieldKeys($resource, $v, $bundle, $service_path);
         }
         else {
           // TODO: this is an error, if we get here then we have


### PR DESCRIPTION
Added additional condition in sanitize function to handle case when key is a non-vocabulary term such as the key/index (0,1,2...) of a hydra:member array.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue https://github.com/tripal/tripal/issues/1019 - hydra:member array not rendered.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
Implement a hydra:member instance to any field. Below is a sample code:

```
foreach ($items as $i => $item) {
  $entity->{$field_name}['und'][$delta]['value']['hydra:member'][$i] = array( 
    'rdfs:label' => $item['label'],
    'local:count' => $item['count'], 
   );
}
```

Save your code and clear the cache. Reload web service page containing your field.

A sample output of hydra:member implementation.
![image](https://user-images.githubusercontent.com/15472253/68220378-4abf8000-ffad-11e9-8efb-1f5264bfae45.png)


## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
