### PR TITLE
Fixes for web services bugs

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -147,7 +147,8 @@ class TripalContentService_v0_1 extends TripalWebService {
         FIELD_LOAD_CURRENT, ['field_id' => $field['id']]);
     }
 
-    $this->addEntityField($this->resource, $term, $entity, $bundle, $field, $instance, $service_path, $expfield);
+    $field_service_path = $service_path . '/' . urlencode($term['name']);
+    $this->addEntityField($this->resource, $term, $entity, $bundle, $field, $instance, $field_service_path, $expfield);
   }
 
   /**
@@ -319,9 +320,6 @@ class TripalContentService_v0_1 extends TripalWebService {
       $instance_settings = $instance['settings'];
       if (array_key_exists('auto_attach', $instance['settings']) and
         $instance_settings['auto_attach'] == FALSE) {
-        // Add a URL only if there are values. If there are no values then
-        // don't add a URL which would make the end-user think they can get
-        // that information.
         $items = field_get_items('TripalEntity', $entity, $field_name);
         $term_key = $this->getContextTerm($term, ['lowercase', 'spacing']);
         $resource->addContextItem($term_key, $vocabulary . ':' . $accession);
@@ -329,25 +327,16 @@ class TripalContentService_v0_1 extends TripalWebService {
           '@id' => $term['url'],
           '@type' => '@id',
         ]);
-        if ($items and count($items) > 0 and $items[0]['value']) {
-          $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), [
-            'lowercase',
-            'spacing',
-          ]);
-        }
-        else {
-          if ($hide_fields == FALSE) {
-            $this->addResourceProperty($resource, $term, NULL, [
-              'lowercase',
-              'spacing',
-            ]);
-          }
-        }
+        $this->addResourceProperty($resource, $term, $service_path . '/' . $entity->id . '/' . urlencode($term['name']), [
+          'lowercase',
+          'spacing',
+        ]);
         continue;
       }
 
       // Get the details for this field for the JSON-LD response.
-      $this->addEntityField($resource, $term, $entity, $bundle, $field, $instance, $service_path);
+      $field_service_path = $service_path . '/' . $entity->id . '/' . urlencode($term['name']);
+      $this->addEntityField($resource, $term, $entity, $bundle, $field, $instance, $field_service_path);
     }
   }
 
@@ -419,12 +408,25 @@ class TripalContentService_v0_1 extends TripalWebService {
       // If the value is an array and this is the field page then all of those
       // key/value pairs should be added directly to the response.
       if (is_array($values[0])) {
+        if (array_key_exists('@type', $values[0])) {
+          [$vocabulary, $accession] = explode(':', $values[0]['@type']);
+          $term = tripal_get_term_details($vocabulary, $accession);
+          $resource->addContextItem($term['vocabulary']['short_name'], $term['vocabulary']['sw_url']);
+          $resource->addContextItem($values[0]['@type'], $term['url']);
+          $resource->addContextItem($term['name'], $values[0]['@type']);
+          $values[0]['@type'] = $term['name'];
+        }
+
         if ($expfield) {
           foreach ($values[0] as $k => $v) {
+            if ($k == '@type') {
+              continue;
+            }
             $resource->addProperty($k, $v);
           }
         }
         else {
+
           $this->addResourceProperty($resource, $term, $values[0], [
             'lowercase',
             'spacing',
@@ -446,28 +448,54 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       // If this is the expanded field page then we need to swap out
       // the resource for a collection.
-      $response = new TripalWebServiceCollection($service_path . '/' . urlencode($expfield), $this->params);
+      $response = new TripalWebServiceCollection($service_path, $this->params);
       $label = tripal_get_term_details('rdfs', 'label');
       $this->addResourceProperty($response, $label, $instance['label']);
       $i = 0;
+
       foreach ($values as $delta => $element) {
-        $member = new TripalWebServiceResource($service_path . '/' . urlencode($expfield));
+        $member = new TripalWebServiceResource($service_path);
         $member->setID($i);
+
+        // Turn off the @id and @type keys unless the element has these.
+        $member->disableID();
+        $member->disbleType();
+
         // Add the context of the parent resource because all of the keys
         // were santizied and set to match the proper context.
         $member->setContext($resource);
-        $this->setResourceType($member, $term);
+
+        // Iterate through the key/value pairs of the list.
         foreach ($element as $key => $value) {
+          // If this element has an '@id' then replace the generic
+          // service path that each member element automatically gets
+          // with this value.
+          if ($key == '@id') {
+            $member->setServicePath($value);
+            $member->enableID();
+            continue;
+          }
+          if ($key == '@type') {
+            [$vocabulary, $accession] = explode(':', $value);
+            $tterm = tripal_get_term_details($vocabulary, $accession);
+            $member->addContextItem($tterm['vocabulary']['short_name'], $tterm['vocabulary']['sw_url']);
+            $member->addContextItem($value, $tterm['url']);
+            $member->addContextItem($tterm['name'], $value);
+            $member->setType($tterm['name']);
+            $member->enableType();
+            continue;
+          }
           $member->addProperty($key, $value);
         }
-        $response->addMember($member);
-        $i++;
+        if (!empty($element)) {
+          $response->addMember($member);
+          $i++;
+        }
       }
       if ($expfield) {
         $this->resource = $response;
       }
       else {
-        //$this->resource->addProperty($key, $response);
         $this->addResourceProperty($resource, $term, $response, [
           'lowercase',
           'spacing',
@@ -563,6 +591,7 @@ class TripalContentService_v0_1 extends TripalWebService {
           $item_entity = reset($item_entity);
           $bundle = tripal_load_bundle_entity(['name' => $item_entity->bundle]);
           $items['@id'] = $this->getServicePath() . '/' . urlencode($bundle->label) . '/' . $item_eid;
+          $items['@type'] = $bundle->accession;
         }
         unset($items['entity']);
       }
@@ -1026,9 +1055,10 @@ class TripalContentService_v0_1 extends TripalWebService {
 
       // Add in any requested fields
       foreach ($add_fields as $expfield => $expfield_details) {
+        $field_service_path = $service_path . '/' . $entity->id . '/' . urlencode($expfield);
         $this->addEntityField($member, $expfield_details['term'], $entity,
           $bundle, $expfield_details['field'], $expfield_details['instance'],
-          $service_path);
+            $field_service_path);
       }
       $this->resource->addMember($member);
     }

--- a/tripal_ws/includes/TripalWebServiceResource.inc
+++ b/tripal_ws/includes/TripalWebServiceResource.inc
@@ -32,6 +32,44 @@ class TripalWebServiceResource {
 
 
   /**
+   * All resources should have a @type and an @id.  But, there
+   * are times when we don't want any, such as an array of unpblished
+   * properties (e.g. featureloc elements).  These can be set to
+   * TRUE to disable.
+   */
+  protected $disable_type = FALSE;
+  protected $disable_id = FALSE;
+
+
+  /**
+   * Exclude the @type element form the data of this resource.
+   */
+  public function disbleType() {
+    $this->disable_type = TRUE;
+  }
+
+  /**
+   * Include the @type element form the data of this resource.
+   */
+  public function enableType() {
+    $this->disable_type = FALSE;
+  }
+
+  /**
+   * Exclude the @id element form the data of this resource.
+   */
+  public function disableID() {
+    $this->disable_id = TRUE;
+  }
+
+  /**
+   * Include the @id element form the data of this resource.
+   */
+  public function enableID() {
+    $this->disable_id = FALSE;
+  }
+
+  /**
    * Implements the constructor.
    *
    * @param  $service_path
@@ -111,6 +149,20 @@ class TripalWebServiceResource {
     $this->checkKey($type);
     $this->type = $type;
     $this->data['@type'] = $type;
+  }
+
+  /**
+   * Sets the service path for this resource.
+   *
+   * By default, the service path is provided to the constructor, but
+   * this function will allow it to be changed if needed.
+   *
+   * @param $service_path
+   *   The URL for the service path.
+   */
+  public function setServicePath($service_path) {
+    $this->service_path = $service_path;
+    $this->data['@id'] = $service_path;
   }
 
   /**
@@ -341,7 +393,14 @@ class TripalWebServiceResource {
    *   An associative array containing the data section of the response.
    */
   public function getData() {
-    return $this->data;
+    $data = $this->data;
+    if ($this->disable_id) {
+      unset($data['@id']);
+    }
+    if ($this->disable_type) {
+      unset($data['@type']);
+    }
+    return $data;
   }
 
   /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1118 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In the process of trying to make the new Tripal File extension module work with web services I noticed several bugs. They are described with screenshots on the issue listed above.  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1. Before loading of the code in this PR do the following.
2. Make sure your browser has a JSON viewer that allows you to view the web services responses and click on the links. It will make testing this a whole lot easier. 
3.  Also, if you have the demo citrus data loaded that makes testing easy too. But if you have genes with transcripts (mRNA) relationships that will work just fine as well. 
2. To test fix for bug 1:  
    - clear the entire site cache (this will remove cached fields): `drush cc all`. This is important because the problem only occurs with fields that are not cached.
   - using web services, go to any gene page. You will see that many of the fields that are 'null' even if you know they should have values. The relationship field is a good one because there are usually relationships. 
   - switch to this branch (`git checkout 1118-tv3-ws_bugs`) and reload the page. You should now see links to the fields that used to be null, and if you click on `relationships` you will see the data.  
3. To test fix for bug 2:
   - do not clear the cache. For this test we need a cache field.
   - switch back to the master branch:  `git checkout 7.x-3.x`
   - reload the same gene page, and find a field that has a cardinality greater than one but has no value.  A good one that is usually empty is the `contact` field.  Click that field to view it.  You should see that in the `members` array there is an `@id` and a `@type` but nothing else.  This is wrong.
   - switch back to this PR branch: `git checkout 1118-tv3-ws_bugs`
   - reload the page with the contact, the `mebmers` list should not be empty as it should.
4. To test fix for bug 3:  
   - do not clear the cache. For this test we need a cache field.
   - switch back to the master branch:  `git checkout 7.x-3.x`
   - on the gene page click on the link for the `transcript` field.  You should get an error stating:  `The key, @id, has not yet been added to the context. Use the addContextItem() function to add this key prior to adding a value for it.`
   -  switch back to this PR branch: `git checkout 1118-tv3-ws_bugs`. 
   -  reload the transcript page and you should see the list of transcripts for the gene.
5. To test fix for bug 4:
   - do not clear the cache. For this test we need a cache field.
   - switch back to the master branch:  `git checkout 7.x-3.x`
   - click on the link for the field named `map_position`.  You will that the members elements have `@id` and `@type` tags. This is wrong because those are not published resources. They are just properties about the position.  
   -  switch back to this PR branch: `git checkout 1118-tv3-ws_bugs`. 
   -  reload the map_position page and you should see the those elements are now gone.
