### PR TITLE
Expand automated docker build set to include images without Chado

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -41,7 +41,7 @@ jobs:
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images
-        if: ${{ matrix.install-chado == "TRUE" }}
+        if: ${{ matrix.install-chado == 'TRUE' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -53,7 +53,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images WITH NO CHADO
-        if: ${{ matrix.install-chado == "FALSE" }}
+        if: ${{ matrix.install-chado == 'FALSE' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -65,7 +65,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Docker image Drupal focused Docker images.
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == "TRUE" }}
+        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == 'TRUE' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}
@@ -77,7 +77,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build latest using 10.0.x-dev, PHP 8.1, PgSQL 13
-        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == "TRUE" }}
+        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == 'TRUE' }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -56,8 +56,8 @@ jobs:
         if: ${{ matrix.install-chado == 'FALSE' }}
         with:
           image: tripalproject/tripaldocker
-          tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
-          dockerfile: tripaldocker/Dockerfile-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}-noChado
+          tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}-noChado
+          dockerfile: tripaldocker/Dockerfile-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -24,8 +24,8 @@ jobs:
           - "10.0.x-dev"
           - "10.1.x-dev"
         install-chado:
-          - TRUE
-          - FALSE
+          - "TRUE"
+          - "FALSE"
         exclude:
           - php-version: "8.2"
             drupal-version: "9.4.x-dev"
@@ -41,7 +41,7 @@ jobs:
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images
-        if: ${{ matrix.install-chado == TRUE }}
+        if: ${{ matrix.install-chado == "TRUE" }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -53,7 +53,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images WITH NO CHADO
-        if: ${{ matrix.install-chado == FALSE }}
+        if: ${{ matrix.install-chado == "FALSE" }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -65,7 +65,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Docker image Drupal focused Docker images.
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == TRUE }}
+        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == "TRUE" }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}
@@ -77,7 +77,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build latest using 10.0.x-dev, PHP 8.1, PgSQL 13
-        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == TRUE }}
+        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == "TRUE" }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -23,9 +23,6 @@ jobs:
           - "9.5.x-dev"
           - "10.0.x-dev"
           - "10.1.x-dev"
-        install-chado:
-          - "TRUE"
-          - "FALSE"
         exclude:
           - php-version: "8.2"
             drupal-version: "9.4.x-dev"
@@ -41,7 +38,6 @@ jobs:
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images
-        if: ${{ matrix.install-chado == 'TRUE' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -49,11 +45,10 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=${{ matrix.install-chado }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images WITH NO CHADO
-        if: ${{ matrix.install-chado == 'FALSE' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}-noChado
@@ -61,11 +56,11 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=${{ matrix.install-chado }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=FALSE"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Docker image Drupal focused Docker images.
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == 'TRUE' }}
+        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}
@@ -77,7 +72,7 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build latest using 10.0.x-dev, PHP 8.1, PgSQL 13
-        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == 'TRUE' }}
+        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - 4v40g-0-test-docker-build
-      - tv4g0-issue1420-fixDockerBuild
+      - tv4g9-1572-expandDockerBuild
 
 jobs:
   push_to_registry:
@@ -24,18 +23,17 @@ jobs:
           - "9.5.x-dev"
           - "10.0.x-dev"
           - "10.1.x-dev"
+        install-chado:
+          - TRUE
+          - FALSE
         exclude:
           - php-version: "8.2"
-            pgsql-version: "13"
             drupal-version: "9.4.x-dev"
           - php-version: "8.2"
-            pgsql-version: "13"
             drupal-version: "9.5.x-dev"
           - php-version: "8.0"
-            pgsql-version: "13"
             drupal-version: "10.0.x-dev"
           - php-version: "8.0"
-            pgsql-version: "13"
             drupal-version: "10.1.x-dev"
     name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
@@ -43,6 +41,7 @@ jobs:
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Full matrix of Docker images
+        if: ${{ matrix.install-chado == TRUE }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
@@ -50,11 +49,23 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupal-version }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=${{ matrix.install-chado }}"
+          labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      - uses: mr-smithers-excellent/docker-build-push@v5
+        name: Build & push Full matrix of Docker images WITH NO CHADO
+        if: ${{ matrix.install-chado == FALSE }}
+        with:
+          image: tripalproject/tripaldocker
+          tags: drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
+          dockerfile: tripaldocker/Dockerfile-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}-noChado
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=${{ matrix.install-chado }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Build & push Docker image Drupal focused Docker images.
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
+        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == TRUE }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}
@@ -65,8 +76,8 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v5
-        name: Build latest using 9.5.x-dev, PHP 8.1, PgSQL 13
-        if: ${{ matrix.drupal-version == '9.5.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13'}}
+        name: Build latest using 10.0.x-dev, PHP 8.1, PgSQL 13
+        if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' && matrix.install-chado == TRUE }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/tripaldocker/Dockerfile-php8.0-pgsql13
+++ b/tripaldocker/Dockerfile-php8.0-pgsql13
@@ -1,10 +1,5 @@
 FROM php:8.0-apache-bullseye
 
-## Base of this image is from Official DockerHub PHP image.
-## Heavily influenced by https://github.com/statonlab/docker-containers
-
-MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
-
 ARG drupalversion='9.3.x-dev'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -1,11 +1,6 @@
 FROM php:8.1-apache-bullseye
 
-## Base of this image is from Official DockerHub PHP image.
-## Heavily influenced by https://github.com/statonlab/docker-containers
-
-MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
-
-ARG drupalversion='9.4.x-dev'
+ARG drupalversion='10.0.x-dev'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
 ARG installchado=TRUE


### PR DESCRIPTION
# Tripal 4 Core Dev Task

Issue #1572 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
We are working on expanding our automated test suite in extension modules I develop and are finding the current docker builds restrictive. Specifically, we want to ensure we are testing with chado stored in a schema with a different name (e.g. testchado) just like is done in the Tripal core github workflows. However, all the docker builds install chado in a schema named chado.

Furthermore, this image could also provide a good starting point for individuals not wanting to use Chado or for testing that Chado is truely not required.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I ensured that the docker build workflow is passing for all versions here: https://github.com/tripal/tripal/actions/workflows/MAIN-buildDocker.yml

<img width="1221" alt="Screenshot 2023-07-07 at 11 31 36 AM" src="https://github.com/tripal/tripal/assets/1566301/a67fe3ff-4f47-40a9-a2d9-2f14da34087b">

### Manual Testing

#### A) Testing the `-noChado` images to ensure there truely is no Chado installed

```
docker pull tripalproject/tripaldocker:drupal10.0.x-dev-php8.2-pgsql13-noChado
docker run --publish=80:80 --name=tripal1572 -tid tripalproject/tripaldocker:drupal10.0.x-dev-php8.2-pgsql13-noChado
docker exec tripal1572 service postgresql restart
```

Now that you've started up an instance with no chado... Lets confirm that there is no chado installed!

1. Go to localhost and confirm you see the home page of a Drupal site with no errors
2. In the black admin bar choose Tripal, Data Storage > Chado
3. Finally click on "Chado Schema" and confirm that it tells you there is no chado installed.

<img width="1219" alt="Screenshot 2023-07-07 at 1 22 46 PM" src="https://github.com/tripal/tripal/assets/1566301/e0fa664a-d14b-4098-a6d9-d7400905be99">

You can also check the database if you are feeling particularly thorough:
```
docker exec -it tripal1572 drush sql:query "SELECT schema_name FROM information_schema.schemata"
```

You should get:
```
pg_catalog
public
information_schema
```

#### B) Testing the default images to ensure there is Chado installed

Now follow the same path (after stopping the previous container) but with a default docker image such as:

```
docker pull tripalproject/tripaldocker:drupal10.0.x-dev-php8.2-pgsql13
docker run --publish=80:80 --name=tripal1572Chado -tid tripalproject/tripaldocker:drupal10.0.x-dev-php8.2-pgsql13
docker exec tripal1572Chado service postgresql restart
docker exec -it tripal1572Chado drush sql:query "SELECT schema_name FROM information_schema.schemata"
```

The last command should return:
```
pg_catalog
public
information_schema
chado
genetic_code
so
frange
```

And going to Tripal, Data Storage > Chado > Chado Schema should show this:
<img width="1220" alt="Screenshot 2023-07-07 at 1 34 18 PM" src="https://github.com/tripal/tripal/assets/1566301/3f8c55c4-b1f2-4487-b259-27960216e8f3">
