### PR TITLE
Use new api function chado_get_organism_id_from_scientific_name

### DIFF
--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
@@ -421,14 +421,22 @@ class sbo__relationship_widget extends ChadoFieldWidget {
         }
         // Otherwise we need to look it up using the name field determined in the
         // constructor for the current field. There may be more than one name field
-        // (e.g. organism: genus + species) so we want to check both.
+        // so we want to check all. Special case for organism where lookup is complicated.
         else {
-          $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
-          $subject = chado_query($sql, [':keyword' => $subject_name])->fetchAll();
-          if (count($subject) == 1) {
-            $subject_id = $subject[0]->$fkey_rcolumn;
+          if ($base_table == 'organism') {
+            $organism_id = chado_get_organism_id_from_scientific_name($subject_name, []);
+            if (count($organism_id) == 1) {
+              $subject_id = $organism_id[0];
+            }
           }
           else {
+            $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
+            $subject = chado_query($sql, [':keyword' => $subject_name])->fetchAll();
+            if (count($subject) == 1) {
+              $subject_id = $subject[0]->$fkey_rcolumn;
+            }
+          }
+          if (!$subject_id) {
             form_set_error('sbo__relationship][' . $langcode . '][' . $delta . '][subject_name', 'The subject does not exist');
           }
         }
@@ -449,14 +457,22 @@ class sbo__relationship_widget extends ChadoFieldWidget {
         }
         // Otherwise we need to look it up using the name field determined in the
         // constructor for the current field. There may be more than one name field
-        // (e.g. organism: genus + species) so we want to check both.
-        elseif ($object_name) {
-          $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
-          $object = chado_query($sql, [':keyword' => $object_name])->fetchAll();
-          if (count($object) == 1) {
-            $object_id = $object[0]->$fkey_rcolumn;
+        // so we want to check all. Special case for organism where lookup is complicated.
+        else {
+          if ($base_table == 'organism') {
+            $organism_id = chado_get_organism_id_from_scientific_name($object_name, []);
+            if (count($organism_id) == 1) {
+              $object_id = $organism_id[0];
+            }
           }
           else {
+            $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
+            $object = chado_query($sql, [':keyword' => $object_name])->fetchAll();
+            if (count($object) == 1) {
+              $object_id = $object[0]->$fkey_rcolumn;
+            }
+          }
+          if (!$object_id) {
             form_set_error('sbo__relationship][' . $langcode . '][' . $delta . '][object_name', 'The object does not exist');
           }
         }

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
@@ -423,17 +423,16 @@ class sbo__relationship_widget extends ChadoFieldWidget {
         // constructor for the current field. There may be more than one name field
         // so we want to check all. Special case for organism where lookup is complicated.
         else {
-          if ($base_table == 'organism') {
+          $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
+          $subject = chado_query($sql, [':keyword' => $subject_name])->fetchAll();
+          if (count($subject) == 1) {
+            $subject_id = $subject[0]->$fkey_rcolumn;
+          }
+          // Handle special case of looking up organism by its scientific name.
+          if ((!$subject_id) and ($base_table == 'organism')) {
             $organism_id = chado_get_organism_id_from_scientific_name($subject_name, []);
             if (count($organism_id) == 1) {
               $subject_id = $organism_id[0];
-            }
-          }
-          else {
-            $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
-            $subject = chado_query($sql, [':keyword' => $subject_name])->fetchAll();
-            if (count($subject) == 1) {
-              $subject_id = $subject[0]->$fkey_rcolumn;
             }
           }
           if (!$subject_id) {
@@ -459,17 +458,16 @@ class sbo__relationship_widget extends ChadoFieldWidget {
         // constructor for the current field. There may be more than one name field
         // so we want to check all. Special case for organism where lookup is complicated.
         else {
-          if ($base_table == 'organism') {
+          $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
+          $object = chado_query($sql, [':keyword' => $object_name])->fetchAll();
+          if (count($object) == 1) {
+            $object_id = $object[0]->$fkey_rcolumn;
+          }
+          // Handle special case of looking up organism by its scientific name.
+          if ((!object_id) and ($base_table == 'organism')) {
             $organism_id = chado_get_organism_id_from_scientific_name($object_name, []);
             if (count($organism_id) == 1) {
               $object_id = $organism_id[0];
-            }
-          }
-          else {
-            $sql = 'SELECT ' . $fkey_rcolumn . ' FROM {' . $base_table . '} WHERE ' . implode("||' '||", $this->base_name_columns) . '=:keyword';
-            $object = chado_query($sql, [':keyword' => $object_name])->fetchAll();
-            if (count($object) == 1) {
-              $object_id = $object[0]->$fkey_rcolumn;
             }
           }
           if (!$object_id) {

--- a/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
+++ b/tripal_chado/includes/TripalFields/sbo__relationship/sbo__relationship_widget.inc
@@ -464,7 +464,7 @@ class sbo__relationship_widget extends ChadoFieldWidget {
             $object_id = $object[0]->$fkey_rcolumn;
           }
           // Handle special case of looking up organism by its scientific name.
-          if ((!object_id) and ($base_table == 'organism')) {
+          if ((!$object_id) and ($base_table == 'organism')) {
             $organism_id = chado_get_organism_id_from_scientific_name($object_name, []);
             if (count($organism_id) == 1) {
               $object_id = $organism_id[0];


### PR DESCRIPTION
# Bug Fix

Issue #1266 

## Description
This change implements full and complete infraspecific nomenclature support in the ```sbo__relationship``` widget, as mentioned in pull #1267 in this comment https://github.com/tripal/tripal/pull/1267#issuecomment-1341274120.

This change uses the new api function ```chado_get_organism_id_from_scientific_name()``` to handle the difficult task of looking up an organism from its scientific name, which is handled as a special case when the base table is ```organism```. This new api function is from pull #1328, which as of submission has not been merged yet, so this pull request is dependent on that one being merged. *it has been merged*

## Testing?
Testing is basically entering relationships for one organism to another, using real names, or incorrect ones, and observing the result.
Details of testing in this comment https://github.com/tripal/tripal/pull/1396#issuecomment-1428809144