### PR TITLE
Tripal 4 change hook invocation to module handler service

### DIFF
--- a/tripal/src/api/tripal.importer.api.php
+++ b/tripal/src/api/tripal.importer.api.php
@@ -119,11 +119,10 @@ function tripal_run_importer($import_id, TripalJob $job = NULL) {
 
   try {
     // Call the hook_importer_start functions.
-    $modules = \Drupal::moduleHandler()->getImplementations('importer_start');
-    foreach ($modules as $module) {
-      $function = $module . '_importer_start';
-      $function($importer);
-    }
+    $hook = 'importer_start';
+    \Drupal::moduleHandler()->invokeAllWith($hook, function (callable $hook, string $module) {
+      $hook($importer);
+    });
 
     // Run the loader
     tripal_run_importer_run($importer, $logger);
@@ -132,11 +131,10 @@ function tripal_run_importer($import_id, TripalJob $job = NULL) {
     tripal_run_importer_post_run($importer, $logger);
 
     // Call the hook_importer_finish functions.
-    $modules = \Drupal::moduleHandler()->getImplementations('importer_finish');
-    foreach ($modules as $module) {
-      $function = $module . '_importer_finish';
-      $function($importer);
-    }
+    $hook = 'importer_finish';
+    \Drupal::moduleHandler()->invokeAllWith($hook, function (callable $hook, string $module) {
+      $hook($importer);
+    });
 
     // @todo uncomment the section below once these functions are available.
 


### PR DESCRIPTION
# Bug Fix

## Issue #1556 

### Tripal Version: 4.alpha1-dev

## Description
Running the OBO loader under Drupal 10.1 we find that getImplementations() is no longer in Drupal core. More description in issue #1556 

## Testing?
 1. Build a docker under Drupal 10.1 and PHP 8.2 `docker build --tag=tripaldocker:testing-xxxx --build-arg drupalversion="10.1.x-dev" --file tripaldocker/Dockerfile-php8.2-pgsql13 ./`
 2. Go to Tripal -> Data Loaders -> OBO Vocabulary Loader
 3. Select the Gene Ontology (GO)
 4. Import OBO File
 5. `drush trp-run-jobs --username=drupaladmin --root=/var/www/drupal9/web`
 6. Errors as described in issue #1556
 7. If you instead build a docker on this branch, then the import should work. Warning, this import takes a LONG time.

## Question
Is there more to do? Any other hooks that need an update?