### PR TITLE
Implement chado_get_organism_id_from_scientific_name

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.organism.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.organism.api.inc
@@ -82,7 +82,7 @@ function chado_get_organism($identifiers, $options = []) {
   if (isset($identifiers['scientific_name'])) {
     $scientific_name = $identifiers['scientific_name'];
     unset($identifiers['scientific_name']);
-    $organism_ids = chado_get_organism_id_from_scientific_name($scientific_name, ['scientific_name']);
+    $organism_ids = chado_get_organism_id_from_scientific_name($scientific_name, $options);
     if (count($organism_ids) == 1) {
       $identifiers['organism_id'] = $organism_ids[0];
     }
@@ -212,10 +212,15 @@ function chado_get_organism_scientific_name($organism) {
  *   The organism name to be queried. Infraspecific type can be abbreviated.
  *
  * @param $options
- *   Specifies how to search organism table, one or more of the following can be used:
- *   $options = ['scientific_name', 'abbreviation', 'common_name', 'case_sensitive']
- *   Search is case insensitive unless the 'case_sensitive' value is specified.
- *   If not specified, search defaults to scientific_name only, case insensitive.
+ *   An array of options. The following keys are available:
+ *     - check_abbreviation: If TRUE and the $name did not match the
+ *         scientific name, then check the abbreviation.
+ *     - check_common_name: If TRUE and the $name did not match the
+ *         scientific name, then check the common name.
+ *     - case_sensitive: If TRUE then all searches should be case
+ *         sensitive. Default is FALSE.
+ *   If no options are specified, search is for a match of $name to
+ *     the scientific_name only, case insensitive.
  *
  * @return
  *   Array of matching organism_id values.
@@ -223,87 +228,98 @@ function chado_get_organism_scientific_name($organism) {
  * @ingroup tripal_organism_api
  */
 function chado_get_organism_id_from_scientific_name($name, $options = []) {
-  // Default to scientific name if no other search method was specified.
-  if (!in_array('abbreviation', $options, true) and !in_array('common_name', $options, true)) {
-    $options[] = 'scientific_name';
-  }
   $organism_ids = [];
 
-  // By default search is case insensitive because this may handle user input.
-  $lower = '';
-  if (!in_array('case_sensitive', $options, true)) {
-    $name = strtolower($name);
-    $lower = 'LOWER';
+  // Handle missing $name by returning empty array.
+  if (!$name) {
+    return $organism_ids;
   }
 
-  // Try to find name in the abbreviation column. This does not
-  // have a unique constraint, so there may be more than one match.
-  if (in_array('abbreviation', $options, true)) {
-    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(abbreviation) = :name';
-    $args = [':name' => $name];
-    $results = chado_query($sql, $args);
-    while ($organism = $results->fetchField()) {
+  // By default, search is case insensitive because this function may
+  // be used to handle input from users or from data files in loaders.
+  $sql_for_lower = '';
+  if (!in_array('case_sensitive', $options, true)) {
+    $name = strtolower($name);
+    $sql_for_lower = 'LOWER';
+  }
+
+  // Check scientific name first, and if a match is found, nothing
+  // else specified by $options will be checked.
+  // Scientific name is the combination of genus, species,
+  // and optionally infraspecific nomenclature added with Chado 1.3
+  // There is a unique constraint, so expect zero or one match here.
+  $infra_present = false;
+  $limit = 2;
+  if (chado_column_exists('organism', 'infraspecific_name')) {
+    $infra_present = true;
+    $limit = 4;
+  }
+  $parts = preg_split('/\s+/', $name, $limit);
+  // $name could be a single word, so make sure this is defined.
+  if (!array_key_exists(1, $parts)) {
+    $parts[1] = '';
+  }
+  $sql = 'SELECT organism_id FROM {organism} WHERE '.$sql_for_lower.'(genus) = :genus'
+       . ' AND '.$sql_for_lower.'(species) = :species';
+  $args = [ ':genus' => $parts[0], ':species' => $parts[1] ];
+  if ($infra_present) {
+    // When there is no infraspecific name, we can either use the "no_rank"
+    // taxonomic term in the type_id column, or else use NULL.
+    $sql .= ' AND ( type_id = (SELECT cvterm_id FROM {cvterm}'
+         . ' WHERE '.$sql_for_lower.'(name) = :infraspecific_type'
+         . ' AND cv_id = (SELECT cv_id FROM {cv} WHERE name = :taxonomic_rank))';
+    if (!array_key_exists(2, $parts)) {
+      $parts[2] = 'no_rank';
+      $sql .= " OR type_id IS NULL";
+    }
+    else {
+      $parts[2] = chado_unabbreviate_infraspecific_rank($parts[2]);
+    }
+    $sql .= ")";
+    $args[':infraspecific_type'] = $parts[2];
+    $args[':taxonomic_rank'] = 'taxonomic_rank';
+
+    // Infraspecific name, if present.
+    if (array_key_exists(3, $parts)) {
+      $sql .= ' AND '.$sql_for_lower.'(infraspecific_name) = :infraspecific_name';
+      $args[':infraspecific_name'] = $parts[3];
+    }
+    else {
+      // Infraspecific name not present, so this column
+      // must be either an empty string or NULL.
+      $sql .= " AND ( infraspecific_name = '' ) IS NOT FALSE";
+    }
+  }
+  $results = chado_query($sql, $args);
+  while ($organism = $results->fetchField()) {
+    if (!in_array($organism, $organism_ids)) {
       $organism_ids[] = $organism;
     }
   }
 
-  // Try to find name in the common_name column. This does not
-  // have a unique constraint, so there may be more than one match.
-  if (in_array('common_name', $options, true)) {
-    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(common_name) = :name';
-    $args = [':name' => $name];
-    $results = chado_query($sql, $args);
-    while ($organism = $results->fetchField()) {
-      if (!in_array($organism, $organism_ids)) {
+  // Check other search modes only when no match was found for scientific name.
+  if (empty($organism_ids)) {
+    // Try to find $name in the abbreviation column. This does not
+    // have a unique constraint, so there may be more than one match.
+    if (in_array('check_abbreviation', $options, true)) {
+      $sql = 'SELECT organism_id FROM {organism} WHERE '.$sql_for_lower.'(abbreviation) = :name';
+      $args = [':name' => $name];
+      $results = chado_query($sql, $args);
+      while ($organism = $results->fetchField()) {
         $organism_ids[] = $organism;
       }
     }
-  }
 
-  // Try to find name with combination of genus, species,
-  // and optionally infraspecific nomenclature added wich Chado 1.3
-  // Here there is a unique constraint, expect zero or one match.
-  if (in_array('scientific_name', $options, true)) {
-    $infra_present = false;
-    $limit = 2;
-    if (chado_column_exists('organism', 'infraspecific_name')) {
-      $infra_present = true;
-      $limit = 4;
-    }
-    $parts = preg_split('/\s+/', $name, $limit);
-    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(genus) = :genus'
-         . ' AND '.$lower.'(species) = :species';
-    $args = [ ':genus' => $parts[0], ':species' => $parts[1] ];
-    if ($infra_present) {
-      // When there is no infraspecific name, we can either use the "no_rank" taxonomic term
-      // in the type_id column, or else use NULL. Wrap these in parentheses.
-      $sql .= ' AND ( type_id = (SELECT cvterm_id FROM {cvterm} WHERE '.$lower.'(name) = :infraspecific_type'
-           . ' AND cv_id = (SELECT cv_id FROM {cv} WHERE name = :taxonomic_rank))';
-      if (!array_key_exists(2, $parts)) {
-        $parts[2] = 'no_rank';
-        $sql .= " OR type_id IS NULL";
-      }
-      else {
-        $parts[2] = chado_unabbreviate_infraspecific_rank($parts[2]);
-      }
-      $sql .= ")";
-      $args[':infraspecific_type'] = $parts[2];
-      $args[':taxonomic_rank'] = 'taxonomic_rank';
-
-      // Infraspecific name, if present.
-      if (array_key_exists(3, $parts)) {
-        $sql .= ' AND '.$lower.'(infraspecific_name) = :infraspecific_name';
-        $args[':infraspecific_name'] = $parts[3];
-      }
-      else {
-        // Not present, so this must be either empty string or NULL.
-        $sql .= " AND ( infraspecific_name = '' ) IS NOT FALSE";
-      }
-    }
-    $results = chado_query($sql, $args);
-    while ($organism = $results->fetchField()) {
-      if (!in_array($organism, $organism_ids)) {
-        $organism_ids[] = $organism;
+    // Try to find $name in the common_name column. This does not
+    // have a unique constraint, so there may be more than one match.
+    if (in_array('check_common_name', $options, true)) {
+      $sql = 'SELECT organism_id FROM {organism} WHERE '.$sql_for_lower.'(common_name) = :name';
+      $args = [':name' => $name];
+      $results = chado_query($sql, $args);
+      while ($organism = $results->fetchField()) {
+        if (!in_array($organism, $organism_ids)) {
+          $organism_ids[] = $organism;
+        }
       }
     }
   }

--- a/tripal_chado/api/modules/tripal_chado.organism.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.organism.api.inc
@@ -21,8 +21,9 @@
  *   An array with the key stating what the identifier is. Supported keys (only
  *   one of the following unique keys is required):
  *    - organism_id: the chado organism.organism_id primary key.
- *    - genus & species: the chado organism.genus field & organism.species
- *   field. There are also some specially handled keys. They are:
+ *    - genus & species: the chado organism.genus field & organism.species field.
+ *    - scientific_name: Full taxonomic name, can include infraspecific nomenclature.
+ *   There are also some specially handled keys. They are:
  *    - property: An array/object describing the property to select records
  *   for.
  *      It should at least have either a type_name (if unique across cvs) or
@@ -75,6 +76,29 @@ function chado_get_organism($identifiers, $options = []) {
         '%identifier' => print_r($identifiers, TRUE),
       ]
     );
+  }
+
+  // If the scientific_name identifier is used, we look up organism_id from that.
+  if (isset($identifiers['scientific_name'])) {
+    $scientific_name = $identifiers['scientific_name'];
+    unset($identifiers['scientific_name']);
+    // Null will be returned if no match, or more than one match.
+    $organism_id = chado_get_organism_id_from_scientific_name($scientific_name);
+    if ($organism_id) {
+      $identifiers['organism_id'] = $organism_id;
+    }
+    else {
+      tripal_report_error(
+        'tripal_organism_api',
+        TRIPAL_ERROR,
+        "chado_get_organism: The specified scientific name did not uniquely identify an organism.
+          You passed in %scientific_name.",
+        [
+          '%scientific_name' => $scientific_name,
+        ]
+      );
+      return NULL;
+    }
   }
 
   // If one of the identifiers is property then use chado_get_record_with_property().
@@ -179,6 +203,77 @@ function chado_get_organism_scientific_name($organism) {
     }
   }
   return $name;
+}
+
+/**
+ * Returns organism_id matching the specified full scientific name of an organism.
+ *
+ * @param $scientific_name
+ *   The full scientific name of the organism. Infraspecific type can be abbreviated.
+ *
+ * @return
+ *   Matching organism_id value, or null if no match or if multiple matches.
+ *
+ * @ingroup tripal_organism_api
+ */
+function chado_get_organism_id_from_scientific_name($scientific_name) {
+  $organism_id = NULL;
+
+  // First try to find name in the abbreviation column. This does not
+  // have a unique constraint, so we must verify that the count is 1.
+  $sql = "SELECT organism_id FROM {organism} WHERE abbreviation = :name";
+  $args = [':name' => $scientific_name];
+  $result = chado_query($sql, $args)->fetchAll();
+  if (count($result) == 1) {
+    $organism_id = $result[0]->organism_id;
+  }
+
+  // The abbreviation query failed or was ambiguous, so now query on
+  // genus + species and optionally infraspecific nomenclature.
+  else {
+    // Infraspecific nomenclature was added with Chado 1.3
+    $infra_present = false;
+    $limit = 2;
+    if (chado_column_exists('organism', 'infraspecific_name')) {
+      $infra_present = true;
+      $limit = 4;
+    }
+    $parts = preg_split('/\s+/', $scientific_name, $limit);
+    $sql = "SELECT organism_id FROM {organism} WHERE genus = :genus AND species = :species";
+    $args = [ ':genus' => $parts[0], ':species' => $parts[1] ];
+    if ($infra_present) {
+      // When there is no infraspecific name, we can either use the "no_rank" taxonomic term
+      // in the type_id column, or else use NULL. Wrap these in parentheses.
+      $sql .= " AND ( type_id = (SELECT cvterm_id FROM {cvterm} WHERE name = :infraspecific_type"
+           . " AND cv_id = (SELECT cv_id FROM {cv} WHERE name = 'taxonomic_rank'))";
+      if (!array_key_exists(2, $parts)) {
+        $parts[2] = 'no_rank';
+        $sql .= " OR type_id IS NULL";
+      }
+      else {
+        $parts[2] = chado_unabbreviate_infraspecific_rank($parts[2]);
+      }
+      $sql .= ")";
+      $args[':infraspecific_type'] = $parts[2];
+
+      // Infraspecific name, if present.
+      if (array_key_exists(3, $parts)) {
+        $sql .= " AND infraspecific_name = :infraspecific_name";
+        $args[':infraspecific_name'] = $parts[3];
+      }
+      else {
+        // Not present, so this must be either empty string or NULL.
+        $sql .= " AND ( infraspecific_name = '' ) IS NOT FALSE";
+      }
+    }
+    // Unique constraint on organism table ensures we get zero or one record returned.
+    $result = chado_query($sql, $args)->fetchField();
+    if ($result) {
+      $organism_id = $result;
+    }
+  }
+
+  return $organism_id;
 }
 
 /**

--- a/tripal_chado/api/modules/tripal_chado.organism.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.organism.api.inc
@@ -247,6 +247,8 @@ function chado_get_organism_id_from_scientific_name($name, $options = []) {
   // else specified by $options will be checked.
   // Scientific name is the combination of genus, species,
   // and optionally infraspecific nomenclature added with Chado 1.3
+  // For Chado 1.2 and earlier, infraspecific nomenclature had to
+  // be stored in the species column, so limit the split accordingly.
   // There is a unique constraint, so expect zero or one match here.
   $infra_present = false;
   $limit = 2;

--- a/tripal_chado/api/modules/tripal_chado.organism.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.organism.api.inc
@@ -82,10 +82,9 @@ function chado_get_organism($identifiers, $options = []) {
   if (isset($identifiers['scientific_name'])) {
     $scientific_name = $identifiers['scientific_name'];
     unset($identifiers['scientific_name']);
-    // Null will be returned if no match, or more than one match.
-    $organism_id = chado_get_organism_id_from_scientific_name($scientific_name);
-    if ($organism_id) {
-      $identifiers['organism_id'] = $organism_id;
+    $organism_ids = chado_get_organism_id_from_scientific_name($scientific_name, ['scientific_name']);
+    if (count($organism_ids) == 1) {
+      $identifiers['organism_id'] = $organism_ids[0];
     }
     else {
       tripal_report_error(
@@ -206,46 +205,80 @@ function chado_get_organism_scientific_name($organism) {
 }
 
 /**
- * Returns organism_id matching the specified full scientific name of an organism.
+ * Returns organism_id values of organisms matching the specified full
+ * scientific name, abbreviation, or common name of an organism.
  *
- * @param $scientific_name
- *   The full scientific name of the organism. Infraspecific type can be abbreviated.
+ * @param $name
+ *   The organism name to be queried. Infraspecific type can be abbreviated.
+ *
+ * @param $options
+ *   Specifies how to search organism table, one or more of the following can be used:
+ *   $options = ['scientific_name', 'abbreviation', 'common_name', 'case_sensitive']
+ *   Search is case insensitive unless the 'case_sensitive' value is specified.
+ *   If not specified, search defaults to scientific_name only, case insensitive.
  *
  * @return
- *   Matching organism_id value, or null if no match or if multiple matches.
+ *   Array of matching organism_id values.
  *
  * @ingroup tripal_organism_api
  */
-function chado_get_organism_id_from_scientific_name($scientific_name) {
-  $organism_id = NULL;
+function chado_get_organism_id_from_scientific_name($name, $options = []) {
+  // Default to scientific name if no other search method was specified.
+  if (!in_array('abbreviation', $options, true) and !in_array('common_name', $options, true)) {
+    $options[] = 'scientific_name';
+  }
+  $organism_ids = [];
 
-  // First try to find name in the abbreviation column. This does not
-  // have a unique constraint, so we must verify that the count is 1.
-  $sql = "SELECT organism_id FROM {organism} WHERE abbreviation = :name";
-  $args = [':name' => $scientific_name];
-  $result = chado_query($sql, $args)->fetchAll();
-  if (count($result) == 1) {
-    $organism_id = $result[0]->organism_id;
+  // By default search is case insensitive because this may handle user input.
+  $lower = '';
+  if (!in_array('case_sensitive', $options, true)) {
+    $name = strtolower($name);
+    $lower = 'LOWER';
   }
 
-  // The abbreviation query failed or was ambiguous, so now query on
-  // genus + species and optionally infraspecific nomenclature.
-  else {
-    // Infraspecific nomenclature was added with Chado 1.3
+  // Try to find name in the abbreviation column. This does not
+  // have a unique constraint, so there may be more than one match.
+  if (in_array('abbreviation', $options, true)) {
+    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(abbreviation) = :name';
+    $args = [':name' => $name];
+    $results = chado_query($sql, $args);
+    while ($organism = $results->fetchField()) {
+      $organism_ids[] = $organism;
+    }
+  }
+
+  // Try to find name in the common_name column. This does not
+  // have a unique constraint, so there may be more than one match.
+  if (in_array('common_name', $options, true)) {
+    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(common_name) = :name';
+    $args = [':name' => $name];
+    $results = chado_query($sql, $args);
+    while ($organism = $results->fetchField()) {
+      if (!in_array($organism, $organism_ids)) {
+        $organism_ids[] = $organism;
+      }
+    }
+  }
+
+  // Try to find name with combination of genus, species,
+  // and optionally infraspecific nomenclature added wich Chado 1.3
+  // Here there is a unique constraint, expect zero or one match.
+  if (in_array('scientific_name', $options, true)) {
     $infra_present = false;
     $limit = 2;
     if (chado_column_exists('organism', 'infraspecific_name')) {
       $infra_present = true;
       $limit = 4;
     }
-    $parts = preg_split('/\s+/', $scientific_name, $limit);
-    $sql = "SELECT organism_id FROM {organism} WHERE genus = :genus AND species = :species";
+    $parts = preg_split('/\s+/', $name, $limit);
+    $sql = 'SELECT organism_id FROM {organism} WHERE '.$lower.'(genus) = :genus'
+         . ' AND '.$lower.'(species) = :species';
     $args = [ ':genus' => $parts[0], ':species' => $parts[1] ];
     if ($infra_present) {
       // When there is no infraspecific name, we can either use the "no_rank" taxonomic term
       // in the type_id column, or else use NULL. Wrap these in parentheses.
-      $sql .= " AND ( type_id = (SELECT cvterm_id FROM {cvterm} WHERE name = :infraspecific_type"
-           . " AND cv_id = (SELECT cv_id FROM {cv} WHERE name = 'taxonomic_rank'))";
+      $sql .= ' AND ( type_id = (SELECT cvterm_id FROM {cvterm} WHERE '.$lower.'(name) = :infraspecific_type'
+           . ' AND cv_id = (SELECT cv_id FROM {cv} WHERE name = :taxonomic_rank))';
       if (!array_key_exists(2, $parts)) {
         $parts[2] = 'no_rank';
         $sql .= " OR type_id IS NULL";
@@ -255,10 +288,11 @@ function chado_get_organism_id_from_scientific_name($scientific_name) {
       }
       $sql .= ")";
       $args[':infraspecific_type'] = $parts[2];
+      $args[':taxonomic_rank'] = 'taxonomic_rank';
 
       // Infraspecific name, if present.
       if (array_key_exists(3, $parts)) {
-        $sql .= " AND infraspecific_name = :infraspecific_name";
+        $sql .= ' AND '.$lower.'(infraspecific_name) = :infraspecific_name';
         $args[':infraspecific_name'] = $parts[3];
       }
       else {
@@ -266,14 +300,15 @@ function chado_get_organism_id_from_scientific_name($scientific_name) {
         $sql .= " AND ( infraspecific_name = '' ) IS NOT FALSE";
       }
     }
-    // Unique constraint on organism table ensures we get zero or one record returned.
-    $result = chado_query($sql, $args)->fetchField();
-    if ($result) {
-      $organism_id = $result;
+    $results = chado_query($sql, $args);
+    while ($organism = $results->fetchField()) {
+      if (!in_array($organism, $organism_ids)) {
+        $organism_ids[] = $organism;
+      }
     }
   }
 
-  return $organism_id;
+  return $organism_ids;
 }
 
 /**


### PR DESCRIPTION
# New Feature

Issue #1327 

## Description

This adds
1. A new api function ```chado_get_organism_id_from_scientific_name()``` which will look up and return an ```organism_id``` from a taxon name _e.g._ ```Tripalus domesticus subsp. chadoii```
2. A new identifier that can be passed to ```chado_get_organism()``` of ```scientific_name```, which allows the return of an organism given a taxon name (as in 1)
 

## Testing?
Since so far nothing is using this, test in the devel module php window
```
$s = 'Tripalus domesticus subsp. chadoii';  // A fake or a real organism name
$o = chado_get_organism(['scientific_name' => $s], []);
var_dump($o);
```
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->

## Additional Notes:

This will first be used for the ```sbo__relationship``` widget on organism pages, see https://github.com/tripal/tripal/pull/1267#issuecomment-1339482302
