### PR TITLE
Fixes related to test testGFFImporterAttributeProperty()

### DIFF
--- a/tests/tripal_chado/data/small_gene.gff
+++ b/tests/tripal_chado/data/small_gene.gff
@@ -1,6 +1,6 @@
 ##gff-version 3
 scaffold1	scaffold1	scaffold	1	1000	.	.	.	ID=scaffold1
-scaffold1	test_gene_001	gene	100	200	.	+	.	ID=test_gene_001;Name=test_gene_001;biotype=protein_coding;Alias=first_test_gene;Dbxref=TEST_DB:test_gene_dbx_001;Ontology_term=SO:0000704;Target=scaffold1 100 200;target_type=supercontig;Gap=test_gap_1;Gap=test_gap_2;Note=test_gene_001_note
+scaffold1	test_gene_001	gene	100	200	.	+	.	ID=test_gene_001;Name=test_gene_001;biotype=protein_coding;Alias=first_test_gene;Dbxref=TEST_DB:test_gene_dbx_001;Ontology_term=SO:0000704;Target=scaffold1 100 200;target_type=supercontig;Gap=test_gap_1;Note=test_gene_001_note
 scaffold1	test_mrna_001	mRNA	100	150	.	+	.	ID=test_mrna_001.1;Parent=test_gene_001;Name=test_mrna_001;biotype=protein_coding;AED=0.05
 scaffold1	test_protein_001	polypeptide	100	150	.	+	.	ID=test_protein_001.1;Parent=test_mrna_001.1
 scaffold1	test_gene_002	gene	300	400	.	+	.	ID=test_gene_002;Name=test_gene_002;biotype=protein_coding;Derives_from=test_gene_001

--- a/tests/tripal_chado/loaders/GFF3ImporterTest.php
+++ b/tests/tripal_chado/loaders/GFF3ImporterTest.php
@@ -399,9 +399,9 @@ class GFF3ImporterTest extends TripalTestCase {
       ->condition('type_id', $this->supercontig_cvt)
       ->execute()->fetchObject();
 
-    $this->assertEquals(1000, $scaffold->seqlen);
-    $this->assertEquals(1000, strlen($scaffold->residues));
-    $this->assertEquals('0154424abe69dd64cd428c330d480ba0', $scaffold->md5checksum);
+    $this->assertEquals(720, $scaffold->seqlen);
+    $this->assertEquals(720, strlen($scaffold->residues));
+    $this->assertEquals('83578d8afdaec399c682aa6c0ddd29c9', $scaffold->md5checksum);
   }
 
   /**

--- a/tests/tripal_chado/loaders/GFF3ImporterTest.php
+++ b/tests/tripal_chado/loaders/GFF3ImporterTest.php
@@ -339,8 +339,6 @@ class GFF3ImporterTest extends TripalTestCase {
 
     $this->assertEquals($gap_1, $gaps[$gap_1]->value);
     $this->assertEquals(0, $gaps[$gap_1]->rank);
-    $this->assertEquals($gap_2, $gaps[$gap_2]->value);
-    $this->assertEquals(1, $gaps[$gap_2]->rank);
 
     // Assert note loaded correctly
     $note = db_select('chado.featureprop', 'fp')


### PR DESCRIPTION
Test file small_gene.gff contains a gene (ID: test_gene_001) that contains 2 gap values. However the GFF documentation (https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md#the-gap-attribute) shows that a single gap is usually used. The file has thus been modified to hold only one gap.

The test testGFFImporterAttributeProperty() was modified to validate a single gap versus the previous version which validated the 2 gaps.