### PR TITLE
Issue #1258 add radio button option

### DIFF
--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -585,16 +585,28 @@ function tripal_get_vocabularies() {
  *   Indicates if this form element is required.
  * @param $field_name
  *   The name of the field, if this form is being added to a field widget.
- * @param  $delta
+ * @param $delta
  *   The delta value for the field if this form is being added to a field
  *   widget.
+ * @param $callback
+ *   Ajax callback function, defaults to
+ *     'tripal_get_term_lookup_form_ajax_callback'.
+ * @param $wrapper
+ *   Ajax wrapper ID.
+ * @param $validate
+ *   Widget validation configuration.
+ * @param $weight
+ *   The weight value for the field if this form is being added to a field
+ *   widget.
+ * @param $radio
+ *   Display select as a radio button instead of a checkbox.
  *
  * @ingroup tripal_terms_api
  */
 function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
                                      $title = 'Vocabulary Term', $description = '', $is_required = FALSE,
                                      $field_name = '', $delta = 0, $callback = '', $wrapper = '', $validate = [],
-                                     $weight = 0) {
+                                     $weight = 0, $radio = FALSE) {
 
   if (!$callback) {
     $callback = 'tripal_get_term_lookup_form_ajax_callback';
@@ -700,8 +712,12 @@ function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
       }
       $term_element_name = 'term-' . $term->cvterm_id . '-' . $delta;
       $definition = property_exists($term, 'definition') ? $term->definition : '';
+      $select_type = 'checkbox';
+      if ($radio) {
+        $select_type = 'radio';
+      }
       $form['term_match' . $delta]['terms_list' . $delta][$term_element_name] = [
-        '#type' => 'checkbox',
+        '#type' => $select_type,
         '#title' => $term->name,
         '#default_value' => $checked,
         '#attributes' => $attrs,

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -598,15 +598,13 @@ function tripal_get_vocabularies() {
  * @param $weight
  *   The weight value for the field if this form is being added to a field
  *   widget.
- * @param $radio
- *   Display select as a radio button instead of a checkbox.
  *
  * @ingroup tripal_terms_api
  */
 function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
                                      $title = 'Vocabulary Term', $description = '', $is_required = FALSE,
                                      $field_name = '', $delta = 0, $callback = '', $wrapper = '', $validate = [],
-                                     $weight = 0, $radio = FALSE) {
+                                     $weight = 0) {
 
   if (!$callback) {
     $callback = 'tripal_get_term_lookup_form_ajax_callback';
@@ -710,12 +708,8 @@ function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
       $term_element_name = 'term-' . $term->cvterm_id . '-' . $delta;
       $term = chado_expand_var($term, 'field', 'cv.definition');
       $definition = property_exists($term, 'definition') ? $term->definition : '';
-      $select_type = 'checkbox';
-      if ($radio) {
-        $select_type = 'radio';
-      }
       $form['term_match' . $delta]['terms_list' . $delta][$term_element_name] = [
-        '#type' => $select_type,
+        '#type' => 'radio',
         '#title' => $term->name,
         '#default_value' => $checked,
         '#attributes' => $attrs,

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -693,9 +693,6 @@ function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
     // TODO: this should not call the chado functions because we're in the
     // tripal module.
     $terms = chado_generate_var('cvterm', $match, ['return_array' => TRUE]);
-    if ($terms) {
-      $terms = chado_expand_var($terms, 'field', 'cvterm.definition');
-    }
     $num_terms = 0;
     $selected_term = '';
 
@@ -711,6 +708,7 @@ function tripal_get_term_lookup_form(&$form, &$form_state, $default_name = '',
         $attrs = ['checked' => 'checked'];
       }
       $term_element_name = 'term-' . $term->cvterm_id . '-' . $delta;
+      $term = chado_expand_var($term, 'field', 'cv.definition');
       $definition = property_exists($term, 'definition') ? $term->definition : '';
       $select_type = 'checkbox';
       if ($radio) {

--- a/tripal/includes/tripal.fields.inc
+++ b/tripal/includes/tripal.fields.inc
@@ -630,7 +630,7 @@ function tripal_field_instance_settings_form_alter_process($element, &$form_stat
     $element['field_term']['instructions'] = [
       '#type' => 'item',
       '#title' => 'Matching terms',
-      '#markup' => t('Please select the term the best matches the
+      '#markup' => t('Please select the term that best matches the
         content type you want to associate with this field. If the same term exists in
         multiple vocabularies you will see more than one option below.'),
     ];
@@ -650,7 +650,7 @@ function tripal_field_instance_settings_form_alter_process($element, &$form_stat
         $attrs = ['checked' => 'checked'];
       }
       $element['field_term']['term-' . $term->cvterm_id] = [
-        '#type' => 'checkbox',
+        '#type' => 'radio',
         '#title' => $term->name,
         '#default_value' => $default,
         '#attributes' => $attrs,

--- a/tripal_chado/includes/tripal_chado.semweb.inc
+++ b/tripal_chado/includes/tripal_chado.semweb.inc
@@ -2332,7 +2332,7 @@ function tripal_chado_semweb_edit_form($form, &$form_state, $table = NULL, $colu
     $form['terms_list'] = [
       '#type' => 'fieldset',
       '#title' => t('Matching Terms'),
-      '#description' => t('Please select the term the best matches the
+      '#description' => t('Please select the term that best matches the
           content type you want to create. If the same term exists in
           multiple vocabularies you will see more than one option below.'),
     ];
@@ -2352,7 +2352,7 @@ function tripal_chado_semweb_edit_form($form, &$form_state, $table = NULL, $colu
         $attrs = ['checked' => 'checked'];
       }
       $form['terms_list']['term-' . $term->cvterm_id] = [
-        '#type' => 'checkbox',
+        '#type' => 'radio',
         '#title' => $term->name,
         '#default_value' => $default,
         '#attributes' => $attrs,


### PR DESCRIPTION
# New Feature


Issue #1258 

## Description
This adds one more parameter to ```tripal_get_term_lookup_form()``` which allows the use of radio buttons instead of checkboxes, to enforce returning only a single cv term.

Because this is a new parameter at the end, it should not affect existing code or usage, default is to retain the checkboxes as before.

I also updated the parameter documentation for the missing parameters.

The bad thing is that this adds another parameter to a function that already has 12 parameters.

## Testing?
Example from https://github.com/tripal/tripal_analysis_expression/pull/392
```
      // Add the lookup fieldset to the form, radio set to return only one term.
      tripal_get_term_lookup_form($form, $form_state, $default_term_name,
          $title, '', FALSE,  '', $delta,
          'tripal_biomaterial_loader_form_ajax_callback', 
          '', [], 0, TRUE);
```

## Screenshots (if appropriate):
Example
![radio1](https://user-images.githubusercontent.com/8419404/159050364-8b277803-c705-404d-b6aa-b4582380d9cd.png)

## Additional Notes (if any):
If this is acceptable, I can submit another pull request for places where the radio option should be set, _e.g._  ```TripalBundleUIController.inc```

