### PR TITLE
Tripal 4 change chado storage handling of empty fields

### DIFF
--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -7,7 +7,7 @@ fields:
         content_type: bio_data_1
         label: Abbreviation
         type: chado_string_type
-        description: A shortened name (or abbreviation) for the organism (e.g. O.sativa).
+        description: A shortened name (or abbreviation) for the organism (e.g. O. sativa).
         cardinality: 1
         required: false
         storage_settings:
@@ -61,7 +61,7 @@ fields:
         content_type: bio_data_1
         label: Species
         type: chado_string_type
-        description: "The species name of the organism"
+        description: "The species name of the organism."
         cardinality: 1
         required: true
         storage_settings:
@@ -88,7 +88,7 @@ fields:
         content_type: bio_data_1
         label: Common Name
         type: chado_string_type
-        description: "The common name for the organism"
+        description: "The common name for the organism."
         cardinality: 1
         required: false
         storage_settings:

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1097,6 +1097,7 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface {
         // violation.
         $match = $query->execute()->fetchObject();
         if ($match) {
+
           // Add a constraint violation if we have a match and the
           // record_id is 0. This would be an insert but a record already
           // exists. Or, if the record_id isn't the same as the  matched

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1122,14 +1122,22 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
           if (array_key_exists($col, $record['fields'])) {
             $col_val = $record['fields'][$col];
           }
-          // If there is not a NOT NULL constraint on this column, then
-          // we need to handle empty values specially, since they might
-          // be stored as either NULL or as an empty string in the
-          // database table. Create a condition that checks for both.
+          // If there is not a NOT NULL constraint on this column,
+          // and it is of a string type, then we need to handle
+          // empty values specially, since they might be stored
+          // as either NULL or as an empty string in the database
+          // table. Create a condition that checks for both. For
+          // other types, e.g. integer, just check for null.
           if ($table_def['fields'][$col]['not null'] == FALSE and !$col_val) {
-            $query->condition($query->orConditionGroup()
-              ->condition($col, '', '=')
-              ->isNull($col));
+            if (in_array($table_def['fields'][$col]['type'],
+                ['character', 'character varying', 'text'])) {
+              $query->condition($query->orConditionGroup()
+                ->condition($col, '', '=')
+                ->isNull($col));
+            }
+            else {
+              $query->isNull($col);
+            }
           }
           else {
             $query->condition($col, $col_val);


### PR DESCRIPTION
# Bug Fix

## Issue #1544

### Tripal Version: 4.alpha.dev

## Description
This PR changes chado storage validation in the particular case of database columns _without_ a NOT NULL constraint, and when the form field is left blank. When this happens, we check for either a NULL or an empty string in that database column instead of comparing to the string that comes from the form field. The current behavior is to just ignore these with a `continue` 🙈. This means, for example, that you can't enter a new organism with no infraspecies if an organism with the same genus+species and has a subsp. exists.

## Testing?
  1. Create a new analysis "Program, Pipeline, Workflow or Method Name" = 3, "Software Version" = 3, "Data Source Name" = 3.
  2. Create a new analysis "Program, Pipeline, Workflow or Method Name" = 3, "Software Version" = 3, "Data Source Name" = left blank. Before this PR this will fail, after this PR it will succeed.

Alternative test
  1. Create new organism "Tripalus databasica subsp. postgresqlulus"
  2. Create new organism "Tripalus databasica" Before this PR this will fail, after this PR it will succeed.
