### PR TITLE
20211031 pub importer

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.pub.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.pub.api.inc
@@ -252,7 +252,7 @@ function chado_publication_exists($pub_details) {
     $series_name = substr($pub_details['Conference Name'], 0, 255);
   }
 
-  // Make sure the publication is unique using the prefereed import
+  // Make sure the publication is unique using the preferred import
   // duplication check.
   $import_dups_check = variable_get('tripal_pub_import_duplicate_check', 'title_year_media');
   $pubs = [];

--- a/tripal_chado/api/modules/tripal_chado.pub.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.pub.api.inc
@@ -571,8 +571,13 @@ function chado_execute_pub_importer($import_id, $publish = TRUE,
     return FALSE;
   }
 
+  // Summary of importer results for each action
+  $message = 'Done. Publication importer summary:';
+  foreach ($report as $action => $pubs) {
+    $message .= ' ' . $action . '=' . count($pubs);
+  }
   tripal_report_error($message_type, TRIPAL_INFO,
-    "Done.", [], $message_opts);
+    $message, [], $message_opts);
 
   return $report;
 }


### PR DESCRIPTION
# New Feature

## Description
This is a simple change to add a summary line to the publication loader. For example, formerly, the last line of output was

```INFO (PUB_IMPORT): Done.```

After this change, it will now look like

```INFO (PUB_IMPORT): Done. Publication importer summary: error=0 inserted=123 skipped=456 updated=0```

This summarizes elements stored in the ```$results``` array, which is otherwise only used if an email report is generated.
