### PR TITLE
Tripal 3 Issue 1464 typo corrections

### DIFF
--- a/legacy/tripal_db/tripal_db.module
+++ b/legacy/tripal_db/tripal_db.module
@@ -11,7 +11,7 @@
  * Provides functions for managing chado database references which link chado content, such
  * as features and stocks, to records/pages in external databases/websites. For example,
  * you might have a feature record in your site which is also in the NCBI website and by
- * adding a database refrence to your feature, an automatic link to the content at NCBI
+ * adding a database reference to your feature, an automatic link to the content at NCBI
  * is created.
  * @}
  */

--- a/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
+++ b/legacy/tripal_feature/includes/tripal_feature.chado_node.inc
@@ -151,7 +151,7 @@ function chado_feature_form($node, &$form_state) {
     '#description' => t("Choose the feature type."),
     '#required' => TRUE,
     '#default_value' => $feature_type,
-    '#autocomplete_path' => "aadmin/tripal/storage/chado/auto_name/cvterm/$cv_id",
+    '#autocomplete_path' => "admin/tripal/storage/chado/auto_name/cvterm/$cv_id",
   ];
 
   // get the list of organisms

--- a/tripal/includes/TripalFieldQuery.inc
+++ b/tripal/includes/TripalFieldQuery.inc
@@ -17,7 +17,7 @@ class TripalFieldQuery extends EntityFieldQuery {
    * want to filter based on on other Drupal tables. The most important
    * example for this would be Drupal Views.  These variables are only meant
    * to be used by the tripal_field_storage_query() function as that is the
-   * only storage system that should be doing quries on the tripal_entity
+   * only storage system that should be doing queries on the tripal_entity
    * table itself.
    */
   public $relationships = [];
@@ -25,7 +25,7 @@ class TripalFieldQuery extends EntityFieldQuery {
   public $relationshipConditions = [];
 
   /**
-   * Adds a relationsihp via a table join to the tripal_entity table
+   * Adds a relationship via a table join to the tripal_entity table
    *
    * This is specific for Drupal schema tables and is useful for Views
    * integration when non Tripal Storage API fields are attached to an entity.
@@ -172,7 +172,7 @@ class TripalFieldQuery extends EntityFieldQuery {
   }
 
   /**
-   * Overides the EntityFieldQuery::queryCallback function.
+   * Overrides the EntityFieldQuery::queryCallback function.
    */
   public function queryCallback() {
 

--- a/tripal/includes/tripal.entity.inc
+++ b/tripal/includes/tripal.entity.inc
@@ -256,7 +256,7 @@ function tripal_entity_info_alter(&$entity_info) {
 
   if (array_key_exists('TripalEntity', $entity_info)) {
     // Dynamically add in the bundles. Bundles are alternative groups of fields
-    // or configuration associated with an entity type .We want to dynamically
+    // or configuration associated with an entity type. We want to dynamically
     // add the bundles to the entity.
     $bundles = db_select('tripal_bundle', 'tb')
       ->fields('tb')
@@ -376,7 +376,7 @@ function tripal_field_property_get($entity, array $options, $field_name, $entity
 
       // All Tripal/ChadoFields should have a value key. Only the information
       // stored in this value key should be displayed on the page, available
-      // via web services or indexed for searching. This is there is no value
+      // via web services or indexed for searching. Thus if there is no value
       // key, we will not index anything.
       if (!isset($data['value'])) {
         return NULL;

--- a/tripal/tripal_views_query.inc
+++ b/tripal/tripal_views_query.inc
@@ -38,7 +38,7 @@ class tripal_views_query extends views_plugin_query {
     $this->where = [];
     $this->order = [];
 
-    // Creqte the TripalFieldQuery object.
+    // Create the TripalFieldQuery object.
     $this->query = new TripalFieldQuery();
     $this->cquery = new TripalFieldQuery();
     $this->cquery->count();

--- a/tripal_chado/api/modules/tripal_chado.pub.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.pub.api.inc
@@ -613,7 +613,7 @@ function _chado_execute_pub_importer_publish($publish, $job, $message_type, $mes
         chado_publish_records(['bundle_name' => $bundle->name], $job);
       }
       // Note: we won't publish contacts as Tripal v2 did because there is
-      // no consisten way to do that. Each site my use a different term for
+      // no consistent way to do that. Each site my use a different term for
       // different contact content types (e.g. all as one 'Contact' type or
       // specific such as 'Person', 'Organization', etc.).
     }

--- a/tripal_chado/api/tripal_chado.query.api.inc
+++ b/tripal_chado/api/tripal_chado.query.api.inc
@@ -160,7 +160,7 @@
  *   with
  * care. If any user input will be used in the query make sure to put a
  * placeholder in your SQL string and then define the value in the arguments
- * array. This will make sure that the user input is santized and safe through
+ * array. This will make sure that the user input is sanitized and safe through
  * type-checking and escaping. The following code shows an example of how to
  * use user input resulting from a form and would be called withing the form
  * submit function.

--- a/tripal_chado/includes/TripalFields/sio__references/sio__references.inc
+++ b/tripal_chado/includes/TripalFields/sio__references/sio__references.inc
@@ -136,7 +136,7 @@ class sio__references extends ChadoField {
         }
 
 
-        // Build the SQL to find records assocaited with this publication.
+        // Build the SQL to find records associated with this publication.
         $ref_schema = chado_get_schema($reference_table);
         $ref_pkey = $ref_schema['primary key'][0];
         $select = "SELECT REF.* ";
@@ -148,7 +148,7 @@ class sio__references extends ChadoField {
           $from .= "INNER JOIN {cvterm} CVT on REF.type_id = CVT.cvterm_id ";
         }
 
-        // Get the mapping of the refrence table to a CV term in case the
+        // Get the mapping of the reference table to a CV term in case the
         // records in the table don't have a type_id.
         $ref_mapping = db_select('chado_cvterm_mapping', 'CVM')
           ->fields('CVM')

--- a/tripal_chado/includes/TripalImporter/GFF3Importer.inc
+++ b/tripal_chado/includes/TripalImporter/GFF3Importer.inc
@@ -310,7 +310,7 @@ class GFF3Importer extends TripalImporter {
       '#title' => t('Landmark Type'),
       '#type' => 'textfield',
       '#description' => t("Optional. Use this field to specify a Sequence Ontology type
-       for the landmark sequences in the GFF fie (e.g. 'chromosome'). This is only needed if
+       for the landmark sequences in the GFF file (e.g. 'chromosome'). This is only needed if
        the landmark features (first column of the GFF3 file) are not already in the database.."),
     ];
 

--- a/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
+++ b/tripal_chado/includes/TripalImporter/TaxonomyImporter.inc
@@ -98,7 +98,7 @@ class TaxonomyImporter extends TripalImporter {
   public static $cardinality = 0;
 
   /**
-   * Holds the list of all orgainsms currently in Chado. This list
+   * Holds the list of all organisms currently in Chado. This list
    * is needed when checking to see if an organism has already been
    * loaded.
    */

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_AGL.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_AGL.inc
@@ -86,7 +86,7 @@ function tripal_pub_remote_validate_form_AGL($form, $form_state) {
  * A hook for performing the search on the AGL database.
  *
  * @param $search_array
- *   An array containing the serach criteria for the serach
+ *   An array containing the search criteria for the search
  * @param $num_to_retrieve
  *   Indicates the maximum number of publications to retrieve from the remote
  *   database
@@ -430,7 +430,7 @@ function tripal_pub_remote_search_AGL($search_array, $num_to_retrieve, $page) {
  *   been retrieved by tripal_pub_AGL_count() function.
  *
  * @return
- *  An array containing the total_records in the dataaset, the search string
+ *  An array containing the total_records in the dataset, the search string
  *  and an array of the publications that were retrieved.
  *
  * @ingroup tripal_pub
@@ -548,7 +548,7 @@ function tripal_pub_AGL_count($yazc, $search_str) {
     return 0;
   }
 
-  // get the total number of results from the serach
+  // get the total number of results from the search
   $count = yaz_hits($yazc);
   return $count;
 }

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importer_PMID.inc
@@ -64,7 +64,7 @@ function tripal_pub_remote_validate_form_PMID($form, $form_state) {
  * A hook for performing the search on the PubMed database.
  *
  * @param $search_array
- *   An array containing the serach criteria for the serach
+ *   An array containing the search criteria for the search
  * @param $num_to_retrieve
  *   Indicates the maximum number of publications to retrieve from the remote
  *   database
@@ -290,7 +290,7 @@ function tripal_pub_PMID_search_init($search_str, $retmax) {
  *   Any additional arguments to add the efetch query URL
  *
  * @return
- *  An array containing the total_records in the dataaset, the search string
+ *  An array containing the total_records in the dataset, the search string
  *  and an array of the publications that were retrieved.
  *
  * @ingroup tripal_pub

--- a/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
+++ b/tripal_chado/includes/loaders/tripal_chado.pub_importers.inc
@@ -22,7 +22,7 @@ function tripal_pub_importers_list() {
     drupal_set_message(t('The Tripal Pub vocabulary is currently not loaded. ' .
       'This vocabulary is required to be loaded before importing of ' .
       'publications.  <br>Please !import',
-      ['!import' => l('load the Tripal Publication vocabulary', 'aadmin/tripal/loaders/chado_vocabs/obo_loader')]), 'warning');
+      ['!import' => l('load the Tripal Publication vocabulary', 'admin/tripal/loaders/chado_vocabs/obo_loader')]), 'warning');
   }
 
   // clear out the session variable when we view the list.
@@ -96,7 +96,7 @@ function tripal_pub_importers_list() {
     'caption' => '',
     'sticky' => TRUE,
     'colgroups' => [],
-    'empty' => 'There are no currently importers',
+    'empty' => 'There are currently no importers',
   ];
 
   $page .= theme_table($table);

--- a/tripal_chado/includes/setup/tripal_chado.chado_vx_x.inc
+++ b/tripal_chado/includes/setup/tripal_chado.chado_vx_x.inc
@@ -350,7 +350,7 @@ function tripal_chado_add_analysis_organism_mview() {
   $view_name = 'analysis_organism';
   $comment = t('This view is for associating an organism (via it\'s associated features) to an analysis.');
 
-  // this is the SQL used to identify the organism to which an analsysis
+  // this is the SQL used to identify the organism to which an analysis
   // has been used.  This is obtained though the analysisfeature -> feature -> organism
   // joins
   $sql = "

--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -268,7 +268,7 @@ function tripal_chado_field_storage_pre_load($entity_type, $entities, $age,
                                              $fields, $options) {
 
 
-  // Itereate through the entities and add in the Chado record.
+  // Iterate through the entities and add in the Chado record.
   foreach ($entities as $id => $entity) {
 
     // Only deal with Tripal Entities.

--- a/tripal_chado/includes/tripal_chado.fields.inc
+++ b/tripal_chado/includes/tripal_chado.fields.inc
@@ -2345,7 +2345,7 @@ function tripal_chado_bundle_instances_info_linker(&$info, $entity_type, $bundle
 
   // EXPRESSION
   // TODO: this should only show up on gene or mRNA and the GO must be
-  // laoded or this field will crash things.
+  // loaded or this field will crash things.
   //   $expression_table = $table_name . '_expression';
   //   if (chado_table_exists($expression_table)) {
   //     $field_name = 'go__gene_expression';

--- a/tripal_chado/includes/tripal_chado.pub_search.inc
+++ b/tripal_chado/includes/tripal_chado.pub_search.inc
@@ -459,7 +459,7 @@ function tripal_chado_pub_search_form_validate($form, &$form_state) {
   $to_year = $form_state['values']['to_year'];
   $op = $form_state['values']['op'];
 
-  // no need to vlaidate on a reset
+  // no need to validate on a reset
   if ($op == 'Reset') {
     return;
   }

--- a/tripal_chado/includes/tripal_chado.vocab_storage.inc
+++ b/tripal_chado/includes/tripal_chado.vocab_storage.inc
@@ -32,7 +32,7 @@ function tripal_chado_vocab_get_vocabularies() {
     return FALSE;
   }
 
-  // Make sure the materiailzd view is present.
+  // Make sure the materialized view is present.
   if (!chado_table_exists('db2cv_mview')) {
     drupal_set_message('Please update the database using "drush updatedb" before continuing');
     return FALSE;
@@ -85,7 +85,7 @@ function tripal_chado_vocab_get_vocabulary($vocabulary) {
     return FALSE;
   }
 
-  // Make sure the materiailzd view is present.
+  // Make sure the materialized view is present.
   if (!chado_table_exists('db2cv_mview')) {
     drupal_set_message('Please update the database using "drush updatedb" before continuing');
     return FALSE;

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -81,7 +81,7 @@ function tripal_chado_set_globals() {
   // These global variables are meant to be accessed by all Tripal
   // modules to find the chado version installed and if Chado is local.
   // These variables are stored as globals rather than using the
-  // drupal_set_variable functions because the Drupal functions make databaes
+  // drupal_set_variable functions because the Drupal functions make database
   // queries and for long running loaders we don't want those queries
   // repeatedly.
   $GLOBALS["chado_is_installed"]  = chado_is_installed();

--- a/tripal_chado/tripal_chado.views_default.inc
+++ b/tripal_chado/tripal_chado.views_default.inc
@@ -16,7 +16,7 @@ function tripal_chado_views_default_views() {
   $view = tripal_chado_defaultview_admin_custom_tables();
   $views[$view->name] = $view;
 
-  // Default Trial materialized views view.
+  // Default Tripal materialized views view.
   $view = tripal_chado_defaultview_admin_mviews();
   $views[$view->name] = $view;
 
@@ -263,9 +263,9 @@ function tripal_chado_defaultview_admin_mviews() {
   $handler->display->display_options['header']['area']['label'] = 'Description';
   $handler->display->display_options['header']['area']['empty'] = TRUE;
   $handler->display->display_options['header']['area']['content'] = '<p>Materialized Views (MViews) are custom tables populated with a defined SQL statement. Because Chado is highly normalized and highly constrained it serves as a wonderful data storage platform, but unfortunately some queries may be slow. MViews alleviate slowness by aggregating data into tables that are more easy to query. Use MViews to create tables for custom search pages or custom Tripal module development.</p>
-  <p>MViews behaves in the following way:</p>
+  <p>MViews behave in the following way:</p>
   <ul>
-  <li>The SQL statement defined for an MVIEW will be used to populate the table</li>
+  <li>The SQL statement defined for an MView will be used to populate the table</li>
   <li>Altering the table structure of an MView will cause the MView table to be dropped and recreated. All records in the MView will be lost.</li>
   <li>Altering the query of an existing view will not change the MView table. No records will be lost.</li>
   <li>Repopulating an MView that is already populated will result in replacement of all records.</li>
@@ -553,7 +553,7 @@ function tripal_chado_defaultview_admin_cvs_listing() {
   $handler->display->display_options['fields']['nothing_3']['exclude'] = TRUE;
   $handler->display->display_options['fields']['nothing_3']['alter']['text'] = 'Add Term';
   $handler->display->display_options['fields']['nothing_3']['alter']['make_link'] = TRUE;
-  $handler->display->display_options['fields']['nothing_3']['alter']['path'] = 'aadmin/tripal/loaders/chado_vocabs/chado_cv/[cv_id]/cvterm/add';
+  $handler->display->display_options['fields']['nothing_3']['alter']['path'] = 'admin/tripal/loaders/chado_vocabs/chado_cv/[cv_id]/cvterm/add';
   /* Field: Global: Custom text */
   $handler->display->display_options['fields']['nothing_2']['id'] = 'nothing_2';
   $handler->display->display_options['fields']['nothing_2']['table'] = 'views';

--- a/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
+++ b/tripal_ws/includes/TripalWebService/TripalContentService_v0_1.inc
@@ -60,7 +60,7 @@ class TripalContentService_v0_1 extends TripalWebService {
       $bquery->orderBy('tb.label', 'ASC');
       $bundles = $bquery->execute();
 
-      // Iterate through the terms convert the santized name to the real label.
+      // Iterate through the terms convert the sanitized name to the real label.
       $i = 0;
       $ctype_lookup = [];
       $found = FALSE;


### PR DESCRIPTION
# Bug Fix

## Issue #1464 

### Tripal Version: 3.dev

## Description
Typo corrections. The only potentially functional change is correcting `aadmin` to `admin` because it is in a URL path.

## Testing?
Automated testing and code review should be sufficent for this.
