### PR TITLE
Display Issue problem

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
@@ -98,6 +98,12 @@ class data__sequence_record extends ChadoField {
     else {
       $this->addGenericReference($entity, $feature, $field_name);
     }
+
+    // The field should always return a 'value' key so even if we don't
+    // have a sequence we still need to add it
+    if (count(array_keys($entity->{$field_name}['und'])) == 0) {
+      $entity->{$field_name}['und'][0]['value'] = '';
+    }
   }
 
   /**

--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record_formatter.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record_formatter.inc
@@ -28,10 +28,8 @@ class data__sequence_record_formatter extends ChadoFieldFormatter {
     $phase_term = chado_get_semweb_term('featureloc', 'phase');
     $fasta_defline = 'local:fasta_definition';
 
-    $content = [];
-
     foreach ($items as $delta => $item) {
-      if (empty($item['value'])) {
+      if (!$item['value']) {
         continue;
       }
 
@@ -41,24 +39,19 @@ class data__sequence_record_formatter extends ChadoFieldFormatter {
       $residues .= wordwrap($item['value'][$sequence_term], $num_bases, "<br>", TRUE);
       $residues .= '</pre>';
 
-      $content[] = [
+      $element[$delta] = [
         '#type' => 'item',
         '#title' => $item['value'][$label_term],
         '#description' => $item['value'][$description_term],
         '#markup' => $residues,
       ];
-
-
     }
 
-    if (empty($content)) {
+    if (count($element) == 0) {
       $element[0] = [
         '#type' => 'markup',
-        '#markup' => '',
+        '#markup' => 'There are no sequences for this feature.',
       ];
-      return;
     }
-
-    $element[0] = $content;
   }
 }

--- a/tripal_ds/api/tripal_ds.pane.api.inc
+++ b/tripal_ds/api/tripal_ds.pane.api.inc
@@ -39,7 +39,7 @@ function tripal_ds_create_field($field_label, $field_name, $bundle_name) {
   //Build the rest of the passes parameters.
   $group_field_name = 'gp_' . $field_name;
   //Create the field groups.
-  tripal_ds_additional_fields_field_group_info($bundle_name, $field_label, $group_field_name, $field_name);
+  tripal_ds_add_generic_field_group($bundle_name, $field_label, $group_field_name, $field_name);
   //Place the field groups in the layout.
   tripal_ds_update_ds_layout($bundle_name, $field_name, $group_field_name);
 }

--- a/tripal_ds/includes/tripal_ds.ds.inc
+++ b/tripal_ds/includes/tripal_ds.ds.inc
@@ -160,31 +160,6 @@ function _ds_layout_settings_info($bundle_name, $instances) {
         usort($right_fields, tripal_ds_sort_object('label'));
       }
     }
-//     elseif (empty($all_field_groups)) {
-//       //Add the original instances that were passed and the field_groups that
-//       //were created.
-//       $field_group_fields = db_select('field_group', 'fg')
-//         ->fields('fg', ['group_name', 'data'])
-//         ->condition('bundle', $bundle_name, '=')
-//         ->execute()
-//         ->fetchAll();
-
-//       $instance_names = [];
-//       $field_group_names = [];
-//       foreach ($sorted_instances as $key => $instance) {
-//         $instance_names[$key]['field_name'] = $instance['field_name'];
-//         $instance_names[$key]['label'] = $instance['label'];
-
-//       }
-//       foreach ($field_group_fields as $key => $field_group_name) {
-//         $data = unserialize($field_group_name->data);
-//         $field_group_names[$key]['field_name'] = $field_group_name->group_name;
-//         $field_group_names[$key]['label'] = $data['format_settings']['label'];
-
-//       }
-//       $all_field_groups = array_merge($instance_names, $field_group_names);
-//       usort($all_field_groups, tripal_ds_sort_array('label'));
-//    }
 
     // Now build the $region_right array and the fields array.
     $i = 0;

--- a/tripal_ds/includes/tripal_ds.ds.inc
+++ b/tripal_ds/includes/tripal_ds.ds.inc
@@ -41,117 +41,113 @@ function _ds_layout_settings_info($bundle_name, $instances) {
   $region_left = [];
   $prop_fields = [];
   $summary_fields = [];
-  $data_sequence_fields = [];
-  $all_other_fields = [];
+  $unhandled_fields = [];
   $fields_with_regions = [];
   $i = 0;
-  $all_fields = [];
+
 
   try {
+
     // Get the bundle and term objects.
     $bundle = tripal_load_bundle_entity(['name' => $bundle_name]);
     $term = tripal_load_term_entity(['term_id' => $bundle->term_id]);
 
-    // Build one large multidimensional array of all instances to sort in alpha
-    // order to display fields in label alpha order.
+    // Get the list of fields and sort them by label.
+    $sorted_instances = [];
     foreach ($instances as $key => $instance) {
-      $all_fields[$i] = $instance;
+      $sorted_instances[$i] = $instance;
       $i++;
     }
-    usort($all_fields, tripal_ds_sort_array('label'));
+    usort($sorted_instances, tripal_ds_sort_array('label'));
 
-    // Iterate through the fields of this bundle.
-    foreach ($all_fields as $key => $instance) {
+    // Iterate through the fields of this bundle and put them into appropriate
+    // field groups.
+    foreach ($sorted_instances as $key => $instance) {
+      $base_table = array_key_exists('base_table', $instance['settings']) ? $instance['settings']['base_table'] : '';
+      $chado_table = array_key_exists('chado_table', $instance['settings']) ? $instance['settings']['chado_table'] : '';
       $instance_name = $instance['field_name'];
+
+      // Add the bundle type to the summary fields.
       if ($instance_name == "rdfs__type") {
         array_push($summary_fields, $instance_name);
+        continue;
+      }
+
+      // The tripal_chado module adds an image to the organism content
+      // type so we want to make sure that image goes in the summary.
+      // It is not a TripalField so it won't have a chado table.
+      if ($instance_name == 'data__image' and $term->name == 'organism') {
+        array_push($summary_fields, $instance_name);
+        continue;
+      }
+
+      // For fields that have a data__sequence prefix we want to hide these
+      // unless it's the data__sequence_record field which displays all of the
+      // sequence data and should be in it's own fieldset.
+      if (preg_match('/data__sequence/', $instance_name)) {
+        if ($instance_name == 'data__sequence_record') {
+          $instance['display']['default']['label'] = 'hidden';
+          field_update_instance($instance);
+          array_push($unhandled_fields, $instance);
+        }
+        continue;
+      }
+
+      // For the same reason, hide the CDS and protein fields
+      if ($instance_name == 'so__cds' or $instance_name == 'data__protein_sequence'){
+        continue;
+      }
+
+      // If this field holds a value from the prop table then add it to the
+      // properties field group.
+      if (preg_match('/_prop$/', $chado_table)) {
+        array_push($prop_fields, $instance_name);
+        continue;
+      }
+
+      // Put all fields from the base table in the summary and all other
+      // fields that were not handled above into a different array for
+      // handling later.
+      if ($base_table == $chado_table) {
+        array_push($summary_fields, $instance_name);
+        continue;
       }
       else {
-        //TODO: How do we handle non-chado dbs, placement of fields within
-        // tripal panes might need to be done in a hook.
-        $instance_base_table = array_key_exists('base_table', $instance['settings']) ? $instance['settings']['base_table'] : '';
-        $instance_base_chado = array_key_exists('chado_table', $instance['settings']) ? $instance['settings']['chado_table'] : '';
-        $prop_table = strpos($instance_base_chado, 'prop');
-        $data_sequence_record = strpos($instance_name, 'data__sequence_record');
-        $data_sequence = strpos($instance_name, 'data__sequence');
-        if ($instance_base_chado && $instance_base_table) {
-
-          if ($instance_base_chado == $instance_base_table) {
-            if ($data_sequence_record !== FALSE) {
-              array_push($data_sequence_fields, $instance_name);
-            }
-            elseif ($data_sequence !== FALSE or $instance_name == 'so__cds' or $instance_name == 'data__protein_sequence') {
-              // Do nothing as these chado column sequence fields
-              // should be hidden by default.
-            }
-            elseif ($prop_table !== FALSE) {
-              array_push($prop_fields, $instance_name);
-            }
-            else {
-              array_push($summary_fields, $instance_name);
-            }
-
-          }
-          elseif ($instance_base_chado != $instance_base_table) {
-            if ($data_sequence_record !== FALSE) {
-              array_push($data_sequence_fields, $instance_name);
-            }
-            elseif ($data_sequence !== FALSE or $instance_name == 'so__cds' or $instance_name == 'data__protein_sequence') {
-              // Do nothing as these chado column sequence fields
-              // should be hidden by default.
-            }
-            elseif ($prop_table !== FALSE) {
-              array_push($prop_fields, $instance_name);
-            }
-            else {
-              array_push($all_other_fields, $instance);
-
-              // Update the display settings so that the title is hidden.
-              $instance['display']['default']['label'] = 'hidden';
-              field_update_instance($instance);
-            }
-          }
-        }
-        else {
-          // The tripal_chado module adds an image to the organism content
-          // type so we want to make sure that image goes in the summary.
-          // It is not a TripalField so it won't have a chado table.
-          if ($instance_name == 'data__image' and $term->name == 'organism') {
-            array_push($summary_fields, $instance_name);
-          }
-        }
+        // Update the display settings so that the title is hidden.
+        $instance['display']['default']['label'] = 'hidden';
+        field_update_instance($instance);
+        array_push($unhandled_fields, $instance);
       }
-    }
+    } // end looping over fields.
 
-    // Consolidate the field sets.
+    // Create the summary and properties field groups.
     if (!empty($summary_fields)) {
-      _summary_field_group_info($bundle_name, $summary_fields);
+      tripal_ds_add_summary_field_group($bundle_name, $summary_fields);
     }
     if (!empty($prop_fields)) {
-      _prop_field_group_info($bundle_name, $prop_fields);
-    }
-    if (!empty($data_sequence_fields)) {
-      _data_sequence_field_group_info($bundle_name, $data_sequence_fields);
-    }
-    if (!empty($all_other_fields)) {
-      foreach ($all_other_fields as $key => $other_field) {
-        $group_field_name = 'gp_' . $other_field['field_name'];
-
-        // Need to truncate the names because of database field size restrictions,
-        // updating fields here to ensure name consistency.
-        $group_field_name = substr($group_field_name, 0, 27);
-
-        // Add random numbers to ensure the field name is unique within the 32
-        // character limit of the field.
-        $group_field_name = $group_field_name . rand(0, 99999);
-        tripal_ds_additional_fields_field_group_info($bundle_name, $other_field['label'], $group_field_name, $other_field['field_name']);
-      }
+      tripal_ds_add_prop_field_group($bundle_name, $prop_fields);
     }
 
-    // Build one large multidimensional array of all instances to sort in alpha
-    // order to display fields in label alpha order.
+    // All other fields get their own field group (i.e. Tripal Pane).
+    foreach ($unhandled_fields as $key => $other_field) {
+      $group_field_name = 'gp_' . $other_field['field_name'];
+
+      // Need to truncate the names because of database field size restrictions,
+      // updating fields here to ensure name consistency.
+      $group_field_name = substr($group_field_name, 0, 27);
+
+      // Add random numbers to ensure the field name is unique within the 32
+      // character limit of the field.
+      $group_field_name = $group_field_name . rand(0, 99999);
+
+      // Now add a generic field group for this field.
+      tripal_ds_add_generic_field_group($bundle_name, $other_field['label'], $group_field_name, $other_field['field_name']);
+    }
+
+    // Build one large multidimensional array of all field groups to sort
+    // in alpha order to display fields in label alpha order.
     $right_fields = [];
-    $all_field_groups = field_group_info_groups('TripalEntity', $bundle_name);
+    $all_field_groups = field_group_info_groups('TripalEntity', $bundle_name, NULL, TRUE);
 
     if (!empty($all_field_groups)) {
       if (is_array($all_field_groups)) {
@@ -164,31 +160,31 @@ function _ds_layout_settings_info($bundle_name, $instances) {
         usort($right_fields, tripal_ds_sort_object('label'));
       }
     }
-    elseif (empty($all_field_groups)) {
-      //Add the original instances that were passed and the field_groups that
-      //were created.
-      $field_group_fields = db_select('field_group', 'fg')
-        ->fields('fg', ['group_name', 'data'])
-        ->condition('bundle', $bundle_name, '=')
-        ->execute()
-        ->fetchAll();
+//     elseif (empty($all_field_groups)) {
+//       //Add the original instances that were passed and the field_groups that
+//       //were created.
+//       $field_group_fields = db_select('field_group', 'fg')
+//         ->fields('fg', ['group_name', 'data'])
+//         ->condition('bundle', $bundle_name, '=')
+//         ->execute()
+//         ->fetchAll();
 
-      $instance_names = [];
-      $field_group_names = [];
-      foreach ($all_fields as $key => $instance) {
-        $instance_names[$key]['field_name'] = $instance['field_name'];
-        $instance_names[$key]['label'] = $instance['label'];
+//       $instance_names = [];
+//       $field_group_names = [];
+//       foreach ($sorted_instances as $key => $instance) {
+//         $instance_names[$key]['field_name'] = $instance['field_name'];
+//         $instance_names[$key]['label'] = $instance['label'];
 
-      }
-      foreach ($field_group_fields as $key => $field_group_name) {
-        $data = unserialize($field_group_name->data);
-        $field_group_names[$key]['field_name'] = $field_group_name->group_name;
-        $field_group_names[$key]['label'] = $data['format_settings']['label'];
+//       }
+//       foreach ($field_group_fields as $key => $field_group_name) {
+//         $data = unserialize($field_group_name->data);
+//         $field_group_names[$key]['field_name'] = $field_group_name->group_name;
+//         $field_group_names[$key]['label'] = $data['format_settings']['label'];
 
-      }
-      $all_field_groups = array_merge($instance_names, $field_group_names);
-      usort($all_field_groups, tripal_ds_sort_array('label'));
-    }
+//       }
+//       $all_field_groups = array_merge($instance_names, $field_group_names);
+//       usort($all_field_groups, tripal_ds_sort_array('label'));
+//    }
 
     // Now build the $region_right array and the fields array.
     $i = 0;
@@ -337,7 +333,7 @@ function _ds_layout_pub_settings_info($bundle_name, $instances) {
       $group_field_name = $group_field_name . rand(0, 99999);
 
       // Build the field group.
-      tripal_ds_additional_fields_field_group_info($bundle_name, $other_field['label'], $group_field_name, $other_field['field_name']);
+      tripal_ds_add_generic_field_group($bundle_name, $other_field['label'], $group_field_name, $other_field['field_name']);
 
       // Update arrays.
       array_push($temporary_field, $group_field_name, $other_field['field_name']);

--- a/tripal_ds/includes/tripal_ds.field_group.inc
+++ b/tripal_ds/includes/tripal_ds.field_group.inc
@@ -7,7 +7,7 @@
  * @param $fields
  *  Array of the machine names of the children of the field group being created.
  */
-function _summary_field_group_info($bundle_name, $fields) {
+function tripal_ds_add_summary_field_group($bundle_name, $fields) {
   //Tripal pane to nest the summary fieldset within.
   $field_group_tripalpane = new stdClass();
   $field_group_tripalpane->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially*/
@@ -80,7 +80,7 @@ function _summary_field_group_info($bundle_name, $fields) {
  * @param $fields
  *  Array of the machine names of the children of the field group being created.
  */
-function _prop_field_group_info($bundle_name, $fields) {
+function tripal_ds_add_prop_field_group($bundle_name, $fields) {
   //Tripal pane  to nest the fieldset within.
   $field_group_tripalpane = new stdClass();
   $field_group_tripalpane->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially*/
@@ -152,7 +152,7 @@ function _prop_field_group_info($bundle_name, $fields) {
  * @param $fields
  *  Array of the machine names of the children of the field group being created.
  */
-function _data_sequence_field_group_info($bundle_name, $fields) {
+function tripal_ds_add_sequences_field_group($bundle_name, $fields) {
   //Tripal pane  to nest the fieldset within.
   $field_group_tripalpane = new stdClass();
   $field_group_tripalpane->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially*/
@@ -182,7 +182,7 @@ function _data_sequence_field_group_info($bundle_name, $fields) {
   ];
   drupal_write_record('field_group', $field_group_tripalpane);
   //Write to the tripal_ds table to record the new tripal pane.
-  tripal_ds_bundle_menu_item($bundle_name, 'Sequence', 'group_sequence_tripalpane', 'TripalEntity');
+  tripal_ds_bundle_menu_item($bundle_name, 'Sequences', 'group_sequence_tripalpane', 'TripalEntity');
 
   //Table of fields.
   $field_group = new stdClass();
@@ -230,7 +230,7 @@ function _data_sequence_field_group_info($bundle_name, $fields) {
  * @param $field_name
  *  Machine name of the child element.
  */
-function tripal_ds_additional_fields_field_group_info($bundle_name, $field_label, $group_field_name, $field_name) {
+function tripal_ds_add_generic_field_group($bundle_name, $field_label, $group_field_name, $field_name) {
   //Write to the tripal_ds table to record the new tripal pane.
   tripal_ds_bundle_menu_item($bundle_name, $field_label, $group_field_name, 'TripalEntity');
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue # N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Bug # 1:
While testing the current dev branch I found a display bug when a site is first installed.  Several of the feature specific fields, related to the sequence (checksum, length, residues, CDS and protein) were not inside of a Tripal Panel.  They were just floating on the right side.  See screenshot.
![image](https://user-images.githubusercontent.com/1719352/106211869-4832e280-617e-11eb-940c-d9cff42ab876.png)

The problem is that when the layouts are first generated when the site is prepared on the first install, there is no field group caching and there was an if statement that tried to fake a cached info array for the field groups but it had a mistake in it.  I was able to fix this and simplify the code by simply rebuilding the cache with the `field_group_info_groups` function call. that was already being used.  I also took the time to simplify the code logic as well to make it a bit more readable and easier to find the bug. 

Bug # 2:
Also, in the process of fixing the display issue related to the sequence fields I noticed that the "Sequences Pane" was just empty with nothing in it if there was actually no sequence data loaded into Chado.  There should be at least a message.  See screenshot below.

![image](https://user-images.githubusercontent.com/1719352/106212251-08b8c600-617f-11eb-8d87-8994ba332166.png)

Both bugs are now fixed with this PR and the results look correct:

![image](https://user-images.githubusercontent.com/1719352/106212377-51707f00-617f-11eb-946b-98cf46399b5b.png)


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

To test this fix you will unfortunately need to reinstall Tripal, from scratch... twice..

1. First installation use the current 7.x-3.x code
    - Install Chado
    - Prepare Tripal/Chado
    - Create the Citrus organism
    - Create the Citrus analysis
    - Load the Citrus demo data
    - Publish the gene and mRNA features.
    - Go to the gen page and you'll see the messed up display items described above
2. Repeat the same steps above with a new installation but this time use this branch. You'll notice the problems are fixed. 