### PR TITLE
Issue 1366 addGeneParent addProtein

### DIFF
--- a/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
+++ b/tripal_chado/includes/TripalFields/data__sequence_record/data__sequence_record.inc
@@ -369,7 +369,7 @@ class data__sequence_record extends ChadoField {
           $seq_length_term => strlen($gene->residues),
           $seq_md5sum_term => md5($gene->residues),
           $type_term => 'gene',
-          $fasta_defline => chado_get_fasta_defline($gene),
+          $fasta_defline => chado_get_fasta_defline($gene, '', NULL, 'gene'),
         ];
       }
       else {
@@ -426,7 +426,7 @@ class data__sequence_record extends ChadoField {
           $seq_length_term => strlen($protein->residues),
           $seq_md5sum_term => md5($protein->residues),
           $type_term => 'polypeptide',
-          $fasta_defline => chado_get_fasta_defline($protein),
+          $fasta_defline => chado_get_fasta_defline($protein, '', NULL, 'protein'),
         ];
       }
     }


### PR DESCRIPTION
# Bug Fix

Issue #1366 

## Description

This is a bug fix for Issue #1366, the problem is described there.
This fix is very simple, we can pass the missing type name as a parameter to ```chado_get_fasta_defline()```.

## Testing?
This is a warning that shows up only under PHP8, it shows up in the log viewing e.g. a Gene page.
