### PR TITLE
BUG: Tripal 3 PHP8 fix and incorrect use of count

### DIFF
--- a/tripal/views_handlers/tripal_views_handler_field_image.inc
+++ b/tripal/views_handlers/tripal_views_handler_field_image.inc
@@ -50,7 +50,7 @@ class tripal_views_handler_field_image extends tripal_views_handler_field {
   function render($values) {
     $value = $this->get_value($values);
     // Handle single value fields:
-    if (count($value == 1)) {
+    if ($value and count($value) == 1) {
       $fid = $value[0]['fid'];
       if ($fid) {
         $file = file_load($fid);


### PR DESCRIPTION
# Bug Fix
## Issue #1317 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 3.9dev

## Description
Fix a typo in the ```count()``` syntax (the bug), and also avoid ```count()``` on a null value (the PHP8 issue)

## Testing?
See issue #1317 for how to see this error
