### PR TITLE
1252 tv3 get organism select

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.organism.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.organism.api.inc
@@ -156,6 +156,10 @@ function chado_get_organism_scientific_name($organism) {
         $rank = $organism->type_id->name;
       }
     }
+    // For db query where we explicitly supply infraspecific_type
+    elseif (property_exists($organism, 'infraspecific_type')) {
+      $rank = $organism->infraspecific_type;
+    }
     else {
       $rank_term = chado_get_cvterm(['cvterm_id' => $organism->type_id]);
       if ($rank_term) {
@@ -220,9 +224,10 @@ function chado_get_organism_select_options($syncd_only = TRUE) {
     $csql = "SELECT * FROM {organism} ORDER BY genus, species";
     // if present in this site's version of chado, include infraspecific nomenclature in sorting
     if (chado_column_exists('organism', 'infraspecific_name')) {
-      $csql .= ", REPLACE ((SELECT name FROM {cvterm} CVT WHERE CVT.cvterm_id = type_id" .
-               " AND CVT.cv_id = (SELECT cv_id FROM {cv} WHERE name='taxonomic_rank')), 'no_rank', '')," .
-               " infraspecific_name";
+      $csql = "SELECT organism_id, genus, species, type_id,"
+            . " (REPLACE ((SELECT name FROM {cvterm} CVT WHERE CVT.cvterm_id = type_id AND CVT.cv_id ="
+            . "   (SELECT cv_id FROM {cv} WHERE name='taxonomic_rank')), 'no_rank', '')) AS infraspecific_type,"
+            . " infraspecific_name FROM {organism} ORDER BY genus, species, infraspecific_type, infraspecific_name";
     }
     $orgs = chado_query($csql);
 
@@ -372,6 +377,9 @@ function chado_abbreviate_infraspecific_rank($rank) {
     case 'subvariety':
       $abb = 'subvar.';
       break;
+    case 'cultivar':
+      $abb = 'cv.';
+      break;
     case 'forma':
       $abb = 'f.';
       break;
@@ -382,4 +390,42 @@ function chado_abbreviate_infraspecific_rank($rank) {
       $abb = $rank;
   }
   return $abb;
+}
+
+/**
+ * A handy function to expand the infraspecific rank from an abbreviation.
+ *
+ * @param $rank
+ *   The rank below species or its abbreviation.
+ *   A period at the end of the abbreviation is optional.
+ *
+ * @return
+ *   The proper unabbreviated form for the rank.
+ *
+ * @ingroup tripal_organism_api
+ */
+function chado_unabbreviate_infraspecific_rank($rank) {
+  if (preg_match('/^subsp\.?$/', $rank)) {
+    $rank = 'subspecies';
+  }
+  elseif (preg_match('/^ssp\.?$/', $rank)) {
+    $rank = 'subspecies';
+  }
+  elseif (preg_match('/^var\.?$/', $rank)) {
+    $rank = 'varietas';
+  }
+  elseif (preg_match('/^subvar\.?$/', $rank)) {
+    $rank = 'subvarietas';
+  }
+  elseif (preg_match('/^cv\.?$/', $rank)) {
+    $rank = 'cultivar';
+  }
+  elseif (preg_match('/^f\.?$/', $rank)) {
+    $rank = 'forma';
+  }
+  elseif (preg_match('/^subf\.?$/', $rank)) {
+    $rank = 'subforma';
+  }
+  // if none of the above matched, rank is returned unchanged
+  return $rank;
 }


### PR DESCRIPTION
# Bug Fix

Issue #1252

## Description

Modification to the ```function chado_get_organism_select_options()``` to increase efficiency. There should be no functional change.

The original code on my test system was taking about 15 ms per organism. Much of this is occupied by the call to ```chado_get_organism_scientific_name()``` which in turn is occupied in looking up the infraspecific rank with a call to ```chado_get_cvterm(['cvterm_id' => $organism->type_id])```. This is a slightly redundant call, because this information had already been looked up in the original sql. The changes here just save that information and pass it on. This reduces the time per organism from about 15 ms to about 6ms.

I did not modify the portion of the code where ```$syncd_only``` is true, intended for Tripal v2 sites, because I have no way to test that.

## Testing?
If you have as many organisms in the chado.organism table as CarrotOmics, you can test just by observing how long it takes to enter edit mode on any analysis page, assuming the ```obi__organism_linker``` is present.
