### PR TITLE
Fix for PHP compatibility

### DIFF
--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -2593,7 +2593,7 @@ class GFF3Importer extends TripalImporter {
     }
 
     // Get the organism object.
-    [$genus, $species] = explode(':', $organism_attr, 2);
+    list($genus, $species) = explode(':', $organism_attr, 2);
     $organism = new ChadoRecord('organism');
     $organism->setValues([
       'genus' => $genus,


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1040

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a very simple fix. I don't think it even needs a functional review, just a code review.   In the newly updated GFF3 importer a bit of PHP code was used that is not compatible with PHP 7.0.  This fixes it so that it is backwards compatible. It was noticed because I got an error from it on the Tripal v3 demo site when trying to make the new `sequence__data_record` field to work.   After changing the code the error went away.
