### PR TITLE
Issue 1288 use the regex used by handleRequest()

### DIFF
--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -590,7 +590,8 @@ class TripalContentService_v0_1 extends TripalWebService {
           $item_entity = tripal_load_entity($item_etype, [$item_eid]);
           $item_entity = reset($item_entity);
           $bundle = tripal_load_bundle_entity(['name' => $item_entity->bundle]);
-          $items['@id'] = $this->getServicePath() . '/' . urlencode($bundle->label) . '/' . $item_eid;
+          $label = preg_replace('/[^\w]/', '_', $bundle->label);
+          $items['@id'] = $this->getServicePath() . '/' . urlencode($label) . '/' . $item_eid;
           $items['@type'] = $bundle->accession;
         }
         unset($items['entity']);


### PR DESCRIPTION
# Bug Fix

Issue #1288

## Description

The code in ```handleRequest()``` and elsewhere uses this method to "sanitize" the the bundle label
```$label = preg_replace('/[^\w]/', '_', $bundle->label);```

The simple change here uses the same code to generate the URL in ```function sanitizeFieldEntity()``` prior to calling ```urlescape()```

Screenshots in #1288

## Testing?
Was described in #1288. I tried to find the error occurring on other sites, but you need to have a content type containing a space in the name e.g. "Biological Sample" linked from an original content type by a tripal field, and so far have not found any examples.
