### PR TITLE
Check if user is admin before warning

### DIFF
--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -103,14 +103,9 @@ function tripal_chado_vocab_get_vocabulary($vocabulary) {
   $result = chado_query($sql, [':name' => $vocabulary]);
   $result = $result->fetchAssoc();
   if (!$result) {
-    // Only output this error to people who are admins
-    global $user;
-    // Is the user even logged in? If so, are they admin?
-    if ($user->uid && array_search('administrator', $user->roles)) { 
-      drupal_set_message("Could not find details about the vocabulary: $vocabulary. Note: " .
-        "if this vocabulary does exist, try re-populating the db2cv_mview materialized " .
-        "view at Admin > Tripal > Data Storage > Chado > Materialized views.");
-    }
+    tripal_set_message("Could not find details about the vocabulary: $vocabulary. Note: " .
+      "if this vocabulary does exist, try re-populating the db2cv_mview materialized " .
+      "view at Admin > Tripal > Data Storage > Chado > Materialized views.",TRIPAL_NOTICE);
     return FALSE;
   }
 

--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -103,9 +103,14 @@ function tripal_chado_vocab_get_vocabulary($vocabulary) {
   $result = chado_query($sql, [':name' => $vocabulary]);
   $result = $result->fetchAssoc();
   if (!$result) {
-    drupal_set_message("Could not find details about the vocabulary: $vocabulary. Note: " .
-      "if this vocabulary does exist, try re-populating the db2cv_mview materialized " .
-      "view at Admin > Tripal > Data Storage > Chado > Materialized views.");
+    // Only output this error to people who are admins
+    global $user;
+    // Is the user even logged in? If so, are they admin?
+    if (!$user->uid && array_search('administrator', $user->roles)) { 
+      drupal_set_message("Could not find details about the vocabulary: $vocabulary. Note: " .
+        "if this vocabulary does exist, try re-populating the db2cv_mview materialized " .
+        "view at Admin > Tripal > Data Storage > Chado > Materialized views.");
+    }
     return FALSE;
   }
 

--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -106,7 +106,7 @@ function tripal_chado_vocab_get_vocabulary($vocabulary) {
     // Only output this error to people who are admins
     global $user;
     // Is the user even logged in? If so, are they admin?
-    if (!$user->uid && array_search('administrator', $user->roles)) { 
+    if ($user->uid && array_search('administrator', $user->roles)) { 
       drupal_set_message("Could not find details about the vocabulary: $vocabulary. Note: " .
         "if this vocabulary does exist, try re-populating the db2cv_mview materialized " .
         "view at Admin > Tripal > Data Storage > Chado > Materialized views.");


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1283

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The user would be warned if Drupal could not find details about a vocabulary, even if they are not an admin.

## Testing?
Testing is difficult due to the root of this issue mostly being solved by https://github.com/tripal/tripal/issues/500, although some sites still may encounter this infrequently. This message typically appears after a cache clear. If your site suffers from the warning, it should not be shown unless you are logged in as an admin.
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Additional Notes:

While this issue and PR address a specific case of warnings/messages for admins being shown to any user, it is not the only such case. As current Tripal 3 development is mostly over, it is and should be a consideration in Tripal 4 and beyond to ensure that messages only get shown to appropriate users.
