### PR TITLE
Tripal 4 issue1496 fix old workflow versions

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches-ignore:
-      - 9.x-4.x
+      - 4.x
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 10.0.x-dev

--- a/.github/workflows/MAIN-phpunit-php8.1_D9_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D9_3x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.3.x-dev

--- a/.github/workflows/MAIN-phpunit-php8.1_D9_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D9_4x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.4.x-dev

--- a/.github/workflows/MAIN-phpunit-php8.1_D9_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D9_5x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.5.x-dev

--- a/.github/workflows/MAIN-phpunit-php8_D9_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8_D9_2x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.2.x-dev

--- a/.github/workflows/MAIN-phpunit-php8_D9_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8_D9_3x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.3.x-dev

--- a/.github/workflows/MAIN-phpunit-php8_D9_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8_D9_4x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.4.x-dev

--- a/.github/workflows/MAIN-phpunit-php8_D9_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8_D9_5x.yml
@@ -3,7 +3,7 @@ name: PHPUnit
 on:
   push:
     branches:
-      - 9.x-4.x
+      - 4.x
 
 env:
   DRUPALVER: 9.5.x-dev

--- a/.github/workflows/PR-branchNameCheck.yml
+++ b/.github/workflows/PR-branchNameCheck.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: deepakputhraya/action-branch-name@v1.0.0
         with:
           regex: 'tv4g[0-9]-(issue){0,1}\d+-{0,1}\w*' # Regex the branch should match. 
-          ignore: 9.x-4.x,8.x-4.x # Ignore exactly matching branch names from convention
+          ignore: 4.x # Ignore exactly matching branch names from convention


### PR DESCRIPTION
# Bug Fix
## Issue #1496

### Tripal Version: 4.alpha.1 (workflows)

## Description
Correct some version numbers left over from the move from the t4d8 repo
The old version number caused the url to the testing badges to not work, because the tests were never run on the 4.x branch.

## Testing?
This should no longer display `Not Found`
https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg
