### PR TITLE
Tripal 4 add a chado boolean field

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -477,7 +477,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * @param TripalEntity $entity
    *
    * @return array
-   *   The returned array has two elements: an an array of values as described
+   *   The returned array has two elements: an array of values as described
    *   above, and an array of TripalStorage objects,
    */
   public static function getValuesArray($entity) {
@@ -674,7 +674,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $field_defs = $field_manager->getFieldDefinitions($entity_type_id, $bundle);
       foreach ($field_defs as $field_name => $field_def) {
 
-        // Createa  fieldItemlist and iterate through it.
+        // Create a fieldItemlist and iterate through it.
         $items = $field_type_manager->createFieldItemList($entity, $field_name, $entity->get($field_name)->getValue());
         foreach($items as $item) {
 

--- a/tripal/src/Form/TripalEntityForm.php
+++ b/tripal/src/Form/TripalEntityForm.php
@@ -33,6 +33,7 @@ class TripalEntityForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $values = $form_state->getValues();
+dpm($values, "TripalEntityForm save 1 = should be boolean here"); //@@@
     $entity = $this->entity;
     $bundle = $entity->getType();
     $bundle_entity = \Drupal\tripal\Entity\TripalEntityType::load($bundle);

--- a/tripal/src/Form/TripalEntityForm.php
+++ b/tripal/src/Form/TripalEntityForm.php
@@ -33,7 +33,6 @@ class TripalEntityForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $values = $form_state->getValues();
-dpm($values, "TripalEntityForm save 1 = should be boolean here"); //@@@
     $entity = $this->entity;
     $bundle = $entity->getType();
     $bundle_entity = \Drupal\tripal\Entity\TripalEntityType::load($bundle);

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\tripal\Plugin\Field\FieldFormatter;
+
+use Drupal\tripal\TripalField\TripalFormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of default Tripal boolean type formatter.
+ *
+ * @FieldFormatter(
+ *   id = "default_tripal_boolean_type_formatter",
+ *   label = @Translation("Default Boolean Type Formatter"),
+ *   description = @Translation("The default boolean type formatter."),
+ *   field_types = {
+ *     "tripal_boolean_type"
+ *   }
+ * )
+ */
+class DefaultTripalBooleanTypeFormatter extends TripalFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach($items as $delta => $item) {
+      $elements[$delta] = [
+        "#markup" => $item->get("value")->getValue() ? 'True' : 'False',
+      ];
+    }
+
+    return $elements;
+  }
+}

--- a/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\tripal\Plugin\Field\FieldType;
+
+use Drupal\tripal\TripalField\TripalFieldItemBase;
+use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
+use Drupal\tripal\TripalStorage\StoragePropertyValue;
+use Drupal\core\Form\FormStateInterface;
+use Drupal\core\Field\FieldDefinitionInterface;
+
+/**
+ * Plugin implementation of the 'boolean' field type.
+ *
+ * @FieldType(
+ *   id = "tripal_boolean_type",
+ *   label = @Translation("Tripal Boolean Field Type"),
+ *   description = @Translation("A boolean field."),
+ *   default_widget = "default_tripal_boolean_type_widget",
+ *   default_formatter = "default_tripal_boolean_type_formatter"
+ * )
+ */
+class TripalBooleanTypeItem extends TripalFieldItemBase {
+
+  public static $id = "tripal_boolean_type";
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $storage_settings = $field_definition->getSettings();
+    $termIdSpace = $storage_settings['termIdSpace'];
+    $termAccession = $storage_settings['termAccession'];
+
+    return [
+      new BoolStoragePropertyType($entity_type_id, self::$id, "value", $termIdSpace . ':' . $termAccession),
+    ];
+  }
+}

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -26,10 +26,9 @@ class TripalBooleanTypeWidget extends TripalWidgetBase {
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element['value'] = $element + [
-      '#type' => 'textfield',
-      '#default_value' => $items[$delta]->value ?? '',
+      '#type' => 'checkbox',
+      '#default_value' => $items[$delta]->value ?? 0,
       '#placeholder' => $this->getSetting('placeholder'),
-      '#attributes' => ['class' => ['js-text-full', 'text-full']],
     ];
     return $element;
   }

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -25,16 +25,9 @@ class TripalBooleanTypeWidget extends TripalWidgetBase {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-dpm($items[$delta], "TripalBooleanTypeWidget items[$delta]"); //@@@
-$v = $items[$delta]->value;
-dpm($v, 'items[$delta]->value CP1'); //@@@
-$ib = is_bool($v);
-dpm($ib, 'is_bool'); //@@@
-$v = $v ?? false;
-dpm($v, 'items[$delta]->value CP2'); //@@@
     $element['value'] = $element + [
       '#type' => 'checkbox',
-      '#default_value' => $items[$delta]->value ?? false,
+      '#default_value' => $items[$delta]->value ?? NULL,
       '#placeholder' => $this->getSetting('placeholder'),
     ];
     return $element;

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -25,9 +25,16 @@ class TripalBooleanTypeWidget extends TripalWidgetBase {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+dpm($items[$delta], "TripalBooleanTypeWidget items[$delta]"); //@@@
+$v = $items[$delta]->value;
+dpm($v, 'items[$delta]->value CP1'); //@@@
+$ib = is_bool($v);
+dpm($ib, 'is_bool'); //@@@
+$v = $v ?? false;
+dpm($v, 'items[$delta]->value CP2'); //@@@
     $element['value'] = $element + [
       '#type' => 'checkbox',
-      '#default_value' => $items[$delta]->value ?? 0,
+      '#default_value' => $items[$delta]->value ?? false,
       '#placeholder' => $this->getSetting('placeholder'),
     ];
     return $element;

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\tripal\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of default Tripal boolean type widget.
+ *
+ * @FieldWidget(
+ *   id = "default_tripal_boolean_type_widget",
+ *   label = @Translation("Tripal Boolean Widget"),
+ *   description = @Translation("The default boolean type widget."),
+ *   field_types = {
+ *     "tripal_boolean_type"
+ *   }
+ * )
+ */
+class TripalBooleanTypeWidget extends TripalWidgetBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element['value'] = $element + [
+      '#type' => 'textfield',
+      '#default_value' => $items[$delta]->value ?? '',
+      '#placeholder' => $this->getSetting('placeholder'),
+      '#attributes' => ['class' => ['js-text-full', 'text-full']],
+    ];
+    return $element;
+  }
+}

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -237,7 +237,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     else {
       $field_types = \Drupal::service('plugin.manager.field.field_type')->getDefinitions();
       if (!in_array($field_def['type'], array_keys($field_types))) {
-        $this->logger->error('The field type, ' . $field_def['type'] . ' is not a valide field type.');
+        $this->logger->error('The field type, "' . $field_def['type'] . '", is not a valid field type.');
         return FALSE;
       }
     }

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -319,8 +319,6 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
         $schema["columns"][$type->getKey()] = $column;
       }
       else if ($type instanceof BoolStoragePropertyType) {
-// @@@ line 68 in modules/contrib/tripal/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxSchemaFake.php type => int, size => tiny
-// @@@ line 64 & 70 modules/contrib/tripal/tripal/tests/fixtures/feature_parsed_drupal.php type => text
         $column = [
           "type" => "int",
           "size" => "tiny",

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -9,6 +9,7 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\tripal\TripalStorage\IntStoragePropertyType;
 use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;
+use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
 use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\Core\TypedData\DataDefinition;
 use \RuntimeException;
@@ -278,10 +279,10 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
         $properties[$type->getKey()] = DataDefinition::create("string");
       }
       else if ($type instanceof BoolStoragePropertyType) {
-        $properties[$type->getKey()] = DataDefinition::create("string");
+        $properties[$type->getKey()] = DataDefinition::create("boolean");
       }
       else {
-        throw new RuntimeException("Unknown Tripal Property Type class.");
+        throw new RuntimeException('Unknown Tripal Property Type class "' . get_class($type) . '"');
       }
     }
 
@@ -320,11 +321,12 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
       else if ($type instanceof BoolStoragePropertyType) {
         $column = [
           "type" => "boolean",
+          "pgsql_type" => "boolean",
         ];
         $schema["columns"][$type->getKey()] = $column;
       }
       else {
-        throw new RuntimeException("Unknown Tripal Property Type class.");
+        throw new RuntimeException('Unknown Tripal Property Type class "' . get_class($type) . '"');
       }
     }
 

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -319,8 +319,11 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
         $schema["columns"][$type->getKey()] = $column;
       }
       else if ($type instanceof BoolStoragePropertyType) {
+// @@@ line 68 in modules/contrib/tripal/tripal/tests/src/Kernel/TripalDBX/Subclass/TripalDbxSchemaFake.php type => int, size => tiny
+// @@@ line 64 & 70 modules/contrib/tripal/tripal/tests/fixtures/feature_parsed_drupal.php type => text
         $column = [
-          "type" => "boolean",
+          "type" => "int",
+          "size" => "tiny",
           "pgsql_type" => "boolean",
         ];
         $schema["columns"][$type->getKey()] = $column;

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -277,6 +277,9 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
       else if ($type instanceof TextStoragePropertyType) {
         $properties[$type->getKey()] = DataDefinition::create("string");
       }
+      else if ($type instanceof BoolStoragePropertyType) {
+        $properties[$type->getKey()] = DataDefinition::create("string");
+      }
       else {
         throw new RuntimeException("Unknown Tripal Property Type class.");
       }
@@ -311,6 +314,12 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
       else if ($type instanceof TextStoragePropertyType) {
         $column = [
           "type" => "text",
+        ];
+        $schema["columns"][$type->getKey()] = $column;
+      }
+      else if ($type instanceof BoolStoragePropertyType) {
+        $column = [
+          "type" => "boolean",
         ];
         $schema["columns"][$type->getKey()] = $column;
       }

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -1068,6 +1068,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: mrna_is_obsolete
+        content_type: bio_data_9
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: phylotree_name
         content_type: bio_data_10
         label: Name
@@ -1335,33 +1362,6 @@ fields:
             default:
               region: content
               weight: 20
-
-    -   name: dna_library_is_obsolete
-        content_type: bio_data_12
-        label: Is Obsolete
-        type: chado_boolean_type
-        description: Indicates if this record is obsolete.
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: library
-                base_column: is_obsolete
-        settings:
-            termIdSpace: local
-            termAccession: is_obsolete
-            fixed_value: local:is_obsolete
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 90
-          form:
-            default:
-              region: content
-              weight: 90
 
     -   name: genome_assembly_name
         content_type: bio_data_13
@@ -2088,6 +2088,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: qtl_is_obsolete
+        content_type: bio_data_17
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: sequence_variant_name
         content_type: bio_data_18
         label: Name
@@ -2220,6 +2247,33 @@ fields:
             default:
               region: content
               weight: 10
+
+    -   name: sequence_variant_is_obsolete
+        content_type: bio_data_18
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: genetic_marker_name
         content_type: bio_data_19
@@ -2354,6 +2408,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: genetic_marker_is_obsolete
+        content_type: bio_data_19
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: phenotypic_marker_name
         content_type: bio_data_20
         label: Name
@@ -2487,6 +2568,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: phenotypic_marker_is_obsolete
+        content_type: bio_data_20
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: germplasm_name
         content_type: bio_data_21
         label: Name
@@ -2594,6 +2702,32 @@ fields:
               region: content
               weight: 10
 
+    -   name: germplasm_is_obsolete
+        content_type: bio_data_21
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: breeding_cross_name
         content_type: bio_data_22
@@ -2702,6 +2836,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: breeding_cross_is_obsolete
+        content_type: bio_data_22
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: germplasm_variety_name
         content_type: bio_data_23
         label: Name
@@ -2809,6 +2970,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: germplasm_variety_is_obsolete
+        content_type: bio_data_23
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: ril_name
         content_type: bio_data_24
         label: Name
@@ -2915,6 +3103,33 @@ fields:
             default:
               region: content
               weight: 10
+
+    -   name: ril_is_obsolete
+        content_type: bio_data_24
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: biosample_name
         content_type: bio_data_25

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -1310,7 +1310,7 @@ fields:
     -   name: dna_library_is_obsolete
         content_type: bio_data_12
         label: Is Obsolete
-        type: chado_boolean_type_default
+        type: chado_boolean_type
         description: Designates if this library is obsolete and no longer available or of interest.
         cardinality: 1
         required: true

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -1067,6 +1067,32 @@ fields:
               region: content
               weight: 25
 
+    -   name: mrna_organism
+        content_type: bio_data_9
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: organism_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
+
     -   name: mrna_type
         content_type: bio_data_9
         label: Type
@@ -2114,6 +2140,32 @@ fields:
               region: content
               weight: 25
 
+    -   name: qtl_organism
+        content_type: bio_data_17
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: organism_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
+
     -   name: qtl_type
         content_type: bio_data_17
         label: Type
@@ -2300,6 +2352,32 @@ fields:
             default:
               region: content
               weight: 25
+
+    -   name: sequence_variant_organism
+        content_type: bio_data_18
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: organism_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
 
     -   name: sequence_variant_type
         content_type: bio_data_18
@@ -2488,6 +2566,32 @@ fields:
               region: content
               weight: 25
 
+    -   name: genetic_marker_organism
+        content_type: bio_data_19
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: organism_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
+
     -   name: genetic_marker_type
         content_type: bio_data_19
         label: Type
@@ -2674,6 +2778,32 @@ fields:
             default:
               region: content
               weight: 25
+
+    -   name: phenotypic_marker_organism
+        content_type: bio_data_20
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: organism_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
 
     -   name: phenotypic_marker_type
         content_type: bio_data_20

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -912,7 +912,7 @@ fields:
         content_type: bio_data_8
         label: Is Obsolete
         type: chado_boolean_type
-        description: Designates that this gene is obsolete and no longer available or of interest.
+        description: Indicates if this record is obsolete.
         cardinality: 1
         required: false
         storage_settings:
@@ -1340,9 +1340,9 @@ fields:
         content_type: bio_data_12
         label: Is Obsolete
         type: chado_boolean_type
-        description: Designates that this library is obsolete and no longer available or of interest.
+        description: Indicates if this record is obsolete.
         cardinality: 1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -1282,6 +1282,58 @@ fields:
               region: content
               weight: 10
 
+    -   name: dna_library_organism
+        content_type: bio_data_12
+        label: Organism
+        type: chado_organism_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 20
+          form:
+            default:
+              region: content
+              weight: 20
+
+    -   name: dna_library_is_obsolete
+        content_type: bio_data_12
+        label: Is Obsolete
+        type: chado_boolean_type_default
+        description: Designates if this library is obsolete and no longer available or of interest.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: library
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: genome_assembly_name
         content_type: bio_data_13
         label: Name

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -908,6 +908,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: gene_is_analysis
+        content_type: bio_data_8
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: gene_is_obsolete
         content_type: bio_data_8
         label: Is Obsolete
@@ -1067,6 +1094,33 @@ fields:
             default:
               region: content
               weight: 10
+
+    -   name: mrna_is_analysis
+        content_type: bio_data_9
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: mrna_is_obsolete
         content_type: bio_data_9
@@ -2088,6 +2142,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: qtl_is_analysis
+        content_type: bio_data_17
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: qtl_is_obsolete
         content_type: bio_data_17
         label: Is Obsolete
@@ -2247,6 +2328,33 @@ fields:
             default:
               region: content
               weight: 10
+
+    -   name: sequence_variant_is_analysis
+        content_type: bio_data_18
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: sequence_variant_is_obsolete
         content_type: bio_data_18
@@ -2408,6 +2516,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: genetic_marker_is_analysis
+        content_type: bio_data_19
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: genetic_marker_is_obsolete
         content_type: bio_data_19
         label: Is Obsolete
@@ -2567,6 +2702,33 @@ fields:
             default:
               region: content
               weight: 10
+
+    -   name: phenotypic_marker_is_analysis
+        content_type: bio_data_20
+        label: Is Analysis
+        type: chado_boolean_type
+        description: Indicates if this feature was predicted computationally using another feature.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_analysis
+        settings:
+            termIdSpace: local
+            termAccession: is_analysis
+            fixed_value: local:is_analysis
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
 
     -   name: phenotypic_marker_is_obsolete
         content_type: bio_data_20

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -865,6 +865,7 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: feature
+                base_column: organism_id
         settings:
             termIdSpace: OBI
             termAccession: "0100026"
@@ -1292,7 +1293,8 @@ fields:
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
-                base_table: feature
+                base_table: library
+                base_column: organism_id
         settings:
             termIdSpace: OBI
             termAccession: "0100026"

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -908,6 +908,33 @@ fields:
               region: content
               weight: 10
 
+    -   name: gene_is_obsolete
+        content_type: bio_data_8
+        label: Is Obsolete
+        type: chado_boolean_type
+        description: Designates that this gene is obsolete and no longer available or of interest.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+            fixed_value: local:is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
     -   name: mrna_name
         content_type: bio_data_9
         label: Name
@@ -1313,7 +1340,7 @@ fields:
         content_type: bio_data_12
         label: Is Obsolete
         type: chado_boolean_type
-        description: Designates if this library is obsolete and no longer available or of interest.
+        description: Designates that this library is obsolete and no longer available or of interest.
         cardinality: 1
         required: true
         storage_settings:

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanTypeFormatter.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanTypeFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalBooleanTypeFormatter;
+use Drupal\tripal\TripalField\TripalFormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of default Chado boolean type formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_boolean_type_formatter",
+ *   label = @Translation("Chado Boolean Type Formatter"),
+ *   description = @Translation("The Chado boolean type formatter."),
+ *   field_types = {
+ *     "chado_boolean_type"
+ *   }
+ * )
+ */
+class ChadoBooleanTypeFormatter extends DefaultTripalBooleanTypeFormatter {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    return parent::viewElements($items, $langcode);
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal\TripalField\TripalFieldItemBase;
+use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
+use Drupal\tripal\TripalStorage\StoragePropertyValue;
+use Drupal\core\Form\FormStateInterface;
+use Drupal\core\Field\FieldDefinitionInterface;
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
+
+/**
+ * Plugin implementation of the 'boolean' field type for Chado.
+ *
+ * @FieldType(
+ *   id = "chado_boolean_type",
+ *   label = @Translation("Chado Boolean Field Type"),
+ *   description = @Translation("A boolean field."),
+ *   default_widget = "chado_boolean_type_widget",
+ *   default_formatter = "chado_boolean_type_formatter"
+ * )
+ */
+class ChadoBooleanTypeItem extends ChadoFieldItemBase {
+
+  public static $id = "chado_boolean_type";
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $settings = parent::defaultStorageSettings();
+    $settings['storage_plugin_settings']['base_column'] = '';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+dpm("CP5"); //@@@
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $settings = $field_definition->getSetting('storage_plugin_settings');
+
+    // Get the base table columns needed for this field.
+    $base_table = $settings['base_table'];
+$base_table = 'analysis'; dpm($base_table, 'base_table'); //@@@
+    $base_column = $settings['base_column'];
+$base_column = 'is_obsolete'; dpm($base_column, 'base_column'); //@@@
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+dpm($base_pkey_col, 'base_pkey_col'); //@@@
+
+    // Get the property terms by using the Chado table columns they map to.
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $record_id_term = 'SIO:000729';
+    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+$value_term = 'local:is_obsolete';
+dpm($value_term, 'value_term'); //@@@
+
+    return [
+      new ChadoBoolStoragePropertyType($entity_type_id, self::$id,'record_id', $record_id_term, [
+        'action' => 'store_id',
+        'drupal_store' => TRUE,
+        'chado_table' => $base_table,
+        'chado_column' => $base_pkey_col
+      ]),
+      new ChadoBoolStoragePropertyType($entity_type_id, self::$id, "value", $value_term, [
+        'action' => 'store',
+        'chado_table' => $base_table,
+        'chado_column' => $base_column,
+      ]),
+    ];
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
@@ -38,28 +38,22 @@ class ChadoBooleanTypeItem extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function tripalTypes($field_definition) {
-dpm("CP6"); //@@@
     $entity_type_id = $field_definition->getTargetEntityTypeId();
     $settings = $field_definition->getSetting('storage_plugin_settings');
 
     // Get the base table columns needed for this field.
     $base_table = $settings['base_table'];
-$base_table = 'analysis'; dpm($base_table, 'base_table'); //@@@
-//    $base_column = $settings['base_column'];
-$base_column = 'is_obsolete'; dpm($base_column, 'base_column'); //@@@
+    $base_column = $settings['base_column'];
     $chado = \Drupal::service('tripal_chado.database');
     $schema = $chado->schema();
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
     $base_pkey_col = $base_schema_def['primary key'];
-dpm($base_pkey_col, 'base_pkey_col'); //@@@
 
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $record_id_term = 'SIO:000729';
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
-$value_term = 'local:is_obsolete';
-dpm($value_term, 'value_term'); //@@@
 
     return [
       new ChadoBoolStoragePropertyType($entity_type_id, self::$id,'record_id', $record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
@@ -8,6 +8,7 @@ use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
 
 /**
@@ -56,7 +57,7 @@ class ChadoBooleanTypeItem extends ChadoFieldItemBase {
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
 
     return [
-      new ChadoBoolStoragePropertyType($entity_type_id, self::$id,'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'chado_table' => $base_table,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeItem.php
@@ -38,14 +38,14 @@ class ChadoBooleanTypeItem extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function tripalTypes($field_definition) {
-dpm("CP5"); //@@@
+dpm("CP6"); //@@@
     $entity_type_id = $field_definition->getTargetEntityTypeId();
     $settings = $field_definition->getSetting('storage_plugin_settings');
 
     // Get the base table columns needed for this field.
     $base_table = $settings['base_table'];
 $base_table = 'analysis'; dpm($base_table, 'base_table'); //@@@
-    $base_column = $settings['base_column'];
+//    $base_column = $settings['base_column'];
 $base_column = 'is_obsolete'; dpm($base_column, 'base_column'); //@@@
     $chado = \Drupal::service('tripal_chado.database');
     $schema = $chado->schema();

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
@@ -27,30 +27,14 @@ class ChadoBooleanTypeWidget extends TripalBooleanTypeWidget {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
 
     $item_vals = $items[$delta]->getValue();
-dpm($item_vals, 'ChadoBooleanTypeWidget item_vals'); //@@@
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
-// drupal validation accepts: boolean, 0, 1, '0', '1' but not ''
-//    $default_value = array_key_exists('record_id', $item_vals) ? ($item_vals['record_id'] ? 1 : 0) : 0;
-    $default_value = array_key_exists('record_id', $item_vals) ? ($item_vals['record_id'] ? true : false) : false;
-dpm($default_value, 'default_value'); //@@@
+// @@@ drupal validation accepts: boolean, 0, 1, '0', '1' but not ''
+    $default_value = !empty($item_vals['record_id']);
     $element['record_id'] = [
-//      '#type' => 'checkbox',
-      '#default_value' => $default_value, //$item_vals['record_id'] ?? false,
+//@@@      '#type' => 'checkbox',
+      '#default_value' => !empty($item_vals['record_id']),
     ];
     return $element;
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
-dpm($values, 'massageFormValues values 1'); //@@@
-    // Convert to boolean.
-    foreach ($values as $val_key => $value) {
-dpm($value, 'massage '.$val_key); //@@@
-      $values[$val_key]['value'] = $value['value'] ? true : false;
-    }
-dpm($values, 'massageFormValues values 2'); //@@@
-    return $values;
-  }
 }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
@@ -28,10 +28,8 @@ class ChadoBooleanTypeWidget extends TripalBooleanTypeWidget {
 
     $item_vals = $items[$delta]->getValue();
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
-// @@@ drupal validation accepts: boolean, 0, 1, '0', '1' but not ''
     $default_value = !empty($item_vals['record_id']);
     $element['record_id'] = [
-//@@@      '#type' => 'checkbox',
       '#default_value' => !empty($item_vals['record_id']),
     ];
     return $element;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
@@ -27,12 +27,30 @@ class ChadoBooleanTypeWidget extends TripalBooleanTypeWidget {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
 
     $item_vals = $items[$delta]->getValue();
+dpm($item_vals, 'ChadoBooleanTypeWidget item_vals'); //@@@
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
+// drupal validation accepts: boolean, 0, 1, '0', '1' but not ''
+//    $default_value = array_key_exists('record_id', $item_vals) ? ($item_vals['record_id'] ? 1 : 0) : 0;
+    $default_value = array_key_exists('record_id', $item_vals) ? ($item_vals['record_id'] ? true : false) : false;
+dpm($default_value, 'default_value'); //@@@
     $element['record_id'] = [
-      '#type' => 'value',
-      '#default_value' => isset($item_vals['record_id']) ? true : false,
+//      '#type' => 'checkbox',
+      '#default_value' => $default_value, //$item_vals['record_id'] ?? false,
     ];
     return $element;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+dpm($values, 'massageFormValues values 1'); //@@@
+    // Convert to boolean.
+    foreach ($values as $val_key => $value) {
+dpm($value, 'massage '.$val_key); //@@@
+      $values[$val_key]['value'] = $value['value'] ? true : false;
+    }
+dpm($values, 'massageFormValues values 2'); //@@@
+    return $values;
+  }
 }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\Plugin\Field\FieldWidget\TripalBooleanTypeWidget;
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of default Chado boolean type widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_boolean_type_widget",
+ *   label = @Translation("Chado Boolean Widget"),
+ *   description = @Translation("The default boolean type widget."),
+ *   field_types = {
+ *     "chado_boolean_type"
+ *   }
+ * )
+ */
+class ChadoBooleanTypeWidget extends TripalBooleanTypeWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    $item_vals = $items[$delta]->getValue();
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $element['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $item_vals['record_id'] ?? 0,
+    ];
+    return $element;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanTypeWidget.php
@@ -30,7 +30,7 @@ class ChadoBooleanTypeWidget extends TripalBooleanTypeWidget {
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
     $element['record_id'] = [
       '#type' => 'value',
-      '#default_value' => $item_vals['record_id'] ?? 0,
+      '#default_value' => isset($item_vals['record_id']) ? true : false,
     ];
     return $element;
   }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1259,7 +1259,6 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
    *   An array to which any new violations can be added.
    */
   public function validateTypes($values, $chado_table, $record_id, $record, &$violations) {
-dpm($values, 'validateTypes values'); //@@@
 
     $schema = $this->connection->schema();
     $table_def = $schema->getTableDef($chado_table, ['format' => 'drupal']);
@@ -1286,11 +1285,8 @@ dpm($values, 'validateTypes values'); //@@@
         }
       }
       else if ($info['type'] == 'boolean') {
-$v = is_bool($col_val);
-dpm($col_val, 'ChadoStorage col_val '.($v?'is_boolean':'not_boolean')); //@@@
-        if (!is_bool($col_val)
-and (!preg_match('/^[01]$/', $col_val))  //@@@
-) {
+//@@@ should an empty string be acceptable here?
+        if (!is_bool($col_val) and !preg_match('/^[01]$/', $col_val)) {
           $bad_types[$col] = 'Boolean';
         }
       }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1245,6 +1245,7 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
    *   An array to which any new violations can be added.
    */
   public function validateTypes($values, $chado_table, $record_id, $record, &$violations) {
+dpm($values, 'validateTypes values'); //@@@
 
     $schema = $this->connection->schema();
     $table_def = $schema->getTableDef($chado_table, ['format' => 'drupal']);
@@ -1271,7 +1272,11 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
         }
       }
       else if ($info['type'] == 'boolean') {
-        if (!is_bool($col_val)) {
+$v = is_bool($col_val);
+dpm($col_val, 'ChadoStorage col_val '.($v?'is_boolean':'not_boolean')); //@@@
+        if (!is_bool($col_val)
+and (!preg_match('/^[01]$/', $col_val))  //@@@
+) {
           $bad_types[$col] = 'Boolean';
         }
       }
@@ -1297,7 +1302,7 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
     if (count($bad_types) > 0) {
       // Documentation for how to create a violation is here
       // https://github.com/symfony/validator/blob/6.1/ConstraintViolation.php
-      $message = 'The item cannot be saved because the following values are of the wrong type.';
+      $message = 'The item cannot be saved because the following values are of the wrong type: ';
       $params = [];
       foreach ($bad_types as $col => $col_type) {
         $message .=  ucfirst($col) . " should be $col_type. " ;

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1285,7 +1285,6 @@ class ChadoStorage extends PluginBase implements TripalStorageInterface, Contain
         }
       }
       else if ($info['type'] == 'boolean') {
-//@@@ should an empty string be acceptable here?
         if (!is_bool($col_val) and !preg_match('/^[01]$/', $col_val)) {
           $bad_types[$col] = 'Boolean';
         }

--- a/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
@@ -5,7 +5,7 @@ namespace Drupal\tripal_chado\TripalStorage;
 use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
 
 /**
- * Defines the variable character Tripal storage property type.
+ * Defines the boolean Tripal storage property type.
  */
 class ChadoBoolStoragePropertyType extends BoolStoragePropertyType {
 

--- a/tripal_chado/src/TripalStorage/ChadoRealStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoRealStoragePropertyType.php
@@ -5,7 +5,7 @@ namespace Drupal\tripal_chado\TripalStorage;
 use Drupal\tripal\TripalStorage\RealStoragePropertyType;
 
 /**
- * Defines the variable character Tripal storage property type.
+ * Defines the real (floating point) number Tripal storage property type.
  */
 class ChadoRealStoragePropertyType extends RealStoragePropertyType {
 

--- a/tripal_chado/src/TripalStorage/ChadoTextStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoTextStoragePropertyType.php
@@ -5,7 +5,7 @@ namespace Drupal\tripal_chado\TripalStorage;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;
 
 /**
- * Defines the variable character Tripal storage property type.
+ * Defines the fixed length text Tripal storage property type.
  */
 class ChadoTextStoragePropertyType extends TextStoragePropertyType {
 


### PR DESCRIPTION
# Tripal 4 Core Dev Task 
# Add a chado boolean field

## Issue #1551 

### Tripal Version: 4.alpha1-dev

## Description
We are missing a boolean field for use on e.g. `is_obsolete` for the feature table, such as a gene, stock, and pub content types, and others.
Note that some `is_obsolete` columns are integers rather than boolean, such as for the library table. This field will not be appropriate for those.
The yaml for pub is currently not present in `tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml`, so that field will not be added in this pull request.
A few related typos and enhanced error messages (that I triggered while developing this) are in here also.

## Testing?
I have added boolean fields for all content types that have them as boolean (as opposed to integer), see the table below. I had to add an organism field to most of the feature content types, only gene had this field, so that we can test those also. Other missing fields will be added with issue #1550.
 1. Create a docker from this branch (see instructions [here](https://tripaldoc.readthedocs.io/en/latest/contributing/docker-for-testing.html).)
 2. Create an organism (needed for next steps).
 3. Create a new gene, enter a zero for sequence length (that's issue #1387), and do not check "Is Analysis" or "Is Obsolete". Save and verify it displays "False" for both.
 4. Edit the gene, verify the check boxes are unchecked, then check both, and save. Verify it now says "True" for both.
 5. Create a second gene and check "Is Analysis" and "Is Obsolete" when creating. Save and verify both display "True".
 6. Edit the gene, verify the check boxes are both checked, then uncheck both, and save. Verify it now says "False" for both.
 7. Test similarly on mrna, qtl, sequence_variant, genetic_marker, phenotypic_marker
 8. Test similarly on the stock content types, these only have a single "Is Obsolete" field: germplasm, breeding_cross, germplasm_variety, ril
 9. Pub is not implemented here because it is entirely missing from the yaml so that is beyond the scope of this pull request.

## List of boolean fields in Chado 1.3 tables

Only the tables in bold are content types

| boolean field and default | tables |
| ------------------------------------ | --------- |
| is_analysis boolean not null default 'false' | **feature** |
| is_current boolean not null default 'false' | feature_synonym, cell_line_synonym |
| is_current boolean not null default 'true' | pub_dbxref, feature_dbxref, analysis_dbxref, featuremap_dbxref, library_synonym, library_dbxref, stock_dbxref, project_dbxref, cell_line_dbxref |
| is_fmax_partial boolean not null default 'false' | featureloc |
| is_fmin_partial boolean not null default 'false' | featureloc |
| is_internal boolean not null default 'false' | feature_synonym, library_synonym, cell_line_synonym |
| is_not boolean not null default false | feature_cvterm, analysis_cvterm, stock_cvterm |
| is_obsolete boolean default 'false' | **pub** |
| is_obsolete boolean not null default 'false' | **feature**, **stock** |

Content types using **feature** table (6): gene, mrna, qtl, sequence_variant, genetic_marker, phenotypic_marker
Content types using **stock** table (4): germplasm, breeding_cross, germplasm_variety, ril
Content types using **pub** table (1): publication