### PR TITLE
Phylotree scale options, bug fixes

### DIFF
--- a/legacy/tripal_phylogeny/theme/js/tripal_phylogeny.js
+++ b/legacy/tripal_phylogeny/theme/js/tripal_phylogeny.js
@@ -2,129 +2,148 @@
 
 (function ($) {
 
-  var height = 0; // will be dynamically sized
+  "use strict";
 
-  $(document).ready( function () {
+  // Will be dynamically sized.
+  var height = 0;
 
-    // Callback function to determine node size.
-    var nodeSize = function(d) {
-      var size;
-      if (d.cvterm_name == "phylo_root") {
-        size = treeOptions['root_node_size']; 
-      }
-      if (d.cvterm_name == "phylo_interior") {
-        size = treeOptions['interior_node_size']; 
-      }
-      if (d.cvterm_name == "phylo_leaf") {
-        size = treeOptions['leaf_node_size']; 
-      }
-      return size;
-    }
+  // Store our function as a property of Drupal.behaviors.
+  Drupal.behaviors.TripalPhylotree = {
+    attach: function (context, settings) {
 
-    // Callback function to determine the node color.
-    var organismColor = function(d) {
-      var color = null;
-      if (d.genus) {
-        color = organismColors[d.genus + ' ' + d.species];
-      }
-      if (color) { 
-        return color; 
-      }
-      else { 
-        return 'grey'; 
-      }
-    };
-
-    // Callback for mouseover event on graph node d.
-    var nodeMouseOver = function(d) {
-      var el = $(this);
-      el.attr('cursor', 'pointer');
-      var circle = el.find('circle');
-      // highlight in yellow no matter if leaf or interior node
-      circle.attr('fill', 'yellow');
-      if(!d.children) {
-        // only leaf nodes have descriptive text
-        var txt = el.find('text');
-        txt.attr('font-weight', 'bold');
-      }
-    };
-    
-    // Callback for mouseout event on graph node d.
-    var nodeMouseOut = function(d) {
-      var el = $(this);
-      el.attr('cursor', 'default');
-      var circle = el.find('circle');
-      if(!d.children) {
-        // restore the color based on organism id for leaf nodes
-        circle.attr('fill', organismColor(d));
-        var txt = el.find('text');
-        txt.attr('font-weight', 'normal');
-      }
-      else {
-        // restore interior nodes to white
-        circle.attr('fill', 'white');
-      }
-    };
-    
-    // Callback for mousedown/click event on graph node d.
-    var nodeMouseDown = function(d) {
-      var el = $(this);
-      var title = (! d.children ) ? d.name : 'interior node ' + d.phylonode_id;
-
-      if(d.children) {
-        // interior node
-        if(d.phylonode_id) {
-        }
-        else {
-          // this shouldn't happen but ok
-        }
-      }
-      else {
-        // If this node is not associated with a feature but it has an 
-        // organism node then this is a taxonomic node and we want to
-        // link it to the organism page.
-        if (!d.feature_id && d.organism_node_id) {
-          window.location.replace(baseurl + '/node/' + d.organism_node_id);
-        }
-        // leaf node
-      }
-    };
-
-    // AJAX function for retrieving the tree data.
-    $.getJSON(phylotreeDataURL, function(treeData) {
-      displayData(treeData);
-      $('.phylogram-ajax-loader').hide();
-    });
-
-    // Creates the tree using the d3.phylogram.js library.
-    function displayData(treeData) {
-      height = graphHeight(treeData);
-      d3.phylogram.build('#phylogram', treeData, {
-        'width' : treeOptions['phylogram_width'],
-        'height' : height,
-        'fill' : organismColor,
-        'size' : nodeSize,
-        'nodeMouseOver' : nodeMouseOver,
-        'nodeMouseOut' : nodeMouseOut,
-        'nodeMouseDown' : nodeMouseDown,
-        'skipTicks' : treeOptions['skipTicks']
+      // Retrieve the data for this tree.
+      var data_url = Drupal.settings.tripal_chado.phylotree_url;
+      $.getJSON(data_url, function(treeData) {
+        phylogeny_display_data(treeData);
+        $('.phylogram-ajax-loader').hide();
       });
     }
+  }
 
-    /* graphHeight() generate graph height based on leaf nodes */
-    function graphHeight(data) {
-      function countLeafNodes(node) {
-        if(! node.children) {
-          return 1;
-        }
-        var ct = 0;
-        node.children.forEach( function(child) {
-          ct+= countLeafNodes(child);
-        });
-        return ct;
-      }
-      var leafNodeCt = countLeafNodes(data);
-      return 22 * leafNodeCt;
+  // Callback function to determine node size.
+  var phylogeny_node_size = function(d) {
+    var size;
+    var tree_options = Drupal.settings.tripal_chado.tree_options;
+    if (d.cvterm_name == "phylo_root") {
+      size = tree_options['root_node_size'];
     }
-  });
+    if (d.cvterm_name == "phylo_interior") {
+      size = tree_options['interior_node_size'];
+    }
+    if (d.cvterm_name == "phylo_leaf") {
+      size = tree_options['leaf_node_size'];
+    }
+    return size;
+  }
+
+  // Callback function to determine the node color.
+  var phylogeny_organism_color = function(d) {
+    var organism_color = Drupal.settings.tripal_chado.org_colors;
+    var color = null;
+
+    if (d.fo_genus) {
+      color = organism_color[d.fo_organism_id];
+    }
+    if (color) {
+      return color;
+    }
+    else {
+      return 'grey';
+    }
+  };
+
+  // Callback for mouseover event on graph node d.
+  var phylogeny_node_mouse_over = function(d) {
+    var el = $(this);
+    el.attr('cursor', 'pointer');
+    var circle = el.find('circle');
+    // highlight in yellow no matter if leaf or interior node
+    circle.attr('fill', 'yellow');
+    if(!d.children) {
+      // only leaf nodes have descriptive text
+      var txt = el.find('text');
+      txt.attr('font-weight', 'bold');
+    }
+  };
+
+  // Callback for mouseout event on graph node d.
+  var phylogeny_node_mouse_out = function(d) {
+    var el = $(this);
+    el.attr('cursor', 'default');
+    var circle = el.find('circle');
+    if(!d.children) {
+      // restore the color based on organism id for leaf nodes
+      circle.attr('fill', phylogeny_organism_color(d));
+      var txt = el.find('text');
+      txt.attr('font-weight', 'normal');
+    }
+    else {
+      // restore interior nodes to white
+      circle.attr('fill', 'white');
+    }
+  };
+
+  // Callback for mousedown/click event on graph node d.
+  var phylogeny_node_mouse_down = function(d) {
+    var el = $(this);
+    var title = (! d.children ) ? d.name : 'interior node ' + d.phylonode_id;
+
+    if(d.children) {
+      // interior node
+      if(d.phylonode_id) {
+      }
+      else {
+        // this shouldn't happen but ok
+      }
+    }
+    else {
+      if(d.feature_eid) {
+        window.location.href = baseurl + '/bio_data/' + d.feature_eid;
+
+        return;
+      }
+      // If this node is not associated with a feature but it has an
+      // organism node then this is a taxonomic node and we want to
+      // link it to the organism page.
+      if (!d.feature_id && d.organism_nid) {
+        window.location.replace(baseurl + '/node/' + d.organism_nid);
+      }
+      if (!d.feature_id && d.organism_eid) {
+        window.location.replace(baseurl + '/bio_data/' + d.organism_eid);
+      }
+      // leaf node
+    }
+  };
+
+  // Creates the tree using the d3.phylogram.js library.
+  function phylogeny_display_data(treeData) {
+    var height = phylogeny_graph_height(treeData);
+    var tree_options = Drupal.settings.tripal_chado.tree_options;
+    d3.phylogram.build('#phylogram', treeData, {
+      'width' : tree_options['phylogram_width'],
+      'height' : height,
+      'fill' : phylogeny_organism_color,
+      'size' : phylogeny_node_size,
+      'nodeMouseOver' : phylogeny_node_mouse_over,
+      'nodeMouseOut' : phylogeny_node_mouse_out,
+      'nodeMouseDown' : phylogeny_node_mouse_down,
+      'skipTicks' : tree_options['skipTicks']
+    });
+  }
+
+  /* graphHeight() generate graph height based on leaf nodes */
+  function phylogeny_graph_height(data) {
+    function count_leaf_nodes(node) {
+      if(! node.children) {
+        return 1;
+      }
+      var ct = 0;
+      node.children.forEach( function(child) {
+        ct+= count_leaf_nodes(child);
+      });
+      return ct;
+    }
+    var leafNodeCt = count_leaf_nodes(data);
+    return 22 * leafNodeCt;
+  }
 })(jQuery);

--- a/tripal_chado/includes/tripal_chado.phylotree.inc
+++ b/tripal_chado/includes/tripal_chado.phylotree.inc
@@ -60,7 +60,7 @@ function tripal_phylogeny_prepare_tree_viewer($phylotree)
         'interior_node_size' => variable_get('tripal_phylogeny_default_interior_node_size', 1),
         'leaf_node_size' => variable_get('tripal_phylogeny_default_leaf_node_size', 6),
         'skipTicks' => $skip_ticks,
-        'phylogram_scale' => variable_get('tripal_phylogeny_default_phylogram_scale', 6),
+        'phylogram_scale' => variable_get('tripal_phylogeny_default_phylogram_scale', 1),
       ],
       'org_colors' => $colors,
     ],

--- a/tripal_chado/includes/tripal_chado.phylotree.inc
+++ b/tripal_chado/includes/tripal_chado.phylotree.inc
@@ -4,7 +4,8 @@
  *
  * @param $phylotree
  */
-function tripal_phylogeny_prepare_tree_viewer($phylotree) {
+function tripal_phylogeny_prepare_tree_viewer($phylotree)
+{
 
   // If the phylotree is not provided then just return;
   if (!$phylotree) {
@@ -59,6 +60,7 @@ function tripal_phylogeny_prepare_tree_viewer($phylotree) {
         'interior_node_size' => variable_get('tripal_phylogeny_default_interior_node_size', 1),
         'leaf_node_size' => variable_get('tripal_phylogeny_default_leaf_node_size', 6),
         'skipTicks' => $skip_ticks,
+        'phylogram_scale' => variable_get('tripal_phylogeny_default_phylogram_scale', 6),
       ],
       'org_colors' => $colors,
     ],
@@ -99,7 +101,8 @@ function tripal_phylogeny_prepare_tree_viewer($phylotree) {
  *
  * @ingroup tripal_phylogeny
  */
-function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
+function tripal_phylogeny_ajax_get_tree_json($phylotree_id)
+{
 
   $phylotree = chado_generate_var('phylotree', ['phylotree_id' => $phylotree_id]);
 
@@ -135,8 +138,7 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
         LEFT OUTER JOIN [chado_organism] co       ON co.organism_id = o.organism_id
       WHERE n.phylotree_id = :phylotree_id
     ";
-  }
-  else {
+  } else {
     $sql = "
       SELECT
         n.phylonode_id, n.parent_phylonode_id, n.label AS name, n.distance AS length,
@@ -165,13 +167,13 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
 
   if ($results) {
     while ($r = $results->fetchObject()) {
-      $phylonode_id = (int) $r->phylonode_id;
+      $phylonode_id = (int)$r->phylonode_id;
 
       // expect all nodes to have these properties
       $node = [
         'phylonode_id' => $phylonode_id,
-        'parent_phylonode_id' => (int) $r->parent_phylonode_id,
-        'length' => (double) $r->length,
+        'parent_phylonode_id' => (int)$r->parent_phylonode_id,
+        'length' => (double)$r->length,
         'cvterm_name' => $r->cvterm_name,
       ];
 
@@ -186,30 +188,28 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
       }
       // If this node is associated with a feature then add in the details
       if ($r->feature_id) {
-        $node['feature_id'] = (int) $r->feature_id;
+        $node['feature_id'] = (int)$r->feature_id;
         $node['feature_name'] = $r->feature_name;
         if (module_exists('tripal_phylogeny')) {
-          $node['feature_nid'] = (int) $r->feature_nid;
-        }
-        else {
+          $node['feature_nid'] = (int)$r->feature_nid;
+        } else {
           $entity_id = chado_get_record_entity_by_table('feature', $r->feature_id);
-          $node['feature_eid'] = (int) $entity_id;
+          $node['feature_eid'] = (int)$entity_id;
         }
       }
       // Add in the organism fields when they are available via the
       // phylonode_organism table.
       if ($r->organism_id) {
-        $node['organism_id'] = (int) $r->organism_id;
+        $node['organism_id'] = (int)$r->organism_id;
         $node['common_name'] = $r->common_name;
         $node['abbreviation'] = $r->abbreviation;
         $node['genus'] = $r->genus;
         $node['species'] = $r->species;
         if (module_exists('tripal_phylogeny')) {
-          $node['organism_nid'] = (int) $r->organism_nid;
-        }
-        else {
+          $node['organism_nid'] = (int)$r->organism_nid;
+        } else {
           $entity_id = chado_get_record_entity_by_table('organism', $r->organism_id);
-          $node['organism_eid'] = (int) $entity_id;
+          $node['organism_eid'] = (int)$entity_id;
         }
         // If the node does not have a name but is linked to an organism
         // then set the name to be that of the genus and species.
@@ -220,17 +220,16 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
       // Add in the organism fields when they are available via the
       // the phylonode.feature_id FK relationship.
       if ($r->fo_organism_id) {
-        $node['fo_organism_id'] = (int) $r->fo_organism_id;
+        $node['fo_organism_id'] = (int)$r->fo_organism_id;
         $node['fo_common_name'] = $r->fo_common_name;
         $node['fo_abbreviation'] = $r->fo_abbreviation;
         $node['fo_genus'] = $r->fo_genus;
         $node['fo_species'] = $r->fo_species;
         if (module_exists('tripal_phylogeny')) {
-          $node['fo_organism_nid'] = (int) $r->fo_organism_nid;
-        }
-        else {
+          $node['fo_organism_nid'] = (int)$r->fo_organism_nid;
+        } else {
           $entity_id = chado_get_record_entity_by_table('organism', $r->fo_organism_id);
-          $node['fo_organism_eid'] = (int) $entity_id;
+          $node['fo_organism_eid'] = (int)$entity_id;
         }
       }
 
@@ -244,8 +243,7 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
         $parent_ref = &$phylonodes[$node['parent_phylonode_id']];
         // Append node refernce to children.
         $parent_ref['children'][] = &$node;
-      }
-      else {
+      } else {
         $root_phylonode_ref = &$node;
       }
     }
@@ -262,7 +260,8 @@ function tripal_phylogeny_ajax_get_tree_json($phylotree_id) {
  *
  */
 
-function tripal_phylogeny_admin_phylotrees_listing() {
+function tripal_phylogeny_admin_phylotrees_listing()
+{
   $output = '';
 
   // set the breadcrumb
@@ -278,8 +277,7 @@ function tripal_phylogeny_admin_phylotrees_listing() {
   $view = views_embed_view('tripal_phylogeny_admin_phylotree', 'default');
   if (isset($view)) {
     $output .= $view;
-  }
-  else {
+  } else {
     $output .= '<p>The Phylotree module uses primarily views to provide an '
       . 'administrative interface. Currently one or more views needed for this '
       . 'administrative interface are disabled. <strong>Click each of the following links to '
@@ -297,7 +295,8 @@ function tripal_phylogeny_admin_phylotrees_listing() {
  * @param unknown $form
  * @param unknown $form_state
  */
-function tripal_phylogeny_default_plots_form($form, &$form_state) {
+function tripal_phylogeny_default_plots_form($form, &$form_state, array $category = array())
+{
   $form = [];
 
   $form['plot_settings'] = [
@@ -318,6 +317,27 @@ function tripal_phylogeny_default_plots_form($form, &$form_state) {
     ],
     '#size' => 5,
   ];
+
+  $category += array(
+    'category' => '',
+    'recipients' => '',
+    'reply' => '',
+    'weight' => 0,
+    'selected' => 0,
+    'cid' => NULL,
+  );
+  $form['plot_settings']['phylogram_scale'] = [
+    '#type' => 'select',
+    '#title' => t('Phylogram Scale'),
+    '#description' => 'Please specify the scale to use.',
+    '#default_value' => variable_get('tripal_phylogeny_default_phylogram_scale', 1),
+    '#options' => array(
+      1 => t('Linear'),
+      2 => t('Logarithmic'),
+    ),
+    '#size' => 2,
+  ];
+
 
   $form['node_settings'] = [
     '#type' => 'fieldset',
@@ -447,7 +467,8 @@ function tripal_phylogeny_default_plots_form($form, &$form_state) {
  *
  * @ingroup tripal_phylogeny
  */
-function tripal_phylogeny_default_plots_form_validate($form, &$form_state) {
+function tripal_phylogeny_default_plots_form_validate($form, &$form_state)
+{
 
 }
 
@@ -456,7 +477,8 @@ function tripal_phylogeny_default_plots_form_validate($form, &$form_state) {
  * @param unknown $form
  * @param unknown $form_state
  */
-function tripal_phylogeny_default_plots_form_submit($form, &$form_state) {
+function tripal_phylogeny_default_plots_form_submit($form, &$form_state)
+{
   // Rebuild this form after submission so that any changes are reflected in
   // the flat tables.
   $form_state['rebuild'] = TRUE;
@@ -467,6 +489,7 @@ function tripal_phylogeny_default_plots_form_submit($form, &$form_state) {
     variable_set('tripal_phylogeny_default_root_node_size', $form_state['values']['root_node_size']);
     variable_set('tripal_phylogeny_default_interior_node_size', $form_state['values']['interior_node_size']);
     variable_set('tripal_phylogeny_default_leaf_node_size', $form_state['values']['leaf_node_size']);
+    variable_set('tripal_phylogeny_default_phylogram_scale', $form_state['values']['phylogram_scale']);
 
     $num_orgs = $form_state['values']['num_orgs'];
     variable_set("tripal_phylogeny_num_orgs", $num_orgs);
@@ -491,7 +514,8 @@ function tripal_phylogeny_default_plots_form_submit($form, &$form_state) {
  *
  * @param unknown $variables
  */
-function theme_tripal_phylogeny_admin_org_color_tables($variables) {
+function theme_tripal_phylogeny_admin_org_color_tables($variables)
+{
   $fields = $variables['element'];
   $num_orgs = $fields['num_orgs']['#value'];
   $headers = ['Organism', 'Color', ''];
@@ -524,7 +548,8 @@ function theme_tripal_phylogeny_admin_org_color_tables($variables) {
  * @param $form
  * @param $form_state
  */
-function tripal_phylogeny_default_plots_form_ajax_callback($form, $form_state) {
+function tripal_phylogeny_default_plots_form_ajax_callback($form, $form_state)
+{
 
   return $form['node_settings']['org_table'];
 }

--- a/tripal_chado/includes/tripal_chado.phylotree.inc
+++ b/tripal_chado/includes/tripal_chado.phylotree.inc
@@ -295,7 +295,7 @@ function tripal_phylogeny_admin_phylotrees_listing()
  * @param unknown $form
  * @param unknown $form_state
  */
-function tripal_phylogeny_default_plots_form($form, &$form_state, array $category = array())
+function tripal_phylogeny_default_plots_form($form, &$form_state)
 {
   $form = [];
 
@@ -318,14 +318,6 @@ function tripal_phylogeny_default_plots_form($form, &$form_state, array $categor
     '#size' => 5,
   ];
 
-  $category += array(
-    'category' => '',
-    'recipients' => '',
-    'reply' => '',
-    'weight' => 0,
-    'selected' => 0,
-    'cid' => NULL,
-  );
   $form['plot_settings']['phylogram_scale'] = [
     '#type' => 'select',
     '#title' => t('Phylogram Scale'),

--- a/tripal_chado/theme/js/tripal_phylogeny.js
+++ b/tripal_chado/theme/js/tripal_phylogeny.js
@@ -1,16 +1,16 @@
 /* phylotree d3js graphs */
 
 (function ($) {
-    
+
   "use strict";
 
   // Will be dynamically sized.
-  var height = 0; 
+  var height = 0;
 
   // Store our function as a property of Drupal.behaviors.
   Drupal.behaviors.TripalPhylotree = {
     attach: function (context, settings) {
-      
+
       // Retrieve the data for this tree.
       var data_url = Drupal.settings.tripal_chado.phylotree_url;
       $.getJSON(data_url, function(treeData) {
@@ -25,13 +25,13 @@
     var size;
     var tree_options = Drupal.settings.tripal_chado.tree_options;
     if (d.cvterm_name == "phylo_root") {
-      size = tree_options['root_node_size']; 
+      size = tree_options['root_node_size'];
     }
     if (d.cvterm_name == "phylo_interior") {
-      size = tree_options['interior_node_size']; 
+      size = tree_options['interior_node_size'];
     }
     if (d.cvterm_name == "phylo_leaf") {
-      size = tree_options['leaf_node_size']; 
+      size = tree_options['leaf_node_size'];
     }
     return size;
   }
@@ -40,14 +40,15 @@
   var phylogeny_organism_color = function(d) {
     var organism_color = Drupal.settings.tripal_chado.org_colors;
     var color = null;
-    if (d.genus) {
-      color = organism_color[d.organism_id];
+
+    if (d.fo_genus) {
+      color = organism_color[d.fo_organism_id];
     }
-    if (color) { 
-      return color; 
+    if (color) {
+      return color;
     }
-    else { 
-      return 'grey'; 
+    else {
+      return 'grey';
     }
   };
 
@@ -64,7 +65,7 @@
       txt.attr('font-weight', 'bold');
     }
   };
-  
+
   // Callback for mouseout event on graph node d.
   var phylogeny_node_mouse_out = function(d) {
     var el = $(this);
@@ -81,7 +82,7 @@
       circle.attr('fill', 'white');
     }
   };
-  
+
   // Callback for mousedown/click event on graph node d.
   var phylogeny_node_mouse_down = function(d) {
     var el = $(this);
@@ -96,7 +97,12 @@
       }
     }
     else {
-      // If this node is not associated with a feature but it has an 
+      if(d.feature_eid) {
+        window.location.href = baseurl + '/bio_data/' + d.feature_eid;
+
+        return;
+      }
+      // If this node is not associated with a feature but it has an
       // organism node then this is a taxonomic node and we want to
       // link it to the organism page.
       if (!d.feature_id && d.organism_nid) {
@@ -121,7 +127,8 @@
       'nodeMouseOver' : phylogeny_node_mouse_over,
       'nodeMouseOut' : phylogeny_node_mouse_out,
       'nodeMouseDown' : phylogeny_node_mouse_down,
-      'skipTicks' : tree_options['skipTicks']
+      'skipTicks' : tree_options['skipTicks'],
+      'phylogram_scale' : tree_options['phylogram_scale']
     });
   }
 


### PR DESCRIPTION
### New Feature and Bug Fixes
This commit adds the option to change the horizontal scale in phylotrees to either linear (default) or logarithmic, as we've found that a logarithmic scale sometimes makes phylotrees more user-friendly.

This commit also fixes two bugs in the phylotree code where the specified colors for each organism were not working, and the feature names were not linking correctly. These bugs were fixed by @almasaeed2010.

## Testing
These changes can be tested simply by going to any Phylogenetic Tree (set up via the Chado Newick Tree Loader), and clicking on the blue box in the Tree View tab to view all settings for the tree. The scale can be changed under the setting 'Phylogram Scale', and the colors can be changed under 'Node Colors by Organism'.

## Screenshots (if appropriate):
The first screenshot is an example of a phylotree with a linear scale, and the second is of a phylotree with a logarithmic scale.

<img width="521" alt="Screen Shot 2020-06-30 at 3 29 06 PM" src="https://user-images.githubusercontent.com/50276746/86170306-eecfdb80-bae8-11ea-8e33-b291a772fd85.png">

<img width="680" alt="Screen Shot 2020-06-30 at 3 29 38 PM" src="https://user-images.githubusercontent.com/50276746/86170318-f42d2600-bae8-11ea-9fbc-f974ea44d974.png">
