### PR TITLE
Tripal 4 php8 warning fix in OBO loader

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2370,8 +2370,10 @@ class OBOImporter extends ChadoImporterBase {
               $stanza['namespace'][0] = 'EDAM';
             }
             $namespace = $stanza['namespace'][0];
-            $cv = $this->all_cvs[$namespace];
-            $this->obo_namespaces[$namespace] = $cv->cv_id;
+            if (array_key_exists($namespace, $this->all_cvs)) {
+              $cv = $this->all_cvs[$namespace];
+              $this->obo_namespaces[$namespace] = $cv->cv_id;
+            }
           }
 
           // Before caching this stanza, check the term's name to

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2374,6 +2374,9 @@ class OBOImporter extends ChadoImporterBase {
               $cv = $this->all_cvs[$namespace];
               $this->obo_namespaces[$namespace] = $cv->cv_id;
             }
+            else {
+              $this->obo_namespaces[$namespace] = NULL;
+            }
           }
 
           // Before caching this stanza, check the term's name to
@@ -2435,6 +2438,9 @@ class OBOImporter extends ChadoImporterBase {
         if (array_key_exists($namespace, $this->all_cvs)) {
           $cv = $this->all_cvs[$namespace];
           $this->obo_namespaces[$namespace] = $cv->cv_id;
+        }
+        else {
+          $this->obo_namespaces[$namespace] = NULL;
         }
       }
       $this->cacheTermStanza($stanza, $type);

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2432,8 +2432,10 @@ class OBOImporter extends ChadoImporterBase {
       // If this term has a namespace then we want to keep track of it.
       if (array_key_exists('namespace', $stanza)) {
         $namespace = $stanza['namespace'][0];
-        $cv = $this->all_cvs[$namespace];
-        $this->obo_namespaces[$namespace] = $cv->cv_id;
+        if (array_key_exists($namespace, $this->all_cvs)) {
+          $cv = $this->all_cvs[$namespace];
+          $this->obo_namespaces[$namespace] = $cv->cv_id;
+        }
       }
       $this->cacheTermStanza($stanza, $type);
       $this->setItemsHandled($num_read);


### PR DESCRIPTION
# Bug Fix

## Issue #1557 

### Tripal Version: 4.alpha1-dev

## Description
Simple fix to eliminate PHP8 warning.
This is written to have no change to function, thus a null assignment is included. See below for what happens if https://github.com/tripal/tripal/pull/1559/commits/ac448f2b39e5a8a97e6318a8f9b918ae51e9cdd8 is not included.
Note, this loader will not run under Drupal 10 until pull #1558 is merged (update: it is now merged 😀)

## Testing?
 1. Go to Tripal -> Data Loaders -> OBO Vocabulary Loader
 2. Select the Gene Ontology (GO)
 3. Import OBO File
 4. `drush trp-run-jobs --username=drupaladmin --root=/var/www/drupal9/web`
 
#### Error messages and screenshots
With this pull request, the following warnings should NOT appear in `Step 1: Preloading File /tmp/obo_eGvTBM...`
```
 [warning] Undefined array key "external" OBOImporter.php:2373
 [warning] Attempt to read property "cv_id" on null OBOImporter.php:2374
```

#### Notes

Commit https://github.com/tripal/tripal/pull/1559/commits/ac448f2b39e5a8a97e6318a8f9b918ae51e9cdd8 adds a null assignment which makes this pull request not have any functional change, this is what happens silently under PHP7, and also happens under PHP8 but with the warning. If we do not include this null assignment, we see the following error:

`ERROR: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "cv_id" of relation "cvterm" violates not-null constraint
DETAIL:  Failing row contains (3149, null, ends during, , 3458, 0, 1).: INSERT INTO "chado"."cvterm" ("cv_id", "name", "definition", "dbxref_id", "is_relationshiptype", "is_obsolete") VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5) RETURNING cvterm_id; Array
(
)`