### PR TITLE
Remove default select from chado_get_organism_select_options()

### DIFF
--- a/tripal_chado/src/api/tripal_chado.organism.api.inc
+++ b/tripal_chado/src/api/tripal_chado.organism.api.inc
@@ -190,7 +190,6 @@ function chado_get_organism_scientific_name($organism) {
  */
 function chado_get_organism_select_options($published_only = FALSE, $show_common_name = FALSE) {
   $org_list = [];
-  $org_list[] = 'Select an organism';
 
   if ($published_only) {
     throw new \Exception(t('Passing TRUE for the :param parameter is not yet implemented for :func',


### PR DESCRIPTION
# Tripal 4 Core Dev Task

Issue #1505

### Tripal Version: 4.x

## Description
This removes the built-in `Select an organism` from the `chado_get_organism_select_options()` api function.
The "Drupal" way would be for a form to add this itself with `#empty_option` if it is desired.

## Testing?
Currently only used in the gff3 loader, there were two select an organism top selects, now there should only be one.
