### PR TITLE
Alter hooks for field/field instance info arrays

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -636,6 +636,7 @@ function tripal_tripal_cron_notification() {
   foreach ($all_bundles as $bundle_name) {
     // Get the bundle object.
     $bundle = tripal_load_bundle_entity(['name' => $bundle_name->name]);
+    $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
     if (!$bundle) {
       tripal_report_error('tripal', TRIPAL_ERROR, "Unrecognized bundle name '%bundle'.",
         ['%bundle' => $bundle_name]);
@@ -647,7 +648,7 @@ function tripal_tripal_cron_notification() {
       $function = $module . '_bundle_fields_info';
       $entity_type = 'TripalEntity';
       $info = $function($entity_type, $bundle);
-      drupal_alter('bundle_fields_info', $info, $entity_type, $bundle);
+      drupal_alter('bundle_fields_info', $info, $bundle, $term);
       foreach ($info as $field_name => $details) {
 
         // If the field already exists then skip it.
@@ -674,7 +675,7 @@ function tripal_tripal_cron_notification() {
       $function = $module . '_bundle_instances_info';
       $entity_type = 'TripalEntity';
       $info = $function($entity_type, $bundle);
-      drupal_alter('bundle_instances_info', $info, $entity_type, $bundle);
+      drupal_alter('bundle_instances_info', $info, $bundle, $term);
       foreach ($info as $field_name => $details) {
 
         // If the field is already attached to this bundle then skip it.

--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -645,8 +645,9 @@ function tripal_tripal_cron_notification() {
     $modules = module_implements('bundle_fields_info');
     foreach ($modules as $module) {
       $function = $module . '_bundle_fields_info';
-      $info = $function('TripalEntity', $bundle);
-      drupal_alter('bundle_fields_info', $info, 'TripalEntity', $bundle);
+      $entity_type = 'TripalEntity';
+      $info = $function($entity_type, $bundle);
+      drupal_alter('bundle_fields_info', $info, $entity_type, $bundle);
       foreach ($info as $field_name => $details) {
 
         // If the field already exists then skip it.
@@ -671,8 +672,9 @@ function tripal_tripal_cron_notification() {
     $modules = module_implements('bundle_instances_info');
     foreach ($modules as $module) {
       $function = $module . '_bundle_instances_info';
-      $info = $function('TripalEntity', $bundle);
-      drupal_alter('bundle_instances_info', $info, 'TripalEntity', $bundle);
+      $entity_type = 'TripalEntity';
+      $info = $function($entity_type, $bundle);
+      drupal_alter('bundle_instances_info', $info, $entity_type, $bundle);
       foreach ($info as $field_name => $details) {
 
         // If the field is already attached to this bundle then skip it.

--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -646,6 +646,7 @@ function tripal_tripal_cron_notification() {
     foreach ($modules as $module) {
       $function = $module . '_bundle_fields_info';
       $info = $function('TripalEntity', $bundle);
+      drupal_alter('bundle_fields_info', $info, 'TripalEntity', $bundle);
       foreach ($info as $field_name => $details) {
 
         // If the field already exists then skip it.
@@ -671,6 +672,7 @@ function tripal_tripal_cron_notification() {
     foreach ($modules as $module) {
       $function = $module . '_bundle_instances_info';
       $info = $function('TripalEntity', $bundle);
+      drupal_alter('bundle_instances_info', $info, 'TripalEntity', $bundle);
       foreach ($info as $field_name => $details) {
 
         // If the field is already attached to this bundle then skip it.

--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -636,12 +636,13 @@ function tripal_tripal_cron_notification() {
   foreach ($all_bundles as $bundle_name) {
     // Get the bundle object.
     $bundle = tripal_load_bundle_entity(['name' => $bundle_name->name]);
-    $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
     if (!$bundle) {
       tripal_report_error('tripal', TRIPAL_ERROR, "Unrecognized bundle name '%bundle'.",
         ['%bundle' => $bundle_name]);
       return FALSE;
     }
+    $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
+
     // Allow modules to add fields to the new bundle.
     $modules = module_implements('bundle_fields_info');
     foreach ($modules as $module) {

--- a/tripal/api/tripal.fields.api.inc
+++ b/tripal/api/tripal.fields.api.inc
@@ -105,8 +105,12 @@ function hook_bundle_fields_info($entity_type, $bundle) {
  *
  * @param $info
  *  The fields info array for all fields.
+ * @param $bundle
+ *  The bundle content type object that the field belongs to.
+ * @param $term
+ *  The bundle type term.
  */
-function hook_bundle_fields_info_alter(&$info, $entity_type, $bundle) {
+function hook_bundle_fields_info_alter(&$info, $bundle, $term) {
 
 }
 
@@ -136,8 +140,12 @@ function hook_bundle_instances_info($entity_type, $bundle) {
  *
  * @param $info
  *  The field instance info array for all fields.
+ * @param $bundle
+ *  The bundle content type object that the field belongs to.
+ * @param $term
+ *  The bundle type term.
  */
-function hook_bundle_instances_info_alter(&$info, $entity_type, $bundle) {
+function hook_bundle_instances_info_alter(&$info, $bundle, $term) {
 
 }
 /**

--- a/tripal/api/tripal.fields.api.inc
+++ b/tripal/api/tripal.fields.api.inc
@@ -95,6 +95,22 @@ function hook_bundle_fields_info($entity_type, $bundle) {
 }
 
 /**
+ * Allows a module to adjust a field's info settings.
+ *
+ * Modules should only adjust the info array for fields that
+ * they manage and not fields that were created by other modules. For example,
+ * if a field corresponds to a column in a custom table of Chado, then the
+ * tripal_chado module will automatically create a field for it. This function
+ * can be used to override the default settings created by Chado.
+ *
+ * @param $info
+ *  The fields info array for all fields.
+ */
+function hook_bundle_fields_info_alter(&$info, $entity_type, $bundle) {
+
+}
+
+/**
  * Allows a module to return the field instances of a bundle.
  *
  * @param $entity_type
@@ -108,6 +124,22 @@ function hook_bundle_instances_info($entity_type, $bundle) {
 
 }
 
+
+/**
+ * Allows a module to adjust field instances info settings.
+ *
+ * Modules should only adjust the info array for field instances that
+ * they manage and not fields that were created by other modules. For example,
+ * if a field corresponds to a column in a custom table of Chado, then the
+ * tripal_chado module will automatically create a field for it. This function
+ * can be used to override the default settings created by Chado.
+ *
+ * @param $info
+ *  The field instance info array for all fields.
+ */
+function hook_bundle_instances_info_alter(&$info, $entity_type, $bundle) {
+
+}
 /**
  * Indicate if a field has an empty value.
  *

--- a/tripal/includes/tripal.admin_blocks.inc
+++ b/tripal/includes/tripal.admin_blocks.inc
@@ -17,6 +17,7 @@
 function tripal_admin_notification_import_field($field_name_note, $bundle_id, $module, $field_or_instance) {
   // Get the bundle object.
   $bundle = tripal_load_bundle_entity(['name' => $bundle_id]);
+  $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
   if (!$bundle) {
     tripal_report_error('tripal', TRIPAL_ERROR, "Unrecognized bundle name '%bundle'.",
       ['%bundle' => $bundle_id]);
@@ -28,7 +29,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
     $function = $module . '_bundle_fields_info';
     $entity_type = 'TripalEntity';
     $info = $function($entity_type, $bundle);
-    drupal_alter('bundle_fields_info', $info, $entity_type, $bundle);
+    drupal_alter('bundle_fields_info', $info, $bundle, $term);
     foreach ($info as $field_name => $details) {
       $field = field_info_field($field_name);
       if ($details['field_name'] == $field_name_note) {
@@ -48,7 +49,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
       $function = $module . '_bundle_instances_info';
       $entity_type = 'TripalEntity';
       $info = $function($entity_type, $bundle);
-      drupal_alter('_bundle_instances_info', $info, $entity_type, $bundle);
+      drupal_alter('_bundle_instances_info', $info, $bundle, $term);
       foreach ($info as $field_name => $details) {
         if ($details['field_name'] == $field_name_note) {
           // Create the field instance.

--- a/tripal/includes/tripal.admin_blocks.inc
+++ b/tripal/includes/tripal.admin_blocks.inc
@@ -17,14 +17,16 @@
 function tripal_admin_notification_import_field($field_name_note, $bundle_id, $module, $field_or_instance) {
   // Get the bundle object.
   $bundle = tripal_load_bundle_entity(['name' => $bundle_id]);
-  $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
   if (!$bundle) {
     tripal_report_error('tripal', TRIPAL_ERROR, "Unrecognized bundle name '%bundle'.",
       ['%bundle' => $bundle_id]);
     drupal_goto("admin/dashboard");
     return FALSE;
   }
+  $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
 
+
+  $instance = NULL;
   if ($field_or_instance == 'field') {
     $function = $module . '_bundle_fields_info';
     $entity_type = 'TripalEntity';
@@ -49,7 +51,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
       $function = $module . '_bundle_instances_info';
       $entity_type = 'TripalEntity';
       $info = $function($entity_type, $bundle);
-      drupal_alter('_bundle_instances_info', $info, $bundle, $term);
+      drupal_alter('bundle_instances_info', $info, $bundle, $term);
       foreach ($info as $field_name => $details) {
         if ($details['field_name'] == $field_name_note) {
           // Create the field instance.
@@ -73,7 +75,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
       ->execute();
   }
   else {
-    drupal_set_message(t("There was a problem creating: %field", ['%field' => $info[$field_name]['label']]));
+    drupal_set_message(t("There was a problem creating field."), 'error');
   }
 
   drupal_goto("admin/dashboard");

--- a/tripal/includes/tripal.admin_blocks.inc
+++ b/tripal/includes/tripal.admin_blocks.inc
@@ -26,8 +26,9 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
 
   if ($field_or_instance == 'field') {
     $function = $module . '_bundle_fields_info';
-    $info = $function('TripalEntity', $bundle);
-    drupal_alter('bundle_fields_info', $info, 'TripalEntity', $bundle);
+    $entity_type = 'TripalEntity';
+    $info = $function($entity_type, $bundle);
+    drupal_alter('bundle_fields_info', $info, $entity_type, $bundle);
     foreach ($info as $field_name => $details) {
       $field = field_info_field($field_name);
       if ($details['field_name'] == $field_name_note) {
@@ -45,8 +46,9 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
   else {
     if ($field_or_instance == 'instance') {
       $function = $module . '_bundle_instances_info';
-      $info = $function('TripalEntity', $bundle);
-      drupal_alter('_bundle_instances_info', $info, 'TripalEntity', $bundle);
+      $entity_type = 'TripalEntity';
+      $info = $function($entity_type, $bundle);
+      drupal_alter('_bundle_instances_info', $info, $entity_type, $bundle);
       foreach ($info as $field_name => $details) {
         if ($details['field_name'] == $field_name_note) {
           // Create the field instance.

--- a/tripal/includes/tripal.admin_blocks.inc
+++ b/tripal/includes/tripal.admin_blocks.inc
@@ -27,6 +27,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
   if ($field_or_instance == 'field') {
     $function = $module . '_bundle_fields_info';
     $info = $function('TripalEntity', $bundle);
+    drupal_alter('bundle_fields_info', $info, 'TripalEntity', $bundle);
     foreach ($info as $field_name => $details) {
       $field = field_info_field($field_name);
       if ($details['field_name'] == $field_name_note) {
@@ -45,6 +46,7 @@ function tripal_admin_notification_import_field($field_name_note, $bundle_id, $m
     if ($field_or_instance == 'instance') {
       $function = $module . '_bundle_instances_info';
       $info = $function('TripalEntity', $bundle);
+      drupal_alter('_bundle_instances_info', $info, 'TripalEntity', $bundle);
       foreach ($info as $field_name => $details) {
         if ($details['field_name'] == $field_name_note) {
           // Create the field instance.


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
 --->

#

Issue #1089

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
See the issue for a description of the problem that this PR tries to address.

<s>This PR adds two new hooks:

hook_bundle_fields_info_alter(&$info, $entity_type, $bundle): for altering the info array of the fields.
hook_bundle_instances_info_alter(&$info, $entity_type, $bundle) : for altering the info array of the field instances.</s>

Update:  this is no longer an enhancement, because the hooks already exists but were not documented.  This PR now does the following:
1.  Documents the hooks in the API by adding "hook" functions
2.  Calls the alter functions in places where they were missing. This is anywhere the `hook_bundle_field_info` and `hook_bundle_instances_info` functions were called.
3.  Fixes the bug in the notification dashboard where fields could be created but were not using the alter hooks.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

<s>The easiest way to test is to install the [tripal_file](https://github.com/tripal/tripal_file) module.  Be sure to checkout the `for_PR` branch as that will not have active development code. It contains just the basic installation that includes two content types: File and License.  
To test:
1. Do not yet pull this PR code.
2. Download the  the Tripal file module and checkout the `for_PR` branch.
3. Install the tripal_file module.  This will create two new content types: `File` and `License`.  
4. Create a new License content entity.  It will appear under 'Other' category when on the 'Add Tripal Content' page. 
5. Notice that the URI field is a textarea... we don't want this.  
6. Remove the 'File' and 'License' content types.
7. Disable and Unistall the `tripal_file` module
8. Switch Tripal to use this PR's code
9. Re-enable the `tripal_file` module
10.  Create a new license content and you should now see that the field is a textfield and not a textarea.  This is because the alter hook was called and the settings were adjusted.
</s>

Updated Testing instructions:

1. Do not yet pull this PR code.
2. Download the the Tripal file module and checkout the `for_PR` branch.
3. Install the `tripal_file` module.  This will create two new content types: `File` and `License`.  
4. Go to the Admin >> Structure >> Tripal Content Types.  Click  `manage fields` next to the `License` content type.  Notice that the URI field is a "text field".  This is correct. It means the alter hook was called properly.  
5. Remove the URI field from the License content type.  (leave this page open for easy access later).
6. In another tab, run the Drupal Cron at: Admin >> Reports >> Status Report and click the link 'run cron manually.' This will submit a Tripal job to update the Tripal notifications.  Run that job.  It will look at all bundles and check if any have new fields that are available and add a notification to the Dashboard to alert the admin user.
7.  Now go to the Dashboard, and find the section "Tripal Administrative Notifications":
![image](https://user-images.githubusercontent.com/1719352/95011061-e359e800-05e2-11eb-9384-5049a486b2d5.png) You should see the notification that a new `data__uri` field is available.
8.  Click the linked named `Import`.  This should add the new field.  Go back to the mange field page for the `License` content type (should have been left open from step 5).  Refresh.  You should see the URI field as a 'textarea' instead of a 'text field'. This is wrong.  This is the bug.  It means the alter hook was not called. 
9.  Now pull the code for the PR and repeat steps 6-8.  This should fix the bug and the URI field should be a 'text field' like it is supposed to be.  
