### PR TITLE
1077 legacy content

### DIFF
--- a/tripal_chado/includes/TripalFields/data__protein_sequence/data__protein_sequence.inc
+++ b/tripal_chado/includes/TripalFields/data__protein_sequence/data__protein_sequence.inc
@@ -93,7 +93,7 @@ class data__protein_sequence extends ChadoField {
       WHERE
         FR.object_id = :feature_id and
         CVT.name = 'polypeptide' and
-        RCVT.name = 'derives_from'
+        (RCVT.name = 'derives_from' or RCVT.name = 'part_of')
       ORDER BY FR.rank ASC
     ";
     $proteins = chado_query($sql, [':feature_id' => $feature->feature_id]);

--- a/tripal_chado/includes/TripalFields/data__protein_sequence/data__protein_sequence.inc
+++ b/tripal_chado/includes/TripalFields/data__protein_sequence/data__protein_sequence.inc
@@ -93,7 +93,7 @@ class data__protein_sequence extends ChadoField {
       WHERE
         FR.object_id = :feature_id and
         CVT.name = 'polypeptide' and
-        (RCVT.name = 'derives_from' or RCVT.name = 'part_of')
+        RCVT.name  IN ('derives_from', 'part_of')
       ORDER BY FR.rank ASC
     ";
     $proteins = chado_query($sql, [':feature_id' => $feature->feature_id]);

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -237,6 +237,7 @@ class sbo__relationship extends ChadoField {
     // Determine the name and type columns.
     $this->base_name_columns = [];
     $this->base_type_column = 'table_name';
+    //dpm($instance['settings']['chado_table']);
     switch ($instance['settings']['chado_table']) {
 
       // TODO: note that Chado 1.4 will add types to, at least,
@@ -266,6 +267,12 @@ class sbo__relationship extends ChadoField {
         $this->base_name_columns = ['name'];
         $this->base_type_column = 'type_id';
         break;
+
+      case 'feature_relationship':
+        $this->base_name_columns = ['uniquename'];
+        $this->base_type_column = 'type_id';
+      break;
+
       default:
         // @todo update this to use the schema.
         $this->base_name_columns = ['name'];

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -266,7 +266,6 @@ class sbo__relationship extends ChadoField {
         $this->base_name_columns = ['name'];
         $this->base_type_column = 'type_id';
         break;
-
       default:
         // @todo update this to use the schema.
         $this->base_name_columns = ['name'];

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -237,7 +237,6 @@ class sbo__relationship extends ChadoField {
     // Determine the name and type columns.
     $this->base_name_columns = [];
     $this->base_type_column = 'table_name';
-    //dpm($instance['settings']['chado_table']);
     switch ($instance['settings']['chado_table']) {
 
       // TODO: note that Chado 1.4 will add types to, at least,
@@ -267,11 +266,6 @@ class sbo__relationship extends ChadoField {
         $this->base_name_columns = ['name'];
         $this->base_type_column = 'type_id';
         break;
-
-      case 'feature_relationship':
-        $this->base_name_columns = ['uniquename'];
-        $this->base_type_column = 'type_id';
-      break;
 
       default:
         // @todo update this to use the schema.

--- a/tripal_chado/includes/TripalFields/so__transcript/so__transcript_formatter.inc
+++ b/tripal_chado/includes/TripalFields/so__transcript/so__transcript_formatter.inc
@@ -32,7 +32,7 @@ class so__transcript_formatter extends ChadoFieldFormatter {
       $loc = $transcript['SO:0000735'];
       $type = $transcript['rdfs:type'];
 
-      // Add a link i there is an entity.
+      // Add a link if there is an entity.
       if (array_key_exists('entity', $item['value']) and $item['value']['entity']) {
         list($entity_type, $entity_id) = explode(':', $item['value']['entity']);
         $feature_name = l($feature_name, "bio_data/" . $entity_id, ['attributes' => ['target' => "_blank"]]);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug fix

Issue #1077

## Description
For protein sequences in Tripal 3, "part_of" relationships are also shown to make the field backwards compatible with features loaded with the Tripal 2 version of the GFF loader.

As discussed in the issue, this change _does not_ migrate legacy content to use the 'derives_from' relationship. This is still being left up to the individual site to enact that change. 

## Additional Notes (if any):
Also fixes a tiny typo in so__transcript_formatter.inc
