### PR TITLE
fix for #1397 - Drupal provided Extensions menu

### DIFF
--- a/tripal/src/Controller/TripalController.php
+++ b/tripal/src/Controller/TripalController.php
@@ -28,15 +28,6 @@ class TripalController extends ControllerBase{
     ];
   }
 
-  public function tripalExtensions() {
-    //
-    return [
-      '#markup' => 'Not yet upgraded.',
-    ];
-  }
-
-
-
   public function tripalAttachField($id) {
     //tripal_jobs_view in tripal.jobs.inc
     return [

--- a/tripal/tripal.routing.yml
+++ b/tripal/tripal.routing.yml
@@ -34,7 +34,7 @@ tripal.storage:
 tripal.extension:
   path: 'admin/tripal/extension'
   defaults:
-    _controller: '\Drupal\tripal\Controller\TripalController::tripalExtensions'
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'Extensions'
   requirements:
     _permission: 'administer tripal'


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Documentation  --->

# Bug Fix

Issue #1397

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This lets Drupal take responsibility for listing Tripal Extension module admin links on the Tripal Extensions page (`admin/tripal/extension`).

## Testing

A Tripal extension module needs to be installed that provides a menu link with `tripal.extension` as the parent in the modulename.links.menu.yml file. An example [can be found here](https://github.com/tripal/tripal_sequence_similarity_search/blob/4765410b5131f65832bbecfe1f1481e8a1ebb2da/tripal_seq.links.menu.yml). Navigate to yoursite.com/admin/tripal/extension and you should see your extension's menu link there.

## Additional Notes (if any):

This will be accompanied by a documentation update letting developers know how to get their extension's admin links on this menu.