### PR TITLE
Tracked a bug with features which would make feature data invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ docs/docs
 docs/html
 docs/latex
 docs/xml
+composer.json
+composer.lock
+
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Tripal is an toolkit to facilitate construction of online genomic, genetic (and other biological) websites.",
   "require-dev": {
     "doctrine/instantiator": "1.0.*",
-    "statonlab/tripal-test-suite": "1.*"
+    "statonlab/tripal-test-suite": "^1.6"
   },
   "autoload": {
     "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd3ab0a8fd06e0532a7764f20a9aa52b",
+    "content-hash": "4c6dfda22aa98d63d7563b707ee3a64b",
     "packages": [],
     "packages-dev": [
         {
@@ -908,6 +908,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -2202,5 +2203,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/DatabaseSeeders/examples/DevSeedSeeder.php
+++ b/tests/DatabaseSeeders/examples/DevSeedSeeder.php
@@ -1,0 +1,383 @@
+<?php
+
+namespace Tests\DatabaseSeeders;
+
+use StatonLab\TripalTestSuite\Database\Seeder;
+use \Exception;
+
+class DevSeedSeeder extends Seeder
+{
+    /**
+     * Part one:
+     * Chado records.
+     * These are records used by many of the below importers.
+     * ALL importers require an organism.
+     * The expression data loader will associate the data with the
+     * $expression_analysis record. All other importers associate data with the
+     * $sequence_analysis. Uncomment the array to create that chado record.
+     */
+
+protected $organism = [
+        'common_name' => 'F. excelsior miniature',
+        'genus' => 'Fraxinus',
+        'species' => 'excelsior',
+        'abbreviation' => 'F. excelsor',
+        'comment' => 'Loaded with TripalDev Seed.',
+      ];
+
+protected $sequence_analysis = [
+      'name' => 'Fraxinus exclesior miniature dataset',
+      'description' => 'Tripal Dev Seed',
+    ];
+
+    protected $expression_analysis = [
+
+      'name' => 'Fraxinus exclesior miniature dataset Expression Analysis',
+      'description' => 'Tripal Dev Seed',
+    ];
+
+  protected $blastdb = [
+    'name' => 'DevSeed Database: TREMBL',
+    'description' => 'A dummy database created by DevSeed',
+  ];
+
+    /**
+     * Part 2:
+     * Files.
+     * Each importer will take a file argument.  This argument should be an array
+     * with one of the following two keys: file_remote => url where the file is
+     * located file_local => server path where the file is located.
+     */
+
+    protected $landmark_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/sequences/empty_landmarks.fasta'];
+
+    protected $landmark_type = 'supercontig';
+
+    protected $mRNA_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/sequences/mrna_mini.fasta'];
+
+    protected $protein_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/sequences/polypeptide_mini.fasta'];
+
+    protected $gff_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/gff/filtered.gff'];
+
+    protected $blast_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/gff/filtered.gff'];
+
+    protected $biomaterial_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/biomaterials/biomaterials.xml'];
+
+    protected $expression_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/expression/expression.tsv'];
+
+    protected $interpro_file = ['file_remote' => 'https://raw.githubusercontent.com/statonlab/tripal_dev_seed/master/Fexcel_mini/ips/polypeptide_mini.fasta.xml'];
+
+    // Regular expression that will link the protein name to the mRNA parent feature name.
+   // protected $prot_regexp = '/(FRA.*?)(?=:)/';
+
+    protected $prot_regexp = null;
+
+    public function __construct()
+    {
+
+        if ($this->organism) {
+
+            try {
+                $organism = $this->fetch_chado_record('chado.organism', [
+                    'common_name',
+                    'organism_id',
+                ], $this->organism);
+            } catch (\Exception $e) {
+                echo $e->getMessage();
+                exit;
+            }
+
+            $this->organism = $organism;
+
+            if ($this->sequence_analysis) {
+
+                try {
+                    $seq_analysis = $this->fetch_chado_record('chado.analysis', ['analysis_id'],
+                        $this->sequence_analysis);
+                } catch (\Exception $e) {
+                    echo $e->getMessage();
+                    exit;
+                }
+                $this->sequence_analysis = $seq_analysis;
+            }
+
+            if ($this->expression_analysis) {
+                try {
+                    $expression_analysis = $this->fetch_chado_record('chado.analysis', ['analysis_id'],
+                        $this->expression_analysis);
+                } catch (\Exception $e) {
+                    echo $e->getMessage();
+                    exit;
+                }
+
+                $this->expression_analysis = $expression_analysis;
+            }
+        }
+
+        if ($this->blastdb) {
+            try {
+                $blastdb = $this->fetch_chado_record('chado.db', ['db_id'], $this->blastdb);
+            } catch (\Excetion $e) {
+                echo $e->getMessage();
+            }
+
+            $this->blastdb = $blastdb;
+        }
+    }
+
+    /**
+     * Runs all loaders.
+     * Will only run loaders where the files have been uncommented at the start
+     * of the class.
+     */
+    public function up()
+    {
+
+        if ($this->landmark_file) {
+
+            $run_args = [
+                'organism_id' => $this->organism->organism_id,
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                'seqtype' => $this->landmark_type,
+                'method' => 2, //default insert and update
+                'match_type' => 1, //unique name default
+                //optional
+                're_name' => null,
+                're_uname' => null,
+                're_accession' => null,
+                'db_id' => null,
+                'rel_type' => null,
+                're_subject' => null,
+                'parent_type' => null,
+            ];
+            $this->load_landmarks($run_args, $this->landmark_file);
+        }
+
+        if ($this->gff_file) {
+            $run_args = [
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                'organism_id' => $this->organism->organism_id,
+                'use_transaction' => 1,
+                'add_only' => 0,
+                'update' => 1,
+                'create_organism' => 0,
+                'create_target' => 0,
+
+                ///regexps for mRNA and protein.
+                're_mrna' => null,
+                're_protein' => $this->prot_regexp,
+                //optional
+                'target_organism_id' => null,
+                'target_type' => null,
+                'start_line' => null,
+                'landmark_type' => null,
+                'alt_id_attr' => null,
+            ];
+            $this->load_GFF($run_args, $this->gff_file);
+        }
+
+        if ($this->mRNA_file) {
+
+            $run_args = [
+                'organism_id' => $this->organism->organism_id,
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                'seqtype' => 'mRNA',
+                'method' => 2, //default insert and update
+                'match_type' => 1, //unique name default
+                //optional
+                're_name' => null,
+                're_uname' => null,
+                're_accession' => null,
+                'db_id' => null,
+                'rel_type' => null,
+                're_subject' => null,
+                'parent_type' => null,
+            ];
+            $this->load_mRNA_FASTA($run_args, $this->mRNA_file);
+        }
+
+        if ($this->protein_file) {
+            $run_args = [
+                'organism_id' => $this->organism->organism_id,
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                'seqtype' => 'polypeptide',
+                'method' => 2,
+                'match_type' => 1,
+                //optional
+                're_name' => null,
+                're_uname' => null,
+                're_accession' => null,
+                'db_id' => null,
+            ];
+
+            if ($this->prot_regexp) {
+                //links polypeptide to mRNA
+                $run_args['rel_type'] = 'derives_from';
+                $run_args['re_subject'] = $this->prot_regexp;
+                $run_args['parent_type'] = 'mRNA';
+            }
+            $this->load_polypeptide_FASTA($run_args, $this->protein_file);
+        }
+
+        if ($this->interpro_file) {
+
+            $run_args = [
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                //optional
+                'query_type' => 'mRNA',
+                'query_re' => $this->prot_regexp,
+                'query_uniquename' => null,
+                'parsego' => true,
+            ];
+
+            $this->load_interpro_annotations($run_args, $this->interpro_file);
+        }
+
+        if ($this->blast_file) {
+            $run_args = [
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                'no_parsed' => 25,//number results to parse
+                'query_type' => 'mRNA',
+                //optional
+                'blastdb' => $this->blastdb->db_id,
+                'blastfile_ext' => null,
+                'is_concat' => 0,
+                'query_re' => null,
+                'query_uniquename' => 0,
+            ];
+
+            $this->load_blast_annotations($run_args, $this->blast_file);
+        }
+
+        if ($this->biomaterial_file) {
+            $run_args = [
+                'organism_id' => $this->organism->organism_id,
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+            ];
+            //optional: specifies specific CVterms for properties/property values.  Not used here.
+            //'cvterm_configuration' => NULL,
+            //'cvalue_configuration' => NULL];
+
+            $this->load_biomaterials($run_args, $this->biomaterial_file);
+        }
+
+        if ($this->expression_file) {
+            $run_args = [
+                'filetype' => 'mat', //matrix file type
+                'organism_id' => $this->organism->organism_id,
+                'analysis_id' => $this->sequence_analysis->analysis_id,
+                //optional
+                'fileext' => null,
+                're_start' => null,
+                're_stop' => null,
+                'feature_uniquenames' => null,
+                'quantificationunits' => null,
+                'seqtype' => 'mRNA',
+            ];
+            $this->load_expression($run_args, $this->expression_file);
+        }
+    }
+
+    private function load_landmarks($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_chado', 'includes/TripalImporter/FASTAImporter');
+
+        $importer = new \FASTAImporter();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_mRNA_FASTA($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_chado', 'includes/TripalImporter/FASTAImporter');
+
+        $importer = new \FASTAImporter();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_polypeptide_FASTA($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_chado', 'includes/TripalImporter/FASTAImporter');
+
+        $importer = new \FASTAImporter();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_interpro_annotations($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_analysis_interpro', 'includes/TripalImporter/InterProImporter');
+
+        $importer = new \InterProImporter();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_GFF($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_chado', 'includes/TripalImporter/GFF3Importer');
+
+        $importer = new \GFF3Importer();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_blast_annotations($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_analysis_blast', 'includes/TripalImporter/BlastImporter');
+
+        $importer = new \BlastImporter();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_biomaterials($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_biomaterial', 'includes/TripalImporter/tripal_biomaterial_loader_v3');
+
+        $importer = new \tripal_biomaterial_loader_v3();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function load_expression($run_args, $file)
+    {
+        module_load_include('inc', 'tripal_analysis_expression',
+            'includes/TripalImporter/tripal_expression_data_loader');
+
+        $importer = new \tripal_expression_data_loader();
+        $importer->create($run_args, $file);
+        $importer->prepareFiles();
+        $importer->run();
+    }
+
+    private function fetch_chado_record($table, $fields, $factory_array)
+    {
+        $query = db_select($table, 't')->fields('t', $fields);
+
+        foreach ($factory_array as $key => $value) {
+            $query->condition($key, $value);
+        }
+
+        $count_query = $query;
+        $count = (int) $count_query->countQuery()->execute()->fetchField();
+
+        if ($count === 0) {
+            return factory($table)->create($factory_array);
+        }
+
+        if ($count === 1) {
+            return $query->execute()->fetchObject();
+        }
+
+        throw new Exception("Error creating object for: ".$table.".\n Array supplied matches ".$count_query." results, must match 1.");
+    }
+}

--- a/tests/DatabaseSeeders/examples/UsersTableSeeder.php
+++ b/tests/DatabaseSeeders/examples/UsersTableSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\DatabaseSeeders;
+
+use StatonLab\TripalTestSuite\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Seeds the database with users.
+     */
+    public function up()
+    {
+        $new_user = [
+            'name' => 'test user',
+            'pass' => 'secret',
+            'mail' => 'test@example.com',
+            'status' => 1,
+            'init' => 'Email',
+            'roles' => [
+                DRUPAL_AUTHENTICATED_RID => 'authenticated user',
+            ],
+        ];
+
+        // The first parameter is sent blank so a new user is created.
+        user_save(new \stdClass(), $new_user);
+    }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+/**
+ * Class ExampleTest
+ *
+ * Note that test classes must have a suffix of Test.php and the filename
+ * must match the class name.
+ *
+ * @package Tests
+ */
+class ExampleTest extends TripalTestCase {
+  /**
+   * Basic test example.
+   * Tests must begin with the word "test".
+   * See https://phpunit.readthedocs.io/en/latest/ for more information.
+   */
+  public function testBasicExample() {
+    $this->assertTrue(true);
+  }
+}

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -980,6 +980,7 @@ class GFF3Importer extends TripalImporter {
     $attr_terms = [];
     $attr_target = [];
     foreach ($attrs as $attr) {
+      // @TODO Can we replace this with a single trim() function?
       $attr = rtrim($attr);
       $attr = ltrim($attr);
       if (strcmp($attr, '') == 0) {
@@ -1642,7 +1643,7 @@ class GFF3Importer extends TripalImporter {
    */
   private function cacheFeature($gff_feature) {
     // Make sure we're at the end of the file.
-    fseek($this->gff_cache_file, SEEK_END);
+    fseek($this->gff_cache_file, 0, SEEK_END);
 
     // Get the index of this location
     $findex = ftell($this->gff_cache_file);
@@ -1717,7 +1718,6 @@ class GFF3Importer extends TripalImporter {
       $findex = $info['findex'];
       $feature_id = $info['feature_id'];
       $feature = $this->getCachedFeature($findex);
-
       $total++;
       $i++;
 
@@ -1728,7 +1728,7 @@ class GFF3Importer extends TripalImporter {
         $sql .= "(:uniquename_$i, :name_$i, :type_id_$i, :organism_id_$i, :residues_$i, " .
                " :md5checksum_$i, :seqlen_$i, FALSE, FALSE),\n";
         $args[":uniquename_$i"] = $uniquename;
-        $args[":name_$i"] = $feature['name'];
+        $args[":name_$i"] = $feature['name'];     
         $args[":type_id_$i"] = $type_id;
         $args[":organism_id_$i"] = $feature['organism'] ? $feature['organism'] : $this->organism->getID();
         $args[":residues_$i"] = $residues;


### PR DESCRIPTION
# Bug Fix

The latest GFF optimizations create a cached data file however the indexes were not being stored correctly.  This resulted in feature data being mismatched which could lead to major inaccuracies. The issue was that the fseek function requires 3 arguments but was only being supplied 2 arguments. The SEEK_END added to the 2nd argument (which is supposed to be used as an offset) when it should have been the 3rd argument - this converted the SEEK_END into an int value of 2 and so the findex was consistently stored as 2 which is invalid. In this case, fixing this was making sure the 2nd argument was set to a value of 0 and the 3rd argument set to the SEEK_END constant (which holds a value of 2).

This took a few hours to properly track back due to me being new to the GFFImporter.

