### PR TITLE
Restructure Kernel Tests

### DIFF
--- a/tripal/tests/src/Kernel/TripalDBX/ConnectionTest.php
+++ b/tripal/tests/src/Kernel/TripalDBX/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\tripal\Functional\TripalDBX;
+namespace Drupal\Tests\tripal\Kernel\TripalDBX;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal\TripalDBX\TripalDbxConnection;
@@ -115,7 +115,7 @@ class ConnectionTest extends KernelTestBase {
       ->expects($this->any())
       ->method('getTripalDbxClass')
       ->with('Schema')
-      ->willReturn('\Drupal\Tests\tripal\Functional\TripalDBX\Subclass\TripalDbxSchemaFake');
+      ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxSchemaFake');
 
     // Return initialized mock.
     return $dbmock;

--- a/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\tripal\Functional\TripalDBX;
+namespace Drupal\Tests\tripal\Kernel\TripalDBX;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal\TripalDBX\TripalDbxSchema;

--- a/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxConnectionFake.php
+++ b/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxConnectionFake.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Drupal\Tests\tripal\Functional\TripalDBX\Subclass;
+namespace Drupal\Tests\tripal\Kernel\TripalDBX\Subclass;
 
 use Drupal\tripal\TripalDBX\TripalDbxConnection;
-use Drupal\Tests\tripal\Functional\TripalDBX\Subclass\TripalDbxSchemaFake;
+use Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxSchemaFake;
 
 /**
  * Fake connection class.

--- a/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxSchemaFake.php
+++ b/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxSchemaFake.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\tripal\Functional\TripalDBX\Subclass;
+namespace Drupal\Tests\tripal\Kernel\TripalDBX\Subclass;
 
 use Drupal\tripal\TripalDBX\TripalDbxSchema;
 

--- a/tripal/tests/src/Kernel/TripalDBX/TripalDbxFunctionalTest.php
+++ b/tripal/tests/src/Kernel/TripalDBX/TripalDbxFunctionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\tripal\Functional\TripalDBX;
+namespace Drupal\Tests\tripal\Kernel\TripalDBX;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal\TripalDBX\TripalDbx;

--- a/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
+++ b/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Drupal\Tests\tripal_biodb\Functional\Task;
+namespace Drupal\Tests\tripal_biodb\Kernel\Task;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal_biodb\Task\BioTaskBase;
-use Drupal\Tests\tripal_biodb\Functional\Database\Subclass\BioConnectionFake;
+use Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection;
 
 /**
  * Tests for tasks.
@@ -15,7 +15,7 @@ use Drupal\Tests\tripal_biodb\Functional\Database\Subclass\BioConnectionFake;
  * @group Tripal BioDb
  * @group Tripal BioDb Task
  */
-class BioTaskBaseFunctionalTest extends KernelTestBase {
+class BioTaskBaseKernelTest extends KernelTestBase {
 
   /**
    * Test members.
@@ -61,7 +61,7 @@ class BioTaskBaseFunctionalTest extends KernelTestBase {
       ->expects($this->any())
       ->method('getTripalDbxClass')
       ->with('Connection')
-      ->willReturn('\Drupal\Tests\tripal_biodb\Functional\Database\Subclass\BioConnectionFake')
+      ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection')
     ;
 
     // Parameters.
@@ -85,7 +85,7 @@ class BioTaskBaseFunctionalTest extends KernelTestBase {
     //   ->expects($this->any())
     //   ->method('getTripalDbxClass')
     //   ->with('Connection')
-    //   ->willReturn('\Drupal\Tests\tripal_biodb\Functional\Database\Subclass\BioConnectionFake')
+    //   ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection')
     // ;
 
     // Check default values.

--- a/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
+++ b/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\tripal_biodb\Kernel\Task;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal_biodb\Task\BioTaskBase;
-use Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection;
+use Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnectionFake;
 
 /**
  * Tests for tasks.
@@ -15,7 +15,7 @@ use Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection;
  * @group Tripal BioDb
  * @group Tripal BioDb Task
  */
-class BioTaskBaseKernelTest extends KernelTestBase {
+class BioTaskBaseTest extends KernelTestBase {
 
   /**
    * Test members.
@@ -39,6 +39,26 @@ class BioTaskBaseKernelTest extends KernelTestBase {
   }
 
   /**
+   * Setup a mock version of the abstract Bi9oTaskBase for testing.
+   */
+  public function getMock() {
+
+    // Create a mock for the abstract class
+    // but specify not to run the contructor + mention this is an abstract class.
+    $tmock = $this->getMockBuilder(\Drupal\tripal_biodb\Task\BioTaskBase::class)
+      ->setMethods(['getTripalDbxClass'])
+      ->getMockForAbstractClass();
+    // Ensure when getTripalDbxClass() is asked for the connection class, it returns our fake class.
+    $tmock
+      ->expects($this->any())
+      ->method('getTripalDbxClass')
+      ->with('Connection')
+      ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnectionFake');
+
+    return $tmock;
+  }
+
+  /**
    * Tests constructor: check constructor calls.
    *
    * @cover ::__construct
@@ -47,51 +67,87 @@ class BioTaskBaseKernelTest extends KernelTestBase {
    * @cover ::getLogger
    */
   public function testBioTaskBaseConstructor() {
-    // Create a mock for the abstract class.
-    $tmock = $this->getMockBuilder(\Drupal\tripal_biodb\Task\BioTaskBase::class)
-      ->disableOriginalConstructor()
-      ->setMethods([/*'initId',*/ 'getTripalDbxClass'])
-      ->getMockForAbstractClass()
-    ;
-    /*$tmock
-      ->expects($this->once())
-      ->method('initId')
-    ;*/
-    $tmock
-      ->expects($this->any())
-      ->method('getTripalDbxClass')
-      ->with('Connection')
-      ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection')
-    ;
 
-    // Parameters.
+    $tmock = $this->getMock();
+
+    // Because we did not disable the constructor in the above mock,
+    // it should have been run when we created the mock.
+    // Since the variables set by the constructor are protected properties,
+    // we cannot test them directly. As such, we will use PHP closures to
+    // access these properties for testing.
+    //  -- Create a variable to store a copy of this test object for use within the closure.
+    $that = $this;
+    //  -- Create a closure (i.e. a function tied to a variable) that does not need any parameters.
+    //     Within this function we will want all of the assertions we will use to test the private methods.
+    //     Also, $this within the function will actually be the plugin object that you bind later (mind blown).
+    $assertConstructorClosure = function ()  use ($that){
+      $that->assertIsObject($this->connection,
+        "The connection object was not set properly by our constructor.");
+      $that->assertIsObject($this->logger,
+        "The logger object was not set properly by our constructor.");
+      $that->assertIsObject($this->locker,
+        "The locker object was not set properly by our constructor.");
+      $that->assertIsObject($this->state,
+        "The state object was not set properly by our constructor.");
+      $that->assertIsString($this->id,
+        "The id was not set properly by our constructor.");
+
+      $that->assertEquals($this->id, $this->getId(),
+        "Retrieving the ID did not return the id set in the object.");
+      $that->assertEquals($this->logger, $this->getLogger(),
+        "Retrieving the logger did not return the logger set in the object.");
+    };
+    //  -- Now, bind our assertion closure to the $plugin object. This is what makes the plugin available
+    //     inside the function.
+    $doAssertConstructorClosure = $assertConstructorClosure->bindTo($tmock, get_class($tmock));
+    //  -- Finally, call our bound closure function to run the assertions on our plugin.
+    $doAssertConstructorClosure();
+  }
+
+  /**
+   * Tests setting + preparing input/output schema.
+   *
+   * @cover ::setParameters
+   * @cover ::prepareSchemas
+   */
+  public function testBioTaskBaseParameters() {
+
+    $tmock = $this->getMock();
+
+    // Check that input/output schema can be set and prepared.
     $parameters = [
       'input_schemas' => ['insch'],
       'output_schemas' => ['outsch'],
     ];
-
-    // Call the constructor.
-    $reflected_class = new \ReflectionClass(\Drupal\tripal_biodb\Task\BioTaskBase::class);
-    $constructor = $reflected_class->getConstructor();
-    $constructor->invoke($tmock);
-
-    // // Create a new initialized object to cehck constructor work.
-    // $tmock = $this->getMockBuilder(\Drupal\tripal_biodb\Task\BioTaskBase::class)
-    //   ->setMethods(['getTripalDbxClass'])
-    //   ->setConstructorArgs([$parameters])
-    //   ->getMockForAbstractClass()
-    // ;
-    // $tmock
-    //   ->expects($this->any())
-    //   ->method('getTripalDbxClass')
-    //   ->with('Connection')
-    //   ->willReturn('\Drupal\Tests\tripal\Kernel\TripalDBX\Subclass\TripalDbxConnection')
-    // ;
-
-    // Check default values.
     $tmock->setParameters($parameters);
-    $db_name = \Drupal::service('database')->getConnectionOptions()['database'];
-    $this->assertEquals('task-' . $db_name . '-1i-insch-1o-outsch', $tmock->getId(), 'Id set.');
-    $this->assertInstanceOf('\Psr\Log\LoggerInterface', $tmock->getLogger(), 'Logger.');
+    $that = $this;
+    $assertParametersClosure = function ()  use ($that, $parameters){
+      $that->assertIsArray($this->parameters, "Parameters should be an array.");
+      $that->assertArrayHasKey('input_schemas', $this->parameters,
+        "Input schema key not set in parameters array.");
+      $that->assertArrayHasKey('output_schemas', $this->parameters,
+        "Output schema key not set in parameters array.");
+      $that->assertEquals($parameters, $this->parameters,
+        "The parameters we passed in should match those set withing the object.");
+
+      // Check that the prepareSchema function was run for both input and output
+      // schema and that TripalDbxConnection were successfully initialized.
+      $that->assertCount(1, $this->inputSchemas,
+        "We expect there should be one input schema based on the parameters passed in.");
+      $that->assertContainsOnlyInstancesOf(
+        \Drupal\tripal\TripalDBX\TripalDbxConnection::class,
+        $this->inputSchemas,
+        "All input schema should be prepared as TripalDBXConnection objects but are not."
+      );
+      $that->assertCount(1, $this->outputSchemas,
+        "We expect there should be one output schema based on the parameters passed in.");
+      $that->assertContainsOnlyInstancesOf(
+        \Drupal\tripal\TripalDBX\TripalDbxConnection::class,
+        $this->outputSchemas,
+        "All output schema should be prepared as TripalDBXConnection objects but are not."
+      );
+    };
+    $doAssertParametersClosure = $assertParametersClosure->bindTo($tmock, get_class($tmock));
+    $doAssertParametersClosure();
   }
 }

--- a/tripal_chado/src/Task/ChadoUpgrader.php
+++ b/tripal_chado/src/Task/ChadoUpgrader.php
@@ -614,7 +614,7 @@ class ChadoUpgrader extends ChadoTaskBase {
           . $version
           . '.sql'
         ;
-        $success = $this->executeSqlFile(
+        $success = $ref_schema->executeSqlFile(
           $file_path,
           ['chado' => $ref_schema->getQuotedSchemaName(),]
         );

--- a/tripal_chado/tests/src/Kernel/ChadoTestKernelBase.php
+++ b/tripal_chado/tests/src/Kernel/ChadoTestKernelBase.php
@@ -1,9 +1,10 @@
 <?php
-namespace Drupal\Tests\tripal_chado\Functional;
+namespace Drupal\Tests\tripal_chado\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\tripal\TripalDBX\TripalDbx;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Tests\tripal_chado\Functional\ChadoTestTrait;
 
 /**
  * This is a base class for Chado tests.

--- a/tripal_chado/tests/src/Kernel/Task/ChadoClonerTest.php
+++ b/tripal_chado/tests/src/Kernel/Task/ChadoClonerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Drupal\Tests\tripal_chado\Functional\Task;
+namespace Drupal\Tests\tripal_chado\Kernel\Task;
 
-use Drupal\Tests\tripal_chado\Functional\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Task\ChadoCloner;
 
 
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\Task\ChadoCloner;
  * @group Tripal Chado Task
  * @group Tripal Chado Cloner
  */
-class ChadoClonerFunctionalTest extends ChadoTestKernelBase {
+class ChadoClonerTest extends ChadoTestKernelBase {
 
   /**
    * Tests task.

--- a/tripal_chado/tests/src/Kernel/Task/ChadoInstallerTest.php
+++ b/tripal_chado/tests/src/Kernel/Task/ChadoInstallerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Drupal\Tests\tripal_chado\Functional\Task;
+namespace Drupal\Tests\tripal_chado\Kernel\Task;
 
-use Drupal\Tests\tripal_chado\Functional\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Task\ChadoInstaller;
 
 
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\Task\ChadoInstaller;
  * @group Tripal Chado Task
  * @group Tripal Chado Installer
  */
-class ChadoInstallerFunctionalTest extends ChadoTestKernelBase {
+class ChadoInstallerTest extends ChadoTestKernelBase {
 
   /**
    * Tests task.

--- a/tripal_chado/tests/src/Kernel/Task/ChadoRenamerTest.php
+++ b/tripal_chado/tests/src/Kernel/Task/ChadoRenamerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Drupal\Tests\tripal_chado\Functional\Task;
+namespace Drupal\Tests\tripal_chado\Kernel\Task;
 
-use Drupal\Tests\tripal_chado\Functional\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Task\ChadoRenamer;
 
 
@@ -16,7 +16,7 @@ use Drupal\tripal_chado\Task\ChadoRenamer;
  * @group Tripal Chado Task
  * @group Tripal Chado Renamer
  */
-class ChadoRenamerFunctionalTest extends ChadoTestKernelBase {
+class ChadoRenamerTest extends ChadoTestKernelBase {
 
   /**
    * Tests task.

--- a/tripal_chado/tests/src/Kernel/Task/ChadoUpgraderTest.php
+++ b/tripal_chado/tests/src/Kernel/Task/ChadoUpgraderTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Drupal\Tests\tripal_chado\Functional\Task;
+namespace Drupal\Tests\tripal_chado\Kernel\Task;
 
-use Drupal\Tests\tripal_chado\Functional\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Task\ChadoUpgrader;
 
 /**
@@ -15,7 +15,7 @@ use Drupal\tripal_chado\Task\ChadoUpgrader;
  * @group Tripal Chado Task
  * @group Tripal Chado Upgrader
  */
-class ChadoUpgraderFunctionalTest extends ChadoTestKernelBase {
+class ChadoUpgraderTest extends ChadoTestKernelBase {
 
   /**
    * Tests task.
@@ -24,6 +24,11 @@ class ChadoUpgraderFunctionalTest extends ChadoTestKernelBase {
    * @cover ::performTask
    */
   public function testPerformTaskUpgrader() {
+
+    $this->markTestIncomplete(
+      'This test has not been fully implemented yet.'
+    );
+
     // Create a temporary schema.
     $tripaldbx_db = $this->getTestSchema(ChadoTestKernelBase::INIT_DUMMY);
     // Test upgrader.
@@ -33,9 +38,7 @@ class ChadoUpgraderFunctionalTest extends ChadoTestKernelBase {
       'cleanup'  => TRUE,
       // 'filename'  => '/tmp/upgrade_test.sql',
     ]);
-    $this->markTestIncomplete(
-      'This test has not been fully implemented yet.'
-    );
+
     // There are issues with the given incomplete dummy schemas as objects are
     // missing during the upgrade process.
     $success = $upgrader->performTask();


### PR DESCRIPTION
# Tripal 4 Core Dev Task

Issue #1539 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

**This only affects Kernel tests at this point. No existing functional or unit tests have been touched in this PR.**

4.x currently has Kernel and Functional tests mixed together in the tests/src/Functional directory. This does not match [Drupal standards](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/phpunit-file-structure-namespace-and-required-metadata) and makes it difficult to see the difference between the two test types.

This PR moves existing Kernel tests and the ChadoKernelTestBase class into tests/src/Kernel where they belong. I also improved the biotaskbase test using closures to allow direct testing of the protected variables. Additionally I found a bug in the ChadoUpgrader and fixed the task tests so the class name matched the file name.

## Testing?
This only impacts automated tests so if tests pass then we are good to go.

A quick code review of the biotaskbase tests would be helpful but I don't think it need be required.
