### PR TITLE
Issue 1313 field name typos fixed

### DIFF
--- a/tripal_chado/includes/TripalFields/local__contact/local__contact_formatter.inc
+++ b/tripal_chado/includes/TripalFields/local__contact/local__contact_formatter.inc
@@ -6,7 +6,7 @@ class local__contact_formatter extends ChadoFieldFormatter {
   public static $default_label = 'Contact';
 
   // The list of field types for which this formatter is appropriate.
-  public static $field_types = ['local_contact'];
+  public static $field_types = ['local__contact'];
 
 
   /**

--- a/tripal_chado/includes/TripalFields/local__contact/local__contact_widget.inc
+++ b/tripal_chado/includes/TripalFields/local__contact/local__contact_widget.inc
@@ -6,7 +6,7 @@ class local__contact_widget extends ChadoFieldWidget {
   public static $default_label = 'Contact';
 
   // The list of field types for which this formatter is appropriate.
-  public static $field_types = ['local_contact'];
+  public static $field_types = ['local__contact'];
 
   /**
    *

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -1504,7 +1504,7 @@ function tripal_chado_bundle_instances_info_custom(&$info, $entity_type, $bundle
       'entity_type' => $entity_type,
       'bundle' => $bundle->name,
       'label' => 'Contact',
-      'description' => 'An indvidual or organization that serves as a contact for this record.',
+      'description' => 'An individual or organization that serves as a contact for this record.',
       'required' => FALSE,
       'settings' => [
         'auto_attach' => FALSE,
@@ -2278,7 +2278,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
       'entity_type' => $entity_type,
       'bundle' => $bundle->name,
       'label' => 'Contact',
-      'description' => 'Associates an indviddual or organization with this record',
+      'description' => 'Associates an individual or organization with this record',
       'required' => FALSE,
       'settings' => [
         'auto_attach' => FALSE,


### PR DESCRIPTION
# Bug Fix

Issue #1313 

## Description

This fixes two functional and two non-functional typos for the ```local__contact``` field that prevent it from displaying any content because the field cannot be un-hidden. Specifically, ```local_contact``` is changed to ```local__contact``` in two places.