### PR TITLE
Security Fix for Editing Tripal Content

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -1351,12 +1351,15 @@ function tripal_replace_entity_tokens($string, &$entity, $bundle_entity = NULL) 
     $token = preg_replace('/[\[\]]/', '', $token);
     $elements = explode(',', $token);
     $field_name = array_shift($elements);
+
     //$field_name = str_replace(array('.','[',']'), array('__','',''), $field_name);
     if (!property_exists($entity, $field_name) or empty($entity->{$field_name})) {
       $field = field_info_field($field_name);
-      $storage = $field['storage'];
-      $attach_fields[$storage['type']]['storage'] = $storage;
-      $attach_fields[$storage['type']]['fields'][] = $field;
+      if ($field) {
+        $storage = $field['storage'];
+        $attach_fields[$storage['type']]['storage'] = $storage;
+        $attach_fields[$storage['type']]['fields'][] = $field;
+      }
     }
   }
 
@@ -1435,7 +1438,10 @@ function tripal_replace_entity_tokens($string, &$entity, $bundle_entity = NULL) 
  */
 function _tripal_replace_entity_tokens_for_elements($elements, $values) {
   $term_id = array_shift($elements);
-  $value = $values[$term_id];
+  $value = '';
+  if (array_key_exists($term_id, $values)) {
+    $value = $values[$term_id];
+  }
   if (count($elements) == 0) {
     return $value;
   }

--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -712,6 +712,7 @@ function tripal_entity_form_submit($form, &$form_state) {
     }
     return;
   }
+
   if ($form_state['clicked_button']['#name'] == 'unpublish_data') {
     if (entity_access('unpublish', 'TripalEntity', $entity, $user)) {
       $form_state['redirect'] = 'bio_data/' . $entity->id . '/unpublish';
@@ -719,15 +720,15 @@ function tripal_entity_form_submit($form, &$form_state) {
     return;
   }
 
-  $username = $form_state['values']['author_name'];
-  $user = user_load_by_name($username);
-  $entity->uid = $user->uid;
+  if (!array_key_exists('#entity', $form)) {
+    $entity->uid = $user->uid;
 
-  $create_date = $form_state['values']['author_date'];
-  $entity->created = $create_date;
+    $create_date = $form_state['values']['author_date'];
+    $entity->created = $create_date;
 
-  $published = $form_state['values']['status'];
-  $entity->status = $published;
+    $published = $form_state['values']['status'];
+    $entity->status = $published;
+  }
 
   // Allow the fields to perform actions prior to submit.
   $instances = field_info_instances('TripalEntity', $entity->bundle);
@@ -737,6 +738,9 @@ function tripal_entity_form_submit($form, &$form_state) {
     if ($entity_type == 'TripalEntity' and array_key_exists($field_name, $form)) {
       foreach ($form[$field_name][$langcode] as $delta => $field_form) {
         if (!preg_match('/^\d+$/', $delta)) {
+          continue;
+        }
+        if (!array_key_exists('#field', $field_form)) {
           continue;
         }
         $widget_type = $instance['widget']['type'];


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Security / Bug Fix

Issue #1220

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Please see the nice description on issue #1220 for how this security issue can be replicated.

Also, it seems that this switching users caused some warning messages to appear on the page that were not displayed before.  I'm not sure why the user switching hid those but this PR also adds a few checks to make sure those warnings don't appear.  They were simple warnings about arrays not having the keys. You'll see them in the code changes.  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

1.  Pull this fix and retry the steps described in issue #1220. The user switching problem should be fixed.