### PR TITLE
Issue 1362 PHP8 error fixed

### DIFF
--- a/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.loader.inc
@@ -350,6 +350,8 @@ function tripal_bulk_loader_load_data($nid, $job_id) {
 
     // Start Transaction
     $savepoint = '';
+    $transactions = FALSE;
+    $new_transaction_per_row = FALSE;
     switch (variable_get('tripal_bulk_loader_transactions', 'row')) {
       case "none":
         break;


### PR DESCRIPTION
# Bug Fix
Issue #1362 

## Description
A very simple fix for an error in the chado bulk loader appearing under PHP8, initialize the variables so that they always have a value.

## Testing?
PHP8 needed to see the error.
This shows up in the chado bulk loader when "Keep track of inserted record IDs" is set to "No" (the default).
The error shown for each line of the data file
```Undefined variable $new_transaction_per_row tripal_bulk_loader.loader.inc:469```