### PR TITLE
Update Dockerfile-php8-pgsql13

### DIFF
--- a/tripaldocker/Dockerfile-php8-pgsql13
+++ b/tripaldocker/Dockerfile-php8-pgsql13
@@ -205,7 +205,7 @@ RUN service apache2 start \
 ## Configuration files & Activation script
 RUN mv /app/tripaldocker/init_scripts/supervisord.conf /etc/supervisord.conf \
   && mv /app/tripaldocker/default_files/000-default.conf /etc/apache2/sites-available/000-default.conf \
-  && echo "\$settings['trusted_host_patterns'] = [ '^localhost$', '^127\.0\.0\.1$', '\$_SERVER[\'SERVER_NAME\']' ];" >> /var/www/drupal9/web/sites/default/settings.php \
+  && echo "\$settings['trusted_host_patterns'] = [ '^localhost$', '^127\.0\.0\.1$', \$_SERVER['SERVER_NAME'] ];" >> /var/www/drupal9/web/sites/default/settings.php \
   && mv /app/tripaldocker/init_scripts/init.sh /usr/bin/init.sh \
   && chmod +x /usr/bin/init.sh \
   && mv /app/tripaldocker/default_files/xdebug/xdebug_toggle.sh /usr/bin/xdebug_toggle.sh \


### PR DESCRIPTION
Quotes and backslashes were fixed in line 208. The current version of the dockerfile throws error at this line and does not execute this line as expected.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

#

Issue #

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
