### PR TITLE
REVEAL: Adding the title Templates to the content type YAML

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -162,29 +162,29 @@ tripal.tripalentitytype_collection.*:
                  type: string
                  label: "Category"
                  nullable: false
-               # name:
-               #   type: string
-               #   label: "A machine readable content type id (a.k.a., the bundle ID or Entity Type ID)"
-               #   nullable: false
+               name:
+                 type: string
+                 label: "A machine readable content type id (a.k.a., the bundle ID or Entity Type ID)"
+                 nullable: false
                help_text:
                  type: string
                  label: "Text used to describe to the end-user what this content type is used for"
                  nullable: false
-               # url_format:
-               #   type: string
-               #   label: "A tokenzied string for the URL of the content type. Field names in square brackets can be used as tokens."
-               #   nullable: true
-               # title_format:
-               #   type: string
-               #   label: "A tokenzied string for the title of the content type. Field names in square brackets can be used as tokens."
-               #   nullable: true
-               # synonyms:
-               #   type: sequence
-               #   label: "Synonyms"
-               #   nullable: true
-               #   sequence:
-               #      type: string
-               #      label: "Synonym name"
+               url_format:
+                 type: string
+                 label: "A tokenzied string for the URL of the content type. Field names in square brackets can be used as tokens."
+                 nullable: true
+               title_format:
+                 type: string
+                 label: "A tokenzied string for the title of the content type. Field names in square brackets can be used as tokens."
+                 nullable: true
+               synonyms:
+                 type: sequence
+                 label: "Synonyms"
+                 nullable: true
+                 sequence:
+                    type: string
+                    label: "Synonym name"
 
 ## For TripalFieldCollection functionality
 ## focused on using YML files to describe TripalFields

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -240,10 +240,12 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     if ($this->label === NULL) {
       throw new \Exception("The label is required when creating a TripalEntityType.");
     }
+    if ($this->name === NULL) {
+      throw new \Exception("The name is required when creating a TripalEntityType.");
+    }
     if ($this->help_text === NULL) {
       throw new \Exception("The help text is required when creating a TripalEntityType.");
     }
-
     if ($this->termIdSpace === NULL) {
       throw new \Exception("The Term ID Space is required when creating a TripalEntityType.");
     }

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -196,7 +196,7 @@ class TripalEntityTypeForm extends EntityForm {
     $form['url_settings']['msg'] = [
       '#type' => 'item',
       '#markup' => t('
-<p>hTe pattern below is used to specify the URL of content pages of this type. This allows you to present more friendly, informative URLs to your user.</p>
+<p>The pattern below is used to specify the URL of content pages of this type. This allows you to present more friendly, informative URLs to your user.</p>
 
 <p><strong>You must choose a combination of tokens that results in a unique path for each page!</strong></p>'),
     ];

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -164,6 +164,7 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
    *    - label: the human-readable label to be used for the content type.
    *    - category: a human-readable category to group like content types
    *      together.
+   *    - name: the machine-name of the content type.
    *    - help_text: a brief description for how this content type is used.
    *    - url_format: a tokenized string for specifying the format of the URL.
    *    - title_format: a tokenized string for the title.

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -100,16 +100,15 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
    */
   public function validate($details) {
 
-    ## Name is currently autocreated as bio_data_#
-    ## but we will want to change this in a future PR.
-    # if (!array_key_exists('name', $details) or !$details['name']) {
-    #   $this->logger->error(t('Creation of content type, "@type", failed. No name provided.',
-    #       ['@type' => $details['label']]));
-    #   return FALSE;
-    # }
+    if (!array_key_exists('name', $details) or !$details['name']) {
+      $this->logger->error(t('Creation of content type, "@type", failed. No name provided.',
+          ['@type' => $details['label']]));
+      return FALSE;
+    }
 
     if (!array_key_exists('label', $details) or !$details['label']) {
-      $this->logger->error(t('Creation of content type with failed since no label provided.'));
+      $this->logger->error(t('Creation of content name, "@name", failed. No label provided.',
+          ['@name' => $details['name']]));
       return FALSE;
     }
 
@@ -120,36 +119,34 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
     }
 
     if (get_class($details['term']) != 'Drupal\tripal\TripalVocabTerms\TripalTerm') {
-      $this->logger->error(t('Creation of content type, "@type", failed. The provided term was not valid TripalTerm object.',
-          ['@type' => $details['label'], '@term' => $details['label']]));
+      $this->logger->error(t('Creation of content type, "@type", failed. The provided term was not a valid TripalTerm object.',
+          ['@type' => $details['label']]));
       return FALSE;
     }
 
     if (!$details['term']->isValid()) {
-      $this->logger->error(t('Creation of content type, "@type", failed. The provided term was not valid.',
-          ['@type' => $details['label'], '@term' => $details['label']]));
+      $this->logger->error(t('Creation of content type, "@type", failed. The provided TripalTerm object was not valid.',
+          ['@type' => $details['label']]));
       return FALSE;
     }
 
     if (!array_key_exists('category', $details) or !$details['category']) {
-      $this->logger->error(t('Creation of content type, "@type", failed. No category provided.',
+      $this->logger->error(t('Creation of content type, "@type", failed. No category was provided.',
           ['@type' => $details['label']]));
       return FALSE;
     }
 
     if (!array_key_exists('help_text', $details) or !$details['help_text']) {
-      $this->logger->error(t('Creation of content type, "@type", failed. No help_text provided.',
+      $this->logger->error(t('Creation of content type, "@type", failed. No help_text was provided.',
           ['@type' => $details['label']]));
       return FALSE;
     }
 
-    ## This will be added in a future PR
-    ## to keep track of the old bio_data_# used in previous versions of Tripal.
-    # if (array_key_exists('synonyms', $details) and !is_array($details['synonyms'])) {
-    #   $this->logger->error(t('Creation of content type, "@type", failed. The synonyms should be an array.',
-    #       ['@type' => $details['label']]));
-    #   return FALSE;
-    # }
+    if (array_key_exists('synonyms', $details) and !is_array($details['synonyms'])) {
+      $this->logger->error(t('Creation of content type, "@type", failed. The synonyms should be an array.',
+          ['@type' => $details['label']]));
+      return FALSE;
+    }
 
     return TRUE;
   }

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -57,7 +57,7 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
   /**
    * Installs content types using all appropriate YAML files.
    *
-   * The YAML config file prefix is tripal.tripal_content_types.*
+   * The YAML config file prefix is tripal.tripalentitytype_collection.*
    */
   public function install() {
 

--- a/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
+++ b/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\Tests\tripal\Functional\Entity;
+
+use Drupal\Tests\tripal\Functional\TripalTestBrowserBase;
+use Drupal\Core\Url;
+use Drupal\tripal\TripalVocabTerms\TripalTerm;
+
+
+/**
+ * Tests the basic functions of the TripalContentTypes Service.
+ *
+ * @group Tripal
+ * @group Tripal Content
+ */
+class TripalContentTypesTest extends TripalTestBrowserBase {
+
+  /**
+   * Tests the TripalContentTypes class public functions.
+   */
+  public function testTripalContentTypes() {
+
+    // Create the vocabulary term needed for testing the content type.
+    // We'll use the default Tripal IdSpace and Vocabulary plugins.
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
+    $idspace = $idsmanager->createCollection('OBI', "tripal_default_id_space");
+    $vocab = $vmanager->createCollection('OBI', "tripal_default_vocabulary");
+    $term = new TripalTerm([
+      'name' => 'organism',
+      'idSpace' => 'OBI',
+      'vocabulary' => 'OBI',
+      'accession' => '0100026',
+      'definition' => '',
+    ]);
+    $idspace->saveTerm($term);
+
+    // Create a good content type array.
+    $good = [
+      'label' => 'Organism',
+      'term' => $term,
+      'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
+      'category' => 'General',
+      'name' => 'organism',
+      'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
+      'url_format' => "organism/[TripalEntity__entity_id]",
+      'synonyms' => ['bio_data_1']
+    ];
+
+    /** @var \Drupal\tripal\Services\TripalContentTypes $content_type_service **/
+    $content_type_service = \Drupal::service('tripal.tripalentitytype_collection');
+
+    // Test creating a good content type.
+    $is_valid = $content_type_service->validate($good);
+    $this->assertTrue($is_valid, "A good content type definition failed validation check.");
+    $content_type = $content_type_service->createContentType($good);
+    $this->assertTrue(!is_null($content_type), "Failed to create a content type with a valid definition.");
+
+    // Test that when a value is missing it fails validation.
+    $bad = $good;
+    unset($bad['term']);
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition missing the 'term' should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the term is incorret.");
+
+    $bad = $good;
+    unset($bad['name']);
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition missing the 'name' should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the name is incorret.");
+
+
+    $bad = $good;
+    unset($bad['label']);
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition missing the 'label' should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the label is incorret.");
+
+
+    $bad = $good;
+    unset($bad['category']);
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition missing the 'category' should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the category is incorret.");
+
+
+    $bad = $good;
+    unset($bad['help_text']);
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition missing the 'help_text' should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the help_text is incorret.");
+
+
+    $bad = $good;
+    $bad['synonyms'] = 'xyz';
+    $is_valid = $content_type_service->validate($bad);
+    $this->assertFalse($is_valid, "A content type definition with a malformed synonyms list should fail the validation check but it passed.");
+    $content_type = $content_type_service->createContentType($bad);
+    $this->assertTrue(is_null($content_type), "Created a content type when the synonyms are incorret.");
+
+  }
+}

--- a/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
+++ b/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
@@ -62,14 +62,14 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition missing the 'term' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the term is incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the term is incorrect.");
 
     $bad = $good;
     unset($bad['name']);
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition missing the 'name' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the name is incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the name is incorrect.");
 
 
     $bad = $good;
@@ -77,7 +77,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition missing the 'label' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the label is incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the label is incorrect.");
 
 
     $bad = $good;
@@ -85,7 +85,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition missing the 'category' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the category is incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the category is incorrect.");
 
 
     $bad = $good;
@@ -93,7 +93,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition missing the 'help_text' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the help_text is incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the help_text is incorrect.");
 
 
     $bad = $good;
@@ -101,7 +101,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $is_valid = $content_type_service->validate($bad);
     $this->assertFalse($is_valid, "A content type definition with a malformed synonyms list should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the synonyms are incorret.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the synonyms are incorrect.");
 
   }
 }

--- a/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
+++ b/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
@@ -12,6 +12,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *
  * @group Tripal
  * @group Tripal Content
+ * @group Tripal Content Types
  */
 class TripalContentTypesTest extends TripalTestBrowserBase {
 
@@ -56,6 +57,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $content_type = $content_type_service->createContentType($good);
     $this->assertTrue(!is_null($content_type), "Failed to create a content type with a valid definition.");
 
+
     // Test that when a value is missing it fails validation.
     $bad = $good;
     unset($bad['term']);
@@ -63,6 +65,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
     $this->assertFalse($is_valid, "A content type definition missing the 'term' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
     $this->assertTrue(is_null($content_type), "Created a content type when the term is incorrect.");
+
 
     $bad = $good;
     unset($bad['name']);

--- a/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
@@ -44,10 +44,10 @@ class TripalEntityTypeCollectionTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      # 'name' => 'organism',
-      # 'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
-      # 'url_format' => "organism/[TripalEntity__entity_id]",
-      # 'synonyms' => ['bio_data_1']
+      'name' => 'organism',
+      'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
+      'url_format' => "organism/[TripalEntity__entity_id]",
+      'synonyms' => ['bio_data_1']
     ];
 
     /** @var \Drupal\tripal\Services\TripalEntityTypeCollection $content_type_service **/

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
@@ -8,7 +8,7 @@ content_types:
         help_text: Use the organism page for an individual living system, such as animal, plant, bacteria or virus, 
         category: General
         # name: organism
-        # title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
+        title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
         # url_format: "organism/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_1
@@ -18,7 +18,7 @@ content_types:
         help_text: Use the analysis page to for an individual analysis, workflow or pipeline that was performed using statistical or computational means.
         category: General
         # name: analysis
-        # title_format: "[analysis_name]"
+        title_format: "[analysis_name]"
         # url_format: "analysis/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_2
@@ -28,7 +28,7 @@ content_types:
         help_text: Use the project page to provide information about a project that many be linked to multiple sub components such as studies or analyses.
         category: General
         # name: project
-        # title_format: "[project_name]"
+        title_format: "[project_name]"
         # url_format: "project/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_3
@@ -38,7 +38,7 @@ content_types:
         help_text: Use the study page for a systematic investigation.
         category: General
         # name: study
-        # title_format: "[study_name]"
+        title_format: "[study_name]"
         # url_format: "study/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_4
@@ -48,7 +48,7 @@ content_types:
         help_text: Use the contage page a person or institution that can be linked as a responsible party for data or results.
         category: General
         # name: contact
-        # title_format: "[contact_name]"
+        title_format: "[contact_name]"
         # url_format: "contact/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_5        
@@ -58,7 +58,7 @@ content_types:
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
         # name: pub
-        # title_format: "[publication_title]"
+        title_format: "[publication_title]"
         # url_format: "pub/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_6
@@ -68,7 +68,7 @@ content_types:
         help_text: Use the protocol page for a parameterizable description of a process.
         category: General
         # name: protocol
-        # title_format: "[protocol_name]"
+        title_format: "[protocol_name]"
         # url_format: "protocol/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_7
@@ -78,7 +78,7 @@ content_types:
         help_text: Use the gene page for a region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.
         category: Genomic
         # name: gene
-        # title_format: "[gene_name]"
+        title_format: "[gene_name]"
         # url_format: "gene/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_8
@@ -88,7 +88,7 @@ content_types:
         help_text: Use the mRNA page for a messenger RNA whic is the intermediate molecule between DNA and protein. It includes UTR and coding sequences. It does not contain introns.
         category: Genomic
         # name: mRNA
-        # title_format: "[mrna_name]"
+        title_format: "[mrna_name]"
         # url_format: "mRNA/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_9
@@ -98,7 +98,7 @@ content_types:
         help_text: Use the phylogenetic tree page for data or plotting of phylogenetic trees. Usually includes information such as topology, lengths (in time or in expected amounts of variance) and a confidence interval for each length.
         category: Genomic
         # name: phylotree
-        # title_format: "[phylotree_name]"
+        title_format: "[phylotree_name]"
         # url_format: "phylotree/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_10
@@ -108,7 +108,7 @@ content_types:
         help_text: Use the physical map page for a map of annotated with physical features or landmarks such as restriction sites, cloned DNA fragments, genes or genetic markers, along with the physical distances between them. Distance in a physical map is measured in base pairs. A physical map might be ordered relative to a reference map (typically a genetic map) in the process of genome sequencing.
         category: Genomic  
         # name: physical_map 
-        # title_format: "[physical_map_name]"
+        title_format: "[physical_map_name]"
         # url_format: "physical_map/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_11    
@@ -118,7 +118,7 @@ content_types:
         help_text: Use the DNA library page for a collection of DNA molecules that have been cloned in vectors.
         category: Genomic
         # name: dna_library
-        # title_format: "[dna_library_name]"
+        title_format: "[dna_library_name]"
         # url_format: "dna_library/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_12
@@ -128,7 +128,7 @@ content_types:
         help_text: Use the genome assembly page for an analyses specifcally for genome assembly. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the assembly.
         category: Genomic 
         # name:  genome_assembly
-        # title_format: "[genome_assembly_name]"
+        title_format: "[genome_assembly_name]"
         # url_format: "genome_assembly/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_13     
@@ -138,7 +138,7 @@ content_types:
         help_text: Use the genome annotation page for an analyses specifcally for genome annotation. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the structural and functional annotations of the genome.
         category: Genomic
         # name: genome_annotation
-        # title_format: "[genome_annotation_name]"
+        title_format: "[genome_annotation_name]"
         # url_format: "genome_annotation/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_14
@@ -148,7 +148,7 @@ content_types:
         help_text: Use the genome project page to provide information about a genome assembly and annotation project that many be linked to multiple sub analyses.
         category: Genomic
         # name: genome_project
-        # title_format: "[genome_project_name]"
+        title_format: "[genome_project_name]"
         # url_format: "genome_project/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_15
@@ -158,7 +158,7 @@ content_types:
         help_text: Use a genetic map page for a map showing the relative positions of genetic markers in a nucleic acid sequence, based on estimation of non-physical distance such as recombination frequencies.
         category: Genetic
         # name: genetic_map
-        # title_format: "[genetic_map_name]"
+        title_format: "[genetic_map_name]"
         # url_format: "genetic_map/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_16
@@ -168,7 +168,7 @@ content_types:
         help_text: Use a QTL page for a quantitative trait locus (QTL), which is a polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait. Usually it is a marker described by statistical association to quantitative variation in the particular phenotypic trait that is thought to be controlled by the cumulative action of alleles at multiple loci.
         category: Genetic
         # name: QTL
-        # title_format: "[qtl_name]"
+        title_format: "[qtl_name]"
         # url_format: "QTL/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_17
@@ -178,7 +178,7 @@ content_types:
         help_text: Use the sequence variant page for a non exact copy of a sequence feature or genome exhibiting one or more sequence alteration.
         category: Genetic
         # name: sequence_variant
-        # title_format: "[sequence_variant_name]"
+        title_format: "[sequence_variant_name]"
         # url_format: "sequence_variant/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_18
@@ -188,7 +188,7 @@ content_types:
         help_text: Use the genetic marker page for a measurable sequence feature that varies within a population.
         category: Genetic
         # name: genetic_marker
-        # title_format: "[genetic_marker_name]"
+        title_format: "[genetic_marker_name]"
         # url_format: "genetic_marker/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_19
@@ -198,7 +198,7 @@ content_types:
         help_text: Use the heritable phenotypic marker page for a sequence region characterized as a single heritable trait in a phenotype screen. The heritable phenotype may be mapped to a chromosome but generally has not been characterized to a specific gene locus.
         category: Genetic
         # name: phenotypic_marker 
-        # title_format: "[phenotypic_marker_name]"
+        title_format: "[phenotypic_marker_name]"
         # url_format: "phenotypic_marker/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_20
@@ -208,7 +208,7 @@ content_types:
         help_text: Use the germplasm accession page for a living genetic resources such as seeds or tissues that are maintained for the purpose of animal and plant breeding, and preservation.
         category: Germplasm
         # name: germplasm
-        # title_format: "[germplasm_name]"
+        title_format: "[germplasm_name]"
         # url_format: "germplasm/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_21
@@ -218,7 +218,7 @@ content_types:
         help_text: Use the breeding cross page for information about a cross between two germplasm in a breeding application.
         category: Germplasm
         # name: breeding_cross
-        # title_format: "[breeding_cross_name]"
+        title_format: "[breeding_cross_name]"
         # url_format: "breeding_cross/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_22
@@ -228,7 +228,7 @@ content_types:
         help_text: Use the germplasm variety page for information about specific variety of germplasm.
         category: Germplasm
         # name: germplasm_variety
-        # title_format: "[germplasm_variety_name]"
+        title_format: "[germplasm_variety_name]"
         # url_format: "germplasm_variety/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_23
@@ -238,7 +238,7 @@ content_types:
         help_text: Use the recombinant inbred line page to describe a collection of germplasm that were created by crossing and can be used to map quantitative trait loci.
         category: Germplasm
         # name: RIL
-        # title_format: "[ril_name]"
+        title_format: "[ril_name]"
         # url_format: "RIL/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_24
@@ -248,7 +248,7 @@ content_types:
         help_text: Use the biological sample page for any material taken from a biological system for use in a systematic study.
         category: Expression
         # name: biosample
-        # title_format: "[biosample_name]"
+        title_format: "[biosample_name]"
         # url_format: "biosample/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_25
@@ -258,7 +258,7 @@ content_types:
         help_text: Use the assay page to describe an experimental approach used to measure the characteristics of an item. 
         category: Expression
         # name: assay
-        # title_format: "[assay_name]"
+        title_format: "[assay_name]"
         # url_format: "assay/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_26
@@ -268,8 +268,7 @@ content_types:
         help_text: Use the array design page to describe the systematic arrangement of similar objects, usually in rows and columns, used by intstrument to perform an assay.
         category: Expression
         # name: array_design
-        # title_format: "[array_design_name]"
+        title_format: "[array_design_name]"
         # url_format: "array_design/[TripalEntity__entity_id]"
         # synonyms: 
         #     - bio_data_27
-        

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
@@ -5,270 +5,270 @@ content_types:
 
     -   label: Organism
         term: OBI:0100026
-        help_text: Use the organism page for an individual living system, such as animal, plant, bacteria or virus, 
+        help_text: Use the organism page for an individual living system, such as animal, plant, bacteria or virus,
         category: General
-        # name: organism
+        name: organism
         title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
-        # url_format: "organism/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_1
+        url_format: "organism/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_1
 
     -   label:  Analysis
         term: operation:2945
         help_text: Use the analysis page to for an individual analysis, workflow or pipeline that was performed using statistical or computational means.
         category: General
-        # name: analysis
+        name: analysis
         title_format: "[analysis_name]"
-        # url_format: "analysis/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_2
+        url_format: "analysis/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_2
 
     -   label: Project
         term: NCIT:C47885
         help_text: Use the project page to provide information about a project that many be linked to multiple sub components such as studies or analyses.
         category: General
-        # name: project
+        name: project
         title_format: "[project_name]"
-        # url_format: "project/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_3
-              
+        url_format: "project/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_3
+             
     -   label: Study
         term: SIO:001066
         help_text: Use the study page for a systematic investigation.
         category: General
-        # name: study
+        name: study
         title_format: "[study_name]"
-        # url_format: "study/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_4
-        
+        url_format: "study/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_4
+       
     -   label: Contact
         term: local:contact
         help_text: Use the contage page a person or institution that can be linked as a responsible party for data or results.
         category: General
-        # name: contact
+        name: contact
         title_format: "[contact_name]"
-        # url_format: "contact/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_5        
+        url_format: "contact/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_5       
 
     -   label: Publication
         term: TPUB:0000002
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
-        # name: pub
+        name: pub
         title_format: "[publication_title]"
-        # url_format: "pub/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_6
+        url_format: "pub/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_6
 
     -   label: Protocol
         term: sep:00101
         help_text: Use the protocol page for a parameterizable description of a process.
         category: General
-        # name: protocol
+        name: protocol
         title_format: "[protocol_name]"
-        # url_format: "protocol/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_7
-        
+        url_format: "protocol/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_7
+       
     -   label: Gene
         term: SO:0000704
         help_text: Use the gene page for a region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.
         category: Genomic
-        # name: gene
+        name: gene
         title_format: "[gene_name]"
-        # url_format: "gene/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_8
+        url_format: "gene/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_8
 
     -   label: mRNA
         term: SO:0000234
         help_text: Use the mRNA page for a messenger RNA whic is the intermediate molecule between DNA and protein. It includes UTR and coding sequences. It does not contain introns.
         category: Genomic
-        # name: mRNA
+        name: mRNA
         title_format: "[mrna_name]"
-        # url_format: "mRNA/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_9
-            
+        url_format: "mRNA/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_9
+           
     -   label: Phylogenetic Tree
         term: data:0872
         help_text: Use the phylogenetic tree page for data or plotting of phylogenetic trees. Usually includes information such as topology, lengths (in time or in expected amounts of variance) and a confidence interval for each length.
         category: Genomic
-        # name: phylotree
+        name: phylotree
         title_format: "[phylotree_name]"
-        # url_format: "phylotree/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_10
-              
+        url_format: "phylotree/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_10
+             
     -   label: Physical Map
         term: data:1280
         help_text: Use the physical map page for a map of annotated with physical features or landmarks such as restriction sites, cloned DNA fragments, genes or genetic markers, along with the physical distances between them. Distance in a physical map is measured in base pairs. A physical map might be ordered relative to a reference map (typically a genetic map) in the process of genome sequencing.
-        category: Genomic  
-        # name: physical_map 
+        category: Genomic 
+        name: physical_map
         title_format: "[physical_map_name]"
-        # url_format: "physical_map/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_11    
-              
+        url_format: "physical_map/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_11   
+             
     -   label: DNA Library
         term: NCIT:C16223
         help_text: Use the DNA library page for a collection of DNA molecules that have been cloned in vectors.
         category: Genomic
-        # name: dna_library
+        name: dna_library
         title_format: "[dna_library_name]"
-        # url_format: "dna_library/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_12
-        
+        url_format: "dna_library/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_12
+       
     -   label: Genome Assembly
         term: operation:0525
         help_text: Use the genome assembly page for an analyses specifcally for genome assembly. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the assembly.
-        category: Genomic 
-        # name:  genome_assembly
+        category: Genomic
+        name:  genome_assembly
         title_format: "[genome_assembly_name]"
-        # url_format: "genome_assembly/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_13     
+        url_format: "genome_assembly/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_13    
 
     -   label: Genome Annotation
         term: operation:0362
         help_text: Use the genome annotation page for an analyses specifcally for genome annotation. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the structural and functional annotations of the genome.
         category: Genomic
-        # name: genome_annotation
+        name: genome_annotation
         title_format: "[genome_annotation_name]"
-        # url_format: "genome_annotation/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_14
-        
+        url_format: "genome_annotation/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_14
+       
     -   label: Genome Project
         term: local:Genome Project
         help_text: Use the genome project page to provide information about a genome assembly and annotation project that many be linked to multiple sub analyses.
         category: Genomic
-        # name: genome_project
+        name: genome_project
         title_format: "[genome_project_name]"
-        # url_format: "genome_project/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_15
-            
+        url_format: "genome_project/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_15
+           
     -   label: Genetic Map
         term: data:1278
         help_text: Use a genetic map page for a map showing the relative positions of genetic markers in a nucleic acid sequence, based on estimation of non-physical distance such as recombination frequencies.
         category: Genetic
-        # name: genetic_map
+        name: genetic_map
         title_format: "[genetic_map_name]"
-        # url_format: "genetic_map/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_16
-            
+        url_format: "genetic_map/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_16
+           
     -   label: QTL
         term: SO:0000771
         help_text: Use a QTL page for a quantitative trait locus (QTL), which is a polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait. Usually it is a marker described by statistical association to quantitative variation in the particular phenotypic trait that is thought to be controlled by the cumulative action of alleles at multiple loci.
         category: Genetic
-        # name: QTL
+        name: QTL
         title_format: "[qtl_name]"
-        # url_format: "QTL/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_17
-        
+        url_format: "QTL/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_17
+       
     -   label: Sequence Variant
         term: SO:0001060
         help_text: Use the sequence variant page for a non exact copy of a sequence feature or genome exhibiting one or more sequence alteration.
         category: Genetic
-        # name: sequence_variant
+        name: sequence_variant
         title_format: "[sequence_variant_name]"
-        # url_format: "sequence_variant/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_18
+        url_format: "sequence_variant/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_18
 
     -   label: Genetic Marker
         term: SO:0001645
         help_text: Use the genetic marker page for a measurable sequence feature that varies within a population.
         category: Genetic
-        # name: genetic_marker
+        name: genetic_marker
         title_format: "[genetic_marker_name]"
-        # url_format: "genetic_marker/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_19
-        
+        url_format: "genetic_marker/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_19
+       
     -   label: Heritable Phenotypic Marker
         term: SO:0001500
         help_text: Use the heritable phenotypic marker page for a sequence region characterized as a single heritable trait in a phenotype screen. The heritable phenotype may be mapped to a chromosome but generally has not been characterized to a specific gene locus.
         category: Genetic
-        # name: phenotypic_marker 
+        name: phenotypic_marker
         title_format: "[phenotypic_marker_name]"
-        # url_format: "phenotypic_marker/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_20
-        
+        url_format: "phenotypic_marker/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_20
+       
     -   label: Germplasm Accession
         term: CO_010:0000044
         help_text: Use the germplasm accession page for a living genetic resources such as seeds or tissues that are maintained for the purpose of animal and plant breeding, and preservation.
         category: Germplasm
-        # name: germplasm
+        name: germplasm
         title_format: "[germplasm_name]"
-        # url_format: "germplasm/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_21
-        
+        url_format: "germplasm/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_21
+       
     -   label: Breeding Cross
         term: CO_010:0000255
         help_text: Use the breeding cross page for information about a cross between two germplasm in a breeding application.
         category: Germplasm
-        # name: breeding_cross
+        name: breeding_cross
         title_format: "[breeding_cross_name]"
-        # url_format: "breeding_cross/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_22
-        
+        url_format: "breeding_cross/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_22
+       
     -   label: Germplasm Variety
         term: CO_010:0000029
         help_text: Use the germplasm variety page for information about specific variety of germplasm.
         category: Germplasm
-        # name: germplasm_variety
+        name: germplasm_variety
         title_format: "[germplasm_variety_name]"
-        # url_format: "germplasm_variety/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_23
-        
+        url_format: "germplasm_variety/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_23
+       
     -   label: Recombinant Inbred Line
         term: CO_010:0000162
         help_text: Use the recombinant inbred line page to describe a collection of germplasm that were created by crossing and can be used to map quantitative trait loci.
         category: Germplasm
-        # name: RIL
+        name: RIL
         title_format: "[ril_name]"
-        # url_format: "RIL/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_24
-        
+        url_format: "RIL/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_24
+       
     -   label: Biological Sample
         term: sep:00195
         help_text: Use the biological sample page for any material taken from a biological system for use in a systematic study.
         category: Expression
-        # name: biosample
+        name: biosample
         title_format: "[biosample_name]"
-        # url_format: "biosample/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_25
-        
+        url_format: "biosample/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_25
+       
     -   label: Assay
         term: OBI:0000070
-        help_text: Use the assay page to describe an experimental approach used to measure the characteristics of an item. 
+        help_text: Use the assay page to describe an experimental approach used to measure the characteristics of an item.
         category: Expression
-        # name: assay
+        name: assay
         title_format: "[assay_name]"
-        # url_format: "assay/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_26
-        
+        url_format: "assay/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_26
+       
     -   label: Array Design
         term: EFO:0000269
         help_text: Use the array design page to describe the systematic arrangement of similar objects, usually in rows and columns, used by intstrument to perform an assay.
         category: Expression
-        # name: array_design
+        name: array_design
         title_format: "[array_design_name]"
-        # url_format: "array_design/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_27
+        url_format: "array_design/[TripalEntity__entity_id]"
+        synonyms:
+            - bio_data_27

--- a/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
@@ -28,7 +28,7 @@ class ChadoCustomTablesTest extends ChadoTestBrowserBase {
     // Test manager get list of chado custom tables.
     $custom_tables = $manager->getTables($chado_schema_name);
     $this->assertIsArray($custom_tables, "The return value of Custom Table manager getTables is expected to be an array.");
-    $this->assertEmpty($custom_tables, "We just created this test schema so the Custom Table manager should be able to find any tables yet.");
+    $this->assertEmpty($custom_tables, "We just created this test schema so the Custom Table manager should not be able to find any tables yet.");
 
     // Test manager create. This just creates the object.
     $table_name = $this->randomString(25);


### PR DESCRIPTION
# Tripal 4 Core Dev Task

## Issue #1563

### Tripal Version: 4.alpha1-dev

## Description

Currently the default title for any content type is a mishmash of all the required fields. For example, analysis is `[TripalEntityType__label], [analysis_program_version], [analysis_software]`

This specifies the defaults from  the yaml file `tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml` - see issue #1563 for the "once upon a time" tale of this 😕

## Testing

  * Build a docker on this branch
  * Go to `/admin/structure/bio_data`
  * In the "Label" column click on analysis, i.e. `/admin/structure/bio_data/manage/bio_data_2`
  * In **Advanced Settings** you should see the title format and url format specified in the yaml file `tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml`

Previously, this was **[TripalEntityType__label], [analysis_program_version], [analysis_software]**, now it is:

![title](https://github.com/tripal/tripal/assets/8419404/b2f60772-04d7-403f-8b8c-8a6f86c0a392)

Previously, this was **[type]/[TripalEntity__entity_id]**, now it is (ha ha look at that typo, let's fix it! https://github.com/tripal/tripal/pull/1583/commits/1871730397b850e4a93cddb4f6fc2075e5866ad7):

![url](https://github.com/tripal/tripal/assets/8419404/b6e582e9-6e18-4d11-9c3a-8fc90bf4bdc3)



