### PR TITLE
REVEAL: Fix Content Type listing

### DIFF
--- a/tripal/templates/tripal-entity-content-add-list.html.twig
+++ b/tripal/templates/tripal-entity-content-add-list.html.twig
@@ -23,8 +23,8 @@
       <li class="clearfix">
         <a href="{{type.url}}">
           <span class="label">{{ type.title }}</span>
-          <div class="description">{{ type.help }}</div>
         </a>
+        <div class="description">{{ type.help }}</div>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
# Bug Fix

## Issue #1564 

### Tripal Version: 4.alpha1-dev

## Description
Fixes the links in the tripal content listing.
This fix was originally done in PR #1413 by @spficklin but due to the cautionary tale in issue #1564, it was never merged.

## Testing?
Going to Tripal Admin Bar > Content > Add Tripal Content results in the following page which lists the available content types that a curator may want to create pages for. With this single fix, the links are now shown correctly:
![Issue1564](https://github.com/tripal/tripal/assets/8419404/e896e5db-c941-4d22-a35b-c5b44a241211)

