### PR TITLE
Tripal Genotype Loader Badge

### DIFF
--- a/docs/extensions/data_input.rst
+++ b/docs/extensions/data_input.rst
@@ -6,6 +6,10 @@ The following modules provide interfaces for collection and/or loading of biolog
 Genotype Loader
 ----------------
 
+.. image:: https://tripal.readthedocs.io/en/7.x-3.x/_images/Tripal-Gold.png
+  :target: https://tripal.readthedocs.io/en/7.x-3.x/extensions/module_rating.html#Gold
+  :alt: Tripal Rating: Gold
+  
 A Drush-based loader for VCF files that follows the genotype storage rules outline by ND genotypes. It has been optimized to handle very large files and supports customization of ontology terms used.
 
 `Documentation <https://genotypes-loader.readthedocs.io/en/latest/>`__


### PR DESCRIPTION
# Documentation

## Description

This issue is in preparation for request for a gold Tripal extension module badge.
https://github.com/UofS-Pulse-Binfo/genotypes_loader

## Bronze

| Requirement                                                                              | Status        |
|-------------------------------------------------------------|------------|
| Has a public release.  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/releases/tag/7.x-1.1) |
| Should install on a Tripal site appropriate for the versions it supports.  | Yes, tested by TravisCI |
| Defines any custom tables or materialized views in the install file (if applicable).  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/master/genotypes_loader.install#L105-L109) |
| Adds any needed controlled vocabulary terms in the install file (Tripal3).  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/master/genotypes_loader.install#L47) |
| Provides Installation and admin instructions README.md (or RTD).  | Yes, [Readme](https://github.com/UofS-Pulse-Binfo/genotypes_loader#installation) and [RTD](https://genotypes-loader.readthedocs.io/en/latest/index.html) |
| Has a license (distributed with module).  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/master/LICENSE.txt) |

## Silver
| Requirement           | Status |
|------------------- |---------------------|
| Follows basic Drupal Coding standards; specifically, code format and API documentation.  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/master/api/genotypes_loader.api.inc#L55) |
| Uses Tripal API functions. Specifically, it should use the Chado Query API for querying chado (if using chado as the storage system).  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/search?q=chado_query) |
| Tripal Jobs API for long running processes.  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/9334272b960d888d020d1788ff8b9d358b5dc530/includes/genotypes_loader.form.inc#L175) |
| TripalField class to add data to pages (Tripal3).  | NA, doesn't display data |
| Provides ways to customize the module (e.g. drush options, field/formatter settings, admin UI).  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/blob/9334272b960d888d020d1788ff8b9d358b5dc530/includes/genotypes_loader.admin.inc) |
| Latest releases should follow Drupal naming best practices. e.g. first release for Drupal 7 should be: 7.x-1.x.   | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/releases/tag/7.x-1.0) |

## Gold
| Requirement  | Status |
|-------------|---------|
| Extensive documentation for the module (similar to Tripal User’s Guide).  | [Yes, RTD](https://genotypes-loader.readthedocs.io/en/latest/index.html)  |
| Unit testing is implemented using PHPUnit with the TripalTestSuite or something similar.  | [Yes](https://github.com/UofS-Pulse-Binfo/genotypes_loader/tree/master/tests) |
| Continuous integration is setup (e.g. such as with TravisCI).  | [Yes](https://travis-ci.org/github/UofS-Pulse-Binfo/genotypes_loader) |
| Imports data via Tripal’s importer class (Tripal3).  | No, doesn't make sense for large scale genotypic data. |
| Tripal 3 fields are Fully compatible with web services.  | NA, no tripal fields |
| The elementInfo function is fully implemented.  | NA, no tripal fields |
| The query and queryOrder functions fully implemented.  | NA, no tripal fields |
| Web Services uses Tripal’s Web Service Classes (Tripal3).  | NA, no web services |
|  Code sniffing and testing coverage reports (optional but encouraged).  | [Yes](https://codeclimate.com/github/UofS-Pulse-Binfo/genotypes_loader) |
| Drupal.org vetted release (optional but encouraged).  |  |