### PR TITLE
BUG: Tripal 3 OBO Importer checks for file when none specified in local file field

### DIFF
--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -457,11 +457,13 @@ class OBOImporter extends TripalImporter {
       if ($vocab and $vocab->obo_id != $obo_id) {
         form_set_error('uobo_name', 'The vocabulary name must be different from existing vocabularies');
       }
-      // Make sure the file exists. First check if it is a relative path
-      $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $uobo_file;
-      if (!file_exists($dfile)) {
-        if (!file_exists($uobo_file)) {
-          form_set_error('uobo_file', t('The specified path, !path, does not exist or cannot be read.'), ['!path' => $dfile]);
+      // If specified, make sure the file exists. First check if it is a relative path
+      if ($uobo_file) {
+        $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $uobo_file;
+        if (!file_exists($dfile)) {
+          if (!file_exists($uobo_file)) {
+            form_set_error('uobo_file', t('The specified path, !path, does not exist or cannot be read.', ['!path' => $dfile]));
+          }
         }
       }
       if (!$uobo_url and !$uobo_file) {

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -487,7 +487,7 @@ class OBOImporter extends TripalImporter {
       $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $obo_file;
       if (!file_exists($dfile)) {
         if (!file_exists($obo_file)) {
-          form_set_error('obo_file', t('The specified path, !path, does not exist or cannot be read.'), ['!path' => $dfile]);
+          form_set_error('obo_file', t('The specified path, !path, does not exist or cannot be read.', ['!path' => $dfile]));
         }
       }
       if (!$obo_url and !$obo_file) {

--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -484,10 +484,12 @@ class OBOImporter extends TripalImporter {
         form_set_error('obo_name', 'The vocabulary name must be different from existing vocabularies');
       }
       // Make sure the file exists. First check if it is a relative path
-      $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $obo_file;
-      if (!file_exists($dfile)) {
-        if (!file_exists($obo_file)) {
-          form_set_error('obo_file', t('The specified path, !path, does not exist or cannot be read.', ['!path' => $dfile]));
+      if ($obo_file) {
+        $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $obo_file;
+        if (!file_exists($dfile)) {
+          if (!file_exists($obo_file)) {
+            form_set_error('obo_file', t('The specified path, !path, does not exist or cannot be read.', ['!path' => $dfile]));
+          }
         }
       }
       if (!$obo_url and !$obo_file) {


### PR DESCRIPTION
# Bug Fix

## Issue #1209

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 3

## Description
A typo in the form validation error message, and the error is caused by an incorrect checking of file existence when no file has been specified, that is, when the "Local File" box is left empty.

Fix the form_set_error typo, and skip check if $uobo_file is not set.

## Testing?
The error likely only happens under PHP8.
Go to the OBO Vocabulary loader,
Under "Ontology OBO File Reference" select "Sequence Ontology"
"Local File" should be empty, leave it empty.
Click the "Update Ontology Details" button.

Error message before this fix
```TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given in form_set_error() (line 1660 of /var/www/prova/drupal-7.92/includes/form.inc).```
