### PR TITLE
NCBI API key

### DIFF
--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
@@ -214,7 +214,14 @@ function tripal_pub_PMID_search_init($search_str, $retmax) {
     "&usehistory=y" .
     "&term=" . urlencode($search_str);
 
-  usleep(333334);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
+  $api_key = variable_get('tripal_pub_importer_ncbi_api_key', NULL);
+  $sleep_time = 333334;
+  if (!empty($api_key)) {
+    $query_url .= "&api_key=" . $api_key;
+    $sleep_time = 100000;
+  }
+
+  usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
   $rfh = fopen($query_url, "r");
   if (!$rfh) {
     drupal_set_message('Could not perform Pubmed query. Cannot connect to Entrez.', 'error');
@@ -302,6 +309,13 @@ function tripal_pub_PMID_fetch($query_key, $web_env, $rettype = 'null',
     "&query_key=$query_key" .
     "&WebEnv=$web_env";
 
+  $api_key = variable_get('tripal_pub_importer_ncbi_api_key', NULL);
+  $sleep_time = 333334;
+  if (!empty($api_key)) {
+    $fetch_url .= "&api_key=" . $api_key;
+    $sleep_time = 100000;
+  }
+
   foreach ($args as $key => $value) {
     if (is_array($value)) {
       $fetch_url .= "&$key=";
@@ -314,7 +328,7 @@ function tripal_pub_PMID_fetch($query_key, $web_env, $rettype = 'null',
       $fetch_url .= "&$key=$value";
     }
   }
-  usleep(333334);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
+  usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
   $rfh = fopen($fetch_url, "r");
   if (!$rfh) {
     drupal_set_message('ERROR: Could not perform PubMed query.', 'error');

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
@@ -512,7 +512,7 @@ function tripal_pub_importer_ncbi_api_key_form($form, $form_state) {
  * @ingroup tripal_pub
  */
 function tripal_pub_importer_set_ncbi_api_key($form, $form_state) {
-  variable_set('tripal_pub_importer_ncbi_api_key', $form_state['values']['ncbi_api_key']);
+  variable_set('tripal_pub_importer_ncbi_api_key', check_plain($form_state['values']['ncbi_api_key']));
   drupal_set_message('NCBI API key has been saved successfully!');
   return $form['ncbi_api_key'];
 }

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
@@ -85,6 +85,8 @@ function tripal_pub_importers_list() {
           importer to run peridically by adding a cron job. </li> 
      </ol><br>");
 
+  $form = drupal_get_form('tripal_pub_importer_ncbi_api_key_form');
+  $page .= drupal_render($form);
 
   $table = [
     'header' => $headers,
@@ -449,6 +451,70 @@ function tripal_pub_importer_setup_form($form, &$form_state = NULL, $pub_import_
   $form['themed_element']['#theme'] = 'tripal_pub_importer_setup_form_elements';
 
   return $form;
+}
+
+/**
+ * The form used for setting the optional NCBI API key.
+ *
+ * @param $form
+ *   The form element to be populated.
+ * @param $form_state
+ *   The state of the form element to be populated.
+ *
+ * @return array
+ *   The populated form element.
+ *
+ * @ingroup tripal_pub
+ */
+function tripal_pub_importer_ncbi_api_key_form($form, $form_state) {
+  $description = t('Tripal imports publications using NCBI\'s ') 
+    . l('EUtils API', 'https://www.ncbi.nlm.nih.gov/books/NBK25500/')
+    . t(', which limits users and programs to a maximum of 3 requests per second without an API key. '
+        . 'However, NCBI allows users and programs to an increased maximum of 10 requests per second if '
+        . 'they provide a valid API key. This is particularly useful in speeding up large publication imports. '
+        . 'For more information on NCBI API keys, please ')
+    . l('see here', 'https://www.ncbi.nlm.nih.gov/books/NBK25497/#chapter2.Coming_in_December_2018_API_Key', array(
+      'attributes' => array(
+        'target' => 'blank',
+      ),
+    )) . '.';
+
+  $form['ncbi_api_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('(Optional) NCBI API key:'),
+    '#description' => $description,
+    '#default_value' => variable_get('tripal_pub_importer_ncbi_api_key', NULL),
+    '#ajax' => array(
+      'callback' => 'tripal_pub_importer_set_ncbi_api_key',
+      'wrapper' => 'ncbi_api_key',
+    ),
+    '#prefix' => '<div id="ncbi_api_key">',
+    '#suffix' => '</div>',
+  );
+
+  return $form;
+}
+
+/**
+ * This function saves the NCBI API key to the database.
+ *
+ * It is called when the user makes a change to the NCBI API key field and then
+ * moves their cursor out of the field.
+ *
+ * @param $form
+ *   The new form element.
+ * @param $form_state
+ *   The state of the new form element.
+ *
+ * @return array
+ *   The new api key field.
+ *
+ * @ingroup tripal_pub
+ */
+function tripal_pub_importer_set_ncbi_api_key($form, $form_state) {
+  variable_set('tripal_pub_importer_ncbi_api_key', $form_state['values']['ncbi_api_key']);
+  drupal_set_message('NCBI API key has been saved successfully!');
+  return $form['ncbi_api_key'];
 }
 
 /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# New Feature

Issue #1033 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds an option to the `admin/tripal/loaders/pub` page to provide an NCBI API key. The key is then used by the `PubBulkImporter`, which allows for more requests per second to be made to NCBI. 

## Testing
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1. Create an [NCBI API key](https://www.ncbi.nlm.nih.gov/books/NBK25497/#chapter2.Coming_in_December_2018_API_Key)
2. Navigate to `admin/tripal/loaders/pub`
3. Add your API key
4. Create a new Publication Bulk importer or run an existing one

While I was testing I found that the import process is still pretty slow, but I think the speedup is significant enough to be useful. My largest test was ~840 publications, which took ~15 minutes without the API key, and ~12 minutes with the API key.

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
