### PR TITLE
Datetime Fields Showing Wrong Date

### DIFF
--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -398,6 +398,16 @@ function tripal_chado_field_storage_load($entity_type, $entities, $age,
             // as the column value.
             $entity->{$field_name}['und'][0]['value'] = $record->$field_column;
             $entity->{$field_name}['und'][0]['chado-' . $field_table . '__' . $field_column] = $record->$field_column;
+
+            // For datetime columns we need to strip out the milliseconds if
+            // they are there because the Drupal date field can't deal with
+            // miliseconds and causes the displayed time to rever to the
+            // current time.
+            if ($field_type == 'datetime') {
+              $datevalue = $entity->{$field_name}['und'][0]['value'];
+              $datevalue = preg_replace('/^(\d+-\d+-\d+ \d+:\d+:\d+)\.\d+$/', '\1', $datevalue);
+              $entity->{$field_name}['und'][0]['value'] = $datevalue;
+            }
           }
         }
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1147 & #1078

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Tripal borrows the datetime fields from Drupal for showing data in Chado that are dates, but that field cannot handle milliseconds in the date.    It's weird because the datetime field form widget can deal with milliseconds but not the formatter. It just sets the time displayed to the current time.  

Since milliseconds probably aren't the most critical when setting dates when records are added or updated, this PR gets around the problem by removing the millisconds from a time string in Chado if it is there.  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1.  Find a gene or transcript or other entity that has the timeaccessioned or timelastmodified fields.   You may need to enable the field on the content type if you have it hidden.   The entity should not have ever been edited manually through the web interface.
2. Load the page... notice the dates are always the current date/time.
3. Pull this branch
4. Go back to the entity page, and click the 'reload' tab to ensure the cache is not being used.  The date time should now show the actual date in the database.
