### PR TITLE
Tv4g1 issue1507 fix pylotree typo

### DIFF
--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -1040,7 +1040,7 @@ fields:
               region: content
               weight: 10
 
-    -   name: pylotree_name
+    -   name: phylotree_name
         content_type: bio_data_10
         label: Name
         type: chado_string_type
@@ -1093,7 +1093,7 @@ fields:
               region: content
               weight: 15
 
-    -   name: pylotree_type
+    -   name: phylotree_type
         content_type: bio_data_10
         label: Type
         type: chado_additional_type_default


### PR DESCRIPTION
# Bug Fix

Issue #1507

### Tripal Version: 4

## Description
Fix typo "pylotree" to "phylotree" in yml

## Testing?
Go to `/admin/structure/bio_data/manage/bio_data_10/fields`

Fixing this doesn't correct current fields, may need to create a new docker for proper confirmation that typo is fixed.