### PR TITLE
Improve Maintainability as suggested by CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ checks:
   argument-count:
     enabled: false
     config:
-      threshold: 4
+      threshold: 8
   complex-logic:
     enabled: true
     config:
@@ -16,7 +16,7 @@ checks:
   method-complexity:
     enabled: true
     config:
-      threshold: 7
+      threshold: 25
   method-count:
     enabled: false
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -38,7 +38,7 @@ checks:
     config:
       threshold: #language-specific defaults. overrides affect all languages.
   identical-code:
-    enabled: true
+    enabled: false
     config:
       threshold: #language-specific defaults. overrides affect all languages.
 

--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -110,18 +110,31 @@ class ChadoSchema extends TripalDbxSchema {
     if (isset($schema['referring_tables'])) {
       foreach ($schema['referring_tables'] as $tablename) {
 
-        // Ignore the cvterm tables, relationships, chadoprop tables.
-        if ($tablename == 'cvterm_dbxref' || $tablename == 'cvterm_relationship' ||
-          $tablename == 'cvtermpath' || $tablename == 'cvtermprop' || $tablename == 'chadoprop' ||
-          $tablename == 'cvtermsynonym' || preg_match('/_relationship$/', $tablename) ||
-          preg_match('/_cvterm$/', $tablename) ||
-          // Ignore prop tables
-          preg_match('/prop$/', $tablename) || preg_match('/prop_.+$/', $tablename) ||
-          // Ignore nd_tables
-          preg_match('/^nd_/', $tablename)) {
-          continue;
+        $is_base_table = TRUE;
+
+        // Ignore the cvterm tables + chadoprop tables.
+        if (in_array($tablename, ['cvterm_dbxref', 'cvterm_relationship', 'cvtermpath', 'cvtermprop', 'chadoprop', 'cvtermsynonym'])) {
+          $is_base_table = FALSE;
         }
-        else {
+        // Ignore relationship linked tables.
+        elseif (preg_match('/_relationship$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore cvterm annotation linking tables.
+        elseif (preg_match('/_cvterm$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore property tables.
+        elseif (preg_match('/prop$/', $tablename) || preg_match('/prop_.+$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore natural diversity tables.
+        elseif (preg_match('/^nd_/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+
+        // If it's not any of the above then add it to the list.
+        if ($is_base_table === TRUE) {
           array_push($base_tables, $tablename);
         }
       }

--- a/tripal_chado/src/api/ChadoSchema.php
+++ b/tripal_chado/src/api/ChadoSchema.php
@@ -352,18 +352,31 @@ class ChadoSchema {
     if (isset($schema['referring_tables'])) {
       foreach ($schema['referring_tables'] as $tablename) {
 
-        // Ignore the cvterm tables, relationships, chadoprop tables.
-        if ($tablename == 'cvterm_dbxref' || $tablename == 'cvterm_relationship' ||
-          $tablename == 'cvtermpath' || $tablename == 'cvtermprop' || $tablename == 'chadoprop' ||
-          $tablename == 'cvtermsynonym' || preg_match('/_relationship$/', $tablename) ||
-          preg_match('/_cvterm$/', $tablename) ||
-          // Ignore prop tables
-          preg_match('/prop$/', $tablename) || preg_match('/prop_.+$/', $tablename) ||
-          // Ignore nd_tables
-          preg_match('/^nd_/', $tablename)) {
-          continue;
+        $is_base_table = TRUE;
+
+        // Ignore the cvterm tables + chadoprop tables.
+        if (in_array($tablename, ['cvterm_dbxref', 'cvterm_relationship', 'cvtermpath', 'cvtermprop', 'chadoprop', 'cvtermsynonym'])) {
+          $is_base_table = FALSE;
         }
-        else {
+        // Ignore relationship linked tables.
+        elseif (preg_match('/_relationship$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore cvterm annotation linking tables.
+        elseif (preg_match('/_cvterm$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore property tables.
+        elseif (preg_match('/prop$/', $tablename) || preg_match('/prop_.+$/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+        // Ignore natural diversity tables.
+        elseif (preg_match('/^nd_/', $tablename)) {
+          $is_base_table = FALSE;
+        }
+
+        // If it's not any of the above then add it to the list.
+        if ($is_base_table === TRUE) {
           array_push($base_tables, $tablename);
         }
       }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

Issue #1404 
*Issue not completely fixed by this PR*

### Tripal Version: 4

## Description

1. Adjusted the limits used to measure maintainability for our project

Specifically,

- I expanded the max argument count to 8 since Drupal typically has a lot of arguments for dependency injection purposes and what not.
- I expanded the method complexity substantially as the limit felt unobtainable.
- I turned off the identical code detection as it was detecting service calls which should be identical and thus providing many false positives.

2. Expanded some if clauses with way too many criteria for better readability.

Specifically, I updated two identical if clauses in the ChadoSchema classes (both deprecated API class and new Tripal DBX ChadoSchema class). As you will see from the diff I basically just expanded a single if with way too many arguments to multiple if statements which spread out those same arguments. I feel this is much more readable and will be easier to debug --code climate agrees.

## Testing?
The changes to the CodeClimate yml do not need testing as they are just settings.
The ChadoSchema change should be caught by automated testing.
You can see the change in maintainability issues here if you are interested: https://codeclimate.com/github/tripal/tripal/compare/tv4g0-issue1404-improveMaintainability

So basically this PR just needs someone to ok the change in settings as reasonable :-) 
