### PR TITLE
Fix test coverage + add to Tripal 4 readme

### DIFF
--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -63,5 +63,5 @@ jobs:
             git config --global --add safe.directory /var/www/drupal9/web/modules/contrib/tripal
           docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal \
             tripaldocker ./cc-test-reporter after-build clover.xml \
-            --id 37bfc0a7ce6928f7f4be8da9168c5fb65bd49e0a81c082baa08e2747121bec16 \
+            --id ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }} \
             --debug -t clover -p /var/www/drupal9/web/modules/contrib/tripal

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -59,7 +59,7 @@ jobs:
           docker exec tripaldocker ls /var/www/drupal9/web/modules/contrib/tripal
       - name: Publish code coverage to Code Climate
         run: |
-          docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal \
+          docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal tripaldocker \
             git config --global --add safe.directory /var/www/drupal9/web/modules/contrib/tripal
           docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal \
             tripaldocker ./cc-test-reporter after-build clover.xml \

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Publish code coverage to Code Climate
         run: |
           docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal \
+            git config --global --add safe.directory /var/www/drupal9/web/modules/contrib/tripal
+          docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal \
             tripaldocker ./cc-test-reporter after-build clover.xml \
             --id 37bfc0a7ce6928f7f4be8da9168c5fb65bd49e0a81c082baa08e2747121bec16 \
             --debug -t clover -p /var/www/drupal9/web/modules/contrib/tripal

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
 | **PHP 8.0** | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_2x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_2x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_3x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_3x.yml)     | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_4x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_4x.yml)     | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_5x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8_D9_5x.yml)     |                                                                                                                                                                                |
 | **PHP 8.1** |                                                                                                                                                                          | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml) | [![PHPUnit](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg)](https://github.com/tripal/t4d8/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml) |
 
+### Code Coverage
+
+This project uses Code Climate to determine the quality of our codebase and the coverage of our test suite. Compatibility above is based on passing of this test suite.
+
+[![Test Coverage](https://api.codeclimate.com/v1/badges/994fcd39a0eef9cff742/test_coverage)](https://codeclimate.com/github/tripal/tripal/test_coverage)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/994fcd39a0eef9cff742/maintainability)](https://codeclimate.com/github/tripal/tripal/maintainability)
 
 ## Current Timeline
 


### PR DESCRIPTION
# Tripal 4 Core Dev Task  --->

Issue #1403 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The Test coverage has been failing since we moved the tripal 4 codebase back to this repo. This is because the token from code climate changed and was not updated in our workflow.

I also updated the Tripal 4 reame to include the maintainability and test coverage from CodeClimate as suggested by @spficklin awhile back.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

All you need to do is confirm the test coverage job completes with a checkmark and approve the changes to the README as shown below. Note: Test coverage is that of the 4.x branch -it will stay a ? until after this PR is merged and testing can run on the main branch.

![Screen Shot 2023-02-01 at 12 17 51 PM](https://user-images.githubusercontent.com/1566301/216128664-cae17f9d-3842-43b6-b818-75244dd4c131.png)

