### PR TITLE
Tv4g9 issue1439 assert object has attribute

### DIFF
--- a/tripal_chado/tests/src/Functional/api/ChadoCvAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoCvAPITest.php
@@ -56,7 +56,7 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
       $return = chado_insert_cv($cvval['name'], $cvval['definition'], [], $this->schema_name);
       $this->assertNotFalse($return, 'chado_insert_cv failed unexpectedly.');
       $this->assertIsObject($return, 'Should be an updated cv object.');
-      $this->assertObjectHasAttribute('cv_id', $return,
+      $this->assertTrue(property_exists($return, 'cv_id'),
         "The returned object should have the primary key included.");
       $this->assertEquals($cvval['name'], $return->name,
         "The returned object should be the one we asked for.");
@@ -64,7 +64,7 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
       $returnagain = chado_insert_cv($cvval['name'], $cvval['definition'], [], $this->schema_name);
       $this->assertNotFalse($returnagain, 'chado_insert_cv failed unexpectedly.');
       $this->assertIsObject($returnagain, 'Should be an updated cv object.');
-      $this->assertObjectHasAttribute('cv_id', $returnagain,
+      $this->assertTrue(property_exists($returnagain, 'cv_id'),
         "The returned object should have the primary key included.");
       $this->assertEquals($cvval['name'], $returnagain->name,
         "The returned object should be the one we asked for.");
@@ -122,7 +122,7 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
       $return = chado_insert_cvterm($cvtermval, [], $this->schema_name);
       $this->assertNotFalse($return, 'chado_insert_cvterm failed unexpectedly.');
       $this->assertIsObject($return, 'Should be an updated cvterm object.');
-      $this->assertObjectHasAttribute('cvterm_id', $return,
+      $this->assertTrue(property_exists($return, 'cvterm_id'),
         "The returned object should have the primary key included.");
       $this->assertEquals($cvtermval['name'], $return->name,
         "The returned object should be the one we asked for.");
@@ -131,7 +131,7 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
       $returnagain = chado_insert_cvterm($cvtermval, [], $this->schema_name);
       $this->assertNotFalse($returnagain, 'chado_insert_cvterm failed unexpectedly.');
       $this->assertIsObject($returnagain, 'Should be an updated cvterm object.');
-      $this->assertObjectHasAttribute('cvterm_id', $returnagain,
+      $this->assertTrue(property_exists($returnagain, 'cvterm_id'),
         "The returned object should have the primary key included.");
         $this->assertEquals($cvtermval['name'], $return->name,
           "The returned object should be the one we asked for.");
@@ -157,7 +157,7 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
       $return = chado_get_cvterm($cvterm, [], $this->schema_name);
       $this->assertNotFalse($return, 'chado_get_cvterm failed unexpectedly.');
       $this->assertIsObject($return, 'Should be a cvterm object.');
-      $this->assertObjectHasAttribute('cvterm_id', $return,
+      $this->assertTrue(property_exists($return, 'cvterm_id'),
         "The returned object should have the primary key included.");
       $this->assertEquals($cvtermval['name'], $return->name,
         "The returned object should be the one we asked for.");

--- a/tripal_chado/tests/src/Functional/api/ChadoDbAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoDbAPITest.php
@@ -50,7 +50,7 @@ class ChadoDbAPITest extends BrowserTestBase {
 		$return = chado_insert_db($dbval, [], 'testchado');
 		$this->assertNotFalse($return, 'chado_insert_db failed unexpectedly.');
 		$this->assertIsObject($return, 'Should be an updated DB object.');
-		$this->assertObjectHasAttribute('db_id', $return,
+		$this->assertTrue(property_exists($return, 'db_id'),
 			"The returned object should have the primary key included.");
 		$this->assertEquals($dbval['name'], $return->name,
 			"The returned object should be the one we asked for.");
@@ -60,7 +60,7 @@ class ChadoDbAPITest extends BrowserTestBase {
 		$returnagain = chado_insert_db($dbval2, [], 'testchado');
 		$this->assertNotFalse($returnagain, 'chado_insert_db failed unexpectedly.');
 		$this->assertIsObject($returnagain, 'Should be an updated DB object.');
-		$this->assertObjectHasAttribute('db_id', $returnagain,
+		$this->assertTrue(property_exists($returnagain, 'db_id'),
 			"The returned object should have the primary key included.");
 		$this->assertEquals($dbval2['name'], $returnagain->name,
 			"The returned object should be the one we asked for.");
@@ -114,7 +114,7 @@ class ChadoDbAPITest extends BrowserTestBase {
 		$return = chado_insert_dbxref($dbxrefval, [], 'testchado');
 		$this->assertNotFalse($return, 'chado_insert_dbxref failed unexpectedly.');
 		$this->assertIsObject($return, 'Should be an updated Dbxref object.');
-		$this->assertObjectHasAttribute('dbxref_id', $return,
+		$this->assertTrue(property_exists($return, 'dbxref_id'),
 			"The returned object should have the primary key included.");
 		$this->assertEquals($dbxrefval['accession'], $return->accession,
 			"The returned object should be the one we asked for.");
@@ -122,7 +122,7 @@ class ChadoDbAPITest extends BrowserTestBase {
 		$returnagain = chado_insert_dbxref($dbxrefval, [], 'testchado');
 		$this->assertNotFalse($returnagain, 'chado_insert_dbxref failed unexpectedly.');
 		$this->assertIsObject($returnagain, 'Should be an updated Dbxref object.');
-		$this->assertObjectHasAttribute('dbxref_id', $returnagain,
+		$this->assertTrue(property_exists($returnagain, 'dbxref_id'),
 			"The returned object should have the primary key included.");
 			$this->assertEquals($dbxrefval['accession'], $return->accession,
 				"The returned object should be the one we asked for.");
@@ -148,7 +148,7 @@ class ChadoDbAPITest extends BrowserTestBase {
 		$return = chado_get_dbxref($dbxrefval, [], 'testchado');
 		$this->assertNotFalse($return, 'chado_get_dbxref failed unexpectedly.');
 		$this->assertIsObject($return, 'Should be an updated Dbxref object.');
-		$this->assertObjectHasAttribute('dbxref_id', $return,
+		$this->assertTrue(property_exists($return, 'dbxref_id'),
 			"The returned object should have the primary key included.");
 		$this->assertEquals($dbxrefval['accession'], $return->accession,
 			"The returned object should be the one we asked for.");

--- a/tripal_chado/tests/src/Functional/api/ChadoVariablesAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoVariablesAPITest.php
@@ -113,15 +113,15 @@ class ChadoVariablesAPITest extends BrowserTestBase {
 
 		// -- TABLE.
 		$expanded = chado_expand_var($var, 'table', 'featureprop', [], 'testchado');
-		$this->assertObjectHasAttribute('featureprop', $var,
+		$this->assertTrue(property_exists($var, 'featureprop'),
 			"The feature properties should be present once expanded.");
 
 		// -- FIELD.
 		// By default the residues field is not expanded...
-		$this->assertObjectNotHasAttribute('residues', $var,
+		$this->assertFalse(property_exists($var, 'residues'),
 			"The residues should be missing by default.");
 		$expanded = chado_expand_var($var, 'field', 'feature.residues', [], 'testchado');
-		$this->assertObjectHasAttribute('residues', $var,
+		$this->assertTrue(property_exists($var, 'residues'),
 			"The residues should be present once expanded.");
 	}
 }


### PR DESCRIPTION
# Core Tripal 4 Development Task
## Issue #1439 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x alpha

## Description
PHPUnit has deprecated the use of ```assertObjectHasAttribute()``` and a number of other assertions that operate on class/object properties as described here: https://github.com/sebastianbergmann/phpunit/issues/4601

There was already a ```assertIsObject()``` for all of these cases, so we now do a ```assertIsTrue(property_exists($obj, 'key'))```

In addition to the changes listed by Lacey in the issue, there is one instance of ```assertObjectNotHasAttribute()``` that is updated.

## Testing?
Code review and automated testing should be adequate to test these changes.
