### PR TITLE
 BUG: Tripal 4 OBO Importer checks for file when none specified in local file field

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -474,12 +474,12 @@ class OBOImporter extends ChadoImporterBase {
     $public = \Drupal::database();
 
     $obo_id = $form_state->getValue('obo_id');
-    $obo_name = trim($form_state->getValue('obo_name'));
-    $obo_url = trim($form_state->getValue('obo_url'));
-    $obo_file = trim($form_state->getValue('obo_file'));
-    $uobo_name = trim($form_state->getValue('uobo_name'));
-    $uobo_url = trim($form_state->getValue('uobo_url'));
-    $uobo_file = trim($form_state->getValue('uobo_file'));
+    $obo_name = trim($form_state->getValue('obo_name')??'');
+    $obo_url = trim($form_state->getValue('obo_url')??'');
+    $obo_file = trim($form_state->getValue('obo_file')??'');
+    $uobo_name = trim($form_state->getValue('uobo_name')??'');
+    $uobo_url = trim($form_state->getValue('uobo_url')??'');
+    $uobo_file = trim($form_state->getValue('uobo_file')??'');
     // Make sure if the name is changed it doesn't conflict with another OBO.
     if ($form_state->getTriggeringElement()['#name'] == 'update_obo' ) {
 

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -474,12 +474,12 @@ class OBOImporter extends ChadoImporterBase {
     $public = \Drupal::database();
 
     $obo_id = $form_state->getValue('obo_id');
-    $obo_name = trim($form_state->getValue('obo_name')??'');
-    $obo_url = trim($form_state->getValue('obo_url')??'');
-    $obo_file = trim($form_state->getValue('obo_file')??'');
-    $uobo_name = trim($form_state->getValue('uobo_name')??'');
-    $uobo_url = trim($form_state->getValue('uobo_url')??'');
-    $uobo_file = trim($form_state->getValue('uobo_file')??'');
+    $obo_name = trim($form_state->getValue('obo_name') ?? '');
+    $obo_url = trim($form_state->getValue('obo_url') ?? '');
+    $obo_file = trim($form_state->getValue('obo_file') ?? '');
+    $uobo_name = trim($form_state->getValue('uobo_name') ?? '');
+    $uobo_url = trim($form_state->getValue('uobo_url') ?? '');
+    $uobo_file = trim($form_state->getValue('uobo_file') ?? '');
     // Make sure if the name is changed it doesn't conflict with another OBO.
     if ($form_state->getTriggeringElement()['#name'] == 'update_obo' ) {
 

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -506,26 +506,46 @@ class OBOImporter extends ChadoImporterBase {
       }
     }
 
-    // Submitted with 'Import OBO File' button
+    // Submitted with 'Import OBO File' button. This is used both for
+    // reloading a saved ontology and for loading a new ontology.
     if ($form_state->getTriggeringElement()['#name'] == 'op') {
-      if (!$obo_name) {
-        $form_state->setErrorByName('obo_name', t('Please provide a name for the vocabulary'));
+      if ($uobo_name and $obo_name) {
+        $form_state->setErrorByName('obo_name', t('New and existing ontologies are both selected, please select only one'));
       }
-      // Generate error if supplied vocabulary name already exists.
-      $vocab_id = $this->getVocabID($obo_name);
-      if ($vocab_id) {
-        $form_state->setErrorByName('obo_name', t('The vocabulary name must be different from existing vocabularies'));
+      // Generate error if supplied new vocabulary name already exists.
+      if ($obo_name) {
+        $vocab_id = $this->getVocabID($obo_name);
+        if ($vocab_id) {
+          $form_state->setErrorByName('obo_name', t('The vocabulary name must be different from existing vocabularies'));
+        }
       }
-      // If file specified, make sure it exists, either as a relative or absolute path.
-      if (!$this->formValidateFile($obo_file)) {
-        $form_state->setErrorByName('obo_file',
-            t('The specified path, @path, does not exist or cannot be read.', ['@path' => $obo_file]));
+      if ($uobo_name) {
+        // Validate the update existing ontology section
+        if (!$uobo_url and !$uobo_file) {
+          $form_state->setErrorByName('uobo_url', t('Please provide either a URL or a path for the vocabulary.'));
+        }
+        if ($uobo_url and $uobo_file) {
+          $form_state->setErrorByName('uobo_url', t('Please provide only a URL or a path for the vocabulary, but not both.'));
+        }
+        // If file specified, make sure it exists, either as a relative or absolute path.
+        if (!$this->formValidateFile($uobo_file)) {
+          $form_state->setErrorByName('uobo_file',
+              t('The specified path, @path, does not exist or cannot be read.', ['@path' => $uobo_file]));
+        }
       }
-      if (!$obo_url and !$obo_file) {
-        $form_state->setErrorByName('obo_url', t('Please provide either a URL or a path for the vocabulary.'));
-      }
-      if ($obo_url and $obo_file) {
-        $form_state->setErrorByName('obo_url', t('Please provide only a URL or a path for the vocabulary, but not both.'));
+      else {
+        // Validate the load new ontology section
+        if (!$obo_url and !$obo_file) {
+          $form_state->setErrorByName('obo_url', t('Please provide either a URL or a path for the vocabulary.'));
+        }
+        if ($obo_url and $obo_file) {
+          $form_state->setErrorByName('obo_url', t('Please provide only a URL or a path for the vocabulary, but not both.'));
+        }
+        // If file specified, make sure it exists, either as a relative or absolute path.
+        if (!$this->formValidateFile($obo_file)) {
+          $form_state->setErrorByName('obo_file',
+              t('The specified path, @path, does not exist or cannot be read.', ['@path' => $obo_file]));
+        }
       }
     }
   }

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -480,10 +480,8 @@ class OBOImporter extends ChadoImporterBase {
     $uobo_name = trim($form_state->getValue('uobo_name'));
     $uobo_url = trim($form_state->getValue('uobo_url'));
     $uobo_file = trim($form_state->getValue('uobo_file'));
-
     // Make sure if the name is changed it doesn't conflict with another OBO.
-    if ($form_state->getTriggeringElement()['#name'] == 'update_obo_details'  or
-        $form_state->getTriggeringElement()['#name'] == 'update_load_obo') {
+    if ($form_state->getTriggeringElement()['#name'] == 'update_obo' ) {
 
       // Get the current record
       $vocab = $public->select('tripal_cv_obo', 't')
@@ -495,11 +493,13 @@ class OBOImporter extends ChadoImporterBase {
         $form_state->setErrorByName('uobo_name', t('The vocabulary name must be different from existing vocabularies'));
       }
       // Make sure the file exists. First check if it is a relative path
-      $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $uobo_file;
-      if (!file_exists($dfile)) {
-        if (!file_exists($uobo_file)) {
-          $form_state->setErrorByName('uobo_file',
-              t('The specified path, @path, does not exist or cannot be read.'), ['@path' => $dfile]);
+      if ($uobo_file) {
+        $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $uobo_file;
+        if (!file_exists($dfile)) {
+          if (!file_exists($uobo_file)) {
+            $form_state->setErrorByName('uobo_file',
+                t('The specified path, @path, does not exist or cannot be read.', ['@path' => $dfile]));
+          }
         }
       }
       if (!$uobo_url and !$uobo_file) {
@@ -520,11 +520,13 @@ class OBOImporter extends ChadoImporterBase {
         $form_state->setErrorByName('obo_name', t('The vocabulary name must be different from existing vocabularies'));
       }
       // Make sure the file exists. First check if it is a relative path
-      $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $obo_file;
-      if (!file_exists($dfile)) {
-        if (!file_exists($obo_file)) {
-          $form_state->setErrorByName('obo_file',
-              t('The specified path, @path, does not exist or cannot be read.'), ['@path' => $dfile]);
+      if ($obo_file) {
+        $dfile = $_SERVER['DOCUMENT_ROOT'] . base_path() . $obo_file;
+        if (!file_exists($dfile)) {
+          if (!file_exists($obo_file)) {
+            $form_state->setErrorByName('obo_file',
+                t('The specified path, @path, does not exist or cannot be read.', ['@path' => $dfile]));
+          }
         }
       }
       if (!$obo_url and !$obo_file) {


### PR DESCRIPTION
# Bug Fix
## Issue #1444 (Tripal 3 #1209 and pull #1443)

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4 alpha1

## Description
This ports over the changes in pull #1443 which deal with typos in the OBI Importer validation.
In addition to those changes, an incorrect triggering element name is corrected, and one that is not present in the form is removed. This error meant that some of the validation was never performed.

Also we can't pass a null to ```trim()``` so fix this with the null coalescing operator ```??```

## Testing?
Described in issue #1444
