### PR TITLE
Tripal4 issue1561 fix parallel message

### DIFF
--- a/tripal/src/api/tripal.jobs.api.php
+++ b/tripal/src/api/tripal.jobs.api.php
@@ -371,7 +371,7 @@ function tripal_launch_job($do_parallel = 0, $job_id = NULL, $max_jobs = -1, $si
   // First check if any jobs are currently running if they are, don't continue,
   // we don't want to have more than one job script running at a time.
   if (!$do_parallel and tripal_is_job_running()) {
-    print date('Y-m-d H:i:s') . ": Jobs are still running. Use the --parallel=1 option with the Drush command to run jobs in parallel.";
+    print date('Y-m-d H:i:s') . ": Jobs are still running. Use the --parallel option with the Drush command to run jobs in parallel.";
     return;
   }
 


### PR DESCRIPTION
# Bug Fix

## Issue #1561 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.alpha1.dev

## Description
This is a simple correction to the tripal jobs message where `--parallel` does not take an argument, so the message should reflect that.
