### PR TITLE
Small Changes so Tripal/Chado installs without errors on PHP8

### DIFF
--- a/tripal/api/tripal.entities.api.inc
+++ b/tripal/api/tripal.entities.api.inc
@@ -449,7 +449,7 @@ function tripal_create_bundle($args, $job = NULL) {
   $accession = $args['accession'];
   $term_name = $args['term_name'];
   $storage_args = $args['storage_args'];
-  $label = $args['label'];
+  $label = (isset($args['label'])) ? $args['label'] : $args['term_name'];
 
   $message_args = [
     'job' => $job,
@@ -1787,4 +1787,3 @@ function hook_bundle_find_orphans(TripalBundle $bundle, $count = FALSE,
   // See the tripal_chado_bundle_find_orphans() function for an example.
 
 }
-

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -387,13 +387,13 @@ function tripal_get_term_details($vocabulary, $accession) {
       // Let the user know that the url is missing.
       if ($url_missing) {
         //         tripal_add_notification(
-        //           "Missing CV term URL", 
+        //           "Missing CV term URL",
         //           t("The controlled vocabulary, %vocab, is missing a URL. Tripal will handle " .
         //             "this by linking to the cv/lookup page of this site. However, the correct " .
-        //             "should be updated for this site", 
+        //             "should be updated for this site",
         //             ['%vocab' => $term['vocabulary']['short_name']]),
-        //           'Controlled Vocabularies', 
-        //           NULL, 
+        //           'Controlled Vocabularies',
+        //           NULL,
         //           'mising-vocab-' . $term['vocabulary']['short_name']
         //         );
       }
@@ -592,7 +592,7 @@ function tripal_get_vocabularies() {
  * @ingroup tripal_terms_api
  */
 function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
-                                     $title = 'Vocabulary Term', $description = '', $is_required,
+                                     $title = 'Vocabulary Term', $description = '', $is_required = FALSE,
                                      $field_name = '', $delta = 0, $callback = '', $wrapper = '', $validate = [],
                                      $weight = 0) {
 
@@ -671,8 +671,8 @@ function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
     $form['term_match' . $delta]['terms_list' . $delta] = [
       '#type' => 'fieldset',
       '#title' => t('Matching Terms'),
-      '#description' => t('Please select the best matching term. If the 
-        same term exists in multiple vocabularies you will see more than 
+      '#description' => t('Please select the best matching term. If the
+        same term exists in multiple vocabularies you will see more than
         one option below.'),
     ];
     $match = [

--- a/tripal/includes/TripalBundle.inc
+++ b/tripal/includes/TripalBundle.inc
@@ -5,7 +5,7 @@
  */
 class TripalBundle extends Entity {
 
-  public function __construct($values = [], $entity_type) {
+  public function __construct($values = [], $entity_type = NULL) {
     parent::__construct($values, $entity_type);
 
     $this->term = tripal_load_term_entity(['term_id' => $this->term_id]);

--- a/tripal/includes/TripalEntity.inc
+++ b/tripal/includes/TripalEntity.inc
@@ -5,7 +5,7 @@
  */
 class TripalEntity extends Entity {
 
-  public function __construct($values = [], $entity_type) {
+  public function __construct($values = [], $entity_type = NULL) {
     parent::__construct($values, $entity_type);
   }
 

--- a/tripal/includes/TripalVocab.inc
+++ b/tripal/includes/TripalVocab.inc
@@ -5,7 +5,7 @@
  */
 class TripalVocab extends Entity {
 
-  public function __construct($values = [], $entity_type) {
+  public function __construct($values = [], $entity_type = NULL) {
     parent::__construct($values, $entity_type);
 
   }

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -1582,7 +1582,7 @@ function tripal_html5_file_validate($element, &$form_state) {
 /**
  * Implements hook_value() for the html5_file form element.
  */
-function tripal_html5_file_value($element, $input = FALSE, &$form_state) {
+function tripal_html5_file_value($element, $input = FALSE, $form_state = NULL) {
 
   if ($input) {
     if (is_array($input)) {

--- a/tripal/views_handlers/tripal_views_handler_filter_string.inc
+++ b/tripal/views_handlers/tripal_views_handler_filter_string.inc
@@ -265,7 +265,7 @@ class tripal_views_handler_filter_string extends tripal_views_handler_filter {
     foreach ($matches as $match) {
       $phrase = FALSE;
       // Strip off phrase quotes
-      if ($match[2]{0} == '"') {
+      if ($match[2][0] == '"') {
         $match[2] = substr($match[2], 1, -1);
         $phrase = TRUE;
       }

--- a/tripal_chado/api/modules/tripal_chado.pub.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.pub.api.inc
@@ -605,16 +605,18 @@ function _chado_execute_pub_importer_publish($publish, $job, $message_type, $mes
       'vocabulary' => 'TPUB',
       'accession' => '0000002',
     ]);
-    $bundle = tripal_load_bundle_entity(['term_id' => $bundle_term->id]);
-    if ($bundle) {
-      tripal_report_error($message_type, TRIPAL_INFO,
-        "Publishing publications with Drupal...", [], $message_opts);
-      chado_publish_records(['bundle_name' => $bundle->name], $job);
+    if ($bundle_term) {
+      $bundle = tripal_load_bundle_entity(['term_id' => $bundle_term->id]);
+      if ($bundle) {
+        tripal_report_error($message_type, TRIPAL_INFO,
+          "Publishing publications with Drupal...", [], $message_opts);
+        chado_publish_records(['bundle_name' => $bundle->name], $job);
+      }
+      // Note: we won't publish contacts as Tripal v2 did because there is
+      // no consisten way to do that. Each site my use a different term for
+      // different contact content types (e.g. all as one 'Contact' type or
+      // specific such as 'Person', 'Organization', etc.).
     }
-    // Note: we won't publish contacts as Tripal v2 did because there is
-    // no consisten way to do that. Each site my use a different term for
-    // different contact content types (e.g. all as one 'Contact' type or
-    // specific such as 'Person', 'Organization', etc.).
   }
 
   // For backwords compatibility with legacy module do a sync.

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -306,6 +306,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'OBI',
     'accession' => '0100026',
     'term_name' => 'organism',
+    'label' => 'Organism',
     'storage_args' => [
       'data_table' => 'organism',
     ],
@@ -320,6 +321,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'operation',
     'accession' => '2945',
     'term_name' => 'Analysis',
+    'label' => 'Analysis',
     'storage_args' => [
       'data_table' => 'analysis',
     ],
@@ -334,6 +336,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'NCIT',
     'accession' => 'C47885',
     'term_name' => 'Project',
+    'label' => 'Project',
     'storage_args' => [
       'data_table' => 'project',
     ],
@@ -364,6 +367,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'local',
     'accession' => 'contact',
     'term_name' => 'contact',
+    'label' => 'Contract',
     'storage_args' => [
       'data_table' => 'contact',
     ],
@@ -378,6 +382,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'TPUB',
     'accession' => '0000002',
     'term_name' => 'Publication',
+    'label' => 'Publication',
     'storage_args' => [
       'data_table' => 'pub',
     ],
@@ -411,6 +416,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'sep',
     'accession' => '00101',
     'term_name' => 'Protocol',
+    'label' => 'Protocol',
     'storage_args' => [
       'data_table' => 'protocol',
     ],
@@ -430,6 +436,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'SO',
     'accession' => '0000704',
     'term_name' => 'gene',
+    'label' => 'Gene',
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',
@@ -445,6 +452,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'SO',
     'accession' => '0000234',
     'term_name' => 'mRNA',
+    'label' => 'mRNA',
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',
@@ -460,6 +468,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'data',
     'accession' => '0872',
     'term_name' => 'Phylogenetic tree',
+    'label' => 'Phylogenetic Tree',
     'storage_args' => [
       'data_table' => 'phylotree',
     ],
@@ -473,6 +482,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'data',
     'accession' => '1280',
     'term_name' => 'Physical Map',
+    'label' => 'Physical Map',
     'storage_args' => [
       'data_table' => 'featuremap',
       'type_linker_table' => 'featuremapprop',
@@ -489,6 +499,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'NCIT',
     'accession' => 'C16223',
     'term_name' => 'DNA Library',
+    'label' => 'DNA Library',
     'storage_args' => [
       'data_table' => 'library',
       'type_column' => 'type_id',
@@ -539,6 +550,7 @@ function tripal_chado_prepare_genomic_types($job) {
     'vocabulary' => 'local',
     'accession' => 'Genome Project',
     'term_name' => 'Genome Project',
+    'label' => 'Genome Project',
     'storage_args' => [
       'data_table' => 'project',
       'type_linker_table' => 'projectprop',
@@ -563,6 +575,7 @@ function tripal_chado_prepare_expression_types($job) {
     'vocabulary' => 'sep',
     'accession' => '00195',
     'term_name' => 'biological sample',
+    'label' => 'Biological Sample',
     'storage_args' => [
       'data_table' => 'biomaterial',
     ],
@@ -594,6 +607,7 @@ function tripal_chado_prepare_expression_types($job) {
     'vocabulary' => 'EFO',
     'accession' => '0000269',
     'term_name' => 'Assay Design',
+    'label' => 'Array Design',
     'storage_args' => [
       'data_table' => 'arraydesign',
     ],
@@ -723,6 +737,7 @@ function tripal_chado_prepare_genetic_types($job) {
     'vocabulary' => 'SO',
     'accession' => '0000771',
     'term_name' => 'QTL',
+    'label' => 'QTL',
     'storage_args' => [
       'data_table' => 'feature',
       'type_column' => 'type_id',

--- a/tripal_chado/includes/setup/tripal_chado.setup.inc
+++ b/tripal_chado/includes/setup/tripal_chado.setup.inc
@@ -367,7 +367,7 @@ function tripal_chado_prepare_general_types($job) {
     'vocabulary' => 'local',
     'accession' => 'contact',
     'term_name' => 'contact',
-    'label' => 'Contract',
+    'label' => 'Contact',
     'storage_args' => [
       'data_table' => 'contact',
     ],

--- a/tripal_ws/tripal_ws.module
+++ b/tripal_ws/tripal_ws.module
@@ -43,14 +43,16 @@ function tripal_ws_init() {
 
   $vocab = tripal_get_vocabulary_details('hydra');
 
-  // Following the WC3 Hydra documentation, we want to add  LINK to the header
-  // of the site that indicates where the API documentation can be found.
-  // This allows a hydra-enabled client to discover the API and use it.
-  $attributes = array(
-    'rel' => $vocab['sw_url'] . 'apiDocumentation',
-    'href' => $api_url . '/doc/v0.1',
-  );
-  drupal_add_html_head_link($attributes, $header = FALSE);
+  if (is_array($vocab)) {
+    // Following the WC3 Hydra documentation, we want to add  LINK to the header
+    // of the site that indicates where the API documentation can be found.
+    // This allows a hydra-enabled client to discover the API and use it.
+    $attributes = array(
+      'rel' => $vocab['sw_url'] . 'apiDocumentation',
+      'href' => $api_url . '/doc/v0.1',
+    );
+    drupal_add_html_head_link($attributes, $header = FALSE);
+  }
 }
 
 /**


### PR DESCRIPTION
# Bug Fix

Issue #1088

## Description
I encountered errors when trying to install Tripal + Chado on PHP 8. Here are the fixes I needed to have the following run without errors on php8-apache2-postgresql13-debian11:
- Install/Enable tripal, tripal_chado, tripal_ws, tripal_ds
- Install Chado 1.3
- Prepare Tripal + Chado

## Testing?
I've tested this using [this Dockerfile](https://github.com/DivSeek-Canada/tripal-crop-docker/blob/upgrade-versions/Dockerfile).

I haven't tested these changes on an already installed site but do not foresee any problems.

## Screenshots (if appropriate):

## Additional Notes (if any):
I'm going to continue with the errors mentioned in the linked issue and will submit that as a separate PR when done.
