### PR TITLE
Issue 1294 fix non-integer parameter to fetchCol

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
@@ -208,7 +208,7 @@ class data__sequence_record extends ChadoField {
         INNER JOIN {cvterm} CVT on SF.type_id = CVT.cvterm_id
       WHERE FR.object_id = :feature_id
     ";
-    $subtypes = chado_query($sql, [':feature_id' => $feature->feature_id])->fetchCol('name');
+    $subtypes = chado_query($sql, [':feature_id' => $feature->feature_id])->fetchCol();
 
     $exon = 'exon';
     if (!in_array('exon', $subtypes) and in_array('CDS', $subtypes)) {


### PR DESCRIPTION
# Bug Fix

Issue #1294

## Description

```fetchCol()``` accepts an integer parameter, a string was passed causing the error noted in the linked issue. This only appears as an error with PHP8.
