### PR TITLE
Adding Private BioData module

### DIFF
--- a/docs/extensions/administrative.rst
+++ b/docs/extensions/administrative.rst
@@ -3,6 +3,18 @@ Administrative
 
 The following modules provide support to Tripal site administrators.
 
+Private BioData
+-----------------
+
+.. image:: https://tripal.readthedocs.io/en/7.x-3.x/_images/Tripal-Gold.png
+  :target: https://tripal.readthedocs.io/en/7.x-3.x/extensions/module_rating.html#Gold
+  :alt: Tripal Rating: Gold
+  
+Make individual pages private while others of the same Tripal Content Type remain public! This module provides an additional permission, [Content type]: View Private Content for each Tripal Content Type and a TripalField to indicate which exact pages should be private.
+
+`Documentation <https://github.com/tripal/private_biodata/blob/master/README.md>`__
+`Repository <https://github.com/tripal/private_biodata>`__
+
 Tripal Alchemist
 -----------------
 


### PR DESCRIPTION
# Documentation / Badge Request

## Description

This issue is a request for a gold Tripal extension module badge.

Repository: https://github.com/tripal/private_biodata
Documentation: https://github.com/tripal/private_biodata/blob/master/README.md

Make individual pages private while others of the same Tripal Content Type remain public! This module provides an additional permission, [Content type]: View Private Content for each Tripal Content Type and a TripalField to indicate which exact pages should be private.

## Bronze

| Requirement                                                                              | Status        |
|-------------------------------------------------------------|------------|
| Has a public release.  | [Yes](https://github.com/tripal/private_biodata/releases)  |
| Should install on a Tripal site appropriate for the versions it supports.  | Yes as shown by TravisCI  |
| Defines any custom tables or materialized views in the install file (if applicable).  | No Custom Chado tables. Uses the Drupal Schema API for data storage. |
| Adds any needed controlled vocabulary terms in the install file (Tripal3).  | [Yes](https://github.com/tripal/private_biodata/blob/master/private_biodata.install#L11-L17)  |
| Provides Installation and admin instructions README.md (or RTD).  | Yes, in Readme  |
| Has a license (distributed with module).  | [Yes](https://github.com/tripal/private_biodata/blob/master/LICENSE) |

## Silver
| Requirement           | Status |
|------------------- |---------------------|
| Follows basic Drupal Coding standards; specifically, code format and API documentation.  | [Yes](https://github.com/tripal/private_biodata/blob/master/private_biodata.module#L53-L67) |
| Uses Tripal API functions. Specifically, it should use the Chado Query API for querying chado (if using chado as the storage system).  | Yes, using [TripalFields API](https://github.com/tripal/private_biodata/tree/master/includes/TripalFields) |
| Tripal Jobs API for long running processes.  | No long running processes. |
| TripalField class to add data to pages (Tripal3).  | [Yes](https://github.com/tripal/private_biodata/tree/master/includes/TripalFields/ncit__private)  |
| Provides ways to customize the module (e.g. drush options, field/formatter settings, admin UI).  |  Field widget and formatter settings. |
| Latest releases should follow Drupal naming best practices. e.g. first release for Drupal 7 should be: 7.x-1.x.   | Yes, [7.x-3.2](https://github.com/tripal/private_biodata/releases/tag/7.x-3.2) |

## Gold
| Requirement  | Status |
|-------------|---------|
| Extensive documentation for the module (similar to Tripal User’s Guide).  | Not needed for such a simple module. Usage documentation in readme. |
| Unit testing is implemented using PHPUnit with the TripalTestSuite or something similar.  | [Yes](https://github.com/tripal/private_biodata/tree/7.x-3.1#automated-testing) |
| Continuous integration is setup (e.g. such as with TravisCI).   | [Yes](https://travis-ci.org/github/tripal/private_biodata) |
| Imports data via Tripal’s importer class (Tripal3).  | Doesn't import data. |
| Tripal 3 fields are Fully compatible with web services.  | Yes: this field restricts access to the page through WS and through the UI. |
| The elementInfo function is fully implemented.  | [Yes](https://github.com/tripal/private_biodata/blob/master/includes/TripalFields/ncit__private/ncit__private.inc#L113-L126) but this field doesn't support filtering |
| The query and queryOrder functions fully implemented.  | No as this field doesn't support filtering. |
| Web Services uses Tripal’s Web Service Classes (Tripal3).  | n/a |
|  Code sniffing and testing coverage reports (optional but encouraged).  | [Test coverage through codeclimate](https://codeclimate.com/github/tripal/private_biodata) |
| Drupal.org vetted release (optional but encouraged).  | No |