### PR TITLE
issue1530 update node.js from 12 to 16

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Here we fully build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build Docker Image

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Here we fully  build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build the Docker

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -39,7 +39,7 @@ jobs:
             drupal-version: "10.1.x-dev"
     name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images


### PR DESCRIPTION
# Tripal 4 Core Dev Task

## Issue #1530

### Tripal Version: 4.x alpha (docker)

## Description
Node.js 12 actions are deprecated
I think this might be resolved with two 1-byte changes of `actions/checkout@v2` to `actions/checkout@v3`

## Testing?
Automated testing should be sufficient, as it is currently just a deprecation warning 🤷
