### PR TITLE
Tripal 4 bugfix for  schema__additional_type field

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/schema__additional_type.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/schema__additional_type.php
@@ -68,8 +68,20 @@ class schema__additional_type extends ChadoFieldItemBase {
     // Get the Chado table and column this field maps to.
     $storage_settings = $field_definition->getSetting('storage_plugin_settings');
     $base_table = $storage_settings['base_table'];
-    $type_table = $storage_settings['type_table'];
-    $type_column = $storage_settings['type_column'];
+    $type_table = $storage_settings['type_table'] ?? '';
+    $type_column = $storage_settings['type_column'] ?? '';
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table or !$type_table) {
+      $record_id_term = 'SIO:000729';
+      return [
+        new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+          'action' => 'store_id',
+          'drupal_store' => TRUE,
+        ])
+      ];
+    }
 
     // Get the the connecting information about the base table and the
     // the table where the type is stored.  If the base table has a `type_id`

--- a/tripal_chado/src/Plugin/Field/FieldType/schema__additional_type.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/schema__additional_type.php
@@ -42,7 +42,7 @@ class schema__additional_type extends ChadoFieldItemBase {
     $settings = parent::defaultFieldSettings();
     // If a fixed value is set, then the field will will always use the
     // same value and the user will not be allowed the change it using the
-    // widget.  This is necessary content types that correspond to Chado
+    // widget.  This is necessary for content types that correspond to Chado
     // tables with a type_id that should always match the content type (e.g.
     // gene).
     $settings['fixed_value'] = FALSE;
@@ -84,9 +84,9 @@ class schema__additional_type extends ChadoFieldItemBase {
     }
 
     // Get the the connecting information about the base table and the
-    // the table where the type is stored.  If the base table has a `type_id`
-    // column then the base table and the type table are the same. If the
-    // we are using a prop table to store the type_id then the type table and
+    // table where the type is stored. If the base table has a `type_id`
+    // column then the base table and the type table are the same. If we
+    // are using a prop table to store the type_id then the type table and
     // base table will be different.
     $chado = \Drupal::service('tripal_chado.database');
     $schema = $chado->schema();
@@ -149,7 +149,7 @@ class schema__additional_type extends ChadoFieldItemBase {
       'chado_column' => $type_column,
       'empty_value' => 0
     ]);
-    // This fields needs the term name, idspace and accessession for proper
+    // This field needs the term name, idspace and accession for proper
     // display of the type.
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'term_name', $name_term, 128, [
       'action' => 'join',


### PR DESCRIPTION
# Bug Fix
## Issue #1466

### Tripal Version: 4.alpha1.dev

## Description
Applies to field `schema__additional_type`. The change is to make sure `$base_table` and `$type_table` are both defined before continuing to define all the properties for the field. See also issue #1432 and pull #1433 for a similar change on the `obi__organism` field.

I added null coalescing to `$type_table` and `$type_column` because these will be undefined between steps of manually adding the field, causing chaos otherwise, and the partially completed field can't be removed. This simple fix prevents that.

## Testing?
 1. Go to `/admin/structure/bio_data`
 1. For `Biological Sample` select `Manage fields`
 1. `+ Add field`
 1. Select `Chado Type Reference`
 1. For `Label` enter anything
 1. `Save and continue`
 1.  This error is reported before this change:
`Error message
There was a problem creating field BioType: Cannot create a StorageProperty object without a property formatted term:`
and after, the field can be added.
