### PR TITLE
Issue 1272 regex fix for drupal 9 style array placeholders

### DIFF
--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -1751,7 +1751,7 @@ function chado_query($sql, $args = [], $options = []) {
     }
 
     // Now set the Drupal prefix if the table is surrounded by square brackets.
-    if (preg_match_all('/\[(.*?)\]/', $sql, $matches)) {
+    if (preg_match_all('/\[(.+?)\]/', $sql, $matches)) {
       $matches = $matches[1];
       $drupal_tables = array_unique(array_keys(drupal_get_schema()));
       foreach ($matches as $match) {
@@ -1797,7 +1797,7 @@ function chado_query($sql, $args = [], $options = []) {
   // represented and if present don't execute the query but instead warn the
   // administrator.
   else {
-    if (preg_match('/\[(\w*?)\]/', $sql)) {
+    if (preg_match('/\[(\w+?)\]/', $sql)) {
       tripal_report_error('chado_query', TRIPAL_ERROR,
         'The following query does not support external chado databases. Please file an issue with the Drupal.org Tripal Project. Query: @query',
         ['@query' => $sql]


### PR DESCRIPTION
# Bug Fix

Issue #1272

## Description
Change regular expressions to not match for adjacent square brackets by substituting ```+``` for ```*```

## Testing?
Show in Issue #1272

## Additional Notes (if any):

One regex uses ```.``` and the other uses ```\w``` - is that significant?
