### PR TITLE
Tokens Bug

### DIFF
--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -359,16 +359,18 @@ function chado_get_tokens($base_table) {
       foreach ($details['columns'] as $left_field => $right_field) {
 
         $sub_token_prefix = $base_table . '.' . $left_field;
-        $sub_location_prefix = implode(' > ', [$base_table, $left_field]);
-
         $sub_tokens = chado_get_tokens($table);
-        if (is_array($sub_tokens)) {
-          $tokens = array_merge($tokens, $sub_tokens);
+        foreach ($sub_tokens as $key => $sub_token) {
+          $key = preg_replace('/[\[\]]/','', $key);
+          $new_key = '[' . $sub_token_prefix .'>' . $key . ']';
+          $new_location = implode(' > ', [$base_table, $left_field, $sub_token['field']]);
+          $tokens[$new_key] = $sub_token;
+          $tokens[$new_key]['token'] = $new_key;
+          $tokens[$new_key]['location'] = $new_location;
         }
       }
     }
   }
-
   return $tokens;
 }
 
@@ -388,12 +390,14 @@ function chado_get_tokens($base_table) {
  * @ingroup tripal_chado_api
  */
 function chado_replace_tokens($string, $record) {
-  // Get the list of tokens
+
+  // Get the list of tokens.
   $tokens = chado_get_tokens($record->tablename);
 
-  // Determine which tokens were used in the format string
+  // Determine which tokens were used in the format string.
   if (preg_match_all('/\[[^]]+\]/', $string, $used_tokens)) {
-    // Get the value for each token used
+
+    // Get the value for each token used.
     foreach ($used_tokens[0] as $token) {
       $token_info = $tokens[$token];
       if (!empty($token_info)) {
@@ -401,25 +405,22 @@ function chado_replace_tokens($string, $record) {
         $var = $record;
         $value = '';
 
-        // Iterate through each portion of the location string. An example string
-        // might be:  stock > type_id > name.
+        // Iterate through each portion of the location string. An example
+        // string might be:  stock > type_id > name.
         $location = explode('>', $token_info['location']);
         foreach ($location as $index) {
           $index = trim($index);
 
-          // if $var is an object then it is the $node object or a table
-          // that has been expanded.
-          if (is_object($var)) {
-            // check to see if the index is a member of the object. If so,
-            // then reset the $var to this value.
-            if (property_exists($var, $index)) {
+          // if $var is an object then it is and expanded table.
+          // So, we'll reset $var to be this value and allow the
+          // loop to continue to the next level.
+          if (is_object($var) and property_exists($var, $index)) {
+            if (is_object($var->$index)) {
+              $var = $var->$index;
+            }
+            else {
               $value = $var->$index;
             }
-          }
-          // if the $var is an array then there are multiple instances of the same
-          // table in a FK relationship (e.g. relationship tables)
-          elseif (is_array($var)) {
-            $value = $var[$index];
           }
           else {
             tripal_report_error('tripal_chado', TRIPAL_WARNING,


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1199 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The issue reported by @dsenalik in issue #1199 was bigger than just the `obi__organism` field.  There was a bug in the chado token strings.  Tokens for Chado base tables always looked like `[base_table.field_name]`, and these worked just fine. However, when foreign keys are used the tokens are inccorrect. In previous version of Tripal a token, say for the infraspecific name would look like `[organism.type_id>cvterm.name]`. Instead, the token was showing up simply as `[cvterm.name]`. 

This PR fixes this problem for all tokens derived from foreign key relationships in Chado. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
To test this:
1. Find a page in your site that uses the Chado `organism_id` field (or `obi__organism` field). If you need to, add a dummy infraspecific type and name for testing.
2. Navigate to `Structure` > `Tripal Content Types` and select the content type for the page you just looked up.  Then edit the settings for the Organism field.   
3. Open the list of tokens for the organism display. You'll see the foreign key relationships are not in the tokens where they should be.  If you want to, experiment and use the `[cvterm.name]` to specify the infraspecific type. Save and view the data page... no infraspecific type.
4. Pull this PR and return to the content type page and edit the organism field.  Now you should see the tokens with their FKs embedded in the token.   Add the tokens `[organism.type_id>cvterm.name]` and `[organism.infraspecific_name]` to the text box and save.
5. Return to the content page, click the 'Reload' button and you should now see the infraspecific type and name appear on the page.


## Screenshots (if appropriate):

## Additional Notes (if any):

<!--- New features should include in-line code documentation. -->
<!--- Would a user or developer guide be helpful for this feature? -->
