### PR TITLE
Deafult (non Chado) Vocabulary and IdSpace Plugin.

### DIFF
--- a/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
+++ b/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
@@ -437,7 +437,7 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
   }
 
   /**
-   * Retrieve a tern record from tripal_terms table.
+   * Retrieve a term record from tripal_terms table.
    *
    * This function uses the db.name (IdSpace), cv.name (vocabulary)
    * and accession values to uniquely identify a term.

--- a/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
+++ b/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
@@ -15,7 +15,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  */
 class TripalDefaultIdSpace extends TripalIdSpaceBase {
   /**
-   * A simple boolean to prevent Chado queries if the ID space isn't valid.
+   * A simple boolean to prevent queries if the ID space isn't valid.
    *
    * @var bool
    */

--- a/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
+++ b/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
@@ -36,6 +36,12 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
    * {@inheritDoc}
    */
   public function getParent($child) {
+    // Don't get values for an ID space that isn't valid.
+    if (!$this->is_valid) {
+      return NULL;
+    }
+
+    $this->messageLogger->warning('The TripalDefaultIdSpace::getParent() function is currently not implemented');
   }
 
   /**
@@ -228,12 +234,14 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
    * {@inheritDoc}
    */
   public function destroy() {
+    $this->messageLogger->warning('The TripalDefaultIdSpace::destory() function is currently not implemented');
   }
 
   /**
    * {@inheritDoc}
    */
   public function removeTerm($accession) {
+    $this->messageLogger->warning('The TripalDefaultIdSpace::removeTerm() function is currently not implemented');
   }
 
   /**

--- a/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
+++ b/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
@@ -49,8 +49,7 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
 
     // Make sure the description is not too long.
     if (empty($prefix)) {
-      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a urlprefix when calling setURLPrefix().',
-          ['@size' => 255, '@value' => $prefix]);
+      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a urlprefix when calling setURLPrefix().');
       return False;
     }
     if (strlen($prefix) > 255) {
@@ -217,12 +216,12 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
     if (!empty($name) AND (strlen($name) > 255)) {
       $this->messageLogger->error('TripalDefaultIdSpace: The IdSpace name must not be longer than @size characters. ' +
         'The value provided was: @value', ['@size' => 255, '@value' => $name]);
-      return;
+      $this->is_valid = FALSE;
+      return FALSE;
     }
 
     $this->is_valid = TRUE;
-
-    return $this->is_valid;
+    return TRUE;
   }
 
   /**
@@ -249,9 +248,8 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
 
     // Make sure the description is not too long.
     if (empty($description)) {
-      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a description when calling setDescription().',
-          ['@size' => 255, '@value' => $description]);
-        return False;
+      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a description when calling setDescription().');
+      return False;
     }
     if (strlen($description) > 255) {
       $this->messageLogger->error('TripalDefaultIdSpace: The description for the vocabulary ID space must not be longer than @size characters. ' +
@@ -437,9 +435,9 @@ class TripalDefaultIdSpace extends TripalIdSpaceBase {
   }
 
   /**
-   * Retrieve a tern record from tripal_terms table.
+   * Retrieve a term record from tripal_terms table.
    *
-   * This function uses the db.name (IdSpace), cv.name (vocabulary)
+   * This function uses the IdSpace, vocabulary,
    * and accession values to uniquely identify a term.
    *
    * @param TripalTerm $term

--- a/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
+++ b/tripal/src/Plugin/TripalIdSpace/TripalDefaultIdSpace.php
@@ -1,0 +1,671 @@
+<?php
+
+namespace Drupal\tripal\Plugin\TripalIdSpace;
+
+use Drupal\tripal\TripalVocabTerms\TripalIdSpaceBase;
+use Drupal\tripal\TripalVocabTerms\TripalTerm;
+
+/**
+ * Default Implementation of TripalIdSpaceBase
+ *
+ *  @TripalIdSpace(
+ *    id = "tripal_default_id_space",
+ *    label = @Translation("Deafult Tripal IdSpace"),
+ *  )
+ */
+class TripalDefaultIdSpace extends TripalIdSpaceBase {
+  /**
+   * A simple boolean to prevent Chado queries if the ID space isn't valid.
+   *
+   * @var bool
+   */
+  protected $is_valid = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    // Instantiate the TripalLogger
+    $this->messageLogger = \Drupal::service('tripal.logger');
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getParent($child) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setURLPrefix($prefix) {
+    // Don't set a value for an ID space that isn't valid.
+    if (!$this->is_valid) {
+      return False;
+    }
+
+    // Make sure the description is not too long.
+    if (empty($prefix)) {
+      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a urlprefix when calling setURLPrefix().',
+          ['@size' => 255, '@value' => $prefix]);
+      return False;
+    }
+    if (strlen($prefix) > 255) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The urlprefix for the vocabulary ID space must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $prefix]);
+      return False;
+    }
+
+    // Update the record in the Chado `db` table.
+    $conn = \Drupal::service('database');
+    $query = $conn->update('tripal_terms_idspaces')
+      ->fields(['urlprefix' => $prefix])
+      ->condition('name', $this->getName(), '=');
+    $num_updated = $query->execute();
+    if ($num_updated != 1) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The urlprefix could not be updated for the vocabulary ID Space.');
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefaultVocabulary($vocab) {
+    $retval = parent::setDefaultVocabulary($vocab);
+
+    // Don't set a value for an ID space that isn't valid.
+    if (!$this->is_valid) {
+      return False;
+    }
+
+    // Make sure the description is not too long.
+    if (empty($vocab)) {
+      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a default vocabulary when calling setDefaultVocabulary().');
+      return False;
+    }
+    if (strlen($vocab) > 255) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The default vocabulary must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $vocab]);
+      return False;
+    }
+
+    // Update the record in the Chado `db` table.
+    $conn = \Drupal::service('database');
+    $update = $conn->update('tripal_terms_idspaces');
+    $update = $update->fields(['default_vocab' => $vocab]);
+    $update = $update->condition('name', $this->getName(), '=');
+    $num_updated = $update->execute();
+    if ($num_updated != 1) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The default vocabulary could not be updated for the vocabulary ID Space.');
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function recordExists() {
+    $db = $this->loadIdSpace();
+    if ($db and $db['name'] == $this->getName()) {
+      return True;
+    }
+    return False;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getTerm($accession, $options = [ ]) {
+
+
+    if (!$this->is_valid) {
+      return NULL;
+    }
+
+    $conn = \Drupal::service('database');
+    $query = $conn->select('tripal_terms', 'tt');
+    $query = $query->fields('tt');
+    $query = $query->condition('id_space', $this->getName(), '=');
+    $query = $query->condition('accession', $accession, '=');
+    $result = $query->execute();
+    if (!$result) {
+      return NULL;
+    }
+    $cvterm =  $result->fetchObject();
+
+    $term =  new TripalTerm([
+      'name' => $cvterm->name,
+      'definition' => $cvterm->definition,
+      'accession' => $accession,
+      'idSpace' => $this->getName(),
+      'vocabulary' => $cvterm->vocabulary ? $cvterm->vocabulary : $this->getDefaultVocabulary(),
+      'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,
+      'is_relationship_type' => $cvterm->is_relationship_type == 1 ? True : False,
+    ]);
+
+    // We need an IdSpace manager object to look up synonym an property types.
+    /** @var \Drupal\tripal\TripalVocabTerms\PluginManagers\TripalIdSpaceManager $idsmanager */
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+
+    // Add in the synonyms
+    $synonyms = unserialize($cvterm->synonyms);
+    foreach ($synonyms as $tuple) {
+      $synonym_name = $tuple[0];
+      $synonym_type = $tuple[1];
+      $syn_type_term = NULL;
+      if ($synonym_type) {
+        list($syn_idspace_name, $syn_accession) = explode(':', $synonym_type);
+        /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $syn_idspace */
+        $syn_type_idspace = $idsmanager->loadCollection($syn_idspace_name);
+        $syn_type_term = $syn_type_idspace->getTerm($syn_accession);
+      }
+      $term->addSynonym($synonym_name, $syn_type_term);
+    }
+
+    // Add in the property.
+    $properties = unserialize($cvterm->properties);
+    foreach ($properties as $tuple) {
+      list($prop_term_id, $rank, $prop_value) = $tuple;
+      list($prop_idspace_name, $prop_accession) = explode(':', $prop_term_id);
+      /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $syn_idspace */
+      $prop_type_idspace = $idsmanager->loadCollection($prop_idspace_name);
+      $prop_type_term = $prop_type_idspace->getTerm($prop_accession);
+      $term->addProperty($prop_type_term, $prop_value, $rank);
+    }
+
+    $altIds = unserialize($cvterm->altIds);
+    foreach ($altIds as $altId) {
+      list($altId_idspace_name, $altId_accession) = explode(':', $altId);
+      $term->addAltId($altId_idspace_name, $altId_accession);
+    }
+
+    $parents = unserialize($cvterm->parents);
+    foreach ($parents as $tuple) {
+      list($parent_term_id, $rel_type_id) = $tuple;
+      list($parent_idspace_name, $parent_accession) = explode(':', $parent_term_id);
+      list($rel_idspace_name, $rel_accession) = explode(':', $rel_type_id);
+      $parent_idspace = $idsmanager->loadCollection($parent_idspace_name);
+      $parent_term = $parent_idspace->getTerm($parent_accession);
+      $rel_idspace = $idsmanager->loadCollection($rel_idspace_name);
+      $rel_term = $rel_idspace->getTerm($rel_accession);
+      $term->addParent($parent_term, $rel_term);
+    }
+
+    // Set the internal ID.
+    $term->setInternalId($cvterm->term_id);
+
+    return $term;
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function isValid() {
+
+    // Make sure the name of this ID Space does not exceeed the allowed size in Chado.
+    $name = $this->getName();
+
+    if (!empty($name) AND (strlen($name) > 255)) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The IdSpace name must not be longer than @size characters. ' +
+        'The value provided was: @value', ['@size' => 255, '@value' => $name]);
+      return;
+    }
+
+    $this->is_valid = TRUE;
+
+    return $this->is_valid;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function destroy() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function removeTerm($accession) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setDescription($description) {
+
+    // Don't set a value for an ID space that isn't valid.
+    if (!$this->is_valid) {
+      return False;
+    }
+
+    // Make sure the description is not too long.
+    if (empty($description)) {
+      $this->messageLogger->error('TripalDefaultIdSpace: You must provide a description when calling setDescription().',
+          ['@size' => 255, '@value' => $description]);
+        return False;
+    }
+    if (strlen($description) > 255) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The description for the vocabulary ID space must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $description]);
+        return False;
+    }
+
+    // Update the record in the Chado `db` table.
+    $conn = \Drupal::service('database');
+    $query = $conn->update('tripal_terms_idspaces')
+      ->fields(['description' => $description])
+      ->condition('name', $this->getName(), '=');
+    $num_updated = $query->execute();
+    if ($num_updated != 1) {
+      $this->messageLogger->error('TripalDefaultIdSpace: The description could not be updated for the vocabulary ID Space.');
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getURLPrefix() {
+    $db = $this->loadIdSpace();
+    return $db['urlprefix'];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getDescription() {
+    $db = $this->loadIdSpace();
+    return $db['description'];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+   public function getChildren($parent = NULL) {
+
+     /** @var \Drupal\tripal\TripalVocabTerms\PluginManagers\TripalIdSpaceManager $idsmanager */
+     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+
+     // Don't get values for an ID space that isn't valid.
+     if (!$this->is_valid) {
+       return NULL;
+     }
+
+     $children = [];
+     $conn = \Drupal::service('database');
+     $query = $conn->select('tripal_terms', 'tt');
+     $query = $query->fields('tt', ['accession', 'parents']);
+     $query = $query->condition('tt.id_space', $this->getName(), '=');
+     $query->condition('tt.parents', '%"' . $parent->getTermId() . '"%', 'LIKE');
+     $results = $query->execute();
+     while ($cvterm = $results->fetchObject()) {
+       /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term */
+       $term = $this->getTerm($cvterm->accession);
+       $parents = unserialize($cvterm->parents);
+       foreach ($parents as $tuple) {
+         if ($tuple[0] == $parent->getTermId()) {
+           $rel_type_id = $tuple[1];
+           list($rel_idspace_name, $rel_accession) = explode(':', $rel_type_id);
+           /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $syn_idspace */
+           $rel_idspace = $idsmanager->loadCollection($rel_idspace_name);
+           $rel_term = $rel_idspace->getTerm($rel_accession);
+           $children[] = [$term, $rel_term];
+         }
+       }
+     }
+
+     return $children;
+   }
+
+
+  /**
+   * Loads an ID Space record
+   *
+   * @return array
+   *   An associative array containing the columns of the `db1 table
+   *   of Chado or NULL if the db could not be found.
+   */
+  protected function loadIdSpace() {
+
+    $conn = \Drupal::service('database');
+
+    // Get the Chado `db` record for this ID space.
+    $query = $conn->select('tripal_terms_idspaces', 'ids')
+      ->condition('ids.name', $this->getName(), '=')
+      ->fields('ids', ['name', 'urlprefix', 'description', 'default_vocab']);
+    $result = $query->execute();
+    if (!$result) {
+      return NULL;
+    }
+    return $result->fetchAssoc();
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function create() {
+    $conn = \Drupal::service('database');
+
+    // Check if the record already exists in the database, if it
+    // doesn't then insert it.  We don't yet have the description,
+    // URL prefix, etc but that's okay, the name is all that is
+    // required to create a record in the `db` table.
+    $db = $this->loadIdSpace();
+    if (!$db) {
+      $query = $conn->insert('tripal_terms_idspaces');
+      $query->fields(['name' => $this->getName()]);
+      $query->execute();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getDefaultVocabulary() {
+    $db = $this->loadIdSpace();
+    return $db['default_vocab'];
+  }
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getTerms($name, $options = [ ]) {
+    // The list of terms to return
+    $terms = [];
+
+    $conn = \Drupal::service('database');
+    $query1 = $conn->select('tripal_terms', 'tt');
+    $query1 = $query1->fields('tt', ['accession']);
+    $query1 = $query1->condition('tt.id_space', $this->getName(), '=');
+    if (array_key_exists('exact', $options) and $options['exact'] === TRUE) {
+      $query1->condition('tt.name', $name, '=');
+    }
+    else {
+      $query1->condition('tt.name', $name . '%', 'LIKE');
+    }
+    $results = $query1->execute();
+    while ($cvterm = $results->fetchObject()) {
+      /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term */
+      $term = $this->getTerm($cvterm->accession);
+      $terms[$term->getName()][$term->getTermId()] = $term;
+    }
+
+
+    // Now add in any synonyms
+    $query2 = $conn->select('tripal_terms', 'tt');
+    $query2 = $query2->fields('tt', ['accession', 'synonyms']);
+    $query2 = $query2->condition('tt.id_space', $this->getName(), '=');
+    if (array_key_exists('exact', $options) and $options['exact'] === TRUE) {
+      $query2->condition('tt.synonyms', '%"' . $name . '"%', 'LIKE');
+    }
+    else {
+      $query2->condition('tt.synonyms', '%"' . $name . '%', 'LIKE');
+    }
+    $results = $query2->execute();
+    while ($cvterm = $results->fetchObject()) {
+      /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term */
+      $term = $this->getTerm($cvterm->accession);
+      $synonyms = unserialize($cvterm->synonyms);
+      foreach ($synonyms as $tuple) {
+        if (array_key_exists('exact', $options) and $options['exact'] === TRUE) {
+          if ($tuple[0] == $name) {
+            $terms[$tuple[0]][$term->getTermId()] = $term;
+          }
+        }
+        else {
+          if (preg_match("/^$name/", $tuple[0])) {
+            $terms[$tuple[0]][$term->getTermId()] = $term;
+          }
+        }
+      }
+    }
+
+    return $terms;
+  }
+
+  /**
+   * Retrieve a tern record from tripal_terms table.
+   *
+   * This function uses the db.name (IdSpace), cv.name (vocabulary)
+   * and accession values to uniquely identify a term.
+   *
+   * @param TripalTerm $term
+   *   The TripalTerm object to save.
+   * @return object
+   *   The cvterm record in object form.
+   */
+  protected function findTermRecord(TripalTerm $term) {
+
+    $conn = \Drupal::service('database');
+    $query = $conn->select('tripal_terms', 'tt');
+    $query = $query->fields('tt');
+    $query = $query->condition('tt.id_space', $term->getIdSpace(), '=');
+    $query = $query->condition('tt.vocabulary', $term->getVocabulary(), '=');
+    $query = $query->condition('tt.accession', $term->getAccession(), '=');
+    $result = $query->execute();
+    if (!$result) {
+      return NULL;
+    }
+    return $result->fetchObject();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function saveTerm($term, array $options = [ ]) {
+    // Don't save terms that aren't valid
+    if (!$term->isValid()) {
+      $this->messageLogger->error(t('TripalDefaultIdSpace::saveTerm(). The term, "@term" is not valid and cannot be saved. It must include a name, accession, IdSpace and vocabulary.',
+          ['@term' => $term->getIdSpace() . ':' . $term->getAccession()]));
+      return False;
+    }
+
+    // Make sure the idSpace matches.
+    if ($this->getName() != $term->getIdSpace()) {
+      $this->messageLogger->error(t('TripalDefaultIdSpace::saveTerm(). The term, "@term", does not have the same ID space as this one.',
+          ['@term' => $term->getIdSpace() . ':' . $term->getAccession()]));
+      return False;
+    }
+
+    // Get easy to use boolean variables.
+    $fail_if_exists = False;
+    if (array_key_exists('failIfExists', $options)) {
+      $fail_if_exists = $options['failIfExists'];
+    }
+
+    // Does the term exist? If not do an insert, if so, do an update.
+    $cvterm = $this->findTermRecord($term);
+    if (!$cvterm) {
+      if (!$this->insertTerm($term, $options)) {
+        return False;
+      }
+    }
+    if ($cvterm and $fail_if_exists) {
+      return False;
+    }
+    if ($cvterm and !$fail_if_exists) {
+      if (!$this->updateTerm($term, $cvterm, $options)) {
+        return False;
+      }
+    }
+
+    // Set the internal ID.
+    $cvterm = $this->findTermRecord($term);
+    $term->setInternalId($cvterm->term_id);
+
+    return True;
+  }
+
+  /**
+   * Formats the synonyms for saving in the database.
+   *
+   * @param \Drupal\tripal\TripalVocabTerms\TripalTerm $term
+   *   The term object
+   */
+  private function formatTermSynonyms($term) {
+    // Convert the synonyms into a list for storing.
+    $synonyms = $term->getSynonyms();
+    $synonym_list = [];
+    foreach ($synonyms as $synonym => $type) {
+      $type_id = NULL;
+      if ($type) {
+        $type_id = $type->getTermId();
+      }
+      $synonym_list[] = [$synonym, $type_id];
+    }
+    return $synonym_list;
+  }
+
+  /**
+   * Formats the parents for saving in the database.
+   *
+   * @param \Drupal\tripal\TripalVocabTerms\TripalTerm $term
+   *   The term object
+   */
+  private function formatTermParents($term) {
+    // In the parents array, the key is the term ID for the parent
+    // (e.g. GO:0008150). The value is a tuple that should contain as its
+    // first element the parent term and the second element the relationship
+    // term.
+    $parents = $term->getParents();
+    $parents_list = [];
+    foreach ($parents as $parent_term_id => $tuple) {
+      $rel_type_term = $tuple[1];
+      $parents_list[] = [$parent_term_id, $rel_type_term->getTermId()];
+    }
+    return $parents_list;
+  }
+
+  /**
+   * Formats the synonyms for saving in the database.
+   *
+   * @param \Drupal\tripal\TripalVocabTerms\TripalTerm $term
+   *   The term object
+   */
+  private function formatTermProperties($term) {
+    // properties is an associative array where the first level key is the
+    // term_id for the property. The second level key is the rank and the
+    // value is a tuple with the first element being the TripalTerm for the
+    // property type and the second being the propertly value.
+    $properties = $term->getProperties();
+    $property_list = [];
+    foreach ($properties as $term_id => $ranks) {
+      foreach ($ranks as $rank => $tuple) {
+        $prop_value = $tuple[1];
+        $property_list[] = [$term_id, $rank, $prop_value];
+      }
+    }
+    return $property_list;
+  }
+
+  /**
+   * Inserts a new term.
+   *
+   * The term should be checked that it does not exist
+   * prior to calling this function.
+   *
+   * @param \Drupal\tripal\TripalVocabTerms\TripalTerm $term
+   *   The term object to update
+   *
+   * @param array $options
+   *   The options passed to the saveTerm() function.
+   *
+   * @return boolean
+   *   True if the insert was successful, false otherwise.
+   */
+  protected function insertTerm(TripalTerm $term, array $options) {
+
+    // Instantiate a TripalDBX connection for Chado.
+    $conn = \Drupal::service('database');
+    try {
+
+      // Add the new term record.
+      $insert = $conn->insert('tripal_terms');
+      $insert->fields([
+        'id_space' => $term->getIdSpace(),
+        'vocabulary' => $term->getVocabulary(),
+        'name' => $term->getName(),
+        'accession' => $term->getAccession(),
+        'definition' => $term->getDefinition(),
+        'is_obsolete' => $term->isObsolete() ? 1 : 0,
+        'is_relationship_type' => $term->isRelationshipType() ? 1 : 0,
+        'synonyms' => serialize($this->formatTermSynonyms($term)),
+        'properties' => serialize($this->formatTermProperties($term)),
+        'altIds' => serialize($term->getAltIds()),
+        'parents' => serialize($this->formatTermParents($term)),
+      ]);
+      $insert->execute();
+      $cvterm = $this->findTermRecord($term);
+      if (!$cvterm) {
+        return False;
+      }
+    }
+    catch (Exception $e) {
+      $this->messageLogger->error('TripalDefaultIdSpace::insertTerm(). could not insert the term record: @message',
+          ['@message' => $e->getMessage()]);
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * Updates an existing term.
+   *
+   * The term should be checked that it already exists
+   * prior to execution of this function.
+   *
+   * @param \Drupal\tripal\TripalVocabTerms\TripalTerm $term
+   *   The term object to update
+   * @param object $cvterm
+   *   The record object for the term to update from the Chado cvterm table.
+   * @param array $options
+   *   The options passed to the saveTerm() function.
+   *
+   * @return boolean
+   *   True if the update was successful, false otherwise.
+   */
+  protected function updateTerm(TripalTerm $term, object &$cvterm, array $options) {
+
+    // Instantiate a TripalDBX connection for Chado.
+    $conn = \Drupal::service('database');
+
+    try {
+      $update = $conn->update('tripal_terms');
+      $update->fields([
+        'id_space' => $term->getIdSpace(),
+        'vocabulary' => $term->getVocabulary(),
+        'name' => $term->getName(),
+        'accession' => $term->getAccession(),
+        'definition' => $term->getDefinition(),
+        'is_obsolete' => $term->isObsolete() ? 1 : 0,
+        'is_relationship_type' => $term->isRelationshipType() ? 1 : 0,
+        'synonyms' => serialize($this->formatTermSynonyms($term)),
+        'properties' => serialize($this->formatTermProperties($term)),
+        'altIds' => serialize($term->getAltIds()),
+        'parents' => serialize($this->formatTermParents($term)),
+      ]);
+      $update->condition('term_id', $cvterm->term_id);
+      $update->execute();
+      $cvterm = $this->findTermRecord($term);
+    }
+    catch (Exception $e) {
+      $this->messageLogger->error('ChadoIdSpace: could not update the cvterm record: @message',
+          ['@message' => $e->getMessage()]);
+      return False;
+    }
+    return True;
+  }
+}

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Drupal\tripal\Plugin\TripalVocabulary;
+
+use Drupal\tripal\TripalVocabTerms\TripalVocabularyBase;
+
+/**
+ * Chado implementation of the TripalVocabularyBase.
+ *
+ *  @TripalVocabulary(
+ *    id = "tripal_default_vocabulary",
+ *    label = @Translation("Deafult Tripal Vocabulary Plugin"),
+ *  )
+ */
+class TripalDefaultVocabulary extends TripalVocabularyBase {
+  /**
+   * An instance of the TripalLogger.
+   *
+   * @var \Drupal\tripal\Services\TripalLogger
+   */
+  protected $messageLogger = NULL;
+
+  /**
+   * A simple boolean to prevent Chado queries if the vocabulary isn't valid.
+   *
+   * @var bool
+   */
+  protected $is_valid = False;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    // Instantiate the TripalLogger
+    $this->messageLogger = \Drupal::service('tripal.logger');
+  }
+
+  /**
+   * Loads a Vocabulary record from Chado.
+   *
+   * This function queries the `cv` table of Chado to get the values
+   * for the vocabulary.
+   *
+   * @return
+   *   An associative array containing the columns of the `db1 table
+   *   of Chado or NULL if the db could not be found.
+   */
+  protected function loadVocab() {
+
+    $conn = \Drupal::service('database');
+
+    // Get the Chado `db` record for this ID space.
+    $query = $conn->select('tripal_terms_vocabs', 'vocabs')
+      ->condition('name', $this->getName(), '=')
+      ->fields('vocabs', ['name', 'label', 'url', 'idspaces']);
+    $result = $query->execute();
+    if ($result) {
+      return $result->fetchAssoc();
+    }
+    return NULL;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getIdSpaceNames() {
+    $cv = $this->loadVocab();
+    $idspaces = unserialize($cv['idspaces']);
+    return $idspaces;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getLabel() {
+    $cv = $this->loadVocab();
+    return $cv['label'];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function recordExists() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function isValid() {
+
+    // Make sure the name of this collection does not exceeed the allowed size in Chado.
+    $name = $this->getName();
+    if (!empty($name) AND (strlen($name) > 255)) {
+      $this->messageLogger->error('TripalDefaultVocabular: The vocabulary name must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $this->getName()]);
+    }
+    $this->is_valid = TRUE;
+
+    return $this->is_valid;
+  }
+
+  /**
+   * Returns the namespace of the vocabulary
+   *
+   * This should be identical to the name of the collection, and
+   * therefore, there is no setter function.
+   *
+   * @return string $namespace
+   *   The namespace of the vocabulary.
+   */
+  public function getNameSpace() {
+    return $this->getName();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function destroy() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setURL($url) {
+    // @todo there may be a problem in the future if we are able to
+    // associate borrowed terms with a vocabulary.  If we
+    // add the ID space of borrowed terms to a vocabulary then
+    // setting the URL will be incorrect for those ID spaces.
+
+    // Don't set a value for a vocabulary that isn't valid.
+    if (!$this->is_valid) {
+      return False;
+    }
+
+    // This value goes to the Chado `db.url` column, so check its size
+    // to make sure it doesn't exceed it.
+    if (strlen($url) > 255) {
+      $this->messageLogger->error('TripalDefaultVocabulary: The vocabulary name must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $this->getName()]);
+          return False;
+    }
+
+    // If we don't have any ID spaces then there is no URL.
+    $id_spaces = $this->getIdSpaceNames();
+    if (count($id_spaces) == 0) {
+      $this->messageLogger->error('TripalDefaultVocabulary: Cannot set the URL when no ID spaces are present for the vocabulary.');
+      return False;
+    }
+
+    // Update the record in the Chado `db` table for the URL for all ID spaces.
+    $conn = \Drupal::service('database');
+    $update = $conn->update('tripal_terms_vocabs');
+    $update = $update->fields(['url' => $url]);
+    $update = $update->condition('name', $this->getName(), '=');
+    $num_updated = $update->execute();
+    if ($num_updated != 1) {
+      $this->messageLogger->error(t('TripalDefaultVocabulary: The URL could not be updated for the vocabulary, "@vocab.',
+          ['@vocab' => $this->getName()]));
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getURL() {
+    $cv = $this->loadVocab();
+    return $cv['url'];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setLabel($label) {
+    // Don't set a value for a vocabulary that isn't valid.
+    if (!$this->is_valid) {
+      return False;
+    }
+
+    // Make sure the label is not too long.
+    if (empty($label)) {
+      $this->messageLogger->error('TripalDeafultVocabulary: You must provide a label when calling setLabel().',
+          ['@size' => 255, '@value' => $label]);
+      return False;
+    }
+    if (strlen($label) > 255) {
+      $this->messageLogger->error('TripalDeafultVocabulary: The label for the vocabulary must not be longer than @size characters. ' +
+          'The value provided was: @value',
+          ['@size' => 255, '@value' => $label]);
+      return False;
+    }
+
+
+    // Update the record in the Chado `cv` table.
+    $chado = \Drupal::service('database');
+    $update = $chado->update('tripal_terms_vocabs');
+    $update = $update->fields(['label' => $label]);
+    $update = $update->condition('name', $this->getName(), '=');
+    $num_updated = $update->execute();
+    if ($num_updated != 1) {
+      $this->logInvalidCondition('TripalDeafultVocabulary: The label could not be updated for the vocabulary.');
+      return False;
+    }
+    return True;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function create() {
+
+    // Check if the record already exists in the database, if it
+    // doesn't then insert it.  We don't yet have the definition,
+    // but that's okay, the name is all that isrequired to create
+    // a record in the `cv` table.
+    $conn = \Drupal::service('database');
+    $vocab = $this->loadVocab();
+    if (!$vocab) {
+      $query = $conn->insert('tripal_terms_vocabs');
+      $query = $query->fields([
+        'name' => $this->getName(),
+        'idspaces' => serialize([]),
+      ]);
+      $query->execute();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function addIdSpace($idSpace) {
+
+    $idspaces = $this->getIdSpaceNames();
+    $idspaces[] = $idSpace;
+
+    $conn = \Drupal::service('database');
+    $update = $conn->update('tripal_terms_vocabs');
+    $update = $update->fields(['idspaces' => serialize($idspaces)]);
+    $update = $update->condition('name', $this->getName(), '=');
+    $update->execute();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function removeIdSpace($idSpace) {
+    $idspaces = $this->getIdSpaceNames();
+    if (in_array($idSpace, $idspaces)) {
+      $idspaces = array_diff($idspaces, [$idSpace]);
+      $conn = \Drupal::service('database');
+      $update = $conn->update('tripal_terms_vocabs');
+      $update = $update->fields(['idspaces' => serialize($idspaces)]);
+      $update = $update->condition('name', $this->getName(), '=');
+      $update->execute();
+    }
+  }
+}

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -92,7 +92,7 @@ class TripalDefaultVocabulary extends TripalVocabularyBase {
     // Make sure the name of this collection does not exceeed the allowed size in Chado.
     $name = $this->getName();
     if (!empty($name) AND (strlen($name) > 255)) {
-      $this->messageLogger->error('TripalDefaultVocabular: The vocabulary name must not be longer than @size characters. ' +
+      $this->messageLogger->error('TripalDefaultVocabulary: The vocabulary name must not be longer than @size characters. ' +
           'The value provided was: @value',
 	  ['@size' => 255, '@value' => $this->getName()]);
       $this->is_valid = FALSE;
@@ -119,6 +119,14 @@ class TripalDefaultVocabulary extends TripalVocabularyBase {
    * {@inheritDoc}
    */
   public function destroy() {
+    $this->messageLogger->warning('The TripalDefaultVocabulary::destroy() function is currently not implemented');
+  }
+
+    /**
+   * {@inheritdoc}
+   */
+  public function getTerms($name, $exact = True){
+    $this->messageLogger->warning('The TripalDefaultVocabulary::getTerms() function is currently not implemented');
   }
 
   /**

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -95,11 +95,12 @@ class TripalDefaultVocabulary extends TripalVocabularyBase {
     if (!empty($name) AND (strlen($name) > 255)) {
       $this->messageLogger->error('TripalDefaultVocabular: The vocabulary name must not be longer than @size characters. ' +
           'The value provided was: @value',
-          ['@size' => 255, '@value' => $this->getName()]);
+	  ['@size' => 255, '@value' => $this->getName()]);
+      $this->is_valid = FALSE;
+      return FALSE;
     }
     $this->is_valid = TRUE;
-
-    return $this->is_valid;
+    return TRUE;
   }
 
   /**

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -5,7 +5,7 @@ namespace Drupal\tripal\Plugin\TripalVocabulary;
 use Drupal\tripal\TripalVocabTerms\TripalVocabularyBase;
 
 /**
- * Chado implementation of the TripalVocabularyBase.
+ * Default implementation of the TripalVocabularyBase.
  *
  *  @TripalVocabulary(
  *    id = "tripal_default_vocabulary",

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -238,7 +238,7 @@ class TripalDefaultVocabulary extends TripalVocabularyBase {
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $id = $idsmanager->loadCollection($idSpace);
     if ($id) {
-      $id_spaces = $this->getIdSpacesCache();
+      $id_spaces = $this->getIdSpaceNames();
       $id_spaces[] = $idSpace;
       $conn = \Drupal::service('database');
       $update = $conn->update('tripal_terms_vocabs');

--- a/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
+++ b/tripal/src/Plugin/TripalVocabulary/TripalDefaultVocabulary.php
@@ -246,8 +246,8 @@ class TripalDefaultVocabulary extends TripalVocabularyBase {
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $id = $idsmanager->loadCollection($idSpace);
     if ($id) {
-      $id_spaces = $this->getIdSpaceNames();
-      $id_spaces[] = $idSpace;
+      $idspaces = $this->getIdSpaceNames();
+      $idspaces[] = $idSpace;
       $conn = \Drupal::service('database');
       $update = $conn->update('tripal_terms_vocabs');
       $update = $update->fields(['idspaces' => serialize($idspaces)]);

--- a/tripal/tests/src/Functional/Plugin/TripalDefaultIdSpaceTest.php
+++ b/tripal/tests/src/Functional/Plugin/TripalDefaultIdSpaceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\tripal\Functional\Plugin;
+
+use Drupal\Core\Database\Database;
+use Drupal\Tests\tripal\Functional\TripalTestBrowserBase;
+use Drupal\Core\Test\FunctionalTestSetupTrait;
+use Drupal\tripal\TripalVocabTerms\TripalTerm;
+
+
+
+/**
+ * Tests for the TripalDefaultIdSpace classes
+ *
+ * @group Tripal
+ * @group TripalDefaultIdSpace
+ */
+class TripalDefaultIdSpaceTest extends TripalTestBrowserBase {
+
+
+  /**
+   * A helper function to retrieve an id_space record.
+   *
+   * @param string $dbname
+   *   The name of the id_space to lookup.
+   *
+   * @return A database query result.
+   */
+  protected function getIdSpace($id_space) {
+
+    $conn = \Drupal::service('database');
+    $query = $conn->select('tripal_terms_idspaces', 'idspace');
+    $query = $query->condition('name', $id_space, '=');
+    $query = $query->fields('idspace');
+    $result = $query->execute();
+    if (!$result) {
+      return [];
+    }
+    return $result->fetchAssoc();
+  }
+
+  /**
+   * Tests the TripalDefaultIdSpace and TripalDefaultVocabulary Classes
+   *
+   */
+  public function testTripaDefaultIdSpace() {
+
+    // Create Collection managers.
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
+
+    // These are the values we'll use for the ID space and vocablary.
+    $GO_idspace = 'GO';
+    $GO_cc_namespace = 'cellular_component';
+    $GO_bp_namespace = 'biological_process';
+    $GO_mf_namespace = 'molecular_function';
+    $GO_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
+    $GO_cc_label = 'Gene Ontology Cellular Component Vocabulary';
+    $GO_bp_label = 'Gene Ontology Biological Process Vocabulary';
+    $GO_mf_label = 'Gene Ontology Molecular Function Vocabulary';
+    $GO_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
+    $GO_url = 'http://geneontology.org/';
+
+    //
+    // Testing TripalDefaultIdSpace Functionality
+    //
+
+    // Create the ID space object and make sure a Chado record got created.
+    $GO = $idsmanager->createCollection($GO_idspace, "tripal_default_id_space");
+    $db = $this->getIdSpace($GO_idspace);
+    $this->assertTrue($db['name'] == $GO_idspace, 'The name was not set correctly by the TripaDefaultIdSpace object.');
+    $this->assertEmpty($db['description'], 'The description should not be set by the TripaDefaultIdSpace object just yet.');
+    $this->assertEmpty($db['urlprefix'], 'The URL prefix should not be set by the TripaDefaultIdSpace object just yet.');
+
+    // Set the description to make sure it gets set in Chado.
+    $GO->setDescription($GO_description);
+    $db = $this->getIdSpace($GO_idspace);
+    $this->assertTrue($db['name'] == $GO_idspace, 'The name was not set correctly after updating by the TripaDefaultIdSpace object.');
+    $this->assertTrue($db['description'] == $GO_description, 'The description was not set correctly by the TripaDefaultIdSpace object.');
+    $this->assertEmpty($db['urlprefix'], 'The URL prefix should not be set by the TripaDefaultIdSpace object just yet.');
+
+    // Set the URL prefix to make sure it gets set in Chado.
+    $GO->setURLPrefix($GO_urlprefix);
+    $db = $this->getIdSpace($GO_idspace);
+    $this->assertTrue($db['name'] == $GO_idspace, 'The name was not set correctly after updating by the TripaDefaultIdSpace object.');
+    $this->assertTrue($db['description'] == $GO_description, 'The description was not set correctly after updating by the TripaDefaultIdSpace object.');
+    $this->assertTrue($db['urlprefix'] == $GO_urlprefix, 'The URL prefix was not set correctly by the TripaDefaultIdSpace object.');
+
+    // Make sure the getters work.
+    $this->assertTrue($GO->getURLPrefix() == $GO_urlprefix, "The TripaDefaultIdSpace object did not return a correct URL prefix.");
+    $this->assertTrue($GO->getDescription() == $GO_description, "The TripaDefaultIdSpace object did not return a correct description.");
+
+    // Change the description and URL prefix and make sure it updates
+    $GO->setDescription('Changed');
+    $GO->setURLPrefix('Changed');
+    $this->assertTrue($GO->getDescription() == 'Changed', "The TripaDefaultIdSpace object did not update the description.");
+    $this->assertTrue($GO->getURLPrefix() == 'Changed', "The TripaDefaultIdSpace object did not update the URL prefix.");
+
+  }
+}

--- a/tripal/tests/src/Functional/Plugin/TripalDefaultVocabularyTest.php
+++ b/tripal/tests/src/Functional/Plugin/TripalDefaultVocabularyTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Drupal\Tests\tripal\Functional\Plugin;
+
+use Drupal\Core\Database\Database;
+use Drupal\Tests\tripal\Functional\TripalTestBrowserBase;
+use Drupal\Core\Test\FunctionalTestSetupTrait;
+use Drupal\tripal\TripalVocabTerms\TripalTerm;
+
+
+/**
+ * Tests for the TripalDefaultVocabulary classes
+ *
+ * @group Tripal
+ * @group TripalDefaultVocabulary
+ */
+class TripalDefaultVocabularyTest extends TripalTestBrowserBase {
+
+  /**
+   * A helper function to retrieve a vocabulary record.
+   *
+   * @param string $vocabulary
+   *   The name of the id_space to lookup.
+   *
+   * @return object
+   *   A database query result.
+   */
+  protected function getVocabulary($vocabulary) {
+
+    $conn = \Drupal::service('database');
+    $query = $conn->select('tripal_terms_vocabs', 'vocab');
+    $query = $query->condition('name', $vocabulary, '=');
+    $query = $query->fields('vocab');
+    $result = $query->execute();
+    if (!$result) {
+      return [];
+    }
+    return $result->fetchAssoc();
+  }
+
+
+  /**
+   * A helper function to retrieve an id_space record.
+   *
+   * @param string $id_space
+   *   The name of the id_space to lookup.
+   *
+   * @return object
+   *   A database query result.
+   */
+  protected function getIdSpace($id_space) {
+
+    $conn = \Drupal::service('database');
+    $query = $conn->select('tripal_terms_idspaces', 'idspace');
+    $query = $query->fields('idspace');
+    $query = $query->condition('name', $id_space, '=');
+    $result = $query->execute();
+    if (!$result) {
+      return [];
+    }
+    return $result->fetchAssoc();
+  }
+
+
+  /**
+   * Tests the TripalDefaultIdSpace and TripalDefaultVocabulary Classes
+   *
+   */
+  public function testTripalDefaultVocabulary() {
+
+    // Create Collection managers.
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
+
+    // These are the values we'll use for the ID space and vocablary.
+    $GO_idspace = 'GO';
+    $GO_cc_namespace = 'cellular_component';
+    $GO_bp_namespace = 'biological_process';
+    $GO_mf_namespace = 'molecular_function';
+    $GO_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
+    $GO_cc_label = 'Gene Ontology Cellular Component Vocabulary';
+    $GO_bp_label = 'Gene Ontology Biological Process Vocabulary';
+    $GO_mf_label = 'Gene Ontology Molecular Function Vocabulary';
+    $GO_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
+    $GO_url = 'http://geneontology.org/';
+
+    //
+    // Testing TripalVocabulary Functionality
+    //
+
+    // Make sure the Vocabulary does not yet exist.
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $cc */
+    $cc = $vmanager->createCollection($GO_cc_namespace, "tripal_default_vocabulary");
+    $cv = $this->getVocabulary($GO_cc_namespace);
+    $this->assertTrue($cv['name'] == $GO_cc_namespace, 'The name was not set correctly by the TripalVocabulary object.');
+    $this->assertEmpty($cv['label'], 'The label should not be set by the TripalVocabulary object just yet.');
+
+    // Set the definition to make sure it gets set in the database.
+    $cc->setLabel($GO_cc_label);
+    $cv = $this->getVocabulary($GO_cc_namespace);
+    $this->assertTrue($cv['name'] == $GO_cc_namespace, 'The name was not set correctly by the TripalVocabulary object.');
+    $this->assertTrue($cv['label'] == $GO_cc_label, 'The label was not set correctly by the TripalVocabulary object.');
+
+    // Make sure the getter works.
+    $this->assertTrue($cc->getLabel() == $GO_cc_label, "The TripalVocabulary object did not return a correct label.");
+
+    // Associate the IDSpace with the vocabulary,
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $GO */
+    $GO = $idsmanager->createCollection($GO_idspace, "tripal_default_id_space");
+    $id_spaces = $cc->getIdSpaceNames();
+    $this->assertFalse(in_array($GO_idspace, $id_spaces), 'ID spaces should not be set yet in the TripalVocabulary');
+    $cc->addIdSpace($GO_idspace);
+    $id_spaces = $cc->getIdSpaceNames();
+    $this->assertTrue(in_array($GO_idspace, $id_spaces), 'The ID space is missing from the TripalVocabulary');
+
+    // Add a URL to the vocabulary, it should show up in the
+    // database table for the ID space.
+    $cv = $this->getVocabulary($GO_cc_namespace);
+    $this->assertEmpty($cv['url'], 'The URL should not be set by the TripalVocabulary object just yet.');
+    $cc->setURL($GO_url);
+    $cv = $this->getVocabulary($GO_cc_namespace);
+    $this->assertTrue($cv['url'] == $GO_url, 'The URL was not set correctly by the TripalVocabulary object.');
+    $this->assertTrue($cc->getURL() == $GO_url, 'The URL was not retrieved by the TripalVocabulary object.');
+
+    // Test adding a URL without an ID space.
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $bp */
+    $bp = $vmanager->createCollection($GO_bp_namespace, "tripal_default_vocabulary");
+    $bp->setLabel($GO_bp_label);
+    $bp->setURL($GO_url);
+    $this->assertFalse($bp->getURL() == $GO_url, 'The URL should not be set without an ID Space');
+
+    // Test adding a default vocabulary to an ID space.  This should call the
+    // addIdSpace() function on the vocabulary as well.
+    $GO->setDefaultVocabulary($GO_bp_namespace);
+    $this->assertTrue($GO->getDefaultVocabulary() == $GO_bp_namespace, 'The default vocabulary was not set correctly by the ChadoIdSpace object.');
+    $bp->setURL($GO_url);
+    $this->assertTrue($bp->getURL() == $GO_url, 'The URL was not set correctly by the TripalVocabulary after setting the default vocabulary.');
+
+    //
+    // Testing multiple ID spaces per Vocabulary
+    //
+    $EDAM_data_idspace = 'data';
+    $EDAM_format_idspace = 'format';
+    $EDAM_operation_idspace = 'operation';
+    $EDAM_topic_idspace = 'topic';
+    $EDAM_namespace = 'EDAM';
+    $EDAM_data_description = "Information, represented in an information artefact.";
+    $EDAM_format_description = "A defined way or layout of representing and structuring data";
+    $EDAM_operation_description = "A function that processes a set of inputs and results in a set of outputs";
+    $EDAM_topic_description = "A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology";
+    $EDAM_label = 'Gene Ontology Cellular Component Vocabulary';
+    $EDAM_urlprefix = "http://edamontology.org/{db}_{accession}";
+    $EDAM_url = 'http://edamontology.org';
+
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $edam */
+    $edam = $vmanager->createCollection($EDAM_namespace, "tripal_default_vocabulary");
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $edam_data */
+    $edam_data = $idsmanager->createCollection($EDAM_data_idspace, "tripal_default_id_space");
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $edam_format */
+    $edam_format = $idsmanager->createCollection($EDAM_format_idspace, "tripal_default_id_space");
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $edam_operation */
+    $edam_operation = $idsmanager->createCollection($EDAM_operation_idspace, "tripal_default_id_space");
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $edam_topic */
+    $edam_topic = $idsmanager->createCollection($EDAM_topic_idspace, "tripal_default_id_space");
+
+    $edam_data->setDefaultVocabulary($EDAM_namespace);
+    $edam_format->setDefaultVocabulary($EDAM_namespace);
+    $edam_operation->setDefaultVocabulary($EDAM_namespace);
+    $edam_topic->setDefaultVocabulary($EDAM_namespace);
+    $edam->setLabel($EDAM_label);
+    $edam->setURL($EDAM_url);
+    $edam_data->setURLPrefix($EDAM_urlprefix);
+    $edam_format->setURLPrefix($EDAM_urlprefix);
+    $edam_operation->setURLPrefix($EDAM_urlprefix);
+    $edam_topic->setURLPrefix($EDAM_urlprefix);
+    $edam_data->setDescription($EDAM_data_description);
+    $edam_format->setDescription($EDAM_format_description);
+    $edam_operation->setDescription($EDAM_operation_description);
+    $edam_topic->setDescription($EDAM_topic_description);
+
+    // Make sure that all of the ID spaces have been aded to the vocabulary.
+    $id_spaces = $edam->getIdSpaceNames();
+    $this->assertTrue(in_array($EDAM_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($EDAM_format_idspace, $id_spaces), "The EDAM format ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($EDAM_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($EDAM_topic_idspace, $id_spaces), "The EDAM topic ID space is missing from the vocabulary ID spaces.");
+
+    // Just do a nother check to make sure the vocabularies and ID spaces got setup correctly.
+    $this->assertTrue($edam->getLabel() == $EDAM_label, "The EDAM label was not correctly returned.");
+    $this->assertTrue($edam->getURL() == $EDAM_url, "The EDAM URL was not correctly returned.");
+    $this->assertTrue($edam->getNameSpace() == $EDAM_namespace, "The EDAM namespace was not correctly returned.");
+    $this->assertTrue($edam_data->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM data ID Space is not correct.");
+    $this->assertTrue($edam_format->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM format ID Space is not correct.");
+    $this->assertTrue($edam_operation->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM operation ID Space is not correct.");
+    $this->assertTrue($edam_topic->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM topic ID Space is not correct.");
+    $this->assertTrue($edam_data->getDescription() == $EDAM_data_description, "The EDAM data ID space's description was not correctly returned.");
+    $this->assertTrue($edam_format->getDescription() == $EDAM_format_description, "The EDAM format ID space's description was not correctly returned.");
+    $this->assertTrue($edam_operation->getDescription() == $EDAM_operation_description, "The EDAM operation ID space's description was not correctly returned.");
+    $this->assertTrue($edam_topic->getDescription() == $EDAM_topic_description, "The EDAM topic ID space's description was not correctly returned.");
+    $this->assertTrue($edam_data->getURLPrefix() == $EDAM_urlprefix, "The EDAM data ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_format->getURLPrefix() == $EDAM_urlprefix, "The EDAM format ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_operation->getURLPrefix() == $EDAM_urlprefix, "The EDAM operation ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_topic->getURLPrefix() == $EDAM_urlprefix, "The EDAM topic ID space's URL PRefix space description was not correctly returned.");
+
+    // Test removing an ID space
+    $edam->removeIdSpace($EDAM_format_idspace);
+    $edam->removeIdSpace($EDAM_topic_idspace);
+    $id_spaces = $edam->getIdSpaceNames();
+    $this->assertTrue(in_array($EDAM_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
+    $this->assertFalse(in_array($EDAM_format_idspace, $id_spaces), "The EDAM format ID space is not missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($EDAM_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
+    $this->assertFalse(in_array($EDAM_topic_idspace, $id_spaces), "The EDAM topic ID space is not missing from the vocabulary ID spaces.");
+  }
+}

--- a/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
+++ b/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
@@ -356,7 +356,7 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
     $this->assertTrue($dummy->isValid(), 'The dummy TripalTerm reports it is not valid when it is.');
 
     //
-    // Inserting (Saving) Terms to Chado.
+    // Inserting (Saving) Terms.
     //
 
     // We need to save the comment term first s this is used
@@ -427,7 +427,7 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
     $this->assertTrue($parents['GO:0008150'][1]->getName() == 'is_a', 'The getTerm->getParents function did not return parents in the correct format (type).');
 
     //
-    // Updating (Saving) Terms in Chado.
+    // Updating (Saving) Terms.
     //
 
     // Remove all optional attributes and save.

--- a/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
+++ b/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
@@ -87,56 +87,591 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
 	}
 
 	/**
+	 * A helper function to retrieve a term record.
+	 *
+	 * @param string $cvname
+	 * @param string $cvterm_name
+	 */
+	protected function getCVterm($cvname, $cvterm_name) {
+
+	  $conn = \Drupal::service('database');
+	  $query = $conn->select('tripal_terms', 'tt');
+	  $query = $query->fields('tt');
+	  $query = $query->condition('vocabulary', $cvname, '=');
+	  $query = $query->condition('name', $cvterm_name, '=');
+	  $result = $query->execute();
+	  if (!$result) {
+	    return [];
+	  }
+	  return $result->fetchAssoc();
+	}
+
+
+	/**
    * Basic tests for Tripal Term.
    *
    * @group TripalVocabTerms
    */
   public function testTripalTerm() {
 
-    // Test the TripalTerm object.
-    // --Test creation of a TripalTerm provided the expected input.
-    //   NOTE: the use Drupal\tripal\TripalVocabTerms\TripalTerm
-    //   at the top of this file allows us to use TripalTerm here.
-    $term = new TripalTerm([
-      'name' => 'gene',
-      'definition' => 'A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.',
-      'idSpace' => 'SO',
-      'accession' => '0000704',
-      'vocabulary' => 'sequence'
+    // Create Collection managers.
+    /** @var \Drupal\tripal\TripalVocabTerms\PluginManagers\TripalIdSpaceManager $idsmanager */
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    /** @var \Drupal\tripal\TripalVocabTerms\PluginManagers\TripalVocabularyManager $vmanager */
+    $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
+
+    // These are the values we'll use for the ID space and vocablary.
+    $GO_idspace = 'GO';
+    $GO_cc_namespace = 'cellular_component';
+    $GO_bp_namespace = 'biological_process';
+    $GO_mf_namespace = 'molecular_function';
+    $GO_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
+    $GO_cc_label = 'Gene Ontology Cellular Component Vocabulary';
+    $GO_bp_label = 'Gene Ontology Biological Process Vocabulary';
+    $GO_mf_label = 'Gene Ontology Molecular Function Vocabulary';
+    $GO_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
+    $GO_url = 'http://geneontology.org/';
+
+    /** @var \Drupal\tripal\Plugin\TripalIdSpace\TripalDefaultIdSpace $GO */
+    $GO = $idsmanager->createCollection($GO_idspace, "tripal_default_id_space");
+    $GO->setDescription($GO_description);
+    $GO->setURLPrefix($GO_urlprefix);
+
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $cc */
+    $cc = $vmanager->createCollection($GO_cc_namespace, "tripal_default_vocabulary");
+    $cc->setLabel($GO_cc_label);
+    $cc->setURL($GO_url);
+
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $bp */
+    $bp = $vmanager->createCollection($GO_bp_namespace, "tripal_default_vocabulary");
+    $bp->setLabel($GO_bp_label);
+    $bp->setURL($GO_url);
+
+    /** @var \Drupal\tripal\Plugin\TripalVocabulary\TripalDefaultVocabulary $bb */
+    $mf = $vmanager->createCollection($GO_mf_namespace, "tripal_default_vocabulary");
+    $mf->setLabel($GO_mf_label);
+    $mf->setURL($GO_url);
+
+    $GO->setDefaultVocabulary($GO_cc_namespace);
+
+    // First create a term for the comment property.
+    $rdfs_vocab = $vmanager->createCollection("rdfs", "tripal_default_vocabulary");
+    $rdfs_vocab->setLabel('Resource Description Framework Schema');
+    $rdfs_vocab->setURL('https://www.w3.org/TR/rdf-schema/');
+    $rdfs_id = $idsmanager->createCollection('rdfs', "tripal_default_id_space");
+    $rdfs_id->setDescription('Resource Description Framework Schema	');
+    $rdfs_id->setURLPrefix('http://www.w3.org/2000/01/rdf-schema#{accession}');
+    $rdfs_id->setDefaultVocabulary('rdfs', 'tripal_default_vocabulary');
+    $comment = new TripalTerm();
+    $comment->setName('comment');
+    $comment->setIdSpace('rdfs');
+    $comment->setVocabulary('rdfs');
+    $comment->setAccession('comment');
+    $this->assertTrue($comment->getName() == 'comment', 'The "comment" TripalTerm returned an incorrect name.');
+    $this->assertTrue($comment->getAccession() == 'comment', 'The "comment" TripalTerm returned an incorrect accession.');
+    $this->assertTrue($comment->getTermId() == 'rdfs:comment', 'The "comment" TripalTerm returned an incorrect term ID.');
+    $this->assertTrue($comment->getVocabulary() == 'rdfs', 'The "comment" TripalTerm returned an incorrect vocabulary.');
+    $this->assertTrue($comment->getIdSpace() == 'rdfs', 'The "comment" TripalTerm returned an incorrect ID space.');
+    $this->assertTrue($comment->getURL() == 'http://www.w3.org/2000/01/rdf-schema#comment', 'The "comment" TripalTerm returned an incorrect URL.');
+
+    // Create a parent term using the built-in setters.
+    $parent = new TripalTerm();
+    $parent->setName('biological_process');
+    $parent->setIdSpace('GO');
+    $parent->setVocabulary('biological_process');
+    $parent->setAccession('0008150');
+    $parent_definition = 'A biological process represents a specific objective that the organism is ' .
+        'genetically programmed to achieve. Biological processes are often described by their outcome ' .
+        'or ending state, e.g., the biological process of cell division results in the creation of two ' .
+        'daughter cells (a divided cell) from a single parent cell. A biological process is accomplished ' .
+        'by a particular set of molecular functions carried out by specific gene products (or ' .
+        'macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.';
+    $parent->setDefinition($parent_definition);
+    $parent->addAltId('GO', '0000004');
+    $parent->addAltId('GO', '0007582');
+    $parent->addAltId('GO', '0044699');
+    $parent->addSynonym('biological process');
+    $parent->addSynonym('physiological process');
+    $parent->addSynonym('single organism process');
+    $parent->addSynonym('single-organism process');
+    $parent_comment = 'Note that, in addition to forming the root of the biological process ontology, ' .
+        'this term is recommended for use for the annotation of gene products whose biological process ' .
+        'is unknown. When this term is used for annotation, it indicates that no information was available ' .
+        'about the biological process of the gene product annotated as of the date the annotation was made; ' .
+        'the evidence code \'no data\' (ND), is used to indicate this.';
+    $parent->addProperty($comment, $parent_comment);
+
+    // Run a suite of tests on the term.
+    $this->assertTrue($parent->getName() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect name.');
+    $this->assertTrue($parent->getAccession() == '0008150', 'The "biological_process" TripalTerm returned an incorrect accession.');
+    $this->assertTrue($parent->getTermId() == 'GO:0008150', 'The "biological_process" TripalTerm returned an incorrect term ID.');
+    $this->assertTrue($parent->getDefinition() == $parent_definition, 'The "biological process" TripalTerm returned and incorrect definition.');
+    $this->assertTrue($parent->getVocabulary() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect vocabulary.');
+    $this->assertTrue($parent->getIdSpace() == 'GO', 'The "biological_process" TripalTerm returned an incorrect ID space.');
+    $this->assertTrue($parent->getURL() == 'http://amigo.geneontology.org/amigo/term/GO:0008150', 'The "biological_process" TripalTerm returned an incorrect URL.');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $parent->removeSynonym('physiological process');
+    $parent->removeSynonym('single-organism process');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
+    $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertTrue(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $parent->removeAltId('GO', '0007582');
+    $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertFalse(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm contains an alternative ID that should have been removed.');
+    $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $properties = $parent->getProperties();
+    $this->assertTrue(array_key_exists('rdfs:comment', $properties), 'The "biological_process" TripalTerm is missing the comment property.');
+    $this->assertTrue($properties['rdfs:comment'][0][1] == $parent_comment, 'The "biological_process" TripalTerm comment property value was not returned correctly.');
+    $parent->removeProperty('rdfs', 'comment', 0);
+    $properties = $parent->getProperties();
+    $this->assertEmpty($properties, 'The "biological_process" TripalTerm should not have any properties');
+
+    // Recreate the term using the constructor instead of the setters.
+    $parent = new TripalTerm([
+      'name' => 'biological_process',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0008150',
+      'definition' => $parent_definition,
+      'altIDs' => [
+        ['GO', '0000004'],
+        ['GO', '0007582'],
+        ['GO', '0044699'],
+      ],
+      'synonyms' => [
+        'biological process',
+        'physiological process',
+        'single organism process',
+        'single-organism process',
+      ],
+      'properties' => [
+        [$comment, $parent_comment],
+      ],
     ]);
-    $this->assertIsObject(
-      $term,
-      'When trying to create a new TripalTerm, an object was not produced.'
-    );
-    $this->assertInstanceOf(
-      TripalTerm::class,
-      $term,
-      'The term created was not of type TripalTerm.'
-    );
 
-    // --Test that we can pull out all the properties we set on creation.
-    // @todo
+    // Re-run the same tests above on this recreated term.// Run a suite of tests on the term.
+    $this->assertTrue($parent->getName() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect name.');
+    $this->assertTrue($parent->getAccession() == '0008150', 'The "biological_process" TripalTerm returned an incorrect accession.');
+    $this->assertTrue($parent->getTermId() == 'GO:0008150', 'The "biological_process" TripalTerm returned an incorrect term ID.');
+    $this->assertTrue($parent->getDefinition() == $parent_definition, 'The "biological process" TripalTerm returned and incorrect definition.');
+    $this->assertTrue($parent->getVocabulary() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect vocabulary.');
+    $this->assertTrue($parent->getIdSpace() == 'GO', 'The "biological_process" TripalTerm returned an incorrect ID space.');
+    $this->assertTrue($parent->getURL() == 'http://amigo.geneontology.org/amigo/term/GO:0008150', 'The "biological_process" TripalTerm returned an incorrect URL.');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $parent->removeSynonym('physiological process');
+    $parent->removeSynonym('single-organism process');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
+    $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertTrue(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $parent->removeAltId('GO', '0007582');
+    $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $this->assertFalse(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm contains an alternative ID that should have been removed.');
+    $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
+    $properties = $parent->getProperties();
+    $this->assertTrue(array_key_exists('rdfs:comment', $properties), 'The "biological_process" TripalTerm is missing the comment property.');
+    $this->assertTrue($properties['rdfs:comment'][0][1] == $parent_comment, 'The "biological_process" TripalTerm comment property value was not returned correctly.');
+    $parent->removeProperty('rdfs', 'comment', 0);
+    $properties = $parent->getProperties();
+    $this->assertEmpty($properties, 'The "biological_process" TripalTerm should not have any properties');
 
-    // --Test that we can set new properties and retrieve them.
-    // @todo
+    // Next create a relationship type term.
+    $is_a = new TripalTerm();
+    $is_a->setName('is_a');
+    $is_a->setIdSpace('GO');
+    $is_a->setVocabulary('biological_process');
+    $is_a->setAccession('is_a');
+    $is_a->setIsRelationshipType(True);
+    $this->assertTrue($is_a->isRelationshipType(), 'The "is_a" TripalTerm failed to indicate it is a relationship term.');
 
-    // --Test retrieving the default vocabulary object.
-    // @todo
+    // Next create a child term and set its parent.
+    $child = new TripalTerm();
+    $child->setName('biological phase');
+    $child->setIdSpace('GO');
+    $child->setVocabulary('biological_process');
+    $child->setAccession('0044848');
+    $child->setDefinition('A distinct period or stage in a biological process or cycle.');
+    $child_comment = 'Note that phases are is_a disjoint from other biological processes. ' .
+        'happens_during relationships can operate between phases and other biological processes ' .
+        'e.g. DNA replication happens_during S phase.';
+    $child->addProperty($comment, $child_comment);
+    $child->addParent($parent, $is_a);
 
-    // --Test retrieving the ID Space object.
-    // @todo
+    // Test the parent/child relationship.
+    $parents = $child->getParents();
+    $this->assertTrue(array_key_exists('GO:0008150', $parents), 'The "biological phase" TripalTerm did not return a parent.');
+    $this->assertTrue($parents['GO:0008150'][0]->getTermId() == 'GO:0008150', 'The "biological phase" TripalTerm parent is out of order. The parent term should be first in the tuple.');
+    $this->assertTrue($parents['GO:0008150'][1]->getTermId() == 'GO:is_a', 'The "biological phase" TripalTerm parent is out of order. The relationship term should be second in the tuple.');
+    $child->removeParent('GO', '0008150');
+    $parents = $child->getParents();
+    $this->assertEmpty($parents, 'The "biological phase" TripalTerm should not have any parents after they were removed.');
 
-    // --Test retrieving the attribution URL for a term.
-    // @todo
+    // Recreate the parent relationship using the constructor.
+    $child = new TripalTerm([
+      'name' => 'biological phase',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'definition' => 'A distinct period or stage in a biological process or cycle.',
+      'accession' => '0044848',
+      'properties' => [
+        [$comment, $child_comment]
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
 
-    // --Test term equality.
-    // @todo
+    // Repeat the tests for the relationships.
+    $parents = $child->getParents();
+    $this->assertTrue(array_key_exists('GO:0008150', $parents), 'The "biological phase" TripalTerm did not return a parent.');
+    $this->assertTrue($parents['GO:0008150'][0]->getTermId() == 'GO:0008150', 'The "biological phase" TripalTerm parent is out of order. The parent term should be first in the tuple.');
+    $this->assertTrue($parents['GO:0008150'][1]->getTermId() == 'GO:is_a', 'The "biological phase" TripalTerm parent is out of order. The relationship term should be second in the tuple.');
+    $child->removeParent('GO', '0008150');
+    $parents = $child->getParents();
+    $this->assertEmpty($parents, 'The "biological phase" TripalTerm should not have any parents after they were removed.');
 
-    // --Test that you can save a term to permanent storage and then retrieve it.
-    // @todo
+    // Make sure the isVald works.
+    $dummy = new TripalTerm();
+    $this->assertFalse($dummy->isValid(), 'The dummy TripalTerm reports it is valid when it is not (Test 1).');
+    $dummy->setName('dummy');
+    $this->assertFalse($dummy->isValid(), 'The dummy TripalTerm reports it is valid when it is not (Test 2).');
+    $dummy->setIdSpace('GO');
+    $this->assertFalse($dummy->isValid(), 'The dummy TripalTerm reports it is valid when it is not (Test 3).');
+    $dummy->setVocabulary('biological_process');
+    $this->assertFalse($dummy->isValid(), 'The dummy TripalTerm reports it is valid when it is not (Test 4).');
+    $dummy->setAccession('dummy');
+    $this->assertTrue($dummy->isValid(), 'The dummy TripalTerm reports it is not valid when it is.');
 
-    // --Test the static suggestTerms() functionality.
-    // @todo
+    //
+    // Inserting (Saving) Terms to Chado.
+    //
+
+    // We need to save the comment term first s this is used
+    // for a property in our new child term below.
+    $rdfs_id->saveTerm($comment);
+    $GO->saveTerm($parent);
+    $GO->saveTerm($is_a);
+
+    $cvterm = $this->getCVterm('rdfs', 'comment');
+    $this->assertTrue(!empty($cvterm) and $cvterm['name'] == 'comment', 'The term did not save a proper cvterm record  (Test #1).');
+    $comment2 = $rdfs_id->getTerm('comment');
+    $this->assertFalse($comment2->isRelationshipType(), 'The getTerm function did not return a term with the is_relationshiptype value loaded properly.');
+
+    // Create a new term for saving.
+    $new_child_def = 'The internally coordinated responses (actions or inactions) of animals (individuals or groups) to internal or external stimuli, via a mechanism that involves nervous system activity. Source: PMID:20160973, GOC:ems, GOC:jl, ISBN:0395448956';
+    $new_child_comment = 'Note that this term is in the subset of terms that should not be used for direct gene product annotation. Instead, select a child term or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation reviews. 2. While a broader definition of behavior encompassing plants and single cell organisms would be justified on the basis of some usage (see PMID:20160973 for discussion), GO uses a tight definition that limits behavior to animals and to responses involving the nervous system, excluding plant responses that GO classifies under development, and responses of unicellular organisms that has general classifications for covering the responses of cells in multicellular organisms (e.g. cell chemotaxis).';
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        'behavioral response to stimulus',
+        'behaviour',
+        'behavioural response to stimulus',
+        'single-organism behavior'
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $cvterm = $this->getCVterm('biological_process', 'behavior');
+    $this->assertTrue(!empty($cvterm) and $cvterm['name'] == 'behavior', 'The term did not save a proper cvterm record (Test #2).');
+
+    // Now that the term is saved, load it and see if all of the attributes are properly set.
+    $new_child2 = $GO->getTerm('0007610');
+    $this->assertTrue($new_child2->getName() == 'behavior', 'The getTerm function did not return a term with the name loaded properly.');
+    $this->assertTrue($new_child2->getDefinition() == $new_child_def, 'The getTerm function did not return a term with the definition loaded properly.');
+    $this->assertFalse($new_child2->isObsolete(), 'The getTerm function did not return a term with the is_obsolete value loaded properly.');
+    $this->assertFalse($new_child2->isRelationshipType(), 'The getTerm function did not return a term with the is_obsolete value loaded properly.');
+    $props = $new_child2->getProperties();
+    $this->assertTrue(array_keys($props)[0] == 'rdfs:comment', 'The getTerm->getProperties function did not return properties in the correct format (keys).');
+    $this->assertTrue(count($props['rdfs:comment'][0]) == 2, 'The getTerm->getProperties function did not return properties in the correct format (tuples).');
+    $this->assertTrue($props['rdfs:comment'][0][0]->getName() == 'comment',  'The getTerm->getProperties function did not return properties in the correct format (type).');
+    $this->assertTrue($props['rdfs:comment'][0][1] == $new_child_comment, 'The getTerm->getProperties function did not return properties in the correct format (value).');
+    $altIds = $new_child2->getAltIds();
+    $this->assertTrue(in_array('GO:0044709', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #1).');
+    $this->assertTrue(in_array('GO:0023032', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #2).');
+    $this->assertTrue(in_array('GO:0044708', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #3).');
+    $synonyms = $new_child2->getSynonyms();
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #1).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #2).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #3).');
+    $this->assertTrue(in_array('single-organism behavior', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #4).');
+    $parents = $new_child2->getParents();
+    $this->assertTrue(array_keys($parents)[0] == 'GO:0008150', 'The getTerm->getParents function did not return parents in the correct format (keys).');
+    $this->assertTrue($parents['GO:0008150'][0]->getName() == 'biological_process',  'The getTerm->getParents function did not return parents in the correct format (term).');
+    $this->assertTrue($parents['GO:0008150'][1]->getName() == 'is_a', 'The getTerm->getParents function did not return parents in the correct format (type).');
+
+    //
+    // Updating (Saving) Terms in Chado.
+    //
+
+    // Remove all optional attributes and save.
+    $new_child2->removeAltId('GO', '0044709');
+    $new_child2->removeAltId('GO', '0023032');
+    $new_child2->removeAltId('GO', '0044708');
+    $new_child2->removeSynonym('behavioral response to stimulus');
+    $new_child2->removeSynonym('behavioural response to stimulus');
+    $new_child2->removeSynonym('behaviour');
+    $new_child2->removeSynonym('single-organism behavior');
+    $new_child2->removeParent('GO', '0008150');
+    $new_child2->removeProperty('rdfs', 'comment', 0);
+    $GO->saveTerm($new_child2);
+    $new_child3 = $GO->getTerm('0007610');
+    $this->assertTrue(count(array_keys($new_child3->getProperties())) == 0, 'Updates to a term are not removing properties correctly');
+    $this->assertTrue(count($new_child3->getAltIds()) == 0, 'Updates to a term are not removing alt IDs correctly');
+    $this->assertTrue(count(array_keys($new_child3->getSynonyms())) == 0, 'Updates to a term are not removing synonyms correctly');
+    $this->assertTrue(count(array_keys($new_child3->getParents())) == 0, 'Updates to a term are not removing parents correctly');
+
+    // Add back in at least 1 attribute and save.
+    $new_child3->addSynonym('behaviour');
+    $new_child3->addAltId('GO', '0044708');
+    $new_child3->addParent($parent, $is_a);
+    $new_child3->addProperty($comment, $new_child_comment);
+    $GO->saveTerm($new_child3);
+    $new_child4 = $GO->getTerm('0007610');
+    $this->assertTrue(count(array_keys($new_child4->getProperties())) == 1, 'Updates to a term are not adding properties correctly');
+    $this->assertTrue(count($new_child4->getAltIds()) == 1, 'Updates to a term are not adding alt IDs correctly');
+    $this->assertTrue(count(array_keys($new_child4->getSynonyms())) == 1, 'Updates to a term are not adding synonyms correctly');
+    $this->assertTrue(count(array_keys($new_child4->getParents())) == 1, 'Updates to a term are not adding parents correctly');
+
+    // Test updating of the boolean values
+    $new_child4->setIsObsolete(True);
+    $new_child4->setIsRelationshipType(True);
+    $GO->saveTerm($new_child4);
+    $new_child5 = $GO->getTerm('0007610');
+    $this->assertTrue($new_child5->isRelationshipType(), 'Updates to the relationship type did not get set when updating a term.');
+    $this->assertTrue($new_child5->isObsolete(), 'Updates to the obsolete value did not get set when updating a term.');
+    $new_child5->setIsObsolete(False);
+    $new_child5->setIsRelationshipType(False);
+    $GO->saveTerm($new_child5);
+    $new_child6 = $GO->getTerm('0007610');
+    $this->assertFalse($new_child6->isRelationshipType(), 'Updates to the relationship type did not get unset when updating a term.');
+    $this->assertFalse($new_child6->isObsolete(), 'Updates to the obsolete value did not get unset when updating a term.');
+
+    //
+    // Finding Terms
+    //
+
+    // Restore the parent to its full state.
+    $parent = new TripalTerm([
+      'name' => 'biological_process',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0008150',
+      'definition' => $parent_definition,
+      'altIDs' => [
+        ['GO', '0000004'],
+        ['GO', '0007582'],
+        ['GO', '0044699'],
+      ],
+      'synonyms' => [
+        'biological process',
+        'physiological process',
+        'single organism process',
+        'single-organism process',
+      ],
+      'properties' => [
+        [$comment, $parent_comment],
+      ],
+    ]);
+
+    $GO->saveTerm($parent);
+
+    // Restore the child to its full state.
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        'behavioral response to stimulus',
+        'behaviour',
+        'behavioural response to stimulus',
+        'single-organism behavior'
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+
+    $terms = $GO->getTerms('behav');
+    $this->assertTrue(count(array_keys($terms)) == 4, 'Searching for a non exact term did not yield the correct number of matches.');
+    $this->assertTrue(in_array('behavior', array_keys($terms)), 'Searching for a term did not return the matched name of a term.');
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term (Test #1).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #2).');
+    $this->assertTrue(in_array('behaviour', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #3).');
+    $terms = $GO->getTerms('behav', ['exact' => True]);
+    $this->assertTrue(count(array_keys($terms)) == 0, 'Searching for an exact term that does not match anything did not return 0 matches.');
+    $terms = $GO->getTerms('behavioral response to stimulus', ['exact' => True]);
+    $this->assertTrue(count(array_keys($terms)) == 1, 'Searching for an exact term using the synonym did not return a match.');
+    $terms = $GO->getTerms('biological');
+    $this->assertTrue(count(array_keys($terms)) == 2, 'Searching for a non exact term that should match two terms did not.');
+
+    //
+    // Get Children
+    //
+
+    // Restore the child to its full state.
+    $child = new TripalTerm([
+      'name' => 'biological phase',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'definition' => 'A distinct period or stage in a biological process or cycle.',
+      'accession' => '0044848',
+      'properties' => [
+        [$comment, $child_comment]
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($child);
+
+    $children = $GO->getChildren($parent);
+    $this->assertTrue(count($children) == 2, 'The number of children returned for the parent is incorrect.');
+    $child_names = [$children[0][0]->getName(), $children[1][0]->getName()];
+    $this->assertTrue(in_array('behavior', $child_names), 'The list of children for the parent does not have a correct child name (Test #1).');
+    $this->assertTrue(in_array('biological phase', $child_names), 'The list of children for the parent does not have a correct child name (Test #2).');
+    $rel_types = [$children[0][1]->getName(), $children[1][1]->getName()];
+    $this->assertTrue(in_array('is_a', $rel_types), 'The list of children relationship types for the parent does not have the correct type.');
+
+
+    //
+    // Testing synonym types.
+    //
+
+    // Create a type for the synonyms.
+    $syn_vocab = $vmanager->createCollection("synonym_type", "tripal_default_vocabulary");
+    $syn_id = $idsmanager->createCollection('synonym_type', "tripal_default_id_space");
+    $exact = new TripalTerm();
+    $exact->setName('exact');
+    $exact->setIdSpace('synonym_type');
+    $exact->setVocabulary('synonym_type');
+    $exact->setAccession('exact');
+    $syn_id->saveTerm($exact);
+
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        ['behavioral response to stimulus', $exact],
+        ['behaviour', $exact],
+        ['behavioural response to stimulus', $exact],
+        ['single-organism behavior', $exact]
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(count(array_keys($synonyms)) == 4, 'The number of synonyms returned is not correct.');
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing (Test #1).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The synonyms is missing (Test #2).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($synonyms)), 'The synonyms is missing (Test #3).');
+    $this->assertTrue(in_array('single-organism behavior', array_keys($synonyms)), 'The synonyms is missing (Test #4).');
+    $this->assertTrue($synonyms['behavioral response to stimulus']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['behaviour']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['behavioural response to stimulus']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['single-organism behavior']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+
+    // Repeat the test,but adding the synonyms using setters.
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(count($synonyms) == 0, 'There should be no synonyms but some were returned.');
+    $new_child->addSynonym('behavioral response to stimulus', $exact);
+    $new_child->addSynonym('behaviour', $exact);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #3).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #2).');
+    $this->assertTrue($synonyms['behavioral response to stimulus']->getName() == 'exact', 'The synonym type is incorrect after using the addSynonyms function (Test #1).');
+    $this->assertTrue($synonyms['behaviour']->getName() == 'exact', 'The synonym type is incorrect after using the addSynonyms function (Test #1).');
+
+    //
+    // Saving an invalid term
+    //
+    $dummy = new TripalTerm();
+    $dummy->setName('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #1)');
+    $dummy->setDefinition('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #2)');
+    $dummy->setAccession('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #3)');
+    $dummy->setIdSpace('GO');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #4)');
+    $dummy->setVocabulary('biological_process');
+    $this->assertTrue($GO->saveTerm($dummy), 'A valid term did not return True when saving');
+
+    // Try to save a term that doesn't belong to the idSpace
+    $this->assertFalse($rdfs_id->saveTerm($dummy), 'A term that did not belong to an idSpace should not have been saved.');
 
 	}
 }

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -153,7 +153,180 @@ function tripal_schema() {
 
   // Adds a table for administrative notifications on the dashboard.
   $schema['tripal_admin_notifications'] = tripal_tripal_admin_notifications_schema();
+
+  $schema['tripal_terms'] = tripal_tripal_terms_schema();
+  $schema['tripal_terms_idspaces'] = tripal_tripal_terms_idspaces_schema();
+  $schema['tripal_terms_vocabs'] = tripal_tripal_terms_vocabs_schema();
   return $schema;
+}
+
+/**
+ *
+ */
+function tripal_tripal_terms_vocabs_schema() {
+  return [
+    'fields' => [
+      'vocab_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'name' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'label' => [
+        'type' => 'varchar',
+        'length' => 1024,
+        'not null' => FALSE,
+      ],
+      'url' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+      'idspaces' => [
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+    ],
+    'indexes' => [
+      'name' => ['name'],
+    ],
+    'unique keys' => [
+      'label_unq1' => ['name'],
+    ],
+    'primary key' => ['vocab_id'],
+  ];
+}
+
+/**
+ *
+ */
+function tripal_tripal_terms_idspaces_schema() {
+  return [
+    'fields' => [
+      'idspace_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'name' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'description' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+      'urlprefix' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+      'default_vocab' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+    ],
+    'indexes' => [
+      'name' => ['name'],
+    ],
+    'unique keys' => [
+      'label_unq1' => ['name'],
+    ],
+    'primary key' => ['idspace_id'],
+  ];
+}
+
+/**
+ *
+ */
+function tripal_tripal_terms_schema() {
+  // @todo: Storing parents and synonyms in a text field will make it
+  // slow to lookup terms by those names.  Since this table is just to
+  // provide some sort of default storage so that Tripal can work without
+  // Chado it may not be that big of a deal.  But if there is a case
+  // where this table is used for storing massive numbers of terms it
+  // will need to be optimized.
+  return [
+    'fields' => [
+      'term_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'name' => [
+        'type' => 'varchar',
+        'length' => 1024,
+        'not null' => TRUE,
+      ],
+      'definition' => [
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+      'accession' => [
+        'type' => 'varchar',
+        'length' => 1024,
+        'not null' => TRUE,
+      ],
+      'is_obsolete' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+      ],
+      'is_relationship_type' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+      ],
+      'id_space' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'vocabulary' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'parents' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+      'altIds' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+      'synonyms' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+      'properties' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+    ],
+    'indexes' => [
+      'term_id' => ['term_id'],
+      'name' => ['name'],
+      'vocabulary' => ['vocabulary'],
+      'id_space' => ['id_space'],
+      'name_vocab' => ['name', 'id_space', 'vocabulary'],
+    ],
+    'unique keys' => [
+      'term_full_accession' => ['id_space', 'accession'],
+    ],
+    'primary key' => ['term_id'],
+  ];
 }
 
 /**

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -75,12 +75,12 @@ class ChadoIdSpace extends TripalIdSpaceBase {
           'The value provided was: @value',
           ['@size' => $this->db_def['fields']['name']['size'],
            '@value' => $this->getName()]);
-      return;
+      $this->is_valid = FALSE;
+      return FALSE;
     }
 
-    $this->is_valid = True;
-
-    return $this->is_valid;
+    $this->is_valid = TRUE;
+    return TRUE;
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -237,9 +237,10 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     $query->join('1:dbxref', 'DBX', '"CVT".dbxref_id = "DBX".dbxref_id');
     $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
     $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
-    $query->fields('CVT', ['cvterm_id', 'name', 'definition', 'is_obsolete', 'is_relationshiptype'])
-      ->condition('DB.name', $this->getName(), '=')
-      ->condition('DBX.accession', $accession, '=');
+    $query->fields('CVT', ['cvterm_id', 'name', 'definition', 'is_obsolete', 'is_relationshiptype']);
+    $query->fields('CV', ['name']);
+    $query->condition('DB.name', $this->getName(), '=');
+    $query->condition('DBX.accession', $accession, '=');
     $cvterm = $query->execute()->fetchObject();
     // @debug print "CVTERM looked up by ChadoIdSpace->getTerm() in db: ".$chado->getSchemaName().". " . print_r($cvterm, TRUE) . "\n";
 
@@ -251,7 +252,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       'definition' => $cvterm->definition,
       'accession' => $accession,
       'idSpace' => $this->getName(),
-      'vocabulary' => $this->getDefaultVocabulary(),
+      'vocabulary' => $cvterm->CV_name ? $cvterm->CV_name : $this->getDefaultVocabulary(),
       'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,
       'is_relationship_type' => $cvterm->is_relationshiptype == 1 ? True : False,
     ]);

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -125,6 +125,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     // Let's let the collection be deleted as far as
     // Tripal is concerned but leave the record in Chado.
     // So, do nothing here.
+    $this->messageLogger->warning('The ChadoIdSpace::destroy() function is currently not implemented');
   }
 
   /**
@@ -163,7 +164,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     if (!$this->is_valid) {
       return NULL;
     }
-
+    $this->messageLogger->warning('The ChadoIdSpace::getParent() function is currently not implemented');
   }
 
   /**
@@ -891,7 +892,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    * {@inheritdoc}
    */
   public function removeTerm($accession) {
-
+    $this->messageLogger->warning('The ChadoIdSpace::removeTerm() function is currently not implemented');
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
+++ b/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
@@ -72,11 +72,12 @@ class ChadoVocabulary extends TripalVocabularyBase {
           'The value provided was: @value',
           ['@size' => $this->cv_def['fields']['name']['size'],
            '@value' => $this->getName()]);
+      $this->is_valid = FALSE;
+      return FALSE;
 
     }
-    $this->is_valid = True;
-
-    return $this->is_valid;
+    $this->is_valid = TRUE;
+    return TRUE;
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
+++ b/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
@@ -121,6 +121,7 @@ class ChadoVocabulary extends TripalVocabularyBase {
     // Let's let the collection be deleted as far as
     // Tripal is concerned but leave the record in Chado.
     // So, do nothing here.
+    $this->messageLogger->warning('The ChadoVocabulary::destroy() function is currently not implemented');
   }
 
 
@@ -254,7 +255,7 @@ class ChadoVocabulary extends TripalVocabularyBase {
    * {@inheritdoc}
    */
   public function getTerms($name, $exact = True){
-
+    $this->messageLogger->warning('The ChadoVocabulary::getTerms() function is currently not implemented');
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
+++ b/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
@@ -375,7 +375,7 @@ class ChadoVocabulary extends TripalVocabularyBase {
       ->condition('name', $this->getName(), '=');
     $num_updated = $query->execute();
     if ($num_updated != 1) {
-      $this->logInvalidCondition('ChadoVocabulary: The label could not be updated for the vocabulary.');
+      $this->messageLogger->error('ChadoVocabulary: The label could not be updated for the vocabulary.');
       return False;
     }
     return True;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Tripal 4 Core Dev Task

Issue #1400

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR fixes issue #1400.  It adds two new plugins that implements the TripalVocabulary and TripalIdSpace for generic terms. It does not use Chado and therefore can be used for modules that don't want to use Chado but need terms.   It can also be used for testing core Tripal functionality in functional tests when terms are needed by Chado is not installed.  

This issue was not part of our Alpha 2 release plan, but when I was trying to get functional testing working for PR #1413 I needed to be able to create terms that were not stored in the Chado schema.  I could not use a Mock term because the content type and field services need to be able to lookup terms.  So, this was necessary. I'm providing it as a separate PR to make it simple to review rather than as part of PR #1413.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I think this PR only needs a code review.  Nothing uses these new plugins so there's no way to test. However, I did createa  full suite of functional tests for these new plugins. Also, the presence of these plugins allowed me to create some functional testing for the TripalTerm class independent of the tests done in the tripal_chado module.  

So, if this PR passes all tests, and a code review looks good I think it can be merged.  I will be using it for more functional testing in PR #1413, so if someting isn't quite right I can fix it there (but I did test it already and it works :-) ....
