### PR TITLE
Change Automated PHPunit testing workflow to be triggered on pull requests

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - 9.x-4.x
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   run-tests:


### PR DESCRIPTION
This change is triggered by Issue #1477.
It turns out the automated testing has never run on pull requests from forked repositories. After much reading I suspect this is because it only runs on pushes to local branches. Since the branch for these PRs from forked repositories is not local, this workflow is not triggered.

Thus I added the pull_request action which will be triggered for all pull request opening and whenever a commit is pushed to any pull request branch even if it's in a fork -or at least that is what the docs imply.

Anyway, once I confirm it runs I'm going to merge it because I am 100% sure this will not hurt nor will it open us up to security concerns (this workflow does not have access to secrets when run by a fork triggered by this action and is read-only).

See here for more: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
