### PR TITLE
Proposed Fix to Issue #1022 - A and B

### DIFF
--- a/tests/tripal_ws/http/TripalWebServicesContentTest.php
+++ b/tests/tripal_ws/http/TripalWebServicesContentTest.php
@@ -38,10 +38,18 @@ class TripalWebServicesContentTest extends TripalTestCase {
    */
   public function testGettingListOfEntitiesInABundle() {
     // Get bundle label
-    $label = db_query('SELECT label FROM tripal_bundle LIMIT 1')->fetchField();
+    $label = db_query('SELECT label, name FROM tripal_bundle LIMIT 1')->fetchObject();
+
+    // Grant user permission to view bundle.
+    $bundle_name = 'view ' . $label->name;
+    if (!user_access($bundle_name)) {
+      // Either the user is anonymous or registered.
+      $role_id = (user_is_anonymous()) ? DRUPAL_ANONYMOUS_RID : DRUPAL_AUTHENTICATED_RID;
+      user_role_grant_permissions($role_id, array($bundle_name));
+    }
 
     // Call /web-services/content/v0.1/[label]
-    $response = $this->get("web-services/content/v0.1/$label");
+    $response = $this->get("web-services/content/v0.1/$label->label");
 
     // Verify the returned JSON matches the structure
     $response->assertSuccessful();
@@ -56,6 +64,6 @@ class TripalWebServicesContentTest extends TripalTestCase {
 
     // Verify the collection is of the correct type
     $json = $response->json();
-    $this->assertEquals($json['label'], "$label Collection");
+    $this->assertEquals($json['label'], "$label->label Collection");
   }
 }

--- a/tests/tripal_ws/http/TripalWebServicesContentTest.php
+++ b/tests/tripal_ws/http/TripalWebServicesContentTest.php
@@ -12,6 +12,14 @@ class TripalWebServicesContentTest extends TripalTestCase {
 
   /** @test */
   public function testGettingMainContentList() {
+    // Grant user permission to all content.
+    $role_id = (user_is_anonymous()) ? DRUPAL_ANONYMOUS_RID : DRUPAL_AUTHENTICATED_RID;
+    $bundles = db_query('SELECT name FROM tripal_bundle');
+    foreach($bundles as $bundle) {
+      $bundle_name = 'view ' . $bundle->name;
+      user_role_grant_permissions($role_id, array($bundle_name));
+    }
+
     $response = $this->get('web-services/content/v0.1');
 
     // Make sure it returned valid json
@@ -40,16 +48,13 @@ class TripalWebServicesContentTest extends TripalTestCase {
     // Get bundle label
     $label = db_query('SELECT label, name FROM tripal_bundle LIMIT 1')->fetchObject();
 
-    // Grant user permission to view bundle.
-    $bundle_name = 'view ' . $label->name;
-    if (!user_access($bundle_name)) {
-      // Either the user is anonymous or registered.
-      $role_id = (user_is_anonymous()) ? DRUPAL_ANONYMOUS_RID : DRUPAL_AUTHENTICATED_RID;
-      user_role_grant_permissions($role_id, array($bundle_name));
-    }
+    // Grant user permission to this content.
+    $role_id = (user_is_anonymous()) ? DRUPAL_ANONYMOUS_RID : DRUPAL_AUTHENTICATED_RID;
+    user_role_grant_permissions($role_id, array('view ' . $label->name));
 
     // Call /web-services/content/v0.1/[label]
-    $response = $this->get("web-services/content/v0.1/$label->label");
+    $ctype = preg_replace('/[^\w]/', '_', $label->label);
+    $response = $this->get("web-services/content/v0.1/" . $ctype);
 
     // Verify the returned JSON matches the structure
     $response->assertSuccessful();

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -875,6 +875,13 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
     $bundle = tripal_load_bundle_entity(['label' => $ctype]);
+    
+    // Check that the user has access to this bundle.  If not then the
+    // function call will throw an error.
+    if (!user_access('view ' . $bundle->name)) {
+      throw new Exception("Permission Denied.");
+    }
+        
     $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
     $term = reset($term);
 
@@ -1043,6 +1050,11 @@ class TripalContentService_v0_1 extends TripalWebService {
     // Iterate through the terms and add an entry in the collection.
     $i = 0;
     while ($bundle = $bundles->fetchObject()) {
+      if (!user_access('view ' . $bundle->name)) {
+        // Show only content types users have access to and skip the rest.
+        continue;
+      }
+      
       $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
       $term = reset($entity);
       $vocab = $term->vocab;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue https://github.com/tripal/tripal/issues/1022 - Limited access works only in viewing an entity (for anonymous user)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
A. EntryPoint
When resources are listed in **/web-services/content/v0.1**, all content types become available to user regardless of permission settings. The proposed fix in doContentTypeList() function excludes any content types based on permission configuration.

B. Content Type
While users will not be able to see content types they don't have permission through EntryPoint, they are not restricted to access a specific content type directly through the url. The proposed fix in doEntityList() ensures that content type is first checked for permission before rendering any information.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):
Configure a permission to an anonymous user by clicking on/off the checkbox for each content type you want to permit/restrict.

![Screen Shot 2019-11-05 at 1 10 17 PM](https://user-images.githubusercontent.com/15472253/68311202-d6511380-0076-11ea-8aa3-2a8bba777388.png)

To test

A. EntryPoint 
head to **web-services/content/v0.1**, content types where you have set to have permission to to view should become part of the list, otherwise excluded.

B. Content Type
for content type you have no view permission, access **web-services/content/v0.1/your restricted content type** (since this link is not available in A). A message "Permission Denied" will be displayed for this content.

![Screen Shot 2019-11-06 at 9 34 56 AM](https://user-images.githubusercontent.com/15472253/68312550-d81bd680-0078-11ea-84db-7f673e0c32b1.png)


## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
