### PR TITLE
Issue 1300 FASTA importer organism selector infraspecific nomenclature

### DIFF
--- a/tripal_chado/includes/TripalImporter/FASTAImporter.inc
+++ b/tripal_chado/includes/TripalImporter/FASTAImporter.inc
@@ -70,6 +70,7 @@ class FASTAImporter extends TripalImporter {
    */
   public function form($form, &$form_state) {
 
+    // get the list of organisms
     $organisms = chado_get_organism_select_options(FALSE);
     $form['organism_id'] = [
       '#title' => t('Organism'),

--- a/tripal_chado/includes/TripalImporter/FASTAImporter.inc
+++ b/tripal_chado/includes/TripalImporter/FASTAImporter.inc
@@ -70,14 +70,7 @@ class FASTAImporter extends TripalImporter {
    */
   public function form($form, &$form_state) {
 
-    // get the list of organisms
-    $sql = "SELECT * FROM {organism} ORDER BY genus, species";
-    $org_rset = chado_query($sql);
-    $organisms = [];
-    $organisms[''] = '';
-    while ($organism = $org_rset->fetchObject()) {
-      $organisms[$organism->organism_id] = "$organism->genus $organism->species ($organism->common_name)";
-    }
+    $organisms = chado_get_organism_select_options(FALSE);
     $form['organism_id'] = [
       '#title' => t('Organism'),
       '#type' => t('select'),

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -298,14 +298,7 @@ class GFF3Importer extends TripalImporter {
   public function form($form, &$form_state) {
 
     // get the list of organisms
-    $sql = "SELECT * FROM {organism} ORDER BY genus, species";
-    $org_rset = chado_query($sql);
-    $organisms = [];
-    $organisms[''] = '';
-    while ($organism = $org_rset->fetchObject()) {
-      $organisms[$organism->organism_id] = "$organism->genus $organism->species ($organism->common_name)";
-    }
-
+    $organisms = chado_get_organism_select_options(FALSE);
     $form['organism_id'] = [
       '#title' => t('Existing Organism'),
       '#type' => 'select',


### PR DESCRIPTION
# Bug Fix
Proposed fix for issue #1300 

Issue #1300

## Description
Replace db query for organism selector with existing function ```chado_get_organism_select_options()``` so that infraspecific nomenclature is displayed. However, common name is no longer displayed.

## Testing?
Described in issue #1300
