### PR TITLE
Tripal 4 rename some remaining .inc files to .php - issue1502 - part 2

### DIFF
--- a/tripal/templates/tripal_entity.page.php
+++ b/tripal/templates/tripal_entity.page.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains tripal_entity.page.inc.
+ * Contains tripal_entity.page.php.
  *
  * Page callback for Tripal Content entities.
  */

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -49,14 +49,14 @@ function tripal_theme() {
 
   $theme['tripal_entity'] = array(
     'render element' => 'elements',
-    'file' => 'templates/tripal_entity.page.inc',
+    'file' => 'templates/tripal_entity.page.php',
     'template' => 'tripal_entity',
   );
 
   $theme['tripal_entity_content_add_list'] = [
     'render element' => 'types',
     'variables' => ['types' => NULL],
-    'file' => 'templates/tripal_entity.page.inc',
+    'file' => 'templates/tripal_entity.page.php',
   ];
 
   return $theme;


### PR DESCRIPTION
# Bug Fix

## Issue #1502 

### Tripal Version: 4.x alpha 1

## Description
@laceysanderson has noted: All the api files in `tripal_chado` end in `.inc` as was the custom in Drupal 7. This has changed in recent versions of drupal. Now all PHP files should end in `.php` with no exceptions.

This pull changes the one remaining file mentioned in https://github.com/tripal/tripal/issues/1502#issuecomment-1542979716 that was not fixed in pull #1512