### PR TITLE
This typographical error causes 404 errors

### DIFF
--- a/tripal_ws/tripal_ws.module
+++ b/tripal_ws/tripal_ws.module
@@ -39,7 +39,7 @@ require_once "includes/TripalFields/WebServicesFieldFormatter.inc";
 function tripal_ws_init() {
   global $base_url;
 
-  $api_url = $base_url . '/web-sevices/';
+  $api_url = $base_url . '/web-services/';
 
   $vocab = tripal_get_vocabulary_details('hydra');
 


### PR DESCRIPTION
Particularly with link checkers, this typo causes nearly every page to show up with an unnecessary 404 error due to this link

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#

Issue #

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
