### PR TITLE
ChadoRecord class bug

### DIFF
--- a/tripal_chado/api/ChadoRecord.inc
+++ b/tripal_chado/api/ChadoRecord.inc
@@ -108,13 +108,6 @@ class ChadoRecord {
    */
   protected $required_cols = [];
 
-
-  /**
-   * @var array
-   *   An array of default values.
-   */
-  protected $default_values = [];
-
   /**
    * @var boolean
    *   An array of required columns which have yet to be set.
@@ -175,16 +168,13 @@ class ChadoRecord {
       $this->column_names[] = $column_name;
     }
 
-    // Get the required columns and default values.
+    // Get the required columns.
     foreach ($this->schema['fields'] as $column => $col_schema) {
       foreach ($col_schema as $param => $val) {
         if (preg_match('/not null/i', $param) and $col_schema[$param]) {
           $this->required_cols[] = $column;
           // Currently all required columns are missing.
           $this->missing_required_col[$column] = TRUE;
-        }
-        if (preg_match('/default/i', $param) and $col_schema[$param] !== '') {
-          $this->default_values[$column] = $col_schema[$param];
         }
       }
     }
@@ -578,10 +568,8 @@ class ChadoRecord {
       throw new Exception($message);
     }
 
-    // Make sure that the value is not NULL if this is a required field and if
-    // it doesn't have a default value.
-    if (in_array($column_name, $this->required_cols) and $value === '__NULL__' and
-        !array_key_exists($column_name, $this->default_values)) {
+    // Make sure that the value is not NULL if this is a required field.
+    if (in_array($column_name, $this->required_cols) and $value === '__NULL__') {
       $message = t('ChadoRecord::setValue(). The column named, "!column", ' .
         'requires a value for the table: "!table".',
         [

--- a/tripal_chado/api/ChadoRecord.inc
+++ b/tripal_chado/api/ChadoRecord.inc
@@ -108,6 +108,13 @@ class ChadoRecord {
    */
   protected $required_cols = [];
 
+
+  /**
+   * @var array
+   *   An array of default values.
+   */
+  protected $default_values = [];
+
   /**
    * @var boolean
    *   An array of required columns which have yet to be set.
@@ -168,13 +175,16 @@ class ChadoRecord {
       $this->column_names[] = $column_name;
     }
 
-    // Get the required columns.
+    // Get the required columns and default values.
     foreach ($this->schema['fields'] as $column => $col_schema) {
       foreach ($col_schema as $param => $val) {
         if (preg_match('/not null/i', $param) and $col_schema[$param]) {
           $this->required_cols[] = $column;
           // Currently all required columns are missing.
           $this->missing_required_col[$column] = TRUE;
+        }
+        if (preg_match('/default/i', $param) and $col_schema[$param] !== '') {
+          $this->default_values[$column] = $col_schema[$param];
         }
       }
     }
@@ -391,7 +401,7 @@ class ChadoRecord {
         continue;
       }
 
-      if ($value == '__NULL__') {
+      if ($value === '__NULL__') {
         $sql .= $column . ' = NULL, ';
       }
       else {
@@ -568,8 +578,10 @@ class ChadoRecord {
       throw new Exception($message);
     }
 
-    // Make sure that the value is not NULL if this is a required field.
-    if (in_array($column_name, $this->required_cols) and $value == '__NULL__') {
+    // Make sure that the value is not NULL if this is a required field and if
+    // it doesn't have a default value.
+    if (in_array($column_name, $this->required_cols) and $value === '__NULL__' and
+        !array_key_exists($column_name, $this->default_values)) {
       $message = t('ChadoRecord::setValue(). The column named, "!column", ' .
         'requires a value for the table: "!table".',
         [


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#Bug Fix

Issue #1071 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Loading the EDAM ontology via the TripalFile module caused this error

```
ChadoRecord::setValue(). The column named, "is_obsolete", requires a value for the table: "cvterm".
[site http://default] [TRIPAL ERROR] [TRIPAL_JOB] ChadoRecord::setValue(). The column named, "is_obsolete", requires a value for the table: "cvterm".
```

The problem was due to comparison of values where a `===` should have been used instead of a  `==`.  I've fixed it. 

This is such a simple fix I don't think it needs a functional review. Just a code check.