### PR TITLE
Use property exists instead of array_key_exists

### DIFF
--- a/tripal_chado/api/tripal_chado.variables.api.inc
+++ b/tripal_chado/api/tripal_chado.variables.api.inc
@@ -791,7 +791,7 @@ function chado_expand_var($object, $type, $to_expand, $table_options = []) {
       $foreign_table = $to_expand;
 
       // BASE CASE: don't expand the table it already is expanded
-      if (array_key_exists($foreign_table, $object)) {
+      if (property_exists($object, $foreign_table)) {
         return $object;
       }
       $foreign_table_desc = chado_get_schema($foreign_table);


### PR DESCRIPTION
<!--- Thank you for contributing! -->

<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix
Issue #1088
Issue does not resolve all #1088 just warning pointed out by @spficklin  explicitly.


### description

`array_key_exists()` is deprecated when used on an object.  Switch usage to `property_exists()` for this call.
