### PR TITLE
Issue 1318 Add autocompletes for upcoming chado_linker module

### DIFF
--- a/tripal_chado/api/modules/tripal_chado.analysis.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.analysis.api.inc
@@ -17,6 +17,36 @@
 
 
 /**
+ * Used for autocomplete in forms for identifying analyses
+ *
+ * @param $string
+ *   The string to search for.
+ *
+ * @return
+ *   A json array of terms that begin with the provided string.
+ *
+ * @ingroup tripal_analysis_api
+ */
+function chado_autocomplete_analysis($string = '') {
+  $items = [];
+  $sql = "
+    SELECT
+      B.analysis_id as id, B.name
+    FROM {analysis} B
+    WHERE lower(B.name) like lower(:str)
+    ORDER by B.name
+    LIMIT 25 OFFSET 0
+  ";
+  $records = chado_query($sql, [':str' => $string . '%']);
+  while ($r = $records->fetchObject()) {
+    $key = "$r->name [id: $r->id]";
+    $items[$key] = "$r->name";
+  }
+
+  drupal_json_output($items);
+}
+
+/**
  * Retrieves a chado analysis variable.
  *
  * @param $identifier

--- a/tripal_chado/api/modules/tripal_chado.assay.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.assay.api.inc
@@ -1,21 +1,21 @@
 <?php
 /**
  * @file
- * Provides API functions specifically for managing project
+ * Provides API functions specifically for managing assay
  * records in Chado.
  */
 
 /**
- * @defgroup tripal_project_api Chado Project
+ * @defgroup tripal_assay_api Chado Assay
  * @ingroup tripal_chado_api
  * @{
- * Provides API functions specifically for managing project
- * records in Chado.
+ * Provides API functions for working with assay records in Chado that
+ * go beyond the generic Chado API functions.
  * @}
  */
 
 /**
- * Used for autocomplete in forms for identifying projects
+ * Used for autocomplete in forms for identifying assays
  *
  * @param $string
  *   The string to search for.
@@ -23,16 +23,16 @@
  * @return
  *   A json array of terms that begin with the provided string.
  *
- * @ingroup tripal_project_api
+ * @ingroup tripal_assay_api
  */
-function chado_autocomplete_project($string = '') {
+function chado_autocomplete_assay($string = '') {
   $items = [];
   $sql = "
     SELECT
-      P.project_id as id, P.name
-    FROM {project} P
-    WHERE lower(P.name) like lower(:str)
-    ORDER by P.name
+      B.assay_id as id, B.name
+    FROM {assay} B
+    WHERE lower(B.name) like lower(:str)
+    ORDER by B.name
     LIMIT 25 OFFSET 0
   ";
   $records = chado_query($sql, [':str' => $string . '%']);

--- a/tripal_chado/api/modules/tripal_chado.biomaterial.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.biomaterial.api.inc
@@ -1,21 +1,21 @@
 <?php
 /**
  * @file
- * Provides API functions specifically for managing project
+ * Provides API functions specifically for managing biomaterial
  * records in Chado.
  */
 
 /**
- * @defgroup tripal_project_api Chado Project
+ * @defgroup tripal_biomaterial_api Chado Biomaterial
  * @ingroup tripal_chado_api
  * @{
- * Provides API functions specifically for managing project
+ * Provides API functions specifically for managing biomaterial
  * records in Chado.
  * @}
  */
 
 /**
- * Used for autocomplete in forms for identifying projects
+ * Used for autocomplete in forms for identifying biomaterials
  *
  * @param $string
  *   The string to search for.
@@ -23,16 +23,16 @@
  * @return
  *   A json array of terms that begin with the provided string.
  *
- * @ingroup tripal_project_api
+ * @ingroup tripal_biomaterial_api
  */
-function chado_autocomplete_project($string = '') {
+function chado_autocomplete_biomaterial($string = '') {
   $items = [];
   $sql = "
     SELECT
-      P.project_id as id, P.name
-    FROM {project} P
-    WHERE lower(P.name) like lower(:str)
-    ORDER by P.name
+      B.biomaterial_id as id, B.name
+    FROM {biomaterial} B
+    WHERE lower(B.name) like lower(:str)
+    ORDER by B.name
     LIMIT 25 OFFSET 0
   ";
   $records = chado_query($sql, [':str' => $string . '%']);

--- a/tripal_chado/api/modules/tripal_chado.featuremap.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.featuremap.api.inc
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ * Provides API functions specifically for managing featuremap
+ * records in Chado.
+ */
+
+/**
+ * @defgroup tripal_featuremap_api Chado Featuremap
+ * @ingroup tripal_chado_api
+ * @{
+ * Provides API functions for working with featuremap records in Chado that
+ * go beyond the generic Chado API functions.
+ * @}
+ */
+
+/**
+ * Used for autocomplete in forms for identifying featuremaps
+ *
+ * @param $string
+ *   The string to search for.
+ *
+ * @return
+ *   A json array of terms that begin with the provided string.
+ *
+ * @ingroup tripal_featuremap_api
+ */
+function chado_autocomplete_featuremap($string = '') {
+  $items = [];
+  $sql = "
+    SELECT
+      FM.featuremap_id as id, FM.name
+    FROM {featuremap} FM
+    WHERE lower(FM.name) like lower(:str)
+    ORDER by FM.name
+    LIMIT 25 OFFSET 0
+  ";
+  $records = chado_query($sql, [':str' => $string . '%']);
+  while ($r = $records->fetchObject()) {
+    $key = "$r->name [id: $r->id]";
+    $items[$key] = "$r->name";
+  }
+
+  drupal_json_output($items);
+}

--- a/tripal_chado/api/modules/tripal_chado.study.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.study.api.inc
@@ -1,21 +1,21 @@
 <?php
 /**
  * @file
- * Provides API functions specifically for managing project
+ * Provides API functions specifically for managing study
  * records in Chado.
  */
 
 /**
- * @defgroup tripal_project_api Chado Project
+ * @defgroup tripal_study_api Chado Study
  * @ingroup tripal_chado_api
  * @{
- * Provides API functions specifically for managing project
- * records in Chado.
+ * Provides API functions for working with study records in Chado that
+ * go beyond the generic Chado API functions.
  * @}
  */
 
 /**
- * Used for autocomplete in forms for identifying projects
+ * Used for autocomplete in forms for identifying studies
  *
  * @param $string
  *   The string to search for.
@@ -23,16 +23,16 @@
  * @return
  *   A json array of terms that begin with the provided string.
  *
- * @ingroup tripal_project_api
+ * @ingroup tripal_study_api
  */
-function chado_autocomplete_project($string = '') {
+function chado_autocomplete_study($string = '') {
   $items = [];
   $sql = "
     SELECT
-      P.project_id as id, P.name
-    FROM {project} P
-    WHERE lower(P.name) like lower(:str)
-    ORDER by P.name
+      S.study_id as id, S.name
+    FROM {study} S
+    WHERE lower(S.name) like lower(:str)
+    ORDER by S.name
     LIMIT 25 OFFSET 0
   ";
   $records = chado_query($sql, [':str' => $string . '%']);

--- a/tripal_chado/includes/TripalFields/chado_linker__contact/chado_linker__contact.inc
+++ b/tripal_chado/includes/TripalFields/chado_linker__contact/chado_linker__contact.inc
@@ -98,7 +98,7 @@ class chado_linker__contact extends ChadoField {
           $description_term => [
             'searchable' => TRUE,
             'label' => 'Contact Description',
-            'help' => 'A descriptoin of the contact.',
+            'help' => 'A description of the contact.',
             'operations' => ['contains'],
             'sortable' => TRUE,
             'type' => 'xs:string',
@@ -129,6 +129,11 @@ class chado_linker__contact extends ChadoField {
     $type_term = chado_get_semweb_term('contact', 'type_id');
     $name_term = chado_get_semweb_term('contact', 'name');
     $description_term = chado_get_semweb_term('contact', 'description');
+
+    // Set some defaults for the empty record.
+    $entity->{$field_name}['und'][0] = [
+      'value' => [],
+    ];
 
     // Get the FK that links to the base record.
     $schema = chado_get_schema($field_table);

--- a/tripal_chado/theme/css/tripal_chado.css
+++ b/tripal_chado/theme/css/tripal_chado.css
@@ -18,6 +18,12 @@
   width:100%;
 }
 
+.chado-linker--cell {
+  max-height: 200px;
+  overflow: auto;
+  overflow-wrap: break-word;
+}
+
 .primary-dbxref-widget-links,
 .secondary-dbxref-widget-links {
    clear: both;

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -41,14 +41,18 @@ require_once 'api/ChadoRecord.inc';
 
 // Chado module specific API functions
 require_once 'api/modules/tripal_chado.analysis.api.inc';
+require_once 'api/modules/tripal_chado.assay.api.inc';
+require_once 'api/modules/tripal_chado.biomaterial.api.inc';
 require_once 'api/modules/tripal_chado.contact.api.inc';
 require_once 'api/modules/tripal_chado.cv.api.inc';
 require_once 'api/modules/tripal_chado.db.api.inc';
 require_once 'api/modules/tripal_chado.feature.api.inc';
+require_once 'api/modules/tripal_chado.featuremap.api.inc';
 require_once 'api/modules/tripal_chado.organism.api.inc';
+require_once 'api/modules/tripal_chado.phylotree.api.inc';
 require_once 'api/modules/tripal_chado.pub.api.inc';
 require_once 'api/modules/tripal_chado.stock.api.inc';
-require_once 'api/modules/tripal_chado.phylotree.api.inc';
+require_once 'api/modules/tripal_chado.study.api.inc';
 require_once 'api/modules/tripal_chado.module.DEPRECATED.api.inc';
 
 //
@@ -514,11 +518,35 @@ function tripal_chado_menu() {
   //////////////////////////////////////////////////////////////////////////////
   //                           Auto Completes
   //////////////////////////////////////////////////////////////////////////////
-  $items['admin/tripal/storage/chado/auto_name/dbxref/%/%'] = array(
-    'page callback' => 'chado_autocomplete_dbxref',
-    'page arguments' => array(6, 7),
+  $items['admin/tripal/storage/chado/auto_name/analysis/%'] = array(
+    'page callback' => 'chado_autocomplete_analysis',
+    'page arguments' => array(6),
     'access arguments' => array('access content'),
-    'file' => 'api/modules/tripal_chado.db.api.inc',
+    'file' => 'api/modules/tripal_chado.analysis.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/tripal/storage/chado/auto_name/assay/%'] = array(
+    'page callback' => 'chado_autocomplete_assay',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'file' => 'api/modules/tripal_chado.assay.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/tripal/storage/chado/auto_name/biomaterial/%'] = array(
+    'page callback' => 'chado_autocomplete_biomaterial',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'file' => 'api/modules/tripal_chado.biomaterial.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/tripal/storage/chado/auto_name/contact/%'] = array(
+    'page callback' => 'chado_autocomplete_contact',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'file' => 'api/modules/tripal_chado.contact.api.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
@@ -538,20 +566,11 @@ function tripal_chado_menu() {
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
-
-  $items['admin/tripal/storage/chado/auto_name/pub/%'] = array(
-    'page callback' => 'chado_autocomplete_pub',
-    'page arguments' => array(6),
+  $items['admin/tripal/storage/chado/auto_name/dbxref/%/%'] = array(
+    'page callback' => 'chado_autocomplete_dbxref',
+    'page arguments' => array(6, 7),
     'access arguments' => array('access content'),
-    'file' => 'api/modules/tripal_chado.pub.api.inc',
-    'file path' => drupal_get_path('module', 'tripal_chado'),
-    'type' => MENU_CALLBACK,
-  );
-  $items['admin/tripal/storage/chado/auto_name/contact/%'] = array(
-    'page callback' => 'tripal_autocomplete_contact',
-    'page arguments' => array(6),
-    'access arguments' => array('access content'),
-    'file' => 'api/modules/tripal_chado.contact.api.inc',
+    'file' => 'api/modules/tripal_chado.db.api.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
@@ -563,11 +582,35 @@ function tripal_chado_menu() {
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
+  $items['admin/tripal/storage/chado/auto_name/featuremap/%'] = array(
+    'page callback' => 'chado_autocomplete_featuremap',
+    'page arguments' => array(6),
+    'access arguments' => array('featuremap content'),
+    'file' => 'api/modules/tripal_chado.featuremap.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
   $items['admin/tripal/storage/chado/auto_name/organism/%'] = array(
     'page callback' => 'chado_autocomplete_organism',
     'page arguments' => array(6),
     'access arguments' => array('access content'),
     'file' => 'api/modules/tripal_chado.organism.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/tripal/storage/chado/auto_name/project/%'] = array(
+    'page callback' => 'chado_autocomplete_project',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'file' => 'api/modules/tripal_chado.project.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_chado'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/tripal/storage/chado/auto_name/pub/%'] = array(
+    'page callback' => 'chado_autocomplete_pub',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'file' => 'api/modules/tripal_chado.pub.api.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
@@ -579,11 +622,11 @@ function tripal_chado_menu() {
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );
-  $items['admin/tripal/storage/chado/auto_name/project/%'] = array(
-    'page callback' => 'chado_autocomplete_project',
+    $items['admin/tripal/storage/chado/auto_name/study/%'] = array(
+    'page callback' => 'chado_autocomplete_study',
     'page arguments' => array(6),
     'access arguments' => array('access content'),
-    'file' => 'api/modules/tripal_chado.project.api.inc',
+    'file' => 'api/modules/tripal_chado.study.api.inc',
     'file path' => drupal_get_path('module', 'tripal_chado'),
     'type' => MENU_CALLBACK,
   );


### PR DESCRIPTION
# New Feature

## Issue #1318

### Tripal Version: 3.9

## Description
Most of the changes from issue #1318 pull #1319 will be moved to a new module [chado_linker_fields](https://github.com/tripal/chado_linker_fields). 
However, a few changes needed by the new linker fields are best handled in core tripal:
1. api functions for autocompletes in forms e.g. `function chado_autocomplete_analysis()`
2. some text in the project api that was copied from stock api was removed.
3. typo and PHP8 bugfix in `chado_linker__contact` field
4. a tiny bit of css to accomodate a max_height setting for fields

I did not implement the max_delta and other settings in core tripal because nothing there will use it, and to make this pull request reasonably "safe". In tripal 4 it will be in core, though.

## Testing?
1. Will have to be code review as the functions calling the new api functions are not there yet. These api changes are very very similar to existing ones for other content types, so I hope code review is sufficient. If you really want to test, use the branch from #1319 (now closed) and see the autocompletes in all their glory
2. the text removed from the project api you can see came from the stock api, doesn't apply to project.
3. this is the same as another fix somewhere, I'll have to look up which...
4. this css will be unused in core tripal I hope that's okay. 