### PR TITLE
#1218 add the mview  db2cv_mview on chado install

### DIFF
--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -33,6 +33,8 @@ function tripal_chado_install() {
     // Fix the SOFP feature_property issue from the legacy feature_property.
     tripal_chado_fix_legacy_SOFP_7338();
 
+    module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.chado_vx_x');
+    tripal_chado_add_db2cv_mview_mview();
   }
 
   tripal_insert_variable('bundle_category', 'Bundles can be categorized to allow for grouping');

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -33,8 +33,6 @@ function tripal_chado_install() {
     // Fix the SOFP feature_property issue from the legacy feature_property.
     tripal_chado_fix_legacy_SOFP_7338();
 
-    module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.chado_vx_x');
-    tripal_chado_add_db2cv_mview_mview();
   }
 
   tripal_insert_variable('bundle_category', 'Bundles can be categorized to allow for grouping');
@@ -734,16 +732,20 @@ function tripal_chado_fix_legacy_SOFP_7338() {
     chado_update_record('cvterm', ['cvterm_id' => $id], ['is_relationshiptype' => 0]);
   }
 
-  // Repopulate the mview.
-  $mview_id = chado_get_mview_id('db2cv_mview');
-  global $user;
-  tripal_add_job(
-    'Repopulating db2cv to fix legacy SOFP',
-    'tripal_chado',
-    'chado_populate_mview',
-    [$mview_id],
-    $user->uid
-  );
+  // Repopulate the mview if the table exists.  This is only the case during
+  // an upgrade from Tripal v2. Otherwise the db2cv_mview gets created
+  // during the prepare Chado stage of the install and is not needed here.
+  if (chado_table_exists('db2cv_mview')) {
+    $mview_id = chado_get_mview_id('db2cv_mview');
+    global $user;
+    tripal_add_job(
+      'Repopulating db2cv to fix legacy SOFP',
+      'tripal_chado',
+      'chado_populate_mview',
+      [$mview_id],
+      $user->uid
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# Documentation  --->

# Bug Fix


Issue #1218

## Description
Site is missing an mview not defined in the installed schema.  was added via an update function but not install.

## Testing?
see issue for rapid install testing.

## Screenshots (if appropriate):

## Additional Notes (if any):
I'm pretty rusty, i think that chado install mview checks if the table exists first?  if it doesnt we'll need to add that.
