### PR TITLE
Fix for previous PR on use_button for importers.

### DIFF
--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -57,6 +57,7 @@ class TripalImporter {
    */
   public static $use_analysis = TRUE;
 
+
   /**
    * If the $use_analysis value is set above then this value indicates if the
    * analysis should be required.
@@ -68,6 +69,13 @@ class TripalImporter {
    * form.
    */
   public static $button_text = 'Import File';
+
+  /**
+   * If the form submit button that is provided by the Importer is not
+   * needed (i.e. the child class wants to do something different). Then
+   * set this to FALSE.
+   */
+  public static $use_button = TRUE;
 
   /**
    * Indicates the methods that the file uploader will support.


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# But Fix

Issue # 1143

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In PR #1143 that was just merged the `$use_button` variable was left out of the parent TripalImporter class.  So this means any importer that doesn't specifically include it will break.  The PR #1143 re-added the missing code but broke all importers. This fixes that.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

Just try to use any importer (I tried using the Taxonomy importer) before and after the fix.
