### PR TITLE
Fixes bug in access to legacy pages.

### DIFF
--- a/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
+++ b/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
@@ -648,7 +648,7 @@ function tripal_analysis_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_analysis content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_contact/includes/tripal_contact.chado_node.inc
+++ b/legacy/tripal_contact/includes/tripal_contact.chado_node.inc
@@ -352,7 +352,7 @@ function tripal_contact_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_contact content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
+++ b/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
@@ -410,7 +410,7 @@ function tripal_feature_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_feature content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_featuremap/includes/tripal_featuremap.chado_node.inc
+++ b/legacy/tripal_featuremap/includes/tripal_featuremap.chado_node.inc
@@ -252,7 +252,7 @@ function tripal_featuremap_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_featuremap content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_library/includes/tripal_library.chado_node.inc
+++ b/legacy/tripal_library/includes/tripal_library.chado_node.inc
@@ -530,7 +530,7 @@ function tripal_library_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_library content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_organism/includes/tripal_organism.chado_node.inc
+++ b/legacy/tripal_organism/includes/tripal_organism.chado_node.inc
@@ -86,7 +86,7 @@ function tripal_organism_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_organism content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_phylogeny/includes/tripal_phylogeny.chado_node.inc
+++ b/legacy/tripal_phylogeny/includes/tripal_phylogeny.chado_node.inc
@@ -748,7 +748,7 @@ function chado_phylotree_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_phylotree content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_project/includes/tripal_project.chado_node.inc
+++ b/legacy/tripal_project/includes/tripal_project.chado_node.inc
@@ -486,7 +486,7 @@ function tripal_project_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_project content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_pub/includes/tripal_pub.chado_node.inc
+++ b/legacy/tripal_pub/includes/tripal_pub.chado_node.inc
@@ -586,7 +586,7 @@ function tripal_pub_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_pub content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }

--- a/legacy/tripal_stock/includes/tripal_stock.chado_node.inc
+++ b/legacy/tripal_stock/includes/tripal_stock.chado_node.inc
@@ -999,7 +999,7 @@ function tripal_stock_node_access($node, $op, $account) {
       }
     }
     if ($op == 'view') {
-      if (!user_access('access chado_stock content', $account)) {
+      if (!user_access('access content', $account)) {
         return NODE_ACCESS_DENY;
       }
     }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1221 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
A bug exists that prevents any legacy content from being seen by an anonymous user.    The problem is that each legacy content type has it's own `hook_node_access()` function that checks the permissions for the user and for viewing it checks for a content type specific permission.  However, when we switched the legacy content types over to Tripal v3 we removed the older permission to allow Drupal to create them and Drupal doesn't use a content specific permission for node-based content types (which the legacy types are nodes).  This fix reverts the permissions for viewing content types to just `access content` as it should be. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1. Make sure you have the "view published content" permission turned on.
2. Prior to pull this fix, enable the organism legacy module.  
2. Create a legacy organism page: Content > Add Content > Organisim
3. Log out and try to view the new organism page. You'll get "access denied".
4. Pull the code for this pull request
5. Now go to the organism page while still logged out and you should see the page.

