### PR TITLE
Fix the range for datetime fields to +/-10

### DIFF
--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -1042,9 +1042,8 @@ function tripal_chado_bundle_instances_info_base(&$info, $entity_type, $bundle, 
         $base_info['widget']['settings']['increment'] = 1;
         $base_info['widget']['settings']['tz_handling'] = 'none';
         $base_info['widget']['settings']['collapsible'] = TRUE;
+        $base_info['widget']['settings']['year_range'] = '-10:+10';
 
-        // TODO: Add settings so that the minutes increment by 1.
-        // And turn off the timezone, as the Chado field doesn't support it.
         break;
     }
 


### PR DESCRIPTION
Issue #272 

## Description
The default range for datetime fields is +/- 3 which does not make sense for analysis records. As such, I've changed the default to +/-10 for Tripal-added datetime fields to make date entry easier. This setting can be configured on each Tripal site through the field settings.

## Testing?
1. Go to Structure > Tripal Content Types > Analysis (or any other content type with a datetime field)
2. Delete the datetime field (e.g. Date Performed for Analysis')
3. Check for new fields which will re-add the datetime field with the new settings.
4. Add/Edit an analysis to see the new extended range for the year.
![Screen Shot 2019-11-10 at 9 48 10 PM](https://user-images.githubusercontent.com/1566301/68559764-cd0fd000-0403-11ea-9355-5e9e12f6d7e1.png)
