### PR TITLE
Added fix for issue #1112

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -520,6 +520,9 @@ class TripalContentService_v0_1 extends TripalWebService {
           // Index number (0, 1, 2...) of a hydra:member array.
           $temp[$k] = $this->sanitizeFieldKeys($resource, $v, $bundle, $service_path);
         }
+        elseif ($k == 'entity') {
+          $temp[$k] = $v;
+        }
         else {
           // TODO: this is an error, if we get here then we have
           // a key that isn't using the proper format... what to do?
@@ -879,13 +882,13 @@ class TripalContentService_v0_1 extends TripalWebService {
 
     // Get the TripalBundle, TripalTerm and TripalVocab type for this type.
     $bundle = tripal_load_bundle_entity(['label' => $ctype]);
-    
+
     // Check that the user has access to this bundle.  If not then the
     // function call will throw an error.
     if (!user_access('view ' . $bundle->name)) {
       throw new Exception("Permission Denied.");
     }
-        
+
     $term = entity_load('TripalTerm', ['id' => $bundle->term_id]);
     $term = reset($term);
 
@@ -1058,7 +1061,7 @@ class TripalContentService_v0_1 extends TripalWebService {
         // Show only content types users have access to and skip the rest.
         continue;
       }
-      
+
       $entity = entity_load('TripalTerm', ['id' => $bundle->term_id]);
       $term = reset($entity);
       $vocab = $term->vocab;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


# Bug Fix

Issue #1112 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

While I was working on the Tripal File module (which we need full compatibility with web services) I noticed that fields that link to other entities seem to be missing the `@id` element that links to the corresponding entity. For example, the organism field for any "feature" entity (e.g. Gene, mRNA, SNP, etc.) is missing the `@id` element for the `organism` field.  This very small PR fixes that.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1. Before pulling the branch for this PR, use web services to find an entity that derives from the feature table of Chado. 
2. Load the JSON from web services for the entity (use the JSON fomratter plugin in Chrome to view it nicely).
3.  Note that the `@id` is missing from the organism field.
4.  Pull the branch, and then reload the JSON.  The `@id` should be there.

## Screenshots (if appropriate):
Before:

![image](https://user-images.githubusercontent.com/1719352/96529865-10d99f00-123b-11eb-8c44-9a52a1e82371.png)

After: 

![image](https://user-images.githubusercontent.com/1719352/96529944-34044e80-123b-11eb-8127-e79ea516408d.png)
