### PR TITLE
Add alt text to the AJAX spinner

### DIFF
--- a/tripal/includes/TripalFields/TripalFieldFormatter.inc
+++ b/tripal/includes/TripalFields/TripalFieldFormatter.inc
@@ -186,7 +186,7 @@ class TripalFieldFormatter {
     $pager = preg_replace('/href="\/.+\?page=(.+?)"/', 'href="javascript:void(0)" onclick="tripal_navigate_field_pager(\'' . $field_id . '\', $1)"', $pager);
     $pager = preg_replace('/href="\/.+"/', 'href="javascript:void(0)" onclick="tripal_navigate_field_pager(\'' . $field_id . '\', 0)"', $pager);
 
-    $pager = '<img src="/' . drupal_get_path('module', 'tripal') . '/theme/images/ajax-loader.gif" id="' . $field_id . '-spinner" class="tripal-field-ajax-spinner">' . $pager;
+    $pager = '<img src="/' . drupal_get_path('module', 'tripal') . '/theme/images/ajax-loader.gif" id="' . $field_id . '-spinner" class="tripal-field-ajax-spinner" alt="Loading content">' . $pager;
     return $pager;
   }
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# New Feature

Issue #1246

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add an alt text to a loading image "Loading content" for accessibility and if the image fails to load.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
Use an accessibility tool such as WAVE or view the source code for a page such as an Analysis that has Cross References.

