### PR TITLE
tv3g9 issue1428 Check for null in tripal_chado_field_storage_load()

### DIFF
--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -422,7 +422,7 @@ function tripal_chado_field_storage_load($entity_type, $entities, $age,
         // For text fields that were not handled by a TripalField class we
         // want to automatically expand those fields.
         else {
-          if ($schema['fields'][$field_column]['type'] == 'text') {
+          if ($record and $schema['fields'][$field_column]['type'] == 'text') {
             $record = chado_expand_var($record, 'field', "$field_table.$field_column");
             $entity->{$field_name}['und'][0]['value'] = $record->$field_column;
             // Text fields that have a text_processing == 1 setting need a


### PR DESCRIPTION
# Bug Fix

## Issue #1428

### Tripal Version:  3.x

## Description
In ```function tripal_chado_field_storage_load()``` do not try to expand a variable in a null record.

## Testing?
Testing is done for us by automated testing. Before this change, this line showed up in testing results:
```[site http://127.0.0.1] [TRIPAL ERROR] [TRIPAL_CHADO] Missing $object argument to the chado_expand_var function from tripal_chado_field_storage_load (line: 426)```

With this pull, this line no longer appears.
