### PR TITLE
Fix for sbo__relationship field Issue #1159

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship.inc
@@ -433,7 +433,6 @@ class sbo__relationship extends ChadoField {
     $object_type = $entity->{$field_name}['und'][$delta]['value']['local:relationship_object']['rdfs:type'];
     $object_name = $entity->{$field_name}['und'][$delta]['value']['local:relationship_object']['schema:name'];
 
-
     // Remember the current entity could be either the subject or object!
     // Example: The genetic_marker, MARKER1 , derives from the sequence_variant, VARIANT1.
     // The above relationship will be shown both on marker and variant pages

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
@@ -59,6 +59,9 @@ class sbo__relationship_formatter extends ChadoFieldFormatter {
    */
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
 
+    // Load the Field class into scope for use below.
+    tripal_load_include_field_class('sbo__relationship');
+
     // Get the settings
     $settings = $display['settings'];
     $rows = [];

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_formatter.inc
@@ -78,10 +78,6 @@ class sbo__relationship_formatter extends ChadoFieldFormatter {
       $verb = sbo__relationship::get_rel_verb($rel_type);
       $rel_type_clean = lcfirst(preg_replace('/_/', ' ', $rel_type));
 
-      $clause_parts = [ 'The ', $subject_type, ', ', $subject_name, ', ',
-        $verb, ' ', $rel_type_clean, ' ', $object_type,
-        ', ', $object_name, '.' ];
-
       // Handle some special cases.
       // For mRNA objects we don't want to show the CDS, exons, 5' UTR, etc.
       // we want to show the parent gene and the protein.
@@ -100,22 +96,28 @@ class sbo__relationship_formatter extends ChadoFieldFormatter {
         list($entity_type, $object_entity_id) = explode(':', $item['value']['local:relationship_object']['entity']);
 
         if ($object_entity_id != $entity->id) {
-          $clause_parts[11] = l($clause_parts[11], 'bio_data/' . $object_entity_id);
+          $object_name = l($object_name, 'bio_data/' . $object_entity_id);
         }
       }
       if (array_key_exists('entity', $item['value']['local:relationship_subject'])) {
         list($entity_type, $subject_entity_id) = explode(':', $item['value']['local:relationship_subject']['entity']);
         if ($subject_entity_id != $entity->id) {
-          $clause_parts[3] = l($clause_parts[3], 'bio_data/' . $subject_entity_id);
+          $subject_name = l($subject_name, 'bio_data/' . $subject_entity_id);
         }
       }
 
-      // Add bold font to the object and subject names.
-      $clause_parts[3] = '<b>' . $clause_parts[3] . '</b>';
-      $clause_parts[11] = '<b>' . $clause_parts[11] . '</b>';
+      // Add bold font to the subject and object names.
+      $subject_name = '<b>' . $subject_name . '</b>';
+      $object_name = '<b>' . $object_name . '</b>';
+
+      // The $clause text here will match what is already in $item['value']['SIO:000493']
+      // but we rebuild it here to incorporated links and formatting
+      $clause = 'The ' . $subject_type . ', ' .
+        $subject_name . ', ' . $verb . ' ' . $rel_type_clean . ' ' .
+        $object_type . ', ' . $object_name . '.';
 
       $rows[][] = [
-        'data' => implode('', $clause_parts),
+        'data' => $clause,
         //'class' => array('tripal-entity-unattached field-items')
       ];
     }


### PR DESCRIPTION
# Bug Fix
Issue # 1159

## Description
Fixes problem described in Issue #1159 
modifications to 
sbo__relationship.inc
sbo__relationship_formatter.inc

phrase is now stored as an array, and not imploded to a string until links and bold have been added, regex replacement is completely eliminated. This allowed me to easily fix this part
```
      // @todo add back in bolding...
      // @todo Fix Current Bug: if type name is in the object name, weird bolding happens.
```
although the code there appeared to want to replace the type, not the name, in conflict with the comment.


I have another tiny bug fix thrown in for the get_rel_verb() function, missing "break" and a missing term there.

## Testing?
You just need a relationship where one term is a substring of another

## Screenshots (if appropriate):
![20200128example](https://user-images.githubusercontent.com/8419404/106205993-ffcaf300-6184-11eb-95c4-fa0fbbb14acd.png)
becomes
![20200128example2](https://user-images.githubusercontent.com/8419404/106208505-1d9a5700-6189-11eb-89dd-44effdbb2022.png)
(we are on the "USDA" page, so it is proper for "USDA" to not have a link since it would point to itself)

