### PR TITLE
tripal 3 issue 1538 local__contact widget ajax error fix

### DIFF
--- a/tripal_chado/includes/TripalFields/local__contact/local__contact_widget.inc
+++ b/tripal_chado/includes/TripalFields/local__contact/local__contact_widget.inc
@@ -38,7 +38,7 @@ class local__contact_widget extends ChadoFieldWidget {
     // If the field already has a value then it will come through the $items
     // array.  This happens when editing an existing record.
     if (count($items) > 0 and array_key_exists($delta, $items)) {
-      $name = array_key_exists($name_term, $items[$delta]['value']) ? $items[$delta]['value'][$name_term] : $name;
+      $name = (is_array($items[$delta]['value']) and array_key_exists($name_term, $items[$delta]['value'])) ? $items[$delta]['value'][$name_term] : $name;
       $record_id = tripal_get_field_item_keyval($items, $delta, 'chado-' . $field_table . '__' . $pkey, $record_id);
       if ($field_table == 'biomaterial') {
         $contact_id = tripal_get_field_item_keyval($items, $delta, $linker_field, $contact_id);


### PR DESCRIPTION
# Bug Fix

## Issue #1538 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 3.10

## Description
I have made a small change in the interests of not breaking anything, and of not spending too much time on Tripal 3. I suspect the widget could be looked at more closely, but this will wait for the Tripal 4 version.

When the widget is called, `$items[0]` will look like this
```
$items[0]="array(2) {
  ["value"]=>
  array(4) {
    ["schema:additionalType"]=>
    string(14) "Research Group"
    ["schema:name"]=>
    string(8) "USDA ARS"
    ["schema:description"]=>
    string(71) "United States Department of Agriculture - Agricultural Research Service"
    ["entity"]=>
    string(19) "TripalEntity:177904"
  }
  [0]=>
  string(2) "10"
}
```
but when it is called by Ajax from the relationship field, it looks like this
```
$items[0]="array(3) {
  ["value"]=>
  string(8) "USDA ARS"
  ["chado-biomaterial__biosourceprovider_id"]=>
  string(2) "10"
  ["name"]=>
  string(8) "USDA ARS"
}
```
note that `['value']` is no longer an array in this case!

My very minimal fix is just to check that we have an array before calling `array_key_exists`. I hypothesize this was not flagged under PHP 7.x.

Manual testing confirms that the relationship field now works on a biomaterial page.


## Testing?
Edit a relationship on a biomaterial page that also has a contact.
