### PR TITLE
Bugfix: OBOImporter.inc: Search before retrieving

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
@@ -132,9 +132,10 @@ class data__sequence_record extends ChadoField {
       $featureloc = $this->getFeatureLoc($seq['featureloc_id']);
       $coords = $this->getSequenceCoords($featureloc);
 
-      # SOFIA: if the feature is a srcfeature don't derive sequence from itself
+      // SOFIA: If the feature is a srcfeature don't derive sequence from itself
       if ($feature->feature_id !=  $featureloc->srcfeature_id){
-        # i am not quite sure what the $option is doing, i am going to set it to 0 since there is no seq derived from parent
+	// I am not quite sure what the $option is doing, but I am going to set it 
+	// to 0 since there is no seq derived from parent
         $options = [
           'derive_from_parent' => 0,
          ];

--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
@@ -127,9 +127,19 @@ class data__sequence_record extends ChadoField {
     ];
     $seqs = chado_get_feature_sequences(['feature_id' => $feature->feature_id], $options);
     $featurelocs = [];
+
     foreach ($seqs as $seq) {
       $featureloc = $this->getFeatureLoc($seq['featureloc_id']);
       $coords = $this->getSequenceCoords($featureloc);
+
+      # SOFIA: if the feature is a srcfeature don't derive sequence from itself
+      if ($feature->feature_id !=  $featureloc->srcfeature_id){
+        # i am not quite sure what the $option is doing, i am going to set it to 0 since there is no seq derived from parent
+        $options = [
+          'derive_from_parent' => 0,
+         ];
+         continue;
+      }
 
       $entity->{$field_name}['und'][]['value'] = [
         $sequence_term => $seq['residues'],

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -1540,10 +1540,7 @@ class GFF3Importer extends TripalImporter {
     }
 
     // Cache the GFF feature details for later lookup.
-    // SOFIA: THIS IS IT, HERE is where landmarks don't get cached.
-    //if (strcmp($gff_feature['uniquename'], $gff_feature['landmark']) != 0) {
     $this->cacheFeature($gff_feature);
-    // }
 
     // If this feature has a target then we need to add the target as
     // new feature for insertion.

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -656,7 +656,7 @@ class GFF3Importer extends TripalImporter {
       $this->logMessage("Step 19 of 27: Find cross references...                          ");
       $this->findDbxrefs();
 
-      $this->logMessage("Step 21 of 27: Insert new cross references...                    ");
+      $this->logMessage("Step 20 of 27: Insert new cross references...                    ");
       $this->insertDbxrefs();
 
       $this->logMessage("Step 21 of 27: Get new cross references IDs...                   ");

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -105,6 +105,13 @@ class GFF3Importer extends TripalImporter {
    */
   private $update = TRUE;
 
+
+    /**
+   * A list of features to have names updated.
+   */
+  private $update_names = [];
+
+
   /**
    * If the GFF file contains a 'Target' attribute then the feature and the
    * target will have an alignment created, but to find the proper target
@@ -486,6 +493,7 @@ class GFF3Importer extends TripalImporter {
 
     // Set the private member variables of this class using the loader inputs.
     $this->organism_id = $arguments['organism_id'];
+    $this->update_names=[];
     $this->analysis_id = $arguments['analysis_id'];
     $this->add_only = $arguments['add_only'];
     $this->update = $arguments['update'];
@@ -615,6 +623,9 @@ class GFF3Importer extends TripalImporter {
       $this->logMessage("Step  8 of 26: Processing !num_features features...               ",
           ['!num_features' => number_format(count(array_keys($this->features)))]);
       $this->insertFeatures();
+      $this->logMessage("Step  8.1 of 26: Processing !num_features feature Names to update...               ",
+          ['!num_features' =>  number_format(count(array_keys($this->update_names)))]);
+      $this->updateFeatureNames();
 
       $this->logMessage("Step  9 of 26: Get new feature IDs...                             ");
       $this->findFeatures();
@@ -1230,7 +1241,6 @@ class GFF3Importer extends TripalImporter {
     // Add the properties and parent.
     $ret['properties'] = $attr_others;
     $ret['parent'] = $attr_parent;
-
     return $ret;
   }
 
@@ -1352,6 +1362,7 @@ class GFF3Importer extends TripalImporter {
 
     // The landmark was found, remember it
     $this->landmarks[$landmark_name] = $landmark->getID();
+
     return $landmark;
   }
   /**
@@ -1361,7 +1372,6 @@ class GFF3Importer extends TripalImporter {
    *   The line from the GFF file that is the ##sequence-region comment.
    */
   private function insertHeaderLandmark($line) {
-
     $region_matches = [];
     if (preg_match('/^##sequence-region\s+(\w*?)\s+(\d+)\s+(\d+)$/i', $line, $region_matches)) {
       $rid = $region_matches[1];
@@ -1531,9 +1541,10 @@ class GFF3Importer extends TripalImporter {
     }
 
     // Cache the GFF feature details for later lookup.
-    if (strcmp($gff_feature['uniquename'], $gff_feature['landmark']) != 0) {
+    // SOFIA: THIS IS IT, HERE is where landmarks dont get cached.
+#    if (strcmp($gff_feature['uniquename'], $gff_feature['landmark']) != 0) {
       $this->cacheFeature($gff_feature);
-    }
+#    }
 
     // If this feature has a target then we need to add the target as
     // new feature for insertion.
@@ -1840,6 +1851,58 @@ class GFF3Importer extends TripalImporter {
     }
   }
 
+
+  /**
+   * SOFIA:
+   * UPDATES the feature records in Chado.
+   */
+  private function updateFeatureNames() {
+    $batch_size = 1000;
+    $num_features = count(array_keys($this->update_names));
+    $num_batches = (int) ($num_features / $batch_size) + 1;
+
+    $this->setItemsHandled(0);
+    $this->setTotalItems($num_batches);
+#batch update: https://www.alibabacloud.com/blog/how-does-postgresql-implement-batch-update-deletion-and-insertion_596030
+    $init_sql = "UPDATE {feature}
+        SET name=tmp.name from (values\n";
+
+    $fin_sql = ") as tmp (name,feature_id) where {feature}.feature_id::text=tmp.feature_id\n";
+
+
+    $i = 0;
+    $total = 0;
+    $batch_num = 1;
+    $sql = '';
+    $args = [];
+    foreach ($this->update_names as $feature_id => $new_name){
+
+      $total++;
+      $i++;
+      // Only do an update if this feature already exist in the database and is flagged for update.
+      // SOFIA: future project, make is_obsolute updatable. make sure to add is_obsolute collection to cached feature
+        $sql .= "(:name_$i,:feature_id_$i),\n";
+        $args[":name_$i"] = $new_name;
+        $args[":feature_id_$i"] = $feature_id;
+
+      // If we've reached the size of the batch then let's do the insert.
+      if ($i == $batch_size or $total == $num_features) {
+        if (count($args) > 0) {
+          $sql = rtrim($sql, ",\n");
+          $sql = $init_sql . $sql . $fin_sql;
+          chado_query($sql, $args);
+        }
+        $this->setItemsHandled($batch_num);
+        $batch_num++;
+        // Now reset all of the variables for the next batch.
+        $sql = '';
+        $i = 0;
+        $args = [];
+      }
+    }
+  }
+
+
   /**
    * Check if the features exist in the database.
    */
@@ -1851,7 +1914,7 @@ class GFF3Importer extends TripalImporter {
     $this->setItemsHandled(0);
     $this->setTotalItems($num_batches);
 
-    $sql = "SELECT uniquename, type_id, organism_id, feature_id FROM {feature} WHERE uniquename in (:uniquenames)";
+    $sql = "SELECT uniquename, name, type_id, organism_id, feature_id FROM {feature} WHERE uniquename in (:uniquenames)";
     $i = 0;
     $total = 0;
     $batch_num = 1;
@@ -1881,6 +1944,13 @@ class GFF3Importer extends TripalImporter {
               }
               if ($matched_type_id == $f->type_id and $matched_organism_id == $f->organism_id) {
                 $this->features[$f->uniquename]['feature_id'] = $f->feature_id;
+                $this->features[$f->uniquename]['name'] = $f->name;
+		# SOFIA: check to see if the name has changed
+		if ($f->name != $matched_feature['name']) {
+                  ## need to update name of feature
+		  ## add flag to cached feature that indicates updated needed
+		  $this->update_names[$f->feature_id]=$matched_feature['name'];
+	        }
               }
             }
           }
@@ -2082,6 +2152,7 @@ class GFF3Importer extends TripalImporter {
    *
    */
   private function findDbxrefs() {
+
     $batch_size = 1000;
     $num_dbxrefs = count(array_keys($this->dbxref_lookup));
     $num_batches = (int) ($num_dbxrefs / $batch_size) + 1;
@@ -2240,6 +2311,7 @@ class GFF3Importer extends TripalImporter {
    *
    */
   private function insertDbxrefs() {
+
     $batch_size = 1000;
     $num_dbxrefs = count(array_keys($this->dbxref_lookup));
     $num_batches = (int) ($num_dbxrefs / $batch_size) + 1;
@@ -2821,6 +2893,7 @@ class GFF3Importer extends TripalImporter {
     $name = '';
 
     // If there is no ID or name then try to create a name and ID.
+    // SOFIA: Name typo?? should name be Name?
     if (!array_key_exists('ID', $attrs) and !array_key_exists('name', $attrs)) {
 
       // Check if an alternate ID field is suggested, if so, then use
@@ -2895,7 +2968,6 @@ class GFF3Importer extends TripalImporter {
         throw new Exception(t("A feature with the same ID exists multiple times: !uname", ['!uname' => $uniquename]));
       }
     }
-
     return [
       'name' => $name,
       'uniquename' => $uniquename,

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -1,4 +1,3 @@
-# just wannt to find the link to doc for testing 
 <?php
 
 class GFF3Importer extends TripalImporter {

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -1,3 +1,4 @@
+# just wannt to find the link to doc for testing 
 <?php
 
 class GFF3Importer extends TripalImporter {

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -493,7 +493,6 @@ class GFF3Importer extends TripalImporter {
 
     // Set the private member variables of this class using the loader inputs.
     $this->organism_id = $arguments['organism_id'];
-    $this->update_names=[];
     $this->analysis_id = $arguments['analysis_id'];
     $this->add_only = $arguments['add_only'];
     $this->update = $arguments['update'];
@@ -588,7 +587,7 @@ class GFF3Importer extends TripalImporter {
     $this->openCacheFile();
     // Load the GFF3.
     try {
-      $this->logMessage("Step  1 of 26: Caching GFF3 file...                             ");
+      $this->logMessage("Step  1 of 27: Caching GFF3 file...                             ");
       $this->parseGFF3();
 
       // Prep the database for necessary records.
@@ -596,93 +595,93 @@ class GFF3Importer extends TripalImporter {
       $this->prepNullPub();
       $this->prepDBs();
 
-      $this->logMessage("Step  2 of 26: Find existing landmarks...                         ");
+      $this->logMessage("Step  2 of 27: Find existing landmarks...                         ");
       $this->findLandmarks();
 
-      $this->logMessage("Step  3 of 26: Insert new landmarks (if needed)...                ");
+      $this->logMessage("Step  3 of 27: Insert new landmarks (if needed)...                ");
       $this->insertLandmarks();
 
       if (!$this->skip_protein) {
-        $this->logMessage("Step  4 of 26: Find missing proteins...                           ");
+        $this->logMessage("Step  4 of 27: Find missing proteins...                           ");
         $this->findMissingProteins();
 
-        $this->logMessage("Step  5 of 26: Add missing proteins to list of features...        ");
+        $this->logMessage("Step  5 of 27: Add missing proteins to list of features...        ");
         $this->addMissingProteins();
       }
       else {
-        $this->logMessage("Step  4 of 26: Find missing proteins (Skipped)...                ");
-        $this->logMessage("Step  5 of 26: Add missing proteins to list of features (Skipped)...");
+        $this->logMessage("Step  4 of 27: Find missing proteins (Skipped)...                ");
+        $this->logMessage("Step  5 of 27: Add missing proteins to list of features (Skipped)...");
       }
 
-      $this->logMessage("Step  6 of 26: Find existing features...                          ");
+      $this->logMessage("Step  6 of 27: Find existing features...                          ");
       $this->findFeatures();
 
-      $this->logMessage("Step  7 of 26: Clear attributes of existing features...            ");
+      $this->logMessage("Step  7 of 27: Clear attributes of existing features...            ");
       $this->deleteFeatureData();
 
-      $this->logMessage("Step  8 of 26: Processing !num_features features...               ",
+      $this->logMessage("Step  8 of 27: Processing !num_features features...               ",
           ['!num_features' => number_format(count(array_keys($this->features)))]);
       $this->insertFeatures();
-      $this->logMessage("Step  8.1 of 26: Processing !num_features feature Names to update...               ",
+      $this->logMessage("Step  9 of 27: Processing !num_features feature Names to update...               ",
           ['!num_features' =>  number_format(count(array_keys($this->update_names)))]);
       $this->updateFeatureNames();
 
-      $this->logMessage("Step  9 of 26: Get new feature IDs...                             ");
+      $this->logMessage("Step  10 of 27: Get new feature IDs...                             ");
       $this->findFeatures();
 
-      $this->logMessage("Step 10 of 26: Insert locations...                               ");
+      $this->logMessage("Step 11 of 27: Insert locations...                               ");
       $this->insertFeatureLocs();
 
-      $this->logMessage("Step 11 of 26: Associate parents and children...                 ");
+      $this->logMessage("Step 12 of 27: Associate parents and children...                 ");
       $this->associateChildren();
 
-      $this->logMessage("Step 12 of 26: Calculate child ranks...                          ");
+      $this->logMessage("Step 13 of 27: Calculate child ranks...                          ");
       $this->calculateChildRanks();
 
-      $this->logMessage("Step 13 of 26: Add child-parent relationships...                 ");
+      $this->logMessage("Step 14 of 27: Add child-parent relationships...                 ");
       $this->insertFeatureParents();
 
-      $this->logMessage("Step 14 of 26: Insert properties...                               ");
+      $this->logMessage("Step 15 of 27: Insert properties...                               ");
       $this->insertFeatureProps();
 
-      $this->logMessage("Step 15 of 26: Find synonyms (aliases)...                         ");
+      $this->logMessage("Step 16 of 27: Find synonyms (aliases)...                         ");
       $this->findSynonyms();
 
-      $this->logMessage("Step 16 of 26: Insert new synonyms (aliases)...                  ");
+      $this->logMessage("Step 17 of 27: Insert new synonyms (aliases)...                  ");
       $this->insertSynonyms();
 
-      $this->logMessage("Step 17 of 26: Insert feature synonyms (aliases)...              ");
+      $this->logMessage("Step 18 of 27: Insert feature synonyms (aliases)...              ");
       $this->insertFeatureSynonyms();
 
-      $this->logMessage("Step 18 of 26: Find cross references...                          ");
+      $this->logMessage("Step 19 of 27: Find cross references...                          ");
       $this->findDbxrefs();
 
-      $this->logMessage("Step 19 of 26: Insert new cross references...                    ");
+      $this->logMessage("Step 21 of 27: Insert new cross references...                    ");
       $this->insertDbxrefs();
 
-      $this->logMessage("Step 20 of 26: Get new cross references IDs...                   ");
+      $this->logMessage("Step 21 of 27: Get new cross references IDs...                   ");
       $this->findDbxrefs();
 
-      $this->logMessage("Step 21 of 26: Insert feature cross references...                ");
+      $this->logMessage("Step 22 of 27: Insert feature cross references...                ");
       $this->insertFeatureDbxrefs();
 
-      $this->logMessage("Step 22 of 26: Insert feature ontology terms...                  ");
+      $this->logMessage("Step 23 of 27: Insert feature ontology terms...                  ");
       $this->insertFeatureCVterms();
 
-      $this->logMessage("Step 23 of 26: Insert 'derives_from' relationships...            ");
+      $this->logMessage("Step 24 of 27: Insert 'derives_from' relationships...            ");
       $this->insertFeatureDerivesFrom();
 
-      $this->logMessage("Step 24 of 26: Insert Targets...                                 ");
+      $this->logMessage("Step 25 of 27: Insert Targets...                                 ");
       $this->insertFeatureTargets();
 
-      $this->logMessage("Step 25 of 26: Associate features with analysis....              ");
+      $this->logMessage("Step 26 of 27: Associate features with analysis....              ");
       $this->insertFeatureAnalysis();
 
       if (!empty($this->residue_index)) {
-        $this->logMessage("Step 26 of 26: Adding sequences data...                        ");
+        $this->logMessage("Step 27 of 27: Adding sequences data...                        ");
         $this->insertFeatureSeqs();
       }
-      $this->logMessage("Step 26 of 26: Adding sequences data (Skipped: none available)...");
+      $this->logMessage("Step 27 of 27: Adding sequences data (Skipped: none available)...");
     }
     // On exception, catch the error, clean up the cache file and rethrow
     catch (Exception $e) {
@@ -1059,7 +1058,7 @@ class GFF3Importer extends TripalImporter {
           throw new Exception(t('Each feature can only have one "Target" attribute. The feature %uniquename has more than one.',
               ['%uniquename' => $ret['uniquename']]));
         }
-        # Get the elements of the target.
+        // Get the elements of the target.
         $matches = [];
         if (preg_match('/^(.*?)\s+(\d+)\s+(\d+)(\s+[\+|\-])*$/', trim($tags[$tag_name][0]), $matches)) {
           $attr_target['name'] = $matches[1];
@@ -1541,10 +1540,10 @@ class GFF3Importer extends TripalImporter {
     }
 
     // Cache the GFF feature details for later lookup.
-    // SOFIA: THIS IS IT, HERE is where landmarks dont get cached.
-#    if (strcmp($gff_feature['uniquename'], $gff_feature['landmark']) != 0) {
-      $this->cacheFeature($gff_feature);
-#    }
+    // SOFIA: THIS IS IT, HERE is where landmarks don't get cached.
+    //if (strcmp($gff_feature['uniquename'], $gff_feature['landmark']) != 0) {
+    $this->cacheFeature($gff_feature);
+    // }
 
     // If this feature has a target then we need to add the target as
     // new feature for insertion.
@@ -1853,8 +1852,7 @@ class GFF3Importer extends TripalImporter {
 
 
   /**
-   * SOFIA:
-   * UPDATES the feature records in Chado.
+   * UPDATES the name of feature records in Chado.
    */
   private function updateFeatureNames() {
     $batch_size = 1000;
@@ -1863,7 +1861,7 @@ class GFF3Importer extends TripalImporter {
 
     $this->setItemsHandled(0);
     $this->setTotalItems($num_batches);
-#batch update: https://www.alibabacloud.com/blog/how-does-postgresql-implement-batch-update-deletion-and-insertion_596030
+    // Batch update: https://www.alibabacloud.com/blog/how-does-postgresql-implement-batch-update-deletion-and-insertion_596030
     $init_sql = "UPDATE {feature}
         SET name=tmp.name from (values\n";
 
@@ -1880,10 +1878,10 @@ class GFF3Importer extends TripalImporter {
       $total++;
       $i++;
       // Only do an update if this feature already exist in the database and is flagged for update.
-      // SOFIA: future project, make is_obsolute updatable. make sure to add is_obsolute collection to cached feature
-        $sql .= "(:name_$i,:feature_id_$i),\n";
-        $args[":name_$i"] = $new_name;
-        $args[":feature_id_$i"] = $feature_id;
+      // TO DO: make is_obsolute updatable. Make sure to add is_obsolute collection to cached feature
+      $sql .= "(:name_$i, :feature_id_$i),\n";
+      $args[":name_$i"] = $new_name;
+      $args[":feature_id_$i"] = $feature_id;
 
       // If we've reached the size of the batch then let's do the insert.
       if ($i == $batch_size or $total == $num_features) {
@@ -1945,11 +1943,11 @@ class GFF3Importer extends TripalImporter {
               if ($matched_type_id == $f->type_id and $matched_organism_id == $f->organism_id) {
                 $this->features[$f->uniquename]['feature_id'] = $f->feature_id;
                 $this->features[$f->uniquename]['name'] = $f->name;
-		# SOFIA: check to see if the name has changed
+		// Checking to see if the name has changed and therefore needs updating
 		if ($f->name != $matched_feature['name']) {
-                  ## need to update name of feature
-		  ## add flag to cached feature that indicates updated needed
-		  $this->update_names[$f->feature_id]=$matched_feature['name'];
+                  // Yes. we need to update name of this feature.
+		  // Adding flag to cached feature that indicates updated needed.
+		  $this->update_names[$f->feature_id] = $matched_feature['name'];
 	        }
               }
             }
@@ -2892,9 +2890,7 @@ class GFF3Importer extends TripalImporter {
     $uniquename = '';
     $name = '';
 
-    // If there is no ID or name then try to create a name and ID.
-    // SOFIA: Name typo?? should name be Name?
-    if (!array_key_exists('ID', $attrs) and !array_key_exists('name', $attrs)) {
+    if (!array_key_exists('ID', $attrs) and !array_key_exists('Name', $attrs)) {
 
       // Check if an alternate ID field is suggested, if so, then use
       // that for the name.

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1046,9 +1046,7 @@ class OBOImporter extends TripalImporter {
       list($ontologyID, $base_iri) = $this->baseIRIs[$short_name];
     }
     else {
-      $query_count = 0;   
       $ontology_results =  $this->oboEbiLookup($id, 'query');
-      $query_count++;
       if (!$ontology_results) {
         $ontology_results =  $this->oboEbiLookup($id, 'query-non-local'); 
       }
@@ -1076,9 +1074,9 @@ class OBOImporter extends TripalImporter {
         $defining_ontology = $each['is_defining_ontology'];
         // First result should have defining_ontology=true, but if 
         // it doesn't, use the first result with obo_id=$id
-	if ($defining_ontology == 'false' and $obo_id != $id) {
-	  continue;
-	}
+        if ($defining_ontology == 'false' and $obo_id != $id) {
+          continue;
+        }
         $iri = urlencode(urlencode($each['iri']));
         $ontologyID = $each['ontology_name'];
 	// Type should be 'property' or 'class' in the response
@@ -1102,7 +1100,7 @@ class OBOImporter extends TripalImporter {
           if ( !$defining_ontology and $obo_id != $id ) {    
             continue;
           }  
-      	  $found_iri = urlencode(urlencode($each['iri']));
+          $found_iri = urlencode(urlencode($each['iri']));
           $ontology = $each['ontology_name'];
 	  // Type should be 'property' or 'class' in the response
           $type = $each['type'];

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1104,10 +1104,10 @@ class OBOImporter extends TripalImporter {
           $ontology = $each['ontology_name'];
           // Type should be 'property' or 'class' in the response
           $type = $each['type'];
-	  if ($type == 'property') {
+          if ($type == 'property') {
             $type = 'properties';
-	  }
-	  elseif ( $type == 'class') {
+          }
+          elseif ( $type == 'class') {
             $type = 'terms';
           }
 	  $results = $this->oboEbiLookup($id, $type, $found_iri);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1047,7 +1047,9 @@ class OBOImporter extends TripalImporter {
     }
     else {
       $ontology_results =  $this->oboEbiLookup($id, 'query');
-      if (!$ontology_results) {
+      // If results were received but the number of results is 0, do a query-non-local lookup.
+      if ($ontology_results['response']['numFound'] == 0) {
+        print "oboEbiLookup($id, 'query-non-local')\n";
         $ontology_results =  $this->oboEbiLookup($id, 'query-non-local'); 
       }
       if (!$ontology_results) {
@@ -1104,7 +1106,10 @@ class OBOImporter extends TripalImporter {
           $ontology = $each['ontology_name'];
           // Type should be 'property' or 'class' in the response
           $type = $each['type'];
-	  $results = $this->oboEbiLookup($id, $type, $found_iri);
+          $results = $this->oboEbiLookup($id, $type, $found_iri, $ontology);
+          // if this term is the defining_ontology and we have the correct ID, 
+          // we dont need more, get it and stop
+          break;
         } 
       }
     }
@@ -2547,12 +2552,31 @@ class OBOImporter extends TripalImporter {
    *
    * @ingroup tripal_obo_loader
    */
-  private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL) {
+  private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL, $found_ontology = NULL) {
     //Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
     $ontology = strtolower($parts[0]);
     $ontology = preg_replace('/\s+/', '', $ontology);
-    if ($type_of_search == 'ontology') {
+    if ($found_iri) {
+      // When we cannot grab the ontology from the accession or the IRI cannot be automatically formed we
+      // we need to use the ontology and the IRI found in the previous query.
+      $ontology = $found_ontology;
+      $type = '';
+      if ($type_of_search == 'property') {
+        $type = 'properties';
+      }
+      elseif ( $type_of_search == 'class') {
+        $type = 'terms';
+      }
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $found_iri;
+      print "fullurl: $full_url\n";
+      $options = [];
+      $response = drupal_http_request($full_url, $options);
+      if (!empty($response)) {
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif ($type_of_search == 'ontology') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
       $response = drupal_http_request($full_url, $options);
@@ -2591,21 +2615,6 @@ class OBOImporter extends TripalImporter {
     elseif ($type_of_search == 'query-non-local') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
-    }
-    elseif ($found_iri) {
-      $type = '';
-      if ($type_of_search == 'property') {
-        $type = 'properties';
-      }
-      elseif ( $type_of_search == 'class') {
-        $type = 'terms';
-      }
-      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $found_iri;
-      $options = [];
       $response = drupal_http_request($full_url, $options);
       if (!empty($response)) {
         $response = drupal_json_decode($response->data);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1079,7 +1079,7 @@ class OBOImporter extends TripalImporter {
         }
         $iri = urlencode(urlencode($each['iri']));
         $ontologyID = $each['ontology_name'];
-	// Type should be 'property' or 'class' in the response
+        // Type should be 'property' or 'class' in the response
         $type = $each['type'];
       }
     }

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1102,7 +1102,7 @@ class OBOImporter extends TripalImporter {
           }  
           $found_iri = urlencode(urlencode($each['iri']));
           $ontology = $each['ontology_name'];
-	  // Type should be 'property' or 'class' in the response
+          // Type should be 'property' or 'class' in the response
           $type = $each['type'];
 	  if ($type == 'property') {
             $type = 'properties';

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -952,7 +952,7 @@ class OBOImporter extends TripalImporter {
 
     // Check if the EBI ontology search has this ontology:
     try {
-      $results = $this->oboEbiLookup($ontology, 'ontology');
+      $results = $this->oboEbiLookup($ontology, 'ontology'); 
       if ($results and array_key_exists('config', $results) and array_key_exists('default-namespace', $results['config']['annotations'])) {
         $namespace = $results['config']['annotations']['default-namespace'];
         if (is_array($namespace)) {
@@ -1038,7 +1038,7 @@ class OBOImporter extends TripalImporter {
     $accession = $pair[1];
 
     // First get the ontology so we can build an IRI for the term
-    //$base_iri = '';
+    $base_iri = '';
     $ontologyID = '';
     $iri = '';
     $type ='';
@@ -1046,13 +1046,18 @@ class OBOImporter extends TripalImporter {
       list($ontologyID, $base_iri) = $this->baseIRIs[$short_name];
     }
     else {
-      $full_url = 'https://www.ebi.ac.uk/ols/api/search?q=' . $id;
-      $response = drupal_http_request($full_url, []);
-      if (!$response) {
-        throw new Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !ontology',
-          ['!ontology' => $short_name]));
+      $query_count = 0;   
+      $ontology_results =  $this->oboEbiLookup($id,'query');
+      $query_count++;
+      if (!$ontology_results) {
+        $ontology_results=  $this->oboEbiLookup($id,'query-non-local'); 
+	print('query-non-local');
+	$query_count++;
       }
-      $ontology_results = drupal_json_decode($response->data);
+      if (!$ontology_results) {
+        throw new Exception(t('Did not get a response from EBI OLS trying to lookup ontology x!count: !id',
+          ['!count'=>$query_count,'!id' => $id]));
+      }
       if ($ontology_results['error']) {
 
         $this->logMessage(t('Cannot find the ontology via an EBI OLS lookup: !short_name. \n' .
@@ -1065,30 +1070,61 @@ class OBOImporter extends TripalImporter {
             '!url' => $full_url,
           ]), TRIPAL_WARNING);
       }
-      //What should happen with this stuff?
-      //$base_iri = $ontology_results['config']['baseUris'][0];
-      //$ontologyID = $ontology_results['ontologyId'];
-      //$this->baseIRIs[$short_name] = [$ontologyID, $base_iri];
-      $iri = urlencode(urlencode($ontology_results['response']['docs'][0]['iri']));
-      $ontologyID=$ontology_results['response']['docs'][0]['id'];
-      $type=$ontology_results['response']['docs'][0]['type']; # property|class
+      # this is good, but i think i need to do the decode
+      foreach ($ontology_results['response']['docs'] as $each ){
+        $obo_id = $each['obo_id'];
+        $defining_ontology= $each['is_defining_ontology'];
+	# first defining_ontology shiould be true, but if it isnt, take the one with the obo_id=$id
+	if ($defining_ontology == 'false' and $obo_id != $id){
+	  continue;
+	}
+        $iri = urlencode(urlencode($each['iri']));
+        $ontologyID=$each['ontology_name'];
+        $type=$each['type']; # property|class
+      }
 
     }
 
     // Next get the term.
-    //$iri = urlencode(urlencode($base_iri . $accession));
-    //$full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontologyID . '/terms/' . $iri;
-    $full_url = 'https://www.ebi.ac.uk/ols/ontologies/' . $ontologyID . '/' . $type . '?iri=' . $iri;
-    $response = drupal_http_request($full_url, []);
-    if (!$response) {
-      throw new Exception(t('Did not get a response from EBI OLS trying to lookup term: !id',
-        ['!id' => $id]));
+    $query = $type;
+    if ($type == 'class'){
+      $query = 'term';
     }
-    $results = drupal_json_decode($response->data);
+    $results =  $this->oboEbiLookup($id,$query);
     if (!$results) {
-      $this->logMessage('Error: no data with !url.  The response was: !response', [
-        '!url' => $full_url,
+      $query = 'query-non-local';
+      $ontology_results = $this->oboEbiLookup($id,$query);
+      if($ontology_results ){
+	  foreach ($ontology_results['response']['docs'] as $each ){
+            $obo_id = $each['obo_id'];
+            $defining_ontology= $each['is_defining_ontology'];
+           if (!$defining_ontology and $obo_id != $id){  
+		   continue;
+            }  
+      	    $iri = urlencode(urlencode($each['iri']));
+            $ontology=$each['ontology_name'];
+            $type=$each['type']; # property|class
+	    if ($type == 'property'){
+              $type = 'properties';
+            }elseif($type == 'class'){
+              $type = 'terms';
+            }
+ 	    $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $iri;
+
+            $options = [];
+            $response = drupal_http_request($full_url, $options);
+	    $results = drupal_json_decode($response->data);
+        
+        } 
+      }
+    }
+    if (!$results) {
+                throw new Exception(t('Did not get a response from EBI OLS trying to lookup: !type !id with !url',
+          ['!type'=> $type,'!id' => $id, '!url' => $full_url]));
+      $this->logMessage('Error: no data with !id.  The response was: !response result was:!results', [
+        '!id' => $id,
         '!response' => $response,
+    	'!results' => $results,
       ]);
 
       return FALSE;
@@ -2544,6 +2580,16 @@ class OBOImporter extends TripalImporter {
         $response = drupal_json_decode($response->data);
       }
     }
+    elseif ($type_of_search == 'property') {
+    //The IRI of the terms, this value must be double URL encoded
+      $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':', '_', $accession)));
+      $options = [];
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'properties/' . $iri;
+      $response = drupal_http_request($full_url, $options);
+      if (!empty($response)) {
+        $response = drupal_json_decode($response->data);
+       }
+     }
     elseif ($type_of_search == 'query') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -2547,7 +2547,7 @@ class OBOImporter extends TripalImporter {
    *
    * @ingroup tripal_obo_loader
    */
-  private function oboEbiLookup($accession, $type_of_search, $found_iri) {
+  private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL) {
     //Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
     $ontology = strtolower($parts[0]);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1104,12 +1104,6 @@ class OBOImporter extends TripalImporter {
           $ontology = $each['ontology_name'];
           // Type should be 'property' or 'class' in the response
           $type = $each['type'];
-          if ($type == 'property') {
-            $type = 'properties';
-          }
-          elseif ( $type == 'class') {
-            $type = 'terms';
-          }
 	  $results = $this->oboEbiLookup($id, $type, $found_iri);
         } 
       }
@@ -2603,6 +2597,13 @@ class OBOImporter extends TripalImporter {
       }
     }
     elseif ($found_iri) {
+      $type = '';
+      if ($type_of_search == 'property') {
+        $type = 'properties';
+      }
+      elseif ( $type_of_search == 'class') {
+        $type = 'terms';
+      }
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $found_iri;
       $options = [];
       $response = drupal_http_request($full_url, $options);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1047,16 +1047,14 @@ class OBOImporter extends TripalImporter {
     }
     else {
       $query_count = 0;   
-      $ontology_results =  $this->oboEbiLookup($id,'query');
+      $ontology_results =  $this->oboEbiLookup($id, 'query');
       $query_count++;
       if (!$ontology_results) {
-        $ontology_results=  $this->oboEbiLookup($id,'query-non-local'); 
-	print('query-non-local');
-	$query_count++;
+        $ontology_results =  $this->oboEbiLookup($id, 'query-non-local'); 
       }
       if (!$ontology_results) {
-        throw new Exception(t('Did not get a response from EBI OLS trying to lookup ontology x!count: !id',
-          ['!count'=>$query_count,'!id' => $id]));
+        throw new Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !id',
+          ['!id' => $id]));
       }
       if ($ontology_results['error']) {
 
@@ -1070,63 +1068,63 @@ class OBOImporter extends TripalImporter {
             '!url' => $full_url,
           ]), TRIPAL_WARNING);
       }
-      # this is good, but i think i need to do the decode
-      foreach ($ontology_results['response']['docs'] as $each ){
+      // The following foreach code works but, I am not sure that
+      // I am retrieving each query result from the json associative
+      // array with the correct style
+      foreach ($ontology_results['response']['docs'] as $each ) {
         $obo_id = $each['obo_id'];
-        $defining_ontology= $each['is_defining_ontology'];
-	# first defining_ontology shiould be true, but if it isnt, take the one with the obo_id=$id
-	if ($defining_ontology == 'false' and $obo_id != $id){
+        $defining_ontology = $each['is_defining_ontology'];
+        // First result should have defining_ontology=true, but if 
+        // it doesn't, use the first result with obo_id=$id
+	if ($defining_ontology == 'false' and $obo_id != $id) {
 	  continue;
 	}
         $iri = urlencode(urlencode($each['iri']));
-        $ontologyID=$each['ontology_name'];
-        $type=$each['type']; # property|class
+        $ontologyID = $each['ontology_name'];
+	// Type should be 'property' or 'class' in the response
+        $type = $each['type'];
       }
-
     }
 
     // Next get the term.
     $query = $type;
-    if ($type == 'class'){
+    if ($type == 'class') {
       $query = 'term';
     }
-    $results =  $this->oboEbiLookup($id,$query);
+    $results =  $this->oboEbiLookup($id, $query);
     if (!$results) {
       $query = 'query-non-local';
-      $ontology_results = $this->oboEbiLookup($id,$query);
-      if($ontology_results ){
-	  foreach ($ontology_results['response']['docs'] as $each ){
-            $obo_id = $each['obo_id'];
-            $defining_ontology= $each['is_defining_ontology'];
-           if (!$defining_ontology and $obo_id != $id){  
-		   continue;
-            }  
-      	    $iri = urlencode(urlencode($each['iri']));
-            $ontology=$each['ontology_name'];
-            $type=$each['type']; # property|class
-	    if ($type == 'property'){
-              $type = 'properties';
-            }elseif($type == 'class'){
-              $type = 'terms';
-            }
- 	    $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $iri;
-
-            $options = [];
-            $response = drupal_http_request($full_url, $options);
-	    $results = drupal_json_decode($response->data);
-        
+      $ontology_results = $this->oboEbiLookup($id, $query);
+      if ($ontology_results) {
+        foreach ($ontology_results['response']['docs'] as $each ){
+          $obo_id = $each['obo_id'];
+          $defining_ontology = $each['is_defining_ontology'];
+          if ( !$defining_ontology and $obo_id != $id ) {    
+            continue;
+          }  
+      	  $found_iri = urlencode(urlencode($each['iri']));
+          $ontology = $each['ontology_name'];
+	  // Type should be 'property' or 'class' in the response
+          $type = $each['type'];
+	  if ($type == 'property') {
+            $type = 'properties';
+	  }
+	  elseif ( $type == 'class') {
+            $type = 'terms';
+          }
+	  $results = $this->oboEbiLookup($id, $type, $found_iri);
         } 
       }
     }
     if (!$results) {
-                throw new Exception(t('Did not get a response from EBI OLS trying to lookup: !type !id with !url',
-          ['!type'=> $type,'!id' => $id, '!url' => $full_url]));
-      $this->logMessage('Error: no data with !id.  The response was: !response result was:!results', [
-        '!id' => $id,
-        '!response' => $response,
-    	'!results' => $results,
-      ]);
-
+      throw new Exception(t('Did not get a response from EBI OLS trying to lookup: !type !id with !url',
+        ['!type'=> $type, '!id' => $id, '!url' => $full_url]));
+      $this->logMessage('Error: no data with !id.  The response was: !response result was:!results', 
+        [
+          '!id' => $id,
+          '!response' => $response,
+    	  '!results' => $results,
+        ]);
       return FALSE;
     }
 
@@ -2557,7 +2555,7 @@ class OBOImporter extends TripalImporter {
    *
    * @ingroup tripal_obo_loader
    */
-  private function oboEbiLookup($accession, $type_of_search) {
+  private function oboEbiLookup($accession, $type_of_search, $found_iri) {
     //Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
     $ontology = strtolower($parts[0]);
@@ -2601,6 +2599,14 @@ class OBOImporter extends TripalImporter {
     elseif ($type_of_search == 'query-non-local') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
+      $response = drupal_http_request($full_url, $options);
+      if (!empty($response)) {
+        $response = drupal_json_decode($response->data);
+      }
+    }
+    elseif ($found_iri) {
+      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $found_iri;
+      $options = [];
       $response = drupal_http_request($full_url, $options);
       if (!empty($response)) {
         $response = drupal_json_decode($response->data);

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -2584,8 +2584,8 @@ class OBOImporter extends TripalImporter {
       $response = drupal_http_request($full_url, $options);
       if (!empty($response)) {
         $response = drupal_json_decode($response->data);
-       }
-     }
+      }
+    }
     elseif ($type_of_search == 'query') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1078,7 +1078,7 @@ class OBOImporter extends TripalImporter {
     // Next get the term.
     //$iri = urlencode(urlencode($base_iri . $accession));
     //$full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontologyID . '/terms/' . $iri;
-    $full_url = "https://www.ebi.ac.uk/ols/ontologies/$ontologyID/$type?iri=$iri"
+    $full_url = 'https://www.ebi.ac.uk/ols/ontologies/' . $ontologyID . '/' . $type . '?iri=' . $iri;
     $response = drupal_http_request($full_url, []);
     if (!$response) {
       throw new Exception(t('Did not get a response from EBI OLS trying to lookup term: !id',

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -1038,13 +1038,15 @@ class OBOImporter extends TripalImporter {
     $accession = $pair[1];
 
     // First get the ontology so we can build an IRI for the term
-    $base_iri = '';
+    //$base_iri = '';
     $ontologyID = '';
+    $iri = '';
+    $type ='';
     if (array_key_exists($short_name, $this->baseIRIs)) {
       list($ontologyID, $base_iri) = $this->baseIRIs[$short_name];
     }
     else {
-      $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $short_name;
+      $full_url = 'https://www.ebi.ac.uk/ols/api/search?q=' . $id;
       $response = drupal_http_request($full_url, []);
       if (!$response) {
         throw new Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !ontology',
@@ -1064,14 +1066,19 @@ class OBOImporter extends TripalImporter {
           ]), TRIPAL_WARNING);
       }
       //What should happen with this stuff?
-      $base_iri = $ontology_results['config']['baseUris'][0];
-      $ontologyID = $ontology_results['ontologyId'];
-      $this->baseIRIs[$short_name] = [$ontologyID, $base_iri];
+      //$base_iri = $ontology_results['config']['baseUris'][0];
+      //$ontologyID = $ontology_results['ontologyId'];
+      //$this->baseIRIs[$short_name] = [$ontologyID, $base_iri];
+      $iri = urlencode(urlencode($ontology_results['response']['docs'][0]['iri']));
+      $ontologyID=$ontology_results['response']['docs'][0]['id'];
+      $type=$ontology_results['response']['docs'][0]['type']; # property|class
+
     }
 
     // Next get the term.
-    $iri = urlencode(urlencode($base_iri . $accession));
-    $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontologyID . '/terms/' . $iri;
+    //$iri = urlencode(urlencode($base_iri . $accession));
+    //$full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontologyID . '/terms/' . $iri;
+    $full_url = "https://www.ebi.ac.uk/ols/ontologies/$ontologyID/$type?iri=$iri"
     $response = drupal_http_request($full_url, []);
     if (!$response) {
       throw new Exception(t('Did not get a response from EBI OLS trying to lookup term: !id',


### PR DESCRIPTION
# Issue 1) Doing a search for ontology terms before retrieving term


Hello everyone.
I am trying a new install and load with Tripal 3, v 7.x-3.7.    


I loaded go.obo as a test, all is fine.  

 I loaded [plana.obo](https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/plana.obo) and I am getting errors in the log.  
Some of the urls that the loader is using for checking for data are not formed correctly. Is this an issue someone else has seen?   

here is the error I am getting:
```Performing EBI OLS Lookup for: BFO:0000062
Error: no data with http://www.ebi.ac.uk/ols/api/ontologies/bfo/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FBFO_0000062.
```


The url formed has two problems:
   - BFO:0000062 is not [Term] it is [Typedef] 
   - and it is belongs to OVAE not BFO. 
   
 These bits of info are impossible to get from just the ID or iri.

This is the url that would work with the api since it is from ovae and is a property not a term (the bfo is changed to ovae and terms is changed to properties):
https://www.ebi.ac.uk/ols/ontologies/ovae/properties?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBFO_0000062
This url works better https://www.ebi.ac.uk/ols/api/search?q=BFO:0000062  

Also something else I am seeing is that some terms in the api call are being compounded:
This particular issue was reported in #708 my code fixes this as well.
```
Performing EBI OLS Lookup for: RO:0001001
Error: no data with http://www.ebi.ac.uk/ols/api/ontologies/ro/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FBFO_00000500001001. 
```
Why is BFO_0000050 being merged with 0001001 of RO:0001001?   

RO:0001001 is also a **property** like BFO:0000062 


I wrote code to performed a search api call and retrieve the top hit and use that iri to retrieve the term information. I no longer see either of the errors reported above.



# issue 2) GFF loader Issues   
See issue #1215


Next I moved on to trying to load my gff file. We have transcripts but no contigs. My transcripts are my landmark features. My Ontology_terms= and Name= where not being inserted into chado. I fixed this by commenting out the if statement on line:1545

Then I noticed that the name was not being updated if it was changed and reimported. I added a updateFeatureName function. I am not sure if this should be more general or if a separate update should be made for each piece that needs to be updated. I would like to incorporate an update for is_obsolet. This is something I am not currently using but plan on using in the future when a version of my transcripts or mRNAs are changed. i want to make a feature obsolete and add a new feature.

# issue 3) Sequence display issues 

Now I see my transcript sequences on my transcript pages. I have two, a derived from landmark in addition to the sequence I manually uploaded with the fasta loader. Next I want to figure out how to disable this in the display on the transcript page. I don't want to see both, especially since they are identical.  

I have disabled the derived from srcfeature functionality on line 136 of [tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc](https://github.com/tripal/tripal/pull/1228/files#diff-ea6731947cb4ceeb3a3d9822910b1261b494cf94da06990d4cc1597bc81cc348) but checking to see if the feature_id != srcfeature_id

===

For now, I done with bugs and new features, well i fixed all the ones I have come up with. i will continue loading and customizing my T3 site to see what else I come across. I am been busy with other projects for a while now, I am happy to be back on the tripal train!! I want to help with anything I can fit into my to do list!! I would love to work with someone to better test these changes and get them into a format that might be more suitable for the code base. I have done my best to try to understand the code and to mimic coding style.  

Sofia