### PR TITLE
Bug fix that makes GFFImporter caching of features work correctly

### DIFF
--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -1642,7 +1642,7 @@ class GFF3Importer extends TripalImporter {
    */
   private function cacheFeature($gff_feature) {
     // Make sure we're at the end of the file.
-    fseek($this->gff_cache_file, SEEK_END);
+    fseek($this->gff_cache_file, 0, SEEK_END);
 
     // Get the index of this location
     $findex = ftell($this->gff_cache_file);


### PR DESCRIPTION
The latest GFF optimizations create a cached data file however the indexes were not being stored correctly. This resulted in feature data being mismatched which could lead to major inaccuracies. The issue was that the fseek function requires 3 arguments but was only being supplied 2 arguments. The SEEK_END added to the 2nd argument (which is supposed to be used as an offset) when it should have been the 3rd argument - this converted the SEEK_END into an int value of 2 and so the findex was consistently stored as 2 which is invalid. In this case, fixing this was making sure the 2nd argument was set to a value of 0 and the 3rd argument set to the SEEK_END constant (which holds a value of 2).

This took a few hours to properly track back due to me being new to the GFFImporter.