### PR TITLE
tv3g4 issue#1406 present cbl templates in sorted order

### DIFF
--- a/tripal_bulk_loader/includes/tripal_bulk_loader.chado_node.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.chado_node.inc
@@ -40,6 +40,7 @@ function tripal_bulk_loader_form($node, $form_state) {
 
   $results = db_select('tripal_bulk_loader_template', 't')
     ->fields('t', ['template_id', 'name'])
+    ->orderBy('name')
     ->execute();
   $templates = [];
   foreach ($results as $template) {


### PR DESCRIPTION
# Bug Fix

## Issue #1406

### Tripal Version: 3

## Description
One-line change to add an ```orderBy``` to the db query to retrieve the CBL template list.

## Testing?
Go to this page
/node/add/tripal-bulk-loader
and observe the beautifully alphabetized template list.
