### PR TITLE
Tripal field URLs made clickable

### DIFF
--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
@@ -27,7 +27,12 @@ class chado_linker__prop_formatter extends ChadoFieldFormatter {
 
     $list = [];
     foreach ($items as $index => $item) {
-      $list[$index] = $item['value'];
+      $value = $item['value'];
+      // any URLs are made into clickable links
+      if ( preg_match('/^https?:/i', $value) ) {
+        $value = t('<a href="!url">!url</a>', ['!url' => $value]);
+      }
+      $list[$index] = $value;
     }
 
     // Also need to make sure to not return markup if the field is empty.

--- a/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__prop/chado_linker__prop_formatter.inc
@@ -30,7 +30,7 @@ class chado_linker__prop_formatter extends ChadoFieldFormatter {
       $value = $item['value'];
       // any URLs are made into clickable links
       if ( preg_match('/^https?:/i', $value) ) {
-        $value = t('<a href="!url">!url</a>', ['!url' => $value]);
+        $value = l($value, $value, ['external' => 'TRUE', 'attributes' => ['target' => '_blank']]);
       }
       $list[$index] = $value;
     }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


# New Feature

Issue #1108

## Description
This is a change to ```chado_linker__prop_formatter``` that will make a URL in a tripal field, specifically ```tpub__url``` into a clickable link, as described in issue #1108 
