### PR TITLE
Typo corrections for the 3.9 release

### DIFF
--- a/docs/dev_guide/custom_field/manual_field_creation.rst
+++ b/docs/dev_guide/custom_field/manual_field_creation.rst
@@ -274,7 +274,7 @@ Instead, we put it in at the same level as 'value':
 
   $entity->{$field_name}['und'][0][$linker_field]
 
-We do this because anything in the 'value' element is intended for the end-user.  Anything outside of the 'value' is meant for Tripal.  Adding the organism ID to this field as a Tripal "hidden" value allows Tripal to recognize where these values really came from.   When writing your own fields, you must include any values as "hidden" Tripal values that need to be written to the database table.  A good way to remember if you a value should be visible to the end-user or hidden for Tripal is to ask yourself these questions:
+We do this because anything in the 'value' element is intended for the end-user.  Anything outside of the 'value' is meant for Tripal.  Adding the organism ID to this field as a Tripal "hidden" value allows Tripal to recognize where these values really came from.   When writing your own fields, you must include any values as "hidden" Tripal values that need to be written to the database table.  A good way to remember if your value should be visible to the end-user or hidden for Tripal is to ask yourself these questions:
 
   1.  Does the user need this value?  If yes, put it in the 'value' element.
   2.  Does Tripal need the value when writing back to the Chado table?  If yes, put it as a hidden element.

--- a/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
+++ b/legacy/tripal_analysis/includes/tripal_analysis.chado_node.inc
@@ -150,7 +150,7 @@ function chado_analysis_form($node, &$form_state) {
     '#markup' => t('When adding any type of data it is good to associate it with
         an analysis so that site visitors can identify the source of the data including
         necessary materials and methods.  The fields below imply that all analyses
-        are derived from some software package. But, data can also be derived via retreival
+        are derived from some software package. But, data can also be derived via retrieval
         from an external source or an analysis pipeline with multipel software components.
         In these cases, provide values for the fields below that best makes sense
      '),

--- a/legacy/tripal_core/api/tripal_core.chado_nodes.api.inc
+++ b/legacy/tripal_core/api/tripal_core.chado_nodes.api.inc
@@ -406,7 +406,7 @@ function chado_add_node_form_subtable_ajax_update($form, &$form_state) {
  *   the
  * // value must be an array of column names in
  * // base table. The values from these columns will
- * // be retreived, contentated with a space delimeter
+ * // be retrieved, concatenated with a space delimeter
  * // and provided in a list of checkboxes
  * // for the user to choose which to sync.
  * ),

--- a/legacy/tripal_core/api/tripal_core.tripal_variables.api.inc
+++ b/legacy/tripal_core/api/tripal_core.tripal_variables.api.inc
@@ -83,7 +83,7 @@ function tripal_add_node_variable($nid, $name, $value, $rank = 0) {
  * @param $name
  *   Optional.  The name of the variable.
  * @param $rank
- *   Optional.  The rank of the variable to retreive.
+ *   Optional.  The rank of the variable to retrieve.
  *
  * @return
  *   An array of variable objects.
@@ -120,7 +120,7 @@ function tripal_get_node_variables($nid, $name = '', $rank = '') {
  * @param $name
  *   Optional.  The name of the variable.
  * @param $rank
- *   Optional.  The rank of the variable to retreive.
+ *   Optional.  The rank of the variable to retrieve.
  *
  * @return
  *   Return TRUE if deletion is successful, FALSE otherwise.

--- a/legacy/tripal_cv/api/tripal_cv.api.inc
+++ b/legacy/tripal_cv/api/tripal_cv.api.inc
@@ -27,7 +27,7 @@
  * from the default vocabulary in the drop down.
  *
  * This function uses the Chado table and field name (e.g. 'type_id') to
- * retreive the vocabulary assgined.
+ * retrieve the vocabulary assgined.
  *
  * @param $table
  *   The name of the table that contains a field with a foreign key
@@ -91,7 +91,7 @@ function tripal_get_default_cv_table($cv_id) {
 /**
  * Create an options array to be used in a form element
  * which provides a list of all chado cvterms. Unlike the
- * tripal_get_cvterm_select_option, this function retreives the cvterms using
+ * tripal_get_cvterm_select_option, this function retrieves the cvterms using
  * the default vocabulary set for a given table and field.  It will also
  * notify the administrative user if a default vocabulary is missing for the
  * field and if the vocabulary is empty.

--- a/legacy/tripal_feature/theme/templates/tripal_feature_sequence.tpl.php
+++ b/legacy/tripal_feature/theme/templates/tripal_feature_sequence.tpl.php
@@ -117,14 +117,14 @@ if ($residues or count($featureloc_sequences) > 0) {
   }
 
   /* ADD IN ALIGNMENT SEQUENCES FOR THIS FEATURE
-   * For retreiving the sequence from an alignment we would typically make a call to
+   * For retrieving the sequence from an alignment we would typically make a call to
    * chado_expand_var function.  For example, to retrieve all
    * of the featurelocs in order to get the sequences needed for this template, the
    * following function call would be made:
    *
    *   $feature = chado_expand_var($feature,'table','featureloc');
    *
-   * Then all of the sequences would need to be retreived from the alignments and
+   * Then all of the sequences would need to be retrieved from the alignments and
    * formatted for display below.  However, to simplify this template, this has already
    * been done by the tripal_feature module and the sequences are made available in
    * the variable:

--- a/tripal/api/tripal.terms.api.inc
+++ b/tripal/api/tripal.terms.api.inc
@@ -570,7 +570,7 @@ function tripal_get_vocabularies() {
  * The form elements should work with a flat form (no #tree set for the form)
  * or with a form in a TripalField.
  *
- * Use the tripal_get_term_lookup_form_result() function to retreive the
+ * Use the tripal_get_term_lookup_form_result() function to retrieve the
  * result in a form submit or validate.
  *
  * @param $form

--- a/tripal_chado/api/ChadoSchema.inc
+++ b/tripal_chado/api/ChadoSchema.inc
@@ -243,7 +243,7 @@ class ChadoSchema {
    *  include linker tables (which link two or more base tables), property
    * tables, and relationship tables.  These provide additional information
    * about primary data records and are therefore not base tables.  This
-   * function retreives only the list of tables that are considered 'base'
+   * function retrieves only the list of tables that are considered 'base'
    * tables.
    *
    * @return

--- a/tripal_chado/api/generate_chado_schema_file.php
+++ b/tripal_chado/api/generate_chado_schema_file.php
@@ -98,7 +98,7 @@ if (isset($arguments['v'])) {
     " */\n"
   );
 
-  // The SQL for retreiving details about a table.
+  // The SQL for retrieving details about a table.
   $fksql = "
     SELECT
         tc.constraint_name, tc.table_name, kcu.column_name,

--- a/tripal_chado/api/modules/tripal_chado.feature.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.feature.api.inc
@@ -131,7 +131,7 @@ function chado_reverse_compliment_sequence($sequence) {
  *    - upstream: the number of upstream bases included in the sequence
  *    - downstream: the number of downstream bases included in the
  *      sequence
- *    - defline: the definintion line used to create a FASTA sequence
+ *    - defline: the definition line used to create a FASTA sequence
  *    - residues: the residues
  *    - featureloc_id: the featureloc_id if the sequences is from an
  *        alignment
@@ -175,8 +175,8 @@ function chado_get_feature_sequences($feature, $options) {
     return [];
   }
 
-  // If a relationship was specified then retreive and the sequences that
-  // have the given relationship and the recurse to extract the appropriate
+  // If a relationship was specified then retrieve the sequences that
+  // have the given relationship and then recurse to extract the appropriate
   // sequence.
   if ($rel_part == "object" or $rel_part == "subject") {
     if ($rel_part == "subject") {
@@ -245,8 +245,8 @@ function chado_get_feature_sequences($feature, $options) {
 
   // Prepare the queries we're going to use later during the render phase
   // This SQL statement uses conditionals in the select clause to handle
-  // cases cases where the alignment is in the reverse direction and when
-  // the upstream and downstream extensions go beyond the lenght of the
+  // cases where the alignment is in the reverse direction and when
+  // the upstream and downstream extensions go beyond the length of the
   // parent sequence.
   $parent_sql = '
     SELECT featureloc_id, srcname, srcfeature_id, strand, srctypename, typename,
@@ -558,7 +558,7 @@ function chado_get_feature_sequences($feature, $options) {
       $residues = wordwrap($residues, $num_bases_per_line, "\r\n", TRUE);
     }
 
-    // Get the definintion line for this feature.
+    // Get the definition line for this feature.
     $defline = chado_get_fasta_defline($f, '', NULL, '', $length);
 
     // Add to the sequence array.
@@ -625,7 +625,7 @@ function chado_get_feature_sequences($feature, $options) {
  *         the sequence (e.g. from an aggregated sequence)
  *      'upstream'      => the number of upstream bases in the sequence
  *      'downstream'    => the number of downstream bases in the sequence
- *      'defline'       => the definintion line used to create a FASTA sequence
+ *      'defline'       => the definition line used to create a FASTA sequence
  *      'residues'      => the residues
  *      'featureloc_id' => the featureloc_id if from an alignment
  *

--- a/tripal_chado/api/modules/tripal_chado.module.DEPRECATED.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.module.DEPRECATED.api.inc
@@ -737,7 +737,7 @@ function tripal_reverse_compliment_sequence($sequence) {
  *    - upstream: the number of upstream bases included in the sequence
  *    - downstream: the number of downstream bases included in the
  *      sequence
- *    - defline: the definintion line used to create a FASTA sequence
+ *    - defline: the definition line used to create a FASTA sequence
  *    - residues: the residues
  *    - featureloc_id: the featureloc_id if the sequences is from an
  *        alignment
@@ -798,7 +798,7 @@ function tripal_get_feature_sequences($feature, $options) {
  *         the sequence (e.g. from an aggregated sequence)
  *      'upstream'      => the number of upstream bases in the sequence
  *      'downstream'    => the number of downstream bases in the sequence
- *      'defline'       => the definintion line used to create a FASTA sequence
+ *      'defline'       => the definition line used to create a FASTA sequence
  *      'residues'      => the residues
  *      'featureloc_id' => the featureloc_id if from an alignment
  *
@@ -1279,7 +1279,7 @@ function tripal_phylogeny_import_tree_file($file_name, $format, $options = [], $
  * be returned.
  *
  * @return
- *   If a singe publication is retreived using the identifiers, then a
+ *   If a single publication is retrieved using the identifiers, then a
  *   publication array will be returned.  The array is of the same format
  *   returned by the chado_generate_var() function. Otherwise, FALSE will be
  *   returned.
@@ -1348,7 +1348,7 @@ function tripal_autocomplete_pub($string = '') {
 }
 
 /**
- * Imports a singe publication specified by a remote database cross reference.
+ * Imports a single publication specified by a remote database cross reference.
  *
  * @param $pub_dbxref
  *   The unique database ID for the record to update.  This value must

--- a/tripal_chado/api/modules/tripal_chado.pub.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.pub.api.inc
@@ -44,7 +44,7 @@
  * be returned.
  *
  * @return
- *   If a singe publication is retreived using the identifiers, then a
+ *   If a single publication is retrieved using the identifiers, then a
  *   publication array will be returned.  The array is of the same format
  *   returned by the chado_generate_var() function. Otherwise, FALSE will be
  *   returned.
@@ -324,7 +324,7 @@ function chado_autocomplete_pub($string = '') {
 
 
 /**
- * Imports a singe publication specified by a remote database cross reference.
+ * Imports a single publication specified by a remote database cross reference.
  *
  * @param $pub_dbxref
  *   The unique database ID for the record to update.  This value must

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -487,7 +487,7 @@ function chado_insert_record($table, $values, $options = []) {
   }
 
   // Iterate through the values array and create a new 'insert_values' array
-  // that has all the values needed for insert with all foreign relationsihps
+  // that has all the values needed for insert with all foreign relationships
   // resolved.
   foreach ($values as $field => $value) {
     // Make sure the field is in the table description. If not then return an

--- a/tripal_chado/api/tripal_chado.schema.api.inc
+++ b/tripal_chado/api/tripal_chado.schema.api.inc
@@ -591,7 +591,7 @@ function chado_get_custom_table_schema($table) {
  *  include linker tables (which link two or more base tables), property tables,
  *  and relationship tables.  These provide additional information about
  *  primary data records and are therefore not base tables.  This function
- *  retreives only the list of tables that are considered 'base' tables.
+ *  retrieves only the list of tables that are considered 'base' tables.
  *
  * @return
  *    An array of base table names.

--- a/tripal_chado/includes/TripalFields/local__source_data/local__source_data_widget.inc
+++ b/tripal_chado/includes/TripalFields/local__source_data/local__source_data_widget.inc
@@ -82,7 +82,7 @@ class local__source_data_widget extends ChadoFieldWidget {
     $widget['source_data']['sourceuri'] = [
       '#type' => 'textfield',
       '#title' => 'Data Source URI',
-      '#description' => 'The URI (e.g. web URL) where the source data can be retreived.',
+      '#description' => 'The URI (e.g. web URL) where the source data can be retrieved.',
       '#default_value' => $sourceuri,
     ];
 

--- a/tripal_chado/includes/TripalFields/so__cds/so__cds.inc
+++ b/tripal_chado/includes/TripalFields/so__cds/so__cds.inc
@@ -113,7 +113,7 @@ class so__cds extends ChadoField {
         if ($cds_sequence[0]['residues']) {
           $entity->{$field_name}['und'][$num_seqs++] = [
             'value' => $cds_sequence[0]['residues'],
-            // This field was incorrelctly listed as a field in the featureprop
+            // This field was incorrectly listed as a field in the featureprop
             // table, but really it is a derived field. So, we have to do this
             // hacky fix to get around the problem.
             'chado-featureprop__featureprop_id' => NULL,

--- a/tripal_chado/includes/TripalImporter/FASTAImporter.inc
+++ b/tripal_chado/includes/TripalImporter/FASTAImporter.inc
@@ -745,7 +745,7 @@ class FASTAImporter extends TripalImporter {
         $feature = $results[0];
       }
       else {
-        $this->logMessage("Failed to retreive newly inserted feature '!name (!uname)'", [
+        $this->logMessage("Failed to retrieve newly inserted feature '!name (!uname)'", [
           '!name' => $name,
           '!uname' => $uname,
         ], TRIPAL_ERRORR);
@@ -877,7 +877,7 @@ class FASTAImporter extends TripalImporter {
           $dbxref = $results[0];
         }
         else {
-          $this->logMessage("Failed to retreive newly inserted dbxref '!name (!uname)'",
+          $this->logMessage("Failed to retrieve newly inserted dbxref '!name (!uname)'",
             ['!name' => $name, '!uname' => $uname], TRIPAL_ERROR);
           return 0;
         }
@@ -886,7 +886,7 @@ class FASTAImporter extends TripalImporter {
         $dbxref = $results[0];
       }
 
-      // check to see if the feature dbxref record exists if not, then add it
+      // Check to see if the feature dbxref record exists. If not, then add it.
       $values = [
         'feature_id' => $feature->feature_id,
         'dbxref_id' => $dbxref->dbxref_id,
@@ -902,7 +902,7 @@ class FASTAImporter extends TripalImporter {
       }
     }
 
-    // now add in the relationship if one exists. If not, then add it
+    // Now add in the relationship if one exists.
     if ($rel_type) {
       $values = [
         'organism_id' => $organism_id,
@@ -917,7 +917,7 @@ class FASTAImporter extends TripalImporter {
       }
       $parent_feature = $results[0];
 
-      // check to see if the relationship already exists if not then add it
+      // Check to see if the relationship already exists. If not, then add it.
       $values = [
         'subject_id' => $feature->feature_id,
         'object_id' => $parent_feature->feature_id,

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -260,7 +260,7 @@ class GFF3Importer extends TripalImporter {
   private $features = [];
 
   /**
-   * An associatiave array containing the pointers to the FASTA sequences
+   * An associative array containing the pointers to the FASTA sequences
    * in the GFF file. We don't want to load these into memory as they
    * may be too big!
    */

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_AGL.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_AGL.inc
@@ -431,7 +431,7 @@ function tripal_pub_remote_search_AGL($search_array, $num_to_retrieve, $page) {
  *
  * @return
  *  An array containing the total_records in the dataaset, the search string
- *  and an array of the publications that were retreived.
+ *  and an array of the publications that were retrieved.
  *
  * @ingroup tripal_pub
  */

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
@@ -291,7 +291,7 @@ function tripal_pub_PMID_search_init($search_str, $retmax) {
  *
  * @return
  *  An array containing the total_records in the dataaset, the search string
- *  and an array of the publications that were retreived.
+ *  and an array of the publications that were retrieved.
  *
  * @ingroup tripal_pub
  */
@@ -683,7 +683,7 @@ function tripal_pub_PMID_parse_abstract($xml, &$pub) {
       $pub['Abstract'] = $abstract;
       return;
     }
-    // the abstract text can be just a singe paragraph or be broken into multiple
+    // the abstract text can be just a single paragraph or be broken into multiple
     // abstract texts for structured abstracts.  Here we will just combine then
     // into a single element in the order that they arrive in HTML format
     if ($xml->nodeType == XMLReader::ELEMENT) {

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
@@ -1593,7 +1593,7 @@ function tripal_pub_get_publication_array($pub_id, $skip_existing = TRUE) {
     if (trim($authors->value)) {
       $pub_array['Authors'] = $authors->value;
     }
-    // if there is no 'Author's property then try to retreive authors from the pubauthor table
+    // if there is no 'Authors' property then try to retrieve authors from the pubauthor table
     else {
       $sql = "
       SELECT string_agg(surname || ' ' || givennames, ', ')

--- a/tripal_chado/includes/tripal_chado.publish.inc
+++ b/tripal_chado/includes/tripal_chado.publish.inc
@@ -57,7 +57,7 @@ function tripal_chado_publish_form($form, &$form_state) {
         $field = field_info_field($field_name);
         $instance = field_info_instance('TripalEntity', $field_name, $bundle_name);
 
-        // Exclude data fields from the publish form.
+        // Exclude date fields from the publish form.
         // We do this because the lack of default causes errors.
         if ($field['type'] == 'datetime'){
           continue;

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -389,7 +389,7 @@ function tripal_chado_menu() {
 
   $items['admin/tripal/loaders/pub'] = array(
     'title' => t('Chado Bulk Publication Importer Callback'),
-    'description' => t('Create and modify importers that can connect to and retreive publications from remote databases.'),
+    'description' => t('Create and modify importers that can connect to and retrieve publications from remote databases.'),
     'page callback' => 'tripal_pub_importers_list',
     'access arguments' => array('use chado_pub_bulk importer'),
     'file' => 'includes/loaders/tripal_chado.pub_importers.inc',

--- a/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
+++ b/tripal_ws/includes/TripalFields/remote__data/remote__data.inc
@@ -338,7 +338,7 @@ class remote__data extends WebServicesField {
     $element['data_info']['query'] = [
       '#type' => 'textarea',
       '#title' => 'Query to Execute',
-      '#description' => 'Enter the query that will retreive the remote records. ',
+      '#description' => 'Enter the query that will retrieve the remote records.',
       '#default_value' => $this->instance['settings']['data_info']['query'],
       '#rows' => 3,
       '#required' => TRUE,


### PR DESCRIPTION
# Bug Fix

## Description

These are just corrections of spelling or punctuation, with no functional effect. The majority are in comments, a few are visible to users.

There were a lot of changes of ```retreive``` to ```retrieve``` except in some legacy function names in ```legacy/tripal_core/api/tripal_core.DEPRECATED.inc``` - Lol, I'm not touching those!

(And my branch name is named incorrectly-sorry)