### PR TITLE
Tv4g2 issue1534 chado cvterm autocomplete update

### DIFF
--- a/tripal_chado/src/Controller/ChadoCVTermAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoCVTermAutocompleteController.php
@@ -105,4 +105,38 @@ class ChadoCVTermAutocompleteController extends ControllerBase {
 
     return $id;
   }
+
+  /**
+   * Given a cvterm id number, return the matching cvterm record using
+   * the format cvterm name (db.name:dbxref.accession).
+   * 
+   * @param integer $id
+   *   Cvterm id number to match.
+   * 
+   * @return string
+   *   Cvterm record in cvterm name (db.name:dbxref.accession) format.
+   */
+  public static function formatCVterm(int $id) {
+    $term = null;
+    
+    if ($id > 0) {
+      $sql = "
+        SELECT CONCAT(ct.name, ' (', db.name, ':', dx.accession, ')') 
+        FROM {1:cvterm} AS ct 
+          LEFT JOIN {1:dbxref} AS dx USING(dbxref_id) 
+          LEFT JOIN {1:db} USING(db_id)
+        WHERE ct.cvterm_id = :cvterm_id
+        LIMIT 1 
+      ";
+
+      $connection = \Drupal::service('tripal_chado.database');
+      $result = $connection->query($sql, [':cvterm_id' => $id]);
+
+      if($result) {
+        $term = $result->fetchField();
+      }
+    }
+
+    return $term;
+  }
 }

--- a/tripal_chado/tests/src/Functional/Controller/ChadoTableCvtermAutocompleteTest.php
+++ b/tripal_chado/tests/src/Functional/Controller/ChadoTableCvtermAutocompleteTest.php
@@ -118,5 +118,18 @@ class ChadoTableCvtermAutocompleteTest extends ChadoTestBrowserBase {
       $id = $autocomplete->getCVtermId($i);
       $this->assertEquals($id, 0);
     }
+
+
+    // Test format CVterm method.
+    foreach(json_decode($suggest) as $item) {
+      // ChadoCVTermAutocompleteController::getCVtermId()
+      $id = $autocomplete->getCVtermId($item->value);
+      // Reverse value - get formatted term.
+      $term = $autocomplete->formatCVterm($id);
+      
+      $this->assertNotNull($term);
+      $this->assertIsString($term);
+      $this->assertEquals($term, $item->value);
+    }
   }
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

Chado Cvterm Autocomplete Update 
Issue https://github.com/tripal/tripal/issues/1534

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I have added a method that will return cvterm record in cvterm.name (db.name:dbxref.accession) format given a cvterm id number. This method is called in the same way as the counterpart method to get the cvterm id.

```
$cvterm_id = 1;
$term = ChadoCVTermAutocompleteController::formatCVterm($cvterm_id);
```

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Test by providing cvterm id number to the method to check if the returned value is not null, a string and matches the cvterm record formatted as cvterm.name (db.name:dbxref.accession).

A revised version of the my-autocomplete module is attached where the method will set a default value to the autocomplete field.

[my_autocomplete.zip](https://github.com/tripal/tripal/files/11638302/my_autocomplete.zip)

