### PR TITLE
Remove Interface, Annotation and Exception classes from code coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,21 @@
       <directory suffix=".php">tripal_chado/src</directory>
       <file>tripal_chado/tripal_chado.module</file>
     </include>
+    <exclude>
+      <!-- Exclude Interface classes from coverage -->
+      <directory suffix="Interface.php">tripal/src/Entity</directory>
+      <directory suffix="Interface.php">tripal/src/TripalField/Interfaces</directory>
+      <directory suffix="Interface.php">tripal/src/*/Interfaces</directory>
+      <file>tripal/src/TripalContentTermsInterface.php</file>
+      <directory suffix="Interface.php">tripal_biodb/src/Lock</directory>
+      <directory suffix="Interface.php">tripal_biodb/src/Task</directory>
+      <!-- Exclude Annotation classes from coverage -->
+      <directory suffix=".php">tripal/src/Plugin/Annotation</directory>
+      <directory suffix=".php">tripal/src/*/Annotation</directory>
+      <!-- Exclude Exception classes from coverage -->
+      <directory suffix=".php">tripal/src/TripalDBX/Exceptions</directory>
+      <directory suffix=".php">tripal_biodb/src/Exception</directory>
+    </exclude>
   </coverage>
   <php>
     <!-- Set error reporting to E_ALL. -->


### PR DESCRIPTION

# Tripal 4 Core Dev Task

Issue #1528 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
Literally just changes the configuration of phpunit for code coverage to remove all interface, annotation and exception classes from the total coverage calculation.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
There are no code changes so no need to manual test.

For automated testing, we just want to check codeclimate to ensure that the expected files are now being excluded from the coverage calculations.