### PR TITLE
tv3g9 automated testing with PHP 8.2

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     # Matrix Build for this job.
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '8.0', '8.1']
+        php-versions: ['7.1', '7.2', '8.0', '8.1', '8.2']
     # Name the matrix build so we can tell them apart.
     name: PHPUnit Testing of Tripal Core (PHP ${{ matrix.php-versions }})
 

--- a/docs/dev_guide/CI.rst
+++ b/docs/dev_guide/CI.rst
@@ -38,7 +38,7 @@ First we provide the name, when we want to run the workflow (i.e. on push and PR
       runs-on: ubuntu-latest
 
 
-We want our tests to be run four times, for each of PHP 7.1, 7.2, 8.0, and 8.1. This is done by specifing a matrix build which can be done as follows:
+We want our tests to be run five times, for each of PHP 7.1, 7.2, 8.0, 8.1, and 8.2. This is done by specifing a matrix build which can be done as follows:
 
 .. code-block:: yaml
 
@@ -51,7 +51,7 @@ We want our tests to be run four times, for each of PHP 7.1, 7.2, 8.0, and 8.1. 
       # Matrix Build for this job.
       strategy:
         matrix:
-          php-versions: ['7.1', '7.2', '8.0', '8.1']
+          php-versions: ['7.1', '7.2', '8.0', '8.1', '8.2']
 
       # Name the matrix build so we can tell them apart.
       name: PHPUnit Testing (PHP ${{ matrix.php-versions }})


### PR DESCRIPTION
# New Feature (testing)

## Issue #1434

### Tripal Version: 3.x

## Description
As of Drupal 7.94, PHP 8.2 is supported, so we can add this version to automated testing

## Testing?
Verify if automated testing passes for PHP8.2
