### PR TITLE
Update Tripal 3 README to reflect Tripal 4 release.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,17 @@ about: Create a report to help us improve
 
 ---
 
-## BUG/ERROR report
+# BUG/ERROR report
 <!---
 INSTRUCTIONS: The following template is meant to provide the information that will help other Tripal
  developers diagnose and reproduce your issue. Follow the directions below to complete the template.
   Feel free to delete sections that are not applicable.
 --->
 
-
-
-### System information
+## System information
 <!--Please enter the following information (if able). All information is available in your site's administrator report area (Administration Toolbar > Reports > Status Report) -->
 
-* Tripal Version:
+### Tripal Version:
 * Drupal Version:
 * PostgreSQL Version:
 * PHP Version:
@@ -30,6 +28,7 @@ you're experiencing versus what you expect, really anything you think might best
 
 <!-- What steps are necessary to recreate the bug/error?  Clear instructions here will make it easier for
  us to fix the problem! -->
+ 
 #### Error messages and screenshots
 <!-- Please include any error messages you find.  Including them in ``` as below will make the issue
  more readable. -->

--- a/.github/ISSUE_TEMPLATE/core_task.md
+++ b/.github/ISSUE_TEMPLATE/core_task.md
@@ -1,0 +1,31 @@
+---
+name: Core Development Task
+about: For keeping track of Tripal 4 core development
+
+---
+
+<!---
+INSTRUCTIONS: 
+
+Remember to tag this issue with 1+ groups it relates to.
+
+I suggest using the "Development Branch" section to the right once you create the issue. 
+This links the branch to the issue and will automatically close the issue when the PR is merged.
+--->
+
+# Core Tripal 4 Development Task
+
+<!---
+Fill out the branch name attached to this task below. The various tokens mean:
+
+- `tv4g[0-9]` indicates the functionality group the branch relates to. See tags for groups available.
+- `issue\d+` indicates the issue describing the purpose of the branch. By making a new issue for each 
+   major task before we start working on it, we give room for others to jump in and save you time if 
+   something is already done, beyond scope, or can be made easier by something they are working on!
+- `[optional short descriptor]` can be anything without spaces. This is meant to make the branches more 
+   readable so we don’t have to look up the issue every time. You are encouraged to only have one branch 
+   per issue! That said, there are some edge-cases where multiple branches may be needed (i.e. partitioned 
+   reviews) where variations in the optional short description can make the purpose of multiple branches clear.
+--->
+
+## Branch Name: tv4g[0-9]-issue\d+-[optional short descriptor]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,11 +1,11 @@
 ---
-name: Feature request
+name: Tripal 4 Feature request
 about: Suggest an idea for this project
 
 ---
 
 
-## Feature Request/Discussion
+## Tripal 4 Feature Request
 <!---
 INSTRUCTIONS: The following template is meant to structure your feature request. 
   Please keep in mind, this issue may evolve into discussion for an extension module

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,11 +7,14 @@
 <!---  Please set the header below based on the PR type:
 # New Feature
 # Bug Fix
-# Documentation  --->
+# Tripal 4 Core Dev Task  --->
 
 #
 
 Issue #
+
+<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
+### Tripal Version: 
 
 ## Description
 <!--- Describe your changes in detail -->
@@ -21,11 +24,3 @@ Issue #
 <!--- Please describe in detail how to test these changes. -->
 <!--- Reviewers will use this section to test the submission! -->
 <!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
-<!--- Unit testing guidelines: https://github.com/tripal/tripal/blob/7.x-3.x/tests/README.md -->
-
-## Screenshots (if appropriate):
-
-## Additional Notes (if any):
-
-<!--- New features should include in-line code documentation. -->
-<!--- Would a user or developer guide be helpful for this feature? -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![PHPUnit Tests](https://github.com/tripal/tripal/workflows/PHPUnit%20Tests/badge.svg)
 [![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors)
 [![Documentation Status](https://readthedocs.org/projects/tripal/badge/?version=latest)](https://tripal.readthedocs.io/en/latest/?badge=latest)
 
@@ -19,16 +18,24 @@ Welcome to the home of Tripal Development! If you are thinking to yourself "What
     - [![Tripal 3](https://img.shields.io/badge/dev-7.x--3.x-yellow)](https://github.com/tripal/tripal): Focus is on bug fixes
     - [![Tripal 4](https://img.shields.io/badge/dev-7.x--4.x-yellow)](https://github.com/tripal/tripal/tree/4.x): Full upgrade to Drupal 9/10 (alpha1 released!).
  - Tripal ![Tripal 1.x](https://img.shields.io/badge/unsupported-7.x--1.x-red) and ![Tripal 2.x](https://img.shields.io/badge/unsupported-7.x--2.x-red) are no longer supported by the Project Management Committee, although we will accept community submitted fixes for Tripal 2.x.
+ 
+ ## Tripal 4 Testing Status
+ 
+![Target Drupal Version 9.5.x-dev](https://img.shields.io/badge/Target%20Drupal%20Version-9.5.x-informational)
 
- # Version 3 Resources
+![PostgreSQL 13+](https://img.shields.io/badge/PostreSQL-13+-success)
 
-  - For information on **how to use Tripal** through the Administrative Interface: [Tripal Users Guide](https://tripal.readthedocs.io/en/latest/user_guide.html)
-  - For help **extending Tripal** or understanding how it works: [Tripal Developers Guide](https://tripal.readthedocs.io/en/latest/dev_guide.html)
-  - To check if another group already developed the functionality you need: [Listing of **Available Extension Modules**](https://tripal.readthedocs.io/en/latest/extensions.html)
-  - Tripal is developed by a world-wide community! See the [description of our **Governance Structure**](https://tripal.readthedocs.io/en/latest/contributing/governance.html)
-  - If you are the head of a research group looking to fund Tripal Development: [Guide to **Funding Proposal** Development](https://tripal.readthedocs.io/en/latest/contributing/funding.html)
-  - For how to **install Tripal**, follow the instructions in the online Tripal User's Guide for [Tripal v2](https://tripal.info/tutorials/v2.x/installation) or [Tripal v3](https://tripal.readthedocs.io/en/latest/user_guide.html).
-  - For how to **upgrade from Tripal 2 to Tripal 3**, follow the [Upgrade Instructions](https://tripal.readthedocs.io/en/latest/user_guide/install_tripal/upgrade_from_tripal2.html) in the Tripal v3 User's Guide.
+ | Drupal      | 9.3.x                                                                                                                                                                        | 9.4.x                                                                                                                                                                        | 9.5.x                                                                                                                                                                        | 10.0.x                                                                                                                                                                         |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **PHP 8.0** | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_3x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_3x.yml)     | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_4x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_4x.yml)     | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_5x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_5x.yml)     |                                                                                                                                                                                |
+| **PHP 8.1** | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml) |
+
+# Documentation
+
+- [Tripal 3](https://tripal.readthedocs.io/en/latest/)
+- [Tripal 4](https://tripaldoc.readthedocs.io/en/latest/)
+   - [Requirements](https://tripaldoc.readthedocs.io/en/latest/install/requirements.html)
+   - Use [Tripal Docker](https://tripaldoc.readthedocs.io/en/latest/install/docker.html) to explore or develop extension modules.
 
 # Contribution
 
@@ -42,10 +49,8 @@ Looking to contribute? That's Amazing -Welcome!!! Here's a quick run-down to get
  - For **documentation** contributions, click the "Edit on Github" link at the top of the page you want to improve! [Instructions for our flavour of ReadtheDocs can be found on ReadtheDocs](https://tripal.readthedocs.io/en/latest/contributing/documentation.html).
  - See our quickstart if you need help on how to submit a PR: [ReadtheDocs, how to create a PR](https://tripal.readthedocs.io/en/latest/contributing/pull_requests.html#how-to-create-a-pr).
  - Click on issues > New Issue for helpful issue templates.
- - For Tripal 4 (Drupal 8/9), see the [T4D8 repository](https://github.com/tripal/t4d8).
 
 For more detailed guidelines see our [full Contribution Documentation](https://tripal.readthedocs.io/en/latest/contributing/pull_requests.html)!
-
 
 # Github Communication Tips
 
@@ -63,30 +68,6 @@ For more detailed guidelines see our [full Contribution Documentation](https://t
 # Code of Conduct
 
 Be nice! If that’s insufficient, Tripal community defers to https://www.contributor-covenant.org/
-
-# Required Dependencies
-* Drupal:
-  * Drupal 7.x
-  * Drupal core modules: Search, Path and PHP modules.
-  * Drupal contributed modules:
-    * [Views](http://drupal.org/project/views)
-    * [Entity API](http://drupal.org/project/entity)
-* PostgreSQL 9.3 or higher (9.5 required for Chado 1.2 to 1.3 upgrade)
-* PHP 5.5+
-* UNIX/Linux
-
-# Development Testing
-
-To run PHP unit tests on your local system, run `composer install` to install developer-specific requirements.  Next, create a `.env` file in your `/Tests/` directory that defines the `DRUPAL_ROOT` variable, for example
-
-```
-DRUPAL_ROOT=/var/www/html
-```
-Then run PHPUnit from your root Tripal directory.
-
-PHPUnit tests will also be run in the Travis CI build.
-
-Read our [testing guidelines](https://tripal.readthedocs.io/en/latest/contributing/tests.html).
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Welcome to the home of Tripal Development! If you are thinking to yourself "What
 
 # Current Status
 
- - Recommended Version: ![GitHub release (latest by date)](https://img.shields.io/github/v/release/tripal/tripal?color=brightgreen)
+ - Tripal 4.0-alpha1 has been released!
+    - Use this version to explore Tripal 4 and begin upgrading or creating extension modules!
+    - Upgrade path from Tripal 3 will be developed in future alpha releases.
+    - Note: Tripal 3 sites should be upgraded before November 2023 to keep security support by Drupal.
  - Development:
     - [![Tripal 3](https://img.shields.io/badge/dev-7.x--3.x-yellow)](https://github.com/tripal/tripal): Focus is on bug fixes
-    - [![Tripal 4](https://img.shields.io/badge/dev-7.x--4.x-yellow)](https://github.com/tripal/t4d8): Full upgrade to Drupal 8/9 (development in [T4D8 Repository](https://github.com/tripal/t4d8)).
+    - [![Tripal 4](https://img.shields.io/badge/dev-7.x--4.x-yellow)](https://github.com/tripal/tripal/tree/4.x): Full upgrade to Drupal 9/10 (alpha1 released!).
  - Tripal ![Tripal 1.x](https://img.shields.io/badge/unsupported-7.x--1.x-red) and ![Tripal 2.x](https://img.shields.io/badge/unsupported-7.x--2.x-red) are no longer supported by the Project Management Committee, although we will accept community submitted fixes for Tripal 2.x.
 
- # Resources
+ # Version 3 Resources
 
   - For information on **how to use Tripal** through the Administrative Interface: [Tripal Users Guide](https://tripal.readthedocs.io/en/latest/user_guide.html)
   - For help **extending Tripal** or understanding how it works: [Tripal Developers Guide](https://tripal.readthedocs.io/en/latest/dev_guide.html)


### PR DESCRIPTION
This PR updates the Tripal 3 README to reflect Tripal 4 release. This is needed because 7.x-3.x is currently our default branch and assumedly will stay so until the Tripal 4 beta is released. Thus we need to ensure that people are able to access info for both Tripal 3 + 4 from the default branch readme so that they use the correct version and know where the repo is heading.

I also updated the repository templates to make it easier for us to know what version each issue is relating to and added a core task template for Tripal core developers.

![README](https://user-images.githubusercontent.com/1566301/214113688-46de41d5-643c-4cf2-b1c0-a3a4abbf4166.png)

Rendered templates are:
 - https://github.com/tripal/tripal/blob/tripal3-readme-update/.github/PULL_REQUEST_TEMPLATE.md
 - https://github.com/tripal/tripal/blob/tripal3-readme-update/.github/ISSUE_TEMPLATE/bug_report.md
 - https://github.com/tripal/tripal/blob/tripal3-readme-update/.github/ISSUE_TEMPLATE/core_task.md
 - https://github.com/tripal/tripal/blob/tripal3-readme-update/.github/ISSUE_TEMPLATE/discussion.md
 - https://github.com/tripal/tripal/blob/tripal3-readme-update/.github/ISSUE_TEMPLATE/feature_request.md

