### PR TITLE
Tv4g1 issue1450 deprecated str replace

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -384,7 +384,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $string = str_replace('[' . $token . ']', '', $string);
       }
       else {
-        $string = str_replace('[' . $token . ']', $value, $string);
+        $string = str_replace('[' . $token . ']', $value ?? '', $string);
       }
     }
 


### PR DESCRIPTION
# Bug Fix

## Issue #1450

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.alpha1

## Description
A one-line change to avoid passing a NULL to ```str_replace()``` as described in issue #1450. Procedure to see the error shown there can be used for testing.
