### PR TITLE
Analyzed Phenotypes Gold Badge Request

### DIFF
--- a/docs/extensions/visualization.rst
+++ b/docs/extensions/visualization.rst
@@ -6,6 +6,10 @@ The following modules provide specialized displays for Tripal content types.
 Analyzed Phenotypes
 --------------------
 
+.. image:: https://tripal.readthedocs.io/en/7.x-3.x/_images/Tripal-Gold.png
+  :target: https://tripal.readthedocs.io/en/7.x-3.x/extensions/module_rating.html#Gold
+  :alt: Tripal Rating: Gold
+
 This module provides support and visualization for partially analyzed data stored in a modified GMOD Chado schema. It is meant to support large scale phenotypic data through backwards compatible improvements to the Chado schema including the addition of a project and stock foreign key to the existing phenotype table, optimized queries and well-chosen indexes.
 
 `Documentation <https://analyzedphenotypes.readthedocs.io/en/latest/index.html>`__


### PR DESCRIPTION
# Documentation

## Description

This PR is a request for a gold Tripal extension module badge.

Repository: https://github.com/UofS-Pulse-Binfo/analyzedphenotypes

## Bronze

| Requirement                                                                              | Status        |
|-------------------------------------------------------------|------------|
| Has a public release.  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/releases) |
| Should install on a Tripal site appropriate for the versions it supports.  | Yes (installed on KP and DivSeekCanada) |
| Defines any custom tables or materialized views in the install file (if applicable).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/7.x-3.x/analyzedphenotypes.install#L44) |
| Adds any needed controlled vocabulary terms in the install file (Tripal3).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/7.x-3.x/analyzedphenotypes.install#L120) |
| Provides Installation and admin instructions README.md (or RTD).  | [Yes](https://analyzedphenotypes.readthedocs.io/en/latest/admin_guide/install.html) |
| Has a license (distributed with module).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/7.x-3.x/LICENSE.txt) |

## Silver
| Requirement           | Status |
|------------------- |---------------------|
| Follows basic Drupal Coding standards; specifically, code format and API documentation.  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/7.x-3.x/api/analyzedphenotypes.api.inc) |
| Uses Tripal API functions. Specifically, it should use the Chado Query API for querying chado (if using chado as the storage system).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/search?q=chado_query) |
| Tripal Jobs API for long running processes.  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/1ff8a549344fb2cde1c8a3797f41cf7cf22b03ce/api/analyzedphenotypes.tripaljob.api.inc#L63) |
| TripalField class to add data to pages (Tripal3).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/tree/1ff8a549344fb2cde1c8a3797f41cf7cf22b03ce/includes/TripalFields) |
| Provides ways to customize the module (e.g. drush options, field/formatter settings, admin UI).  | Yes: [cvterm](https://analyzedphenotypes.readthedocs.io/en/latest/admin_guide/setup.html), [fields](https://analyzedphenotypes.readthedocs.io/en/latest/admin_guide/fieldconfig.html) |
| Latest releases should follow Drupal naming best practices. e.g. first release for Drupal 7 should be: 7.x-1.x.   | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/releases) |

## Gold
| Requirement  | Status |
|-------------|---------|
| Extensive documentation for the module (similar to Tripal User’s Guide).  | [Yes](https://analyzedphenotypes.readthedocs.io/en/latest/index.html) |
| Unit testing is implemented using PHPUnit with the TripalTestSuite or something similar.  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/tree/1ff8a549344fb2cde1c8a3797f41cf7cf22b03ce/tests) |
| Continuous integration is setup (e.g. such as with TravisCI).   | [Yes](https://travis-ci.org/github/UofS-Pulse-Binfo/analyzedphenotypes) |
| Imports data via Tripal’s importer class (Tripal3).  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/tree/7.x-3.x/includes/TripalImporter) |
| Tripal 3 fields are Fully compatible with web services.  | Yes |
| The elementInfo function is fully implemented.  | [Yes](https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/blob/7.x-3.x/includes/TripalFields/sio__study/sio__study.inc#L175) |
| The query and queryOrder functions fully implemented.  | NA, doesn't make sense to search/sort on these fields |
| Web Services uses Tripal’s Web Service Classes (Tripal3).  | NA, no additional web services |
|  Code sniffing and testing coverage reports (optional but encouraged).  | [Yes](https://codeclimate.com/github/UofS-Pulse-Binfo/analyzedphenotypes) |
| Drupal.org vetted release (optional but encouraged).  |  |