### PR TITLE
Tripal 3 Fix php8.1 deprecations

### DIFF
--- a/legacy/tripal_core/api/tripal_core.chado_nodes.api.inc
+++ b/legacy/tripal_core/api/tripal_core.chado_nodes.api.inc
@@ -1079,9 +1079,8 @@ function chado_cleanup_orphaned_nodes($table, $nentries = 25000,
  *
  * @ingroup tripal_legacy_chado_node_api
  */
-function chado_cleanup_orphaned_nodes_part($table, $job_id = NULL, $nentries,
+function chado_cleanup_orphaned_nodes_part($table, $job_id, $nentries,
                                            $offset, $linking_table, $node_type) {
-
   $count = 0;
 
   // Retrieve all of the entries in the linker table for a given node type

--- a/legacy/tripal_core/includes/tripal_core.form_elements.inc
+++ b/legacy/tripal_core/includes/tripal_core.form_elements.inc
@@ -101,7 +101,7 @@ function theme_file_upload_combo($variables) {
  *
  * @ingroup tripal_legacy_core
  */
-function file_upload_combo_value_callback($element, $input = FALSE, &$form_state) {
+function file_upload_combo_value_callback($element, $input, &$form_state) {
   $values = [];
 
   if ($input == FALSE) {
@@ -199,7 +199,7 @@ function expand_sequence_combo($element, $form_state, $complete_form) {
  *
  * @ingroup tripal_legacy_core
  */
-function sequence_combo_value_callback($element, $input = FALSE, &$form_state) {
+function sequence_combo_value_callback($element, $input, &$form_state) {
   $upstream = $form['values'][$element['#name']]['upstream'];
   $downstream = $form['values'][$element['#name']]['downstream'];
 

--- a/legacy/tripal_feature/api/tripal_feature.DEPRECATED.inc
+++ b/legacy/tripal_feature/api/tripal_feature.DEPRECATED.inc
@@ -12,7 +12,7 @@
  *
  * @see chado_get_property().
  */
-function tripal_feature_analysis_get_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property, $cv_name = 'tripal') {
+function tripal_feature_analysis_get_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property = NULL, $cv_name = 'tripal') {
 
   tripal_report_error(
     'tripal_deprecated',

--- a/legacy/tripal_feature/api/tripal_feature.DEPRECATED.inc
+++ b/legacy/tripal_feature/api/tripal_feature.DEPRECATED.inc
@@ -60,7 +60,7 @@ function tripal_feature_analysis_get_property($analysis_id = NULL, $feature_id =
  *
  * @see chado_insert_property().
  */
-function tripal_feature_analysis_insert_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property, $value, $update_if_present = 0, $cv_name = 'tripal') {
+function tripal_feature_analysis_insert_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property = NULL, $value = NULL, $update_if_present = 0, $cv_name = 'tripal') {
 
   tripal_report_error(
     'tripal_deprecated',
@@ -113,7 +113,7 @@ function tripal_feature_analysis_insert_property($analysis_id = NULL, $feature_i
  *
  * @see chado_update_property().
  */
-function tripal_feature_analysis_update_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property, $value, $insert_if_missing = 0, $cv_name = 'tripal') {
+function tripal_feature_analysis_update_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property = NULL, $value = NULL, $insert_if_missing = 0, $cv_name = 'tripal') {
 
   tripal_report_error(
     'tripal_deprecated',
@@ -197,7 +197,7 @@ function tripal_feature_analysis_update_property_by_id($analysisfeatureprop_id, 
  *
  * @see chado_delete_property().
  */
-function tripal_feature_analysis_delete_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property, $cv_name = 'tripal') {
+function tripal_feature_analysis_delete_property($analysis_id = NULL, $feature_id = NULL, $analysisfeature_id = NULL, $property = NULL, $cv_name = 'tripal') {
 
   tripal_report_error(
     'tripal_deprecated',

--- a/legacy/tripal_pub/api/tripal_pub.DEPRECATED.inc
+++ b/legacy/tripal_pub/api/tripal_pub.DEPRECATED.inc
@@ -182,7 +182,7 @@ function tripal_pub_import_by_dbxref($pub_dbxref, $do_contact = FALSE, $do_updat
     ]
   );
 
-  return tripal_import_pub_by_dbxref($pub_dbxref, $do_contact, $do_udpate);
+  return tripal_import_pub_by_dbxref($pub_dbxref, $do_contact, $do_update);
 }
 
 /**

--- a/legacy/tripal_pub/api/tripal_pub.DEPRECATED.inc
+++ b/legacy/tripal_pub/api/tripal_pub.DEPRECATED.inc
@@ -170,7 +170,7 @@ function tripal_pub_import_publications($report_email = FALSE, $do_update = FALS
  *
  * @see chado_import_multiple_publications().
  */
-function tripal_pub_import_by_dbxref($pub_dbxref, $do_contact = FALSE, $do_update) {
+function tripal_pub_import_by_dbxref($pub_dbxref, $do_contact = FALSE, $do_update = FALSE) {
 
   tripal_report_error(
     'tripal_deprecated',

--- a/tripal_bulk_loader/includes/tripal_bulk_loader.admin.templates.inc
+++ b/tripal_bulk_loader/includes/tripal_bulk_loader.admin.templates.inc
@@ -20,7 +20,7 @@
  *
  * @ingroup tripal_bulk_loader
  */
-function tripal_bulk_loader_modify_template_base_form($form, &$form_state = NULL, $mode) {
+function tripal_bulk_loader_modify_template_base_form($form, &$form_state = NULL, $mode = '') {
 
   // set the breadcrumb
   $breadcrumb = [];

--- a/tripal_chado/api/modules/tripal_chado.feature.api.inc
+++ b/tripal_chado/api/modules/tripal_chado.feature.api.inc
@@ -493,7 +493,10 @@ function chado_get_feature_sequences($feature, $options) {
 
       // Get the reverse compliment if feature is on the reverse strand.
       $dir = 'forward';
-      $length = strlen($seq);
+      $length = 0;
+      if ($seq) {
+        $length = strlen($seq);
+      }
       if ($parent->strand < 0) {
         $seq = chado_reverse_compliment_sequence($seq);
         $dir = 'reverse';


### PR DESCRIPTION
# Bug Fix

## Issue #1573 

### Tripal Version: 3.10

## Description

This fixes a few deprecations that trigger warnings under PHP8.1, they are of the form
`function do_something($param1, $param2 = 'default', $param3) {`
where `$param3` is a required parameter, but `$param2` is set up as optional.
Under PHP8.1 this is flagged as being impossible.

In some cases I have removed the default value, and in others I have added one, as seemed most appropriate.
Many are for legacy functions, some of which are deprecated, so nothing is likely to break from these changes.

One functional typo in a deprecated legacy function was fixed, `$do_udpate` to `$do_update` 😆 https://github.com/tripal/tripal/pull/1574/commits/e51407f53009f841e8c4b15f9f484f3d269f42d6
And my testing was showing 
`Deprecated function: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in chado_get_feature_sequences() (line 496 of .../sites/all/modules/tripal/tripal_chado/api/modules/tripal_chado.feature.api.inc).`
so I fixed that too https://github.com/tripal/tripal/pull/1574/commits/09d0b04e2388b9ff8c25765135ca87c25a2aabcf

## Testing
I described testing in issue #1573
