### PR TITLE
Missing Synonyms

### DIFF
--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -2760,7 +2760,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
       ],
     ];
   }
-  return;
+
   // SYNONYMS
   $syn_table = $table_name . '_synonym';
   if (chado_table_exists($syn_table)) {


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

#Bug Fix

Issue #1214

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As reported by @mario-lopez-c the synonyms are not appearing on "feature" based pages, or any content type that supports synonyms. The reason is a return statement that must have been accidentally left in during previous testing. Removing the `return` fixes the issue and the synonym field is available.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1.  Go to (or create) any feature page (e.g. gene, mRNA,  etc.).  
2. You'll notice there is no field for synonyms or aliases for the content type.
3. Go to Structure > Tripal Content Types > mRNA (or whatever you are using) and click the 'Manage fields' link.   Notice there is no Synonyms field.
4. Click the 'Check for new fields` link at the top and it will not find a synonym field.
5. Pull the code from this PR.
6. Click the 'Check for new fields` link at the top and it will now find a synonym field!
7. Click the 'Manage Display' at the top and move the new Synonym field where you want it to appear on the page and save.
8. Return to the original page and you should now see a synonym field. You can edit the page and change/add a synonym.
