### PR TITLE
filter out blank lines in bulk loader line count

### DIFF
--- a/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
@@ -152,11 +152,15 @@ function tripal_bulk_loader_load_data($nid, $job_id) {
   $node = node_load($nid);
   print "Template: " . $node->template->name . " (" . $node->template_id . ")\n";
 
-  // Determine the total number of lines in the file.
+  // Determine the total number of non-blank lines in the file.
   $total_lines = 0;
   $handle = fopen($node->file, "r");
   while (!feof($handle)) {
     $line = fgets($handle);
+    $line = trim($line);
+    if (empty($line)) {
+      continue;
+    } // skips blank lines
     $total_lines++;
   }
   fclose($handle);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


# Bug Fix

#

Issue #1178

## Description
Resolve this issue by copying the logic for ignoring blank lines from the loader up to the routine that counts the number of lines

## Testing?
For any bulk loader job, compare the number of lines reported by drush to the number of lines in the file reported by ```sed -e 's/^\s*$/d' | wc -l```

For the same file used for the example in Issue #1178 the output is now correct
```
File: /somepath/test.tsv (2 lines)
```
```
[|||||||||||||||||||||||||||||||||||||||||||||||||||] 100.00%. (2 of 2) Memory: 54448560
```