### PR TITLE
tv3g9-issue1456-separate-installs-for-debugging

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -113,7 +113,15 @@ jobs:
           patch -p1 < ../tripal/tripal_chado_views/views-sql-compliant-three-tier-naming-1971160-30.patch
           echo "==> Install Tripal"
           cd $DRUPAL_ROOT
-          $DRUSH en -y tripal tripal_chado tripal_chado_views tripal_ws tripal_ds
+          $DRUSH en -y tripal
+          echo "==> Install tripal_chado"
+          $DRUSH en -y tripal_chado
+          echo "==> Install tripal_chado_views"
+          $DRUSH en -y tripal_chado_views
+          echo "==> Install tripal_ws"
+          $DRUSH en -y tripal_ws
+          echo "==> Install tripal_ds"
+          $DRUSH en -y tripal_ds
           echo "==> Install Chado"
           $DRUSH eval "module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.3');"
           $DRUSH trp-run-jobs --username=$ACCOUNT_NAME


### PR DESCRIPTION
# Bug Fix

## Issue #1456

### Tripal Version: 7.x-3.xdev

## Description
Try to find what is causing the error message described in the issue when running testing under the current drupal version 7.95
Commit https://github.com/tripal/tripal/pull/1458/commits/601c3042886ddfb29e43a25c58a5e0d831bbafb3 : separate the module enables to know exactly which one is causing it

## Testing?
Testing is with automated testing.