### PR TITLE
Update workflow to automatically build docker

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -11,26 +11,56 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        drupalversion: ['9.3.x-dev', '9.4.x-dev', '9.5.x-dev']
+        php-version:
+          - "8.0"
+          - "8.1"
+        pgsql-version:
+          - "13"
+        drupal-version:
+          - "9.2.x-dev"
+          - "9.3.x-dev"
+          - "9.4.x-dev"
+          - "9.5.x-dev"
+          - "10.0.x-dev"
+        exclude:
+          - php-version: "8.0"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.1"
+            pgsql-version: "13"
+            drupal-version: "9.2.x-dev"
     continue-on-error: true
     name: Docker Build (drupal${{ matrix.drupalversion }})
     steps:
       - uses: actions/checkout@v2
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
-        name: Build & push Docker image
+        name: Build & push Docker image (PHP 8.1 + PgSQL 13)
+        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
         with:
           image: tripalproject/tripaldocker
-          tags: drupal${{ matrix.drupalversion }}
+          tags: drupal${{ matrix.drupalversion }}, drupal${{ matrix.drupalversion }}-php8.1-pgsql13
+          dockerfile: tripaldocker/Dockerfile-php8.1-pgsql13
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupalversion }}"
-          labels: 'tripal.branch=9.x-4.x,drupal.version.label="${{ matrix.label }}"'
+          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="8.1", postgresql.version.label="13"'
       - uses: mr-smithers-excellent/docker-build-push@v5
-        name: Build latest using 9.4.x-dev
-        if: ${{ matrix.drupalversion == '9.4.x-dev' }}
+        name: Build & push Docker image (PHP 8.0 + PgSQL 13)
+        if: ${{ matrix.php-version == '8.0' && matrix.pgsql-version == '13'}}
+        with:
+          image: tripalproject/tripaldocker
+          tags: drupal${{ matrix.drupalversion }}-php8.0-pgsql13
+          dockerfile: tripaldocker/Dockerfile-php8-pgsql13
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          buildArgs: "drupalversion=${{ matrix.drupalversion }}"
+          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="8.0", postgresql.version.label="13"'
+      - uses: mr-smithers-excellent/docker-build-push@v5
+        name: Build latest using 9.5.x-dev, PHP 8.1, PgSQL 13
+        if: ${{ matrix.drupalversion == '9.5.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
         with:
           image: tripalproject/tripaldocker
           tags: latest
@@ -38,4 +68,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupalversion }}"
-          labels: 'tripal.branch=9.x-4.x,drupal.version.label="${{ matrix.drupalversion }}"'
+          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupalversion }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -9,8 +9,10 @@ on:
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
+      matrix:
         php-version:
           - "8.0"
           - "8.1"
@@ -29,7 +31,6 @@ jobs:
           - php-version: "8.1"
             pgsql-version: "13"
             drupal-version: "9.2.x-dev"
-    continue-on-error: true
     name: Docker Build (drupal${{ matrix.drupalversion }})
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -2,9 +2,9 @@ name: Build and Publish Docker image
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
       - 4v40g-0-test-docker-build
-      - tv4g0-328-dockerUpdateLatestTag
+      - tv4g0-issue1420-fixDockerBuild
 
 jobs:
   push_to_registry:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -31,7 +31,7 @@ jobs:
           - php-version: "8.1"
             pgsql-version: "13"
             drupal-version: "9.2.x-dev"
-    name: Docker Build (drupal${{ matrix.drupalversion }})
+    name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
       - uses: actions/checkout@v2
         name: Check out code
@@ -40,33 +40,33 @@ jobs:
         if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
         with:
           image: tripalproject/tripaldocker
-          tags: drupal${{ matrix.drupalversion }}, drupal${{ matrix.drupalversion }}-php8.1-pgsql13
+          tags: drupal${{ matrix.drupal-version }}, drupal${{ matrix.drupal-version }}-php8.1-pgsql13
           dockerfile: tripaldocker/Dockerfile-php8.1-pgsql13
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupalversion }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="8.1", postgresql.version.label="13"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Docker image (PHP 8.0 + PgSQL 13)
         if: ${{ matrix.php-version == '8.0' && matrix.pgsql-version == '13'}}
         with:
           image: tripalproject/tripaldocker
-          tags: drupal${{ matrix.drupalversion }}-php8.0-pgsql13
+          tags: drupal${{ matrix.drupal-version }}-php8.0-pgsql13
           dockerfile: tripaldocker/Dockerfile-php8-pgsql13
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupalversion }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="8.0", postgresql.version.label="13"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build latest using 9.5.x-dev, PHP 8.1, PgSQL 13
-        if: ${{ matrix.drupalversion == '9.5.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
+        if: ${{ matrix.drupal-version == '9.5.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
         with:
           image: tripalproject/tripaldocker
           tags: latest
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupalversion }}"
-          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupalversion }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+          buildArgs: "drupalversion=${{ matrix.drupal-version }}"
+          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'


### PR DESCRIPTION
# Bug Fix

Issue #1420 

### Tripal Version: 4.x-dev

## Description
This PR fixes two things:

1. When we switched back to tripal/tripal the main branch name changed from 9.x-4.x to just 4.x. This change needed to be reflected in the workflow
2. When I started adding automated testing to extension modules, not enough images were being build to test php / drupal versions effectively. This PR adds additional labels + tags to allow extension modules to pull images.

## Testing?
You only need to check that the workflows completed successfully and that [docker hub](https://hub.docker.com/r/tripalproject/tripaldocker/tags) has been updated.

![image](https://user-images.githubusercontent.com/1566301/219782920-a1d2fdc7-53fa-4c89-8565-e6b6846914d1.png)

