### PR TITLE
Tripal 3 Issue 1532 PHP8 fix for chado storage

### DIFF
--- a/tripal_chado/includes/tripal_chado.field_storage.inc
+++ b/tripal_chado/includes/tripal_chado.field_storage.inc
@@ -227,9 +227,9 @@ function tripal_chado_field_storage_write_table($table_name, $values, $base_tabl
     }
 
     // If this table_name is a linker table then we want to be sure to add in
-    // the value for the $base_record_id it it isn't set.  This would only
+    // the value for the $base_record_id if it isn't set.  This would only
     // occur on an insert.
-    if (array_key_exists($base_table, $fkeys) and $base_table != $table_name) {
+    if ($fkeys and array_key_exists($base_table, $fkeys) and $base_table != $table_name) {
       foreach ($fkeys[$base_table]['columns'] as $lkey => $rkey) {
         if ($rkey == $base_pkey and !array_key_exists($lkey, $values) or empty($values[$lkey])) {
           $values[$lkey] = $base_record_id;


### PR DESCRIPTION
# Bug Fix

## Issue #1532

### Tripal Version: 3.10

## Description
Cannot save a new license with the tripal_file module. This looks like another PHP8 error that would not have been visible under PHP 7.x, and the error is in tripal, not the module, trying to look for an array key in a null variable.

## Testing?

1. Run under PHP8.1 ~or probably 8.0~
1. Install tripal_file module
1. Try to create a new license. The following error occurs
`The website encountered an unexpected error. Please try again later. `
and in the log we see:
`TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in tripal_chado_field_storage_write_table() (line 232 of .../sites/all/modules/tripal/tripal_chado/includes/tripal_chado.field_storage.inc).`
1. Try again on this branch. You should be able to save a new license successfully.