### PR TITLE
Issue 1296 initialize $collections array

### DIFF
--- a/tripal/api/tripal.collections.api.inc
+++ b/tripal/api/tripal.collections.api.inc
@@ -112,11 +112,11 @@ function tripal_expire_collections() {
   $max_days = variable_get('tripal_data_collections_lifespan', 30);
   $ctime = time();
 
+  $collections = [];
   $query = db_select('tripal_collection', 'tc');
   $query->fields('tc', ['collection_id']);
   $query->where("((($ctime - create_date) / 60) / 60) / 24 >= $max_days");
   $results = $query->execute();
-  $collections = [];
   while ($collection_id = $results->fetchField()) {
     $collection = new TripalEntityCollection();
     $collection->load($collection_id);

--- a/tripal/api/tripal.collections.api.inc
+++ b/tripal/api/tripal.collections.api.inc
@@ -116,6 +116,7 @@ function tripal_expire_collections() {
   $query->fields('tc', ['collection_id']);
   $query->where("((($ctime - create_date) / 60) / 60) / 24 >= $max_days");
   $results = $query->execute();
+  $collections = [];
   while ($collection_id = $results->fetchField()) {
     $collection = new TripalEntityCollection();
     $collection->load($collection_id);


### PR DESCRIPTION
# Bug Fix

Issue #1296

## Description
This single change defines the ```$collections``` array so that under PHP8 there is no notice about it not being defined

## Testing?
PHP8 required
No collections can be present
Start drush daemon: ```drush trpjob-daemon start --root=xxx/path/xxx```
before fix see notice like
```PHP Notice: Undefined variable: collections in .../sites/all/modules/tripal/tripal/api/tripal.collections.api.inc on line 125 pid 30717```
after fix no notice
