### PR TITLE
For issue #1238 tv3 pubmed importer fix

### DIFF
--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
@@ -898,7 +898,9 @@ function tripal_pub_PMID_parse_date($xml, $element_name) {
         case 'MedlineDate':
           // the medline date is when the date cannot be broken into distinct month day year.
           $xml->read();
-          $date['year'] = preg_replace('/^(\d{4}).*$/', '\1', $xml->value);
+          if (!$date['year']) {
+            $date['year'] = preg_replace('/^.*(\d{4}).*$/', '\1', $xml->value);
+          }
           $date['medline'] = $xml->value;
           break;
         default:


### PR DESCRIPTION
# Bug Fix

Issue #1238

## Description
Issue describes the problem. The fix here changes two things:
1. The medline date is not used to generate the chado.pub pyear value if a year was already obtained
2. The regex now extracts a four-digit value and all other text is removed, previously text on the left side was retained e.g. "Fall 2016"

## Testing?
PubMed id for the publication that triggers this is ```27860473```
