### PR TITLE
Tripal 4 - Fix all the PHP 8.2 deprecations part 2

### DIFF
--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -897,12 +897,13 @@ function tripal_update_8401() {
 /**
  * Implements hook_update_N().
  *
- * Removes PostgreSQL schema clonging functions.
+ * Removes PostgreSQL schema cloning functions.
  */
 function tripal_update_8402() {
   // Remove the Tripal DBX Cloner functions from the Drupal schema.
   tripal_uninstall_cloner();
-  $messenger->addMessage('Removed PostgreSQL schema clonging functions');
+  $messenger = \Drupal::messenger();
+  $messenger->addMessage('Removed PostgreSQL schema cloning functions');
 }
 
 /**


### PR DESCRIPTION
# Tripal 4 Core Dev Task

## Issue #1520


### Tripal Version: 4.x dev docker **running on php 8.2**

## Description
This is similar to the deprecated dynamic property problem, see pull #1521 for more details
Although this one is a bit different, we are in procedural code, and the `$messenger` variable is simply not initialized before use, we just need to add this:

`$messenger = \Drupal::messenger();`

## Testing?
run on php 8.2 and run `drush updatedb`
```
>  [warning] Undefined variable $messenger tripal.install:970
>  [error]  Call to a member function addMessage() on null 
```
if fixed, these should go away.
