### PR TITLE
tv3g4 Issue 1422 fix publish update progress

### DIFF
--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -240,7 +240,6 @@ function chado_publish_records($values, $job = NULL) {
     try {
       // Keep track of how many we've published so far
       // before clearing our chunk,
-      $num_actually_published = $num_actually_published + $i;
       $i = 0;
       while ($record = $records->fetchObject()) {
 
@@ -286,8 +285,9 @@ function chado_publish_records($values, $job = NULL) {
         }
 
         $i++;
+        $num_actually_published++;
         if ($report_progress) {
-          $job->setItemsHandled($i);
+          $job->setItemsHandled($num_actually_published);
         }
       }
     } catch (Exception $e) {
@@ -307,9 +307,6 @@ function chado_publish_records($values, $job = NULL) {
     // Commit our current chunk.
     unset($transaction);
   }
-
-  // Add the last number published to our total.
-  $num_actually_published = $num_actually_published + $i;
 
   tripal_report_error($message_type, TRIPAL_INFO,
     "Successfully published !count !type record(s).",

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -238,8 +238,6 @@ function chado_publish_records($values, $job = NULL) {
     // are already in one.
     $transaction = db_transaction();
     try {
-      // Keep track of how many we've published so far
-      // before clearing our chunk,
       $i = 0;
       while ($record = $records->fetchObject()) {
 

--- a/tripal_chado/api/tripal_chado.api.inc
+++ b/tripal_chado/api/tripal_chado.api.inc
@@ -224,7 +224,7 @@ function chado_publish_records($values, $job = NULL) {
   // Perform the query in chunks.
   $sql = $select . $from . $where . ' LIMIT ' . $chunk_size;
   $more_records_to_publish = TRUE;
-  $num_actually_published = 0; // the full number of records published.
+  $total_records_published = 0;
   $i = 0; //reset on each chunk.
   while ($more_records_to_publish) {
 
@@ -285,9 +285,9 @@ function chado_publish_records($values, $job = NULL) {
         }
 
         $i++;
-        $num_actually_published++;
+        $total_records_published++;
         if ($report_progress) {
-          $job->setItemsHandled($num_actually_published);
+          $job->setItemsHandled($total_records_published);
         }
       }
     } catch (Exception $e) {
@@ -310,7 +310,7 @@ function chado_publish_records($values, $job = NULL) {
 
   tripal_report_error($message_type, TRIPAL_INFO,
     "Successfully published !count !type record(s).",
-    ['!count' => $num_actually_published, '!type' => $bundle->label], $message_opts);
+    ['!count' => $total_records_published, '!type' => $bundle->label], $message_opts);
 
   return TRUE;
 }


### PR DESCRIPTION
# Bug Fix

## Issue #1422

### Tripal Version: 3

## Description
Progress updates on publishing were not happening if more than one batch of 100 entities was published, because the internal batch variable was being used.

## Testing?
Load a whole genome gff3 file with thousands of genes, and then publish mRNA for example. Now the progress is updated
```
INFO (PUBLISH_RECORDS): There are 14336 records to publish.
There are 14336 records to publish.
Percent complete: 0%. Memory: 54,711,184 bytes.
Percent complete: 1%. Memory: 55,774,848 bytes. Duration: 0.08 mins
Percent complete: 2%. Memory: 55,774,848 bytes. Duration: 0.18 mins
Percent complete: 3%. Memory: 55,774,848 bytes. Duration: 0.27 mins
...
Percent complete: 99%. Memory: 55,774,848 bytes. Duration: 8.78 mins
Percent complete: 100%. Memory: 55,774,848 bytes. Duration: 8.88 mins
INFO (PUBLISH_RECORDS): Successfully published 14336 mRNA record(s).
Successfully published 14336 mRNA record(s).
```
