### PR TITLE
Issue #1138 repair damage to sbo__database_cross_reference widget

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
@@ -129,6 +129,7 @@ class sbo__database_cross_reference extends ChadoField {
     $schema = chado_get_schema($field_table);
     $pkey = $schema['primary key'][0];
     $fkey_lcolumn = key($schema['foreign keys'][$base_table]['columns']);
+    $fkey_lcolumn_id = $entity->{'chado_record_id'};
     $fkey_rcolumn = $schema['foreign keys'][$base_table]['columns'][$fkey_lcolumn];
 
     $dbname_term = chado_get_semweb_term('db', 'name');
@@ -143,9 +144,10 @@ class sbo__database_cross_reference extends ChadoField {
     $linker_table = $base_table . '_dbxref';
     $options = ['return_array' => 1];
 
-    // Build the SQL to find records associated with this publication.
+    // Build the SQL to find records associated with this entity.
+    // Note that there is no rank column in the xxx_dbxref tables, so the order part of the widget will not be functional
     $max_items = array_key_exists('max_items', $this->instance['settings']) ? $this->instance['settings']['max_items'] : 10000;
-    $sql = "SELECT REF.accession, DB.name, DB.urlprefix "
+    $sql = "SELECT LINK.".$linker_table."_id AS pkey_id, REF.dbxref_id, REF.accession, DB.db_id, DB.name, DB.urlprefix "
          . "FROM {".$linker_table."} LINK "
          . "INNER JOIN {dbxref} REF on LINK.dbxref_id = REF.dbxref_id "
          . "INNER JOIN {db} DB on REF.db_id = DB.db_id "
@@ -155,7 +157,7 @@ class sbo__database_cross_reference extends ChadoField {
          . "AND NOT DB.name = 'GFF_source' "
          . "ORDER BY REF.accession "  // if we hit the limit, the subset should be consistent
          . "LIMIT :limit";
-    $args = [':id' => $entity->{'chado_record_id'},
+    $args = [':id' => $fkey_lcolumn_id,
              ':limit' => $max_items + 1];
     $records = chado_query($sql, $args);
 
@@ -164,10 +166,18 @@ class sbo__database_cross_reference extends ChadoField {
     while($record = $records->fetchObject()) {
       // Need this check to detect the case where the limit exactly equals the number of records
       if ($delta < $max_items) {
-        $entity->{$field_name}['und'][$delta] = [];
-        $entity->{$field_name}['und'][$delta]['value'][$dbname_term] = $record->name;
-        $entity->{$field_name}['und'][$delta]['value'][$accession_term] = $record->accession;
-        $entity->{$field_name}['und'][$delta]['value'][$dburl_term] = $record->urlprefix;
+        $entity->{$field_name}['und'][$delta] = [
+          'value' => [
+            $dbname_term => $record->name,
+            $accession_term => $record->accession,
+            $dburl_term => $record->urlprefix,
+          ],
+          'chado-' . $field_table . '__' . $pkey => $record->pkey_id,
+          'chado-' . $field_table . '__' . $fkey_lcolumn => $fkey_lcolumn_id,
+          'chado-' . $field_table . '__dbxref_id' => $record->dbxref_id,
+          'db_id' => $record->db_id,
+          'accession' => $record->accession,
+        ];
       }
       $delta++;
     }

--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
@@ -146,7 +146,7 @@ class sbo__database_cross_reference extends ChadoField {
 
     // Build the SQL to find records associated with this entity.
     // Note that there is no rank column in the xxx_dbxref tables, so the order part of the widget will not be functional
-    $max_items = array_key_exists('max_items', $this->instance['settings']) ? $this->instance['settings']['max_items'] : 10000;
+    $max_items = array_key_exists('max_items', $this->instance['settings']) ? $this->instance['settings']['max_items'] : 1000;
     $sql = "SELECT LINK.".$linker_table."_id AS pkey_id, REF.dbxref_id, REF.accession, DB.db_id, DB.name, DB.urlprefix "
          . "FROM {".$linker_table."} LINK "
          . "INNER JOIN {dbxref} REF on LINK.dbxref_id = REF.dbxref_id "

--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference.inc
@@ -40,7 +40,7 @@ class sbo__database_cross_reference extends ChadoField {
     // The number of items to show on a page.
     'items_per_page' => 10,
     // Limit to the number of items to show in cases of large number of cross references.
-    'max_items' => 10000,
+    'max_items' => 1000,
   ];
 
   // The default widget for this field.

--- a/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__database_cross_reference/sbo__database_cross_reference_widget.inc
@@ -8,6 +8,10 @@ class sbo__database_cross_reference_widget extends ChadoFieldWidget {
   // The list of field types for which this formatter is appropriate.
   public static $field_types = ['sbo__database_cross_reference'];
 
+  // The widget may either display ORDER for setting row weights, or allow rearranging, but
+  // the various xxx_dbxref tables do not have rank columns, so this part is non-functional.
+  // We may be able to disable rearranging in a later version of Drupal, but not 7.x
+
   /**
    *
    * @see TripalFieldWidget::form()


### PR DESCRIPTION
# Bug Fix

Issue #1138 and Pull request #1139

## Description

I am sorry, I vandalized the ```sbo__database_cross_reference``` widget and made it so that existing dbxref content is not appearing when editing a page. This happened with [Commit d57135a](https://github.com/tripal/tripal/commit/d57135a9dcc9c58ae80d2205e2e6a79a3b270cee) because I removed some values that the loader should pass on to the widget. This pull request repairs the damage.

## Testing?
Go to a page with this field, e.g. a publication with a PubMed dbxref, and edit. The existing dbxref should display in the widget, new one can be added, existing one deleted, etc.
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Additional Notes (if any):

While I am in here, I noted that this widget, like others, has a facility for rearranging items either through javascript dragging or by using an ORDER column. However, for this particular field, the changes are not saved. The basic reason is that the various ```xxx_dbxref``` tables do not have ```rank``` columns, so there is no place to store the ordering information. I investigated the option of just turning off this reordering functionality for just this widget, but drupal 7.x does not have any easy way to do this, although it has been proposed as a feature for later versions https://www.drupal.org/project/drupal/issues/2264739 so maybe in the future this could be done.
