### PR TITLE
Use bundle description on Add Tripal Content bundle listing.

### DIFF
--- a/tripal/includes/TripalEntityUIController.inc
+++ b/tripal/includes/TripalEntityUIController.inc
@@ -859,10 +859,16 @@ function tripal_add_page() {
       if (!array_key_exists($machine_name . '_fieldset', $content)) {
         $content[$machine_name . '_fieldset'] = $fieldsets[$machine_name . '_fieldset'];
       }
+      if ($bundle->term) {
+        $description = tripal_get_bundle_variable('description', $bundle->id, $bundle->term->definition);
+      }
+      else {
+        $description = tripal_get_bundle_variable('description', $bundle->id, '');
+      }
       $content[$machine_name . '_fieldset'][$bundle->name] = [
         '#type' => 'item',
         '#markup' => l($bundle->label, 'bio_data/add/' . $bundle->id),
-        '#description' => $bundle->term->definition,
+        '#description' => $description,
       ];
     }
   }


### PR DESCRIPTION
# Bug Fix

Issue #1273

## Description

This is a small PR that loads the bundle description to show on the Add Tripal Content bundle listing  (i.e. admin/content/bio_data/add). Originally the term definition was displayed as it was already loaded in the bundle object. However, the Add/Edit for Tripal Content Types (bundles) says that the bundle description will be shown on the Add Tripal content type listing (see screenshot in linked issue) so this PR ensures we meet expectations. This is also very useful as it allows admin to use the bundle description to provide additional context and usage information specific to their site.

## Testing?

### NOT on this branch

1. First, go to the Add Tripal Content Type listing (admin/content/bio_data/add) while NOT on this branch.
2. Notice that the text under the "Analysis" content type is "Apply analytical methods to existing data of a specific type." As shown in the screenshots this is the term definition. (See screenshot 1 below; confirm this is term definition in screenshot 2)
3. Now edit the Analysis content type by going to admin/structure/bio_data and clicking edit beside the "Analysis" content type.
4. Change the description to something else (by default it will also match the term definition) and save. (see screenshot 2 for an example)
5. Return to the Add Tripal Content Type listing (admin/content/bio_data/add) and not the term definition is still shown and not the text you just added. (still looks like screenshot 1)

## On this branch
6. Now switch to this branch and clear the cache.
7. Then refresh the Add Tripal Content Type listing (admin/content/bio_data/add) listing and notice that the text you added in step 4 is now shown under "Analysis" in the listing! (now looks like screenshot 3)

## Screenshots (if appropriate):
### Add Tripal Content Type listing (admin/content/bio_data/add) NOT on this branch
<img width="1065" alt="AddTripalContentListing-default" src="https://user-images.githubusercontent.com/1566301/165804652-607d126f-f78b-4330-96ed-0abc7001a4c8.png">

### Edit Analysis Content Type Form
![EditAnalysisContentType](https://user-images.githubusercontent.com/1566301/165804712-c73d8af9-42c9-4f57-bb7b-a4534fc8f086.png)

### Add Tripal Content Type listing (admin/content/bio_data/add) FIXED (on this branch)
<img width="1065" alt="AddTripalContentListing-fixed" src="https://user-images.githubusercontent.com/1566301/165804692-28712932-af82-46e2-9a56-97e453ada5a2.png">
