### PR TITLE
Tripal 4 Issue 1472 $form_state bugfix

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -461,7 +461,7 @@ class OBOImporter extends ChadoImporterBase {
         \Drupal::messenger()->addMessage(t("The vocabulary @vocab has been added.", ['@vocab' => $obo_name]));
       }
       else {
-        $form_state['rebuild'] = TRUE;
+        $form_state->setRebuild(True);
         \Drupal::messenger()->addError(t("The vocabulary @vocab could not be added.", ['@vocab' => $obo_name]));
       }
     }


### PR DESCRIPTION
# BUG/ERROR report

### Tripal Version: 4.alpha1

### Issue description
I noticed this in the code, but didn't encounter an error until I copied and pasted it elsewhere. Error is
`Error: Cannot use object of type Drupal\Core\Form\FormState as array`

Line 464 of `tripal_chado/src/Plugin/TripalImporter/OBOImporter.php`:
```
$form_state['rebuild'] = TRUE
```
should be
```
$form_state->setRebuild(True);
```

#### Steps to reproduce
Not sure, this is found with code review 🧐