### PR TITLE
Issue 1364 check for description property

### DIFF
--- a/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
+++ b/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
@@ -307,7 +307,7 @@ class ogi__location_on_map extends ChadoField {
           // Map.
           $map_term => [
             $name_term => $featuremap->name,
-            $description_term => property_exists('description', $featuremap)?$featuremap->description:'',
+            $description_term => property_exists($featuremap, 'description')?$featuremap->description:'',
           ],
           $ref_feature_term => [
             $ref_feature_name => $featurepos->map_feature_id->name,

--- a/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
+++ b/tripal_chado/includes/TripalFields/ogi__location_on_map/ogi__location_on_map.inc
@@ -307,7 +307,7 @@ class ogi__location_on_map extends ChadoField {
           // Map.
           $map_term => [
             $name_term => $featuremap->name,
-            $description_term => $featuremap->description,
+            $description_term => property_exists('description', $featuremap)?$featuremap->description:'',
           ],
           $ref_feature_term => [
             $ref_feature_name => $featurepos->map_feature_id->name,


### PR DESCRIPTION
# Bug Fix
Issue #1364

## Description

PHP8 warning from the ```ogi__location_on_map``` field if you don't have a description for your linkage map, as described in Issue #1364 
Super simple fix.