### PR TITLE
Filtering sub elements in Tripal Entity Views.

### DIFF
--- a/tripal/tripal_views_query.inc
+++ b/tripal/tripal_views_query.inc
@@ -112,7 +112,7 @@ class tripal_views_query extends views_plugin_query {
       // For fields compatible with the Tripal storage API, the
       // incoming $field_name is a combination of the entity term ID,
       // followed by the field name and the the sub element string, with
-      // sub elements children separated by a comma.  For non Tripal 
+      // sub elements children separated by a period.  For non Tripal
       // storage API the $field_name is a combination of the table name
       // followed by the table column.  We have to handle both because
       // a TripalEntity can have both types attached.
@@ -121,8 +121,8 @@ class tripal_views_query extends views_plugin_query {
       if (count($elements) > 2) {
         $bundle_term = array_shift($elements);
         $field_name = array_shift($elements);
-        // put the sub elements back together into a string with a 
-        // comma delimeter.
+        $field = field_info_field($field_name);
+        // put the sub elements back together into a string with a comma.
         $element_name = implode(',', $elements);
       }
       if (count($elements) == 2) {
@@ -146,7 +146,7 @@ class tripal_views_query extends views_plugin_query {
         // Construct the field term.
         $field_term = $instance['settings']['term_vocabulary'] . ':' . $instance['settings']['term_accession'];
 
-        // Let's add add on the $field_term to the element_name and add the
+        // Let's add on the $field_term to the element_name and add the
         // query condition.
         if ($element_name) {
           $element_name = $field_term . ',' . $element_name;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue: https://github.com/tripal/tripal_analysis_interpro/issues/31

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
An issue was reported on the Tripal Analysis InterPro project by @martacds.  The problem is that when trying to add a filter to a view it's not working. The example is when trying to add a filter for annotations (CV terms)_ on a feature page (i.e. for InterPro terms).  Adding the filter works just fine, but it doesn't actually do any filtering.  

The problem is actually much bigger than just filtering on annotations (cv terms). It occurs for any field that has sub elements. For example, adding a 'Genus' or 'Species' filter also has no effect as those are sub elements of the `obi__organism` field.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

To test this before pulling the branch, try testing adding a 'Genus' or 'Species' filter to any View that searches a feature.   It will not work.   then pull the branch and rerun the View. The 'Genus' or 'Species' filter should now work.  

You can also test with any other field that has sub elements (e.g. relationships, cv terms).


