### PR TITLE
Remove deprecated functionality to move us closer to D10 support

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -37,14 +37,21 @@ jobs:
       # Check out the repo
       - name: Checkout Repository
         uses: actions/checkout@v2
-      # Here we fully  build a docker using the current checked out code
+      # Here we fully build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build Dockerfile-php8.1-pgsql13
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
+        if: ${{ matrix.php-version == '8.1' && matrix.drupal-version != '10.0.x-dev' && matrix.pgsql-version == '13'}}
         run: |
           docker build --tag=tripaldocker:localdocker \
             --build-arg drupalversion="${{ matrix.drupal-version }}" \
             --build-arg chadoschema='testchado' ./ \
+            --file tripaldocker/Dockerfile-php8.1-pgsql13
+      - name: Build Dockerfile-php8.1-pgsql13 for Drupal 10
+        if: ${{ matrix.php-version == '8.1' && matrix.drupal-version == '10.0.x-dev' && matrix.pgsql-version == '13'}}
+        run: |
+          docker build --tag=tripaldocker:localdocker \
+            --build-arg drupalversion="${{ matrix.drupal-version }}" \
+            --build-arg installchado=FALSE ./ \
             --file tripaldocker/Dockerfile-php8.1-pgsql13
       - name: Build Dockerfile-php8-pgsql13
         if: ${{ matrix.php-version == '8.0' && matrix.pgsql-version == '13'}}

--- a/tripal/tests/src/Functional/Entity/EntityAccessTest.php
+++ b/tripal/tests/src/Functional/Entity/EntityAccessTest.php
@@ -15,7 +15,7 @@ use Drupal\Core\Access\AccessResultForbidden;
  * @group Tripal Permissions
  */
 class EntityAccessTest extends BrowserTestBase {
-    protected $defaultTheme = 'stable';
+    protected $defaultTheme = 'stark';
 
     protected static $modules = ['tripal'];
 

--- a/tripal/tests/src/Functional/TripalImporterTest.php
+++ b/tripal/tests/src/Functional/TripalImporterTest.php
@@ -12,7 +12,7 @@ use Drupal\Core\Url;
  * require database specific implementations.
  */
 class TripalImporterTest extends BrowserTestBase {
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   protected static $modules = ['tripal'];
 

--- a/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
+++ b/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
@@ -17,7 +17,7 @@ use Drupal\Core\Url;
 class TripalRoutePermissionsTest extends BrowserTestBase {
 
   // protected $htmlOutputEnabled = TRUE;
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   protected static $modules = ['tripal', 'file', 'field_ui'];
 

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -24,7 +24,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}

--- a/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
+++ b/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
@@ -17,7 +17,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
 class TripalVocabTermPluginTest extends BrowserTestBase {
 
   // protected $htmlOutputEnabled = TRUE;
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   protected static $modules = ['tripal'];
 

--- a/tripal/tests/src/Functional/bulkPgSchemaInstallerTest.php
+++ b/tripal/tests/src/Functional/bulkPgSchemaInstallerTest.php
@@ -14,7 +14,7 @@ use Drupal\Core\Database\Database;
 class bulkPgSchemaInstallerTest extends BrowserTestBase {
 
   // protected $htmlOutputEnabled = TRUE;
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   protected static $modules = ['tripal'];
 

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -878,7 +878,7 @@ function tripal_install_cloner() {
   $db = \Drupal::database();
 
   $sql_cloner_path =
-    drupal_get_path('module', 'tripal')
+    \Drupal::service('extension.path.resolver')->getPath('module', 'tripal')
     . '/src/TripalDBX/pg-clone-schema/clone_schema.sql';
 
   // Replaces "public." in SQL if it is not the default Drupal schema.
@@ -938,7 +938,7 @@ function tripal_uninstall_cloner() {
   $db = \Drupal::database();
 
   $sql_uninstall_cloner_path =
-    drupal_get_path('module', 'tripal')
+    \Drupal::service('extension.path.resolver')->getPath('module', 'tripal')
     . '/src/TripalDBX/pg-clone-schema/clone_schema_uninstall.sql';
 
   // Replaces "public." in SQL if it is not the default Drupal schema.

--- a/tripal_chado/tests/src/Functional/Forms/chadoInstallerFormTest.php
+++ b/tripal_chado/tests/src/Functional/Forms/chadoInstallerFormTest.php
@@ -14,7 +14,7 @@ use Drupal\Tests\BrowserTestBase;
  */
 class chadoInstallerFormTest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/LoadTest.php
+++ b/tripal_chado/tests/src/Functional/LoadTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\BrowserTestBase;
  */
 class LoadTest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/Services/chadoInstallerTest.php
+++ b/tripal_chado/tests/src/Functional/Services/chadoInstallerTest.php
@@ -15,7 +15,7 @@ use Drupal\Tests\BrowserTestBase;
  */
 class chadoInstallerTest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/api/ChadoComplianceTest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoComplianceTest.php
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\api\ChadoSchema;
  */
 class ChadoComplianceTest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/api/ChadoCustomTablesAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoCustomTablesAPITest.php
@@ -17,7 +17,7 @@ use Drupal\tripal_chado\api\DrupalSchemaExtended;
  */
 class ChadoCustomTablesAPITest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.
@@ -31,7 +31,7 @@ class ChadoCustomTablesAPITest extends BrowserTestBase {
    */
   protected static $schemaName = 'testchado';
 
-  
+
   /**
    * Tests chado.cv associated functions.
    *
@@ -72,7 +72,7 @@ class ChadoCustomTablesAPITest extends BrowserTestBase {
 
     // // This code will probably be broken since I reverted back to the standard
     // // code which does not have the argument isFunctionalTest = TRUE in the functions.
-    // // $chado_schema = chado_get_schema_name('chado'); // Todo - is this really how we want to get the schema name? 
+    // // $chado_schema = chado_get_schema_name('chado'); // Todo - is this really how we want to get the schema name?
     // // Does not seem like it would work with multi-chado instances.
     // global $chado_dot;
     // $chado_dot = "";
@@ -88,6 +88,6 @@ class ChadoCustomTablesAPITest extends BrowserTestBase {
     // $this->assertFalse($connection->schema()->tableExists($table_name), 'ERROR: The custom table was not deleted.');
 
 
-  }  
+  }
 
 }

--- a/tripal_chado/tests/src/Functional/api/ChadoDbAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoDbAPITest.php
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\api\ChadoSchema;
  */
 class ChadoDbAPITest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/api/ChadoQueryAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoQueryAPITest.php
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\api\ChadoSchema;
  */
 class ChadoQueryAPITest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/api/ChadoVariablesAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoVariablesAPITest.php
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\api\ChadoSchema;
  */
 class ChadoVariablesAPITest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tests/src/Functional/api/SchemaAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/SchemaAPITest.php
@@ -17,7 +17,7 @@ use Drupal\tripal_chado\api\ChadoSchema;
  */
 class SchemaAPITest extends BrowserTestBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -122,7 +122,7 @@ function tripal_chado_rebuild_views() {
   // Make sure the Views are present.
   //
   $storage = \Drupal::entityTypeManager()->getStorage('view');
-  $dir = drupal_get_path('module', 'tripal_chado');
+  $dir = \Drupal::service('extension.path.resolver')->getPath('module', 'tripal_chado');
   $fileStorage = new FileStorage($dir);
 
   // The chado_custom_tables view.

--- a/tripaldocker/Dockerfile-php8-pgsql13
+++ b/tripaldocker/Dockerfile-php8-pgsql13
@@ -8,6 +8,7 @@ MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
 ARG drupalversion='9.3.x-dev'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
+ARG installchado=TRUE
 
 # Label docker image
 LABEL drupal.version=${drupalversion}
@@ -195,8 +196,10 @@ RUN service apache2 start \
   && mkdir -p /var/www/drupal9/web/modules/contrib \
   && cp -R /app /var/www/drupal9/web/modules/contrib/tripal \
   && vendor/bin/drush en tripal tripal_biodb tripal_chado ${modules} -y \
-  && vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
-  && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \
+  && if [ "$installchado" = "TRUE" ]; then \
+    vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
+    && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema}; \
+    fi \
   && service apache2 stop \
   && service postgresql stop
 
@@ -209,7 +212,7 @@ RUN mv /app/tripaldocker/init_scripts/supervisord.conf /etc/supervisord.conf \
   && mv /app/tripaldocker/init_scripts/init.sh /usr/bin/init.sh \
   && chmod +x /usr/bin/init.sh \
   && mv /app/tripaldocker/default_files/xdebug/xdebug_toggle.sh /usr/bin/xdebug_toggle.sh \
-  && echo "\$config['system.logging']['error_level'] = 'verbose';" >> /var/www/drupal9/web/sites/default/settings.php 
+  && echo "\$config['system.logging']['error_level'] = 'verbose';" >> /var/www/drupal9/web/sites/default/settings.php
 
 ## Make global commands.
 RUN ln -s /var/www/drupal9/vendor/phpunit/phpunit/phpunit /usr/local/bin/ \

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -8,6 +8,7 @@ MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
 ARG drupalversion='9.4.x-dev'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
+ARG installchado=TRUE
 
 # Label docker image
 LABEL drupal.version=${drupalversion}
@@ -195,8 +196,10 @@ RUN service apache2 start \
   && mkdir -p /var/www/drupal9/web/modules/contrib \
   && cp -R /app /var/www/drupal9/web/modules/contrib/tripal \
   && vendor/bin/drush en tripal tripal_biodb tripal_chado ${modules} -y \
-  && vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
-  && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \
+  && if [ "$installchado" = "TRUE" ]; then \
+    vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
+    && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema}; \
+    fi \
   && service apache2 stop \
   && service postgresql stop
 
@@ -209,7 +212,7 @@ RUN mv /app/tripaldocker/init_scripts/supervisord.conf /etc/supervisord.conf \
   && mv /app/tripaldocker/init_scripts/init.sh /usr/bin/init.sh \
   && chmod +x /usr/bin/init.sh \
   && mv /app/tripaldocker/default_files/xdebug/xdebug_toggle.sh /usr/bin/xdebug_toggle.sh \
-  && echo "\$config['system.logging']['error_level'] = 'verbose';" >> /var/www/drupal9/web/sites/default/settings.php 
+  && echo "\$config['system.logging']['error_level'] = 'verbose';" >> /var/www/drupal9/web/sites/default/settings.php
 
 ## Make global commands.
 RUN ln -s /var/www/drupal9/vendor/phpunit/phpunit/phpunit /usr/local/bin/ \


### PR DESCRIPTION
# Tripal 4 Core Dev Task

Issue #1510

### Tripal Version: 4

## Description
This PR updates the following deprecations with are removed in D10 and breaking things:
 - `drupal_get_path()` => `\Drupal::service('extension.path.resolver')->getPath()`
 - test theme as `stable` => use `stark` or `Olivia` instead, stark preferred.

It also adds an arg to the dockerfile allowing you to tell it to not install chado. This is helpful for general cases but especially important for working on D10 as we do not yet have Tripal DBX working in D10.

## Testing?
This does not need to be tested manually as it should not have any effect. As long as tests pass and the docker is now buildable in D10, I think this can be merged.
