### PR TITLE
tv3g3 php8 errors with Bulk update all titles

### DIFF
--- a/tripal/includes/TripalJob.inc
+++ b/tripal/includes/TripalJob.inc
@@ -332,7 +332,7 @@ class TripalJob {
         if ($lastparam->getName() == 'job_id') {
           $arguments[] = $this->job->job_id;
         }
-        else {
+        elseif ($lastparam->getName() == 'job') {
           $arguments['job'] = $this;
         }
       }

--- a/tripal/includes/TripalJob.inc
+++ b/tripal/includes/TripalJob.inc
@@ -330,7 +330,7 @@ class TripalJob {
       if (count($refparams) > 0) {
         $lastparam = $refparams[count($refparams) - 1];
         if ($lastparam->getName() == 'job_id') {
-          $arguments[] = $this->job->job_id;
+          $arguments['job_id'] = $this->job->job_id;
         }
         elseif ($lastparam->getName() == 'job') {
           $arguments['job'] = $this;

--- a/tripal/includes/TripalJob.inc
+++ b/tripal/includes/TripalJob.inc
@@ -333,7 +333,7 @@ class TripalJob {
           $arguments[] = $this->job->job_id;
         }
         else {
-          $arguments[] = $this;
+          $arguments['job'] = $this;
         }
       }
 

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -7,7 +7,7 @@
  * @param $update
  * @param $type
  */
-function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
+function tripal_update_all_urls_and_titles($bundle_id, $update, $type, $job = NULL) {
 
   // Load all the entity_ids.
   $entity_table = 'chado_' . $bundle_id;
@@ -25,7 +25,9 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
     $elements = explode(',', $bundle_token[0]);
     $field_name = array_shift($elements);
     $field_array = field_info_field($field_name);
-    $fields[] = $field_array['id'];
+    if ($field_array) {
+      $fields[] = $field_array['id'];
+    }
   }
 
   $i = 1;
@@ -54,7 +56,7 @@ function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
       }
     }
     // Check if 50 items have been updated, if so print message.
-    if ($i <= $num_entities) {
+    if (($i % 50 == 0) or ($i == $num_entities)) {
       $mem = number_format(memory_get_usage());
       print $i . "/" . $num_entities . " entities have been updated. Memory usage: $mem bytes.\r";
     }

--- a/tripal/includes/tripal.bulk_update.inc
+++ b/tripal/includes/tripal.bulk_update.inc
@@ -7,7 +7,7 @@
  * @param $update
  * @param $type
  */
-function tripal_update_all_urls_and_titles($bundle_id, $update, $type, $job = NULL) {
+function tripal_update_all_urls_and_titles($bundle_id, $update, $type) {
 
   // Load all the entity_ids.
   $entity_table = 'chado_' . $bundle_id;


### PR DESCRIPTION
# Bug Fix

## Issue #1401

### Tripal Version: 3.x

## Description
The changes resolve warnings that show up under php8.x, where a job is passed to a callback that does not expect an additional (unnamed) parameter

## Testing?
1. Need to run under PHP8.x
2. Go to organism content type /admin/structure/bio_data/manage/bio_data_1 (or any other content type)
3. Click the "Bulk update all titles" button
4. run the job with drush at the command line and hopefully no errors now appear, see issue #1401 for the "before" output.
```
2023-01-31 13:38:56: There are 1 jobs queued.
2023-01-31 13:38:56: Job ID 3977.
2023-01-31 13:38:56: Calling: tripal_update_all_urls_and_titles(bio_data_4, study/[TripalEntity__entity_id], alias)
1/1 entities have been updated. Memory usage: 52,179,464 bytes.
Done.
```
