### PR TITLE
Bulk Loader Bug in Required Fields

### DIFF
--- a/tripal_bulk_loader/includes/tripal_bulk_loader.admin.templates.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.admin.templates.inc
@@ -426,6 +426,10 @@ function tripal_bulk_loader_modify_template_base_form($form, &$form_state = NULL
             '#type' => 'hidden',
             '#value' => $priority,
           ],
+          'required' => [
+            '#type' => 'item',
+            '#markup' => $field['required'] ? '&#10004;' : '',
+          ],
           'field_name' => [
             '#type' => 'item',
             '#markup' => $field['title'],
@@ -1848,7 +1852,16 @@ function tripal_bulk_loader_template_field_form_default_values($mode, &$form_sta
   $v['foreign_record'] = (isset($form_state['values']['foreign_record'])) ? $form_state['values']['foreign_record'] : 'NULL';
   $v['foreign_field_options'] = $ref_chado_fields;
   $v['foreign_field'] = (isset($form_state['values']['foreign_field'])) ? $form_state['values']['foreign_field'] : current($ref_chado_fields);
-  $v['required'] = (isset($form_state['values']['required'])) ? $form_state['values']['required'] : FALSE;
+
+  // The required checkbox should be forced as checked if this database
+  // column is set to 'not null'. Otherwise, use the form state.
+  if (array_key_exists('not null', $table_description['fields'][$field]) and
+      $table_description['fields'][$field]['not null'] === TRUE) {
+    $v['required'] = 'FORCE_TRUE';
+  }
+  else {
+    $v['required'] = (isset($form_state['values']['required'])) ? $form_state['values']['required'] : $template_field['required'];
+  }
 
   if (isset($original_field['regex']) && empty($form_state['storage']['regex']['pattern'])) {
     $form_state['storage']['regex']['pattern'] = $original_field['regex']['pattern'];
@@ -2169,6 +2182,16 @@ function tripal_bulk_loader_template_field_form($form, &$form_state = NULL) {
     '#default_value' => $values['required'],
   ];
 
+  // If the required value is set as "FORCE_TRUE" then that means the
+  // underlying database column is set to NOT NULL so the end-user should
+  // not be able to change if this field is required or not.
+  if ($values['required'] === 'FORCE_TRUE') {
+    $form['fields']['field']['additional']['required']['#attributes']['disabled'] = TRUE;
+    $form['fields']['field']['additional']['required']['#value'] = 1;
+    $form['fields']['field']['additional']['required']['#default_value'] = 1;
+    $form['fields']['field']['additional']['required']['#title'] = 'The database constraints force this field to be required.';
+  }
+
   $form['fields']['field']['additional']['regex_transform'] = [
     '#type' => 'fieldset',
     '#title' => 'Transform Data File Value Rules',
@@ -2188,7 +2211,7 @@ function tripal_bulk_loader_template_field_form($form, &$form_state = NULL) {
   $pattern_default = '';
   $replace_default = '';
 
-  // Check to see if there is more than one regex and if so warn them that 
+  // Check to see if there is more than one regex and if so warn them that
   // this feature is no longer supported. We don't want people to lose existing
   // transformation rules just by tweaking the field so we will only set defaults
   // if there is a single rule and summarize multiple rules statically.
@@ -2420,7 +2443,6 @@ function tripal_bulk_loader_template_field_form_submit($form, &$form_state) {
     $form_state['rebuild'] = FALSE;
     $form_state['redirect'] = 'admin/tripal/loaders/bulk/template/' . $form_state['storage']['template_id'] . '/edit';
   }
-
 }
 
 /**

--- a/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
@@ -524,14 +524,16 @@ function process_data_array_for_line($priority, &$data, &$default_data, $addt) {
   }
 
   // Check that template required fields are present. if a required field is
-  // missing and this
-  // is an optional record then just return. otherwise raise an error
+  // missing and this is an optional record then just return. otherwise raise
+  // an error
   $skip_optional = 0;
   foreach ($table_data['required'] as $field => $required) {
+
     if ($required) {
       // check if the field has no value (or array is empty)
       if (!isset($values[$field]) or
         (is_array($values[$field]) and count($values[$field]) == 0)) {
+
         // check if the record is optional.  For backwards compatiblity we need to
         // check if the 'mode' is set to 'optional'
         if ($table_data['optional'] or preg_match('/optional/', $table_data['mode']) or

--- a/tripal_bulk_loader/theme/templates/tripal_bulk_loader_modify_template_base_form_fields.tpl.php
+++ b/tripal_bulk_loader/theme/templates/tripal_bulk_loader_modify_template_base_form_fields.tpl.php
@@ -18,11 +18,12 @@ $header = [
   'Chado Field',
   'Field Type',
   'Field Settings',
+  'Required',
 ]; //'Data Column', 'Constant Value', 'Referred Record');
 $rows = [];
 
 // This is an array to keep track of the record => field index as well as the number of fields.
-// It is used to make the record column span all the field rows providing more room for 
+// It is used to make the record column span all the field rows providing more room for
 // information and a visual separation between records.
 // Expect: record_id => array(index1, index2, index3)
 $field_record = [];
@@ -81,9 +82,14 @@ foreach (element_children($element) as $key) {
     'class' => ['field-type'],
   ];
 
-  // Finally specify the field value.
-
+  // Specify the field value.
   $row[] = $value;
+
+  // Specify if the field is required.
+  $row[] = [
+    'data' => drupal_render($row_element['required']),
+    'class' => ['field-required'],
+  ];
 
   // Add this field to the table.
   $rows[] = [

--- a/tripal_bulk_loader/theme/tripal_bulk_loader.css
+++ b/tripal_bulk_loader/theme/tripal_bulk_loader.css
@@ -48,6 +48,9 @@
   text-align: center;
   width: 50px;
 }
+#tripal-bulk-loader-modify-template-base-form td.field-required {
+  text-align: center;
+}
 #tripal-bulk-loader-modify-template-base-form td.record {
   width: 100px;
   background-color: #F2F3ED;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1164 and replacemenet for PR #1170

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the bug described in issue #1164 and maybe #1165.   Here's a summary of the problem, but it's a bit complex...

The bulk loader allows the end-user to set a record's field as "required". This forces the input file to have a value for that field.  However, if the end-user can set a record as 'optional', meaning that if all of the required fields are not present then the record is skipped and nothing is updated/inserted/selected.  The problem occurs when database columns are set as "not null".  Consider an insert on the organism table. The `genus` and `species` are both required, but the user did not check both as "required" but suppose the end-user set the record as "optional".   Now suppose a species value was missing from a value in the data table. The bulk loader would fail because it would try to pass a NULL value to the species. It would do this because there are no required fields for the bulk loader record and it ignores the fact that the fields are required for the database table.

What should really happen is that the fields that map to database columns that are marked as 'not null' should always be marked as required.  There is no possible use case where a database column used in the bulk loader that is marked as "not null" should not have a value.  

This PR fixes that by
1.  Forcing all fields mapped to a database table column of "not null" to be required. The user cannot uncheck it. See the screenshot below for how this looks to the user.
![image](https://user-images.githubusercontent.com/1719352/111232337-25328580-85a8-11eb-8fa3-372af3d740ef.png)
2.  It also adds a new "Required" column  to the page when editing a template so the end-user can easily  tell which fields are required. 
![image](https://user-images.githubusercontent.com/1719352/111232432-58751480-85a8-11eb-9c44-86993bd2d6e7.png)



## Testing?
To test this PR, do the following:

1. Download the template and test file provided by @dsenalik on PR #1170 
2. Using the 7.x-3.x version of Tripal, try to import the data file. It will fail.
3. Switch to this branch.
4. Edit each of the fields in the template just so you can ensure that the "mark this field required" checkbox is selected.  The box will be checked automatically for columns in Chado that are "not null".    You have to do this because the template has no required fields and it's hard-coded so we have to fix it.  But the web interface on this branch should automatically set it. Just edit and save each field. It's annoying to do all of them but is has to be done to fix the template.  
5. Now import the file and it should work.
6. You should have a new organism in the database.

