### PR TITLE
Issue 1088 sep__protocol check for null

### DIFF
--- a/tripal_chado/includes/TripalFields/sep__protocol/sep__protocol_widget.inc
+++ b/tripal_chado/includes/TripalFields/sep__protocol/sep__protocol_widget.inc
@@ -40,7 +40,7 @@ class sep__protocol_widget extends ChadoFieldWidget {
 
     // If the field already has a value then it will come through the $items
     // array.  This happens when editing an existing record.
-    if (count($items) > 0 and array_key_exists($delta, $items)) {
+    if (count($items) > 0 and array_key_exists($delta, $items) and $items[$delta]['value']) {
       $protocol_name = array_key_exists($protocol_name_term, $items[$delta]['value']) ? $items[$delta]['value'][$protocol_name_term] : $protocol_name;
     }
 


### PR DESCRIPTION
# Bug Fix

Issue #1088

## Description
Simple fix to avoid passing null to ```array_key_exists()``` as described in this comment https://github.com/tripal/tripal/issues/1088#issuecomment-1212360100

## Testing?
I see it editing an "Assay", not sure if related to another problem, but the fix should be harmless.

