### PR TITLE
Add patch to for Drupal in automated testing

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -93,6 +93,8 @@ jobs:
           cd $DRUPAL_ROOT
           wget --no-check-certificate https://drupal.org/files/drupal.pgsql-bytea.27.patch
           patch -p1 < drupal.pgsql-bytea.27.patch
+          wget --no-check-certificate https://www.drupal.org/files/issues/2022-06-20/3284424-7.patch
+          patch -p1 < 3284424-7.patch
       # Install Tripal, Chado and prepares the Drupal/Chado databases
       # Also patches views.
       - name: Install Tripal


### PR DESCRIPTION
This PR adds a temporary patch to Drupal during Tripal automated testing.
Details for why this is needed are in Tripal #1281. Summary: A commit in Drupal broke querying for non-public schema. There is a patch for Drupal 7 that this PR is applying.

We are just waiting to confirm this patch fixes the automated testing and then this can be merged :-) Once it's merged, we'll update the existing PRs by merging in 7.x-3.x branch and automated testing should be back on-line.

This PR doesn't close #1281 and once that patch is incorporated into Drupal 7 then we should revert the changes in this PR.