### PR TITLE
Remove 'bio_data' from Tripal

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -162,29 +162,29 @@ tripal.tripalentitytype_collection.*:
                  type: string
                  label: "Category"
                  nullable: false
-               # name:
-               #   type: string
-               #   label: "A machine readable content type id (a.k.a., the bundle ID or Entity Type ID)"
-               #   nullable: false
+               name:
+                 type: string
+                 label: "A machine readable content type id (a.k.a., the bundle ID or Entity Type ID)"
+                 nullable: false
                help_text:
                  type: string
                  label: "Text used to describe to the end-user what this content type is used for"
                  nullable: false
-               # url_format:
-               #   type: string
-               #   label: "A tokenzied string for the URL of the content type. Field names in square brackets can be used as tokens."
-               #   nullable: true
+               url_format:
+                 type: string
+                 label: "A tokenzied string for the URL of the content type. Field names in square brackets can be used as tokens."
+                 nullable: true
                # title_format:
                #   type: string
                #   label: "A tokenzied string for the title of the content type. Field names in square brackets can be used as tokens."
                #   nullable: true
-               # synonyms:
-               #   type: sequence
-               #   label: "Synonyms"
-               #   nullable: true
-               #   sequence:
-               #      type: string
-               #      label: "Synonym name"
+               synonyms:
+                 type: sequence
+                 label: "Synonyms"
+                 nullable: true
+                 sequence:
+                    type: string
+                    label: "Synonym name"
 
 ## For TripalFieldCollection functionality
 ## focused on using YML files to describe TripalFields

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -162,7 +162,7 @@ tripal.tripalentitytype_collection.*:
                  type: string
                  label: "Category"
                  nullable: false
-               name:
+               id:
                  type: string
                  label: "A machine readable content type id (a.k.a., the bundle ID or Entity Type ID)"
                  nullable: false

--- a/tripal/config/schema/tripal_entity_type.schema.yml
+++ b/tripal/config/schema/tripal_entity_type.schema.yml
@@ -1,4 +1,4 @@
-tripal.bio_data.*:
+tripal.content_type.*:
   type: config_entity
   label: 'Tripal Content Type'
   mapping:

--- a/tripal/config/schema/tripal_entity_type.schema.yml
+++ b/tripal/config/schema/tripal_entity_type.schema.yml
@@ -3,11 +3,8 @@ tripal.content_type.*:
   label: 'Tripal Content Type'
   mapping:
     id:
-      type: integer
-      label: 'ID'
-    name:
       type: string
-      label: 'Name'
+      label: 'ID'
     label:
       type: label
       label: 'Label'

--- a/tripal/js/tripal.js
+++ b/tripal/js/tripal.js
@@ -116,7 +116,7 @@
    */
   TripalAjaxField.prototype.attach = function () {
     $.ajax({
-      url     : baseurl + '/bio_data/ajax/field_attach/' + this.id,
+      url     : baseurl + '/tripal/ajax/field_attach/' + this.id,
       dataType: 'json',
       type    : 'GET',
       success : this.setFieldContent.bind(this)
@@ -212,7 +212,7 @@ function tripal_navigate_field_pager(id, page) {
   jQuery('#' + id + '-spinner').show();
   jQuery.ajax({
     type   : 'GET',
-    url    : Drupal.settings['basePath'] + 'bio_data/ajax/field_attach/' + id,
+    url    : Drupal.settings['basePath'] + 'tripal/ajax/field_attach/' + id,
     data   : {'page': page},
     success: function (response) {
       jQuery('#' + id + ' .field-items').replaceWith(response['content']);

--- a/tripal/src/Controller/TripalEntityUIController.php
+++ b/tripal/src/Controller/TripalEntityUIController.php
@@ -43,7 +43,7 @@ class TripalEntityUIController extends ControllerBase {
       $bundles[$category]['members'][] = [
         'title' => $entity->getLabel(),
         'help' => $entity->getHelpText(),
-        'url' => Url::fromRoute('entity.tripal_entity.add_form', ['tripal_entity_type' => $entity->getName()]),
+        'url' => Url::fromRoute('entity.tripal_entity.add_form', ['tripal_entity_type' => $entity->id()]),
       ];
     }
 
@@ -84,7 +84,7 @@ class TripalEntityUIController extends ControllerBase {
    */
   public function tripalCheckForFields($tripal_entity_type) {
 
-    $bundle_name = $tripal_entity_type->getName();
+    $bundle_name = $tripal_entity_type->id();
     $term = $tripal_entity_type->getTerm();
 
     //$added = tripal_create_bundle_fields($bundle, $term);

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
 use Drupal\field\Entity\FieldConfig;
+use Symfony\Component\Routing\Route;
 
 
 /**
@@ -47,12 +48,12 @@ use Drupal\field\Entity\FieldConfig;
  *     "status" = "status",
  *   },
  *   links = {
- *     "canonical" = "/bio_data/{tripal_entity}",
- *     "add-page" = "/bio_data/add",
- *     "add-form" = "/bio_data/add/{tripal_entity_type}",
- *     "edit-form" = "/bio_data/{tripal_entity}/edit",
- *     "delete-form" = "/bio_data/{tripal_entity}/delete",
- *     "collection" = "/admin/content/bio_data",
+ *     "canonical" = "/tripal/{tripal_entity_type}/{tripal_entity}",
+ *     "add-page" = "/tripal/add",
+ *     "add-form" = "/tripal/add/{tripal_entity_type}",
+ *     "edit-form" = "/tripal/{tripal_entity}/edit",
+ *     "delete-form" = "/tripal/{tripal_entity}/delete",
+ *     "collection" = "/admin/content/tripal",
  *   },
  *   bundle_entity_type = "tripal_entity_type",
  *   field_ui_base_route = "entity.tripal_entity_type.edit_form"
@@ -69,7 +70,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * @code
       $values = [
         'title' => 'laceytest'.time(),
-        'type' => 'bio_data_1',
+        'type' => 'organism',
         'uid' => 1,
       ];
       $entity = \Drupal\tripal\Entity\TripalEntity::create($values);
@@ -79,7 +80,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * @param array $values
    *   - *title: the title of the entity.
    *   - *user_id: the user_id of the user who authored the content.
-   *   - *type: the type of tripal entity this is (e.g. bio_data_1)
+   *   - *type: the type of tripal entity this is (e.g. organism)
    *   - status: whether the entity is published or not (boolean)
    *   - created: the unix timestamp for when this content was created.
    * @return object
@@ -161,7 +162,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    */
   public function setAlias($path_alias = NULL, $cache = []) {
 
-    $system_path = "/bio_data/" . $this->getID();
+    $system_path = "/" . $this->getType()->getName() . "/" . $this->getID();
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     // If no alias was supplied then we should try to generate one using the
@@ -720,5 +721,17 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     }
 
     return $violations;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @see \Drupal\Core\Entity\EntityBase::urlRouteParameters()
+   */
+  public function urlRouteParameters($rel){
+    $uri_route_parameters = parent::urlRouteParameters($rel);
+    if ($rel == 'canonical') {
+      $uri_route_parameters['tripal_entity_type'] = $this->getType();
+    }
+    return $uri_route_parameters;
   }
 }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -48,7 +48,7 @@ use Symfony\Component\Routing\Route;
  *     "status" = "status",
  *   },
  *   links = {
- *     "canonical" = "/tripal/{tripal_entity_type}/{tripal_entity}",
+ *     "canonical" = "/tripal/{tripal_entity}",
  *     "add-page" = "/tripal/add",
  *     "add-form" = "/tripal/add/{tripal_entity_type}",
  *     "edit-form" = "/tripal/{tripal_entity}/edit",
@@ -154,35 +154,20 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *   The alias to use. It can contain tokens the correspond to field values.
    *   Token should be be compatible with those returned by
    *   tripal_get_entity_tokens().
-   * @param array $cache
-   *   This array is used to store objects you want to cache for performance
-   *   reasons, as well as, cache related options. The following are supported:
-   *   - TripalEntityType $bundle
-   *       The bundle for the current entity.
    */
-  public function setAlias($path_alias = NULL, $cache = []) {
+  public function setAlias($path_alias = NULL) {
 
-    $system_path = "/" . $this->getType()->getName() . "/" . $this->getID();
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    $system_path = "/tripal/" . $this->getID();
 
     // If no alias was supplied then we should try to generate one using the
     // default format set by admins.
     if (!$path_alias) {
 
-      // Load the TripalEntityType entity for this TripalEntity (if it's not
-      // cached). First get the format for the url alias based on the bundle
-      // of the entity. Then replace all the tokens with values from the entity fields.
-      if (isset($cache['bundle'])) {
-        $bundle = $cache['bundle'];
-      }
-      else {
-        $bundle = \Drupal\tripal\Entity\TripalEntityType::load($this->getType());
-      }
-
+      $bundle = \Drupal\tripal\Entity\TripalEntityType::load($this->getType());
       $path_alias = $bundle->getURLFormat();
       $path_alias = $this->replaceTokens($path_alias,
         ['tripal_entity_type' => $bundle]);
-
     }
 
     // Ensure there is a leading slash.
@@ -197,7 +182,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $path = \Drupal::entityTypeManager()->getStorage('path_alias')->create([
       'path' => $system_path,
       'alias' => $path_alias,
-      'langcode' => $langcode,
     ]);
     $path->save();
   }
@@ -721,17 +705,5 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     }
 
     return $violations;
-  }
-
-  /**
-   * {@inheritDoc}
-   * @see \Drupal\Core\Entity\EntityBase::urlRouteParameters()
-   */
-  public function urlRouteParameters($rel){
-    $uri_route_parameters = parent::urlRouteParameters($rel);
-    if ($rel == 'canonical') {
-      $uri_route_parameters['tripal_entity_type'] = $this->getType();
-    }
-    return $uri_route_parameters;
   }
 }

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -557,8 +557,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       'required' => TRUE,
     ];
 
-    $instances = \Drupal::service('entity_field.manager')
-      ->getFieldDefinitions('tripal_entity', $this->name);
+    $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('tripal_entity', $this->id);
     foreach ($instances as $instance_name => $instance) {
 
       $use_field = TRUE;

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -29,7 +29,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *       "html" = "Drupal\tripal\Routing\TripalEntityTypeHtmlRouteProvider",
  *     },
  *   },
- *   config_prefix = "bio_data",
+ *   config_prefix = "content_type",
  *   admin_permission = "manage tripal content types",
  *   bundle_of = "tripal_entity",
  *   entity_keys = {

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -33,7 +33,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *   admin_permission = "manage tripal content types",
  *   bundle_of = "tripal_entity",
  *   entity_keys = {
- *     "id" = "name",
+ *     "id" = "id",
  *     "label" = "label",
  *   },
  *   links = {
@@ -45,7 +45,6 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *   },
  *   config_export = {
  *     "id",
- *     "name",
  *     "label",
  *     "termIdSpace",
  *     "termAccession",
@@ -66,13 +65,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * @var integer
    */
   protected $id;
-
-  /**
-   * The Tripal Content machine name.
-   *
-   * @var string
-   */
-  protected $name;
 
   /**
    * The Tripal Content type label.
@@ -207,15 +199,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    */
    public function save() {
 
-     // First we want to set an id for this content type.
-     if ($this->isNew()) {
-       $config = \Drupal::service('config.factory')->getEditable('tripal.settings');
-       $max_id = $config->get('tripal_entity_type.max_id');
-       $this->id = $max_id + 1;
-       $this->name = $this->getName();
-       $config->set('tripal_entity_type.max_id', $this->id)->save();
-     }
-
      // Set defaults for anything not already set.
      $this->setDefaults();
 
@@ -240,8 +223,8 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     if ($this->label === NULL) {
       throw new \Exception("The label is required when creating a TripalEntityType.");
     }
-    if ($this->name === NULL) {
-      throw new \Exception("The name is required when creating a TripalEntityType.");
+    if ($this->id === NULL) {
+      throw new \Exception("The id is required when creating a TripalEntityType.");
     }
     if ($this->help_text === NULL) {
       throw new \Exception("The help text is required when creating a TripalEntityType.");
@@ -287,7 +270,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * {@inheritdoc}
    */
   public function id() {
-    return $this->name;
+    return $this->id;
   }
 
   /**
@@ -295,27 +278,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    */
   public function getID() {
     return $this->id;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setID($id) {
-    $this->id = $id;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getName() {
-    return $this->name;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setName($name) {
-    $this->name = $name;
   }
 
   /**

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -37,11 +37,11 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *     "label" = "label",
  *   },
  *   links = {
- *     "canonical" = "/admin/structure/bio_data/{tripal_entity_type}",
- *     "add-form" = "/admin/structure/bio_data/add",
- *     "edit-form" = "/admin/structure/bio_data/manage/{tripal_entity_type}",
- *     "delete-form" = "/admin/structure/bio_data/manage/{tripal_entity_type}/delete",
- *     "collection" = "/admin/structure/bio_data"
+ *     "canonical" = "/admin/structure/tripal/{tripal_entity_type}",
+ *     "add-form" = "/admin/structure/tripal/add",
+ *     "edit-form" = "/admin/structure/tripal/manage/{tripal_entity_type}",
+ *     "delete-form" = "/admin/structure/tripal/manage/{tripal_entity_type}/delete",
+ *     "collection" = "/admin/structure/tripal"
  *   },
  *   config_export = {
  *     "id",
@@ -212,7 +212,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
        $config = \Drupal::service('config.factory')->getEditable('tripal.settings');
        $max_id = $config->get('tripal_entity_type.max_id');
        $this->id = $max_id + 1;
-       $this->name = 'bio_data_' . $this->id;
+       $this->name = $this->getName();
        $config->set('tripal_entity_type.max_id', $this->id)->save();
      }
 
@@ -716,4 +716,5 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       return strnatcasecmp($b_value, $a_value);
     }
   }
+
 }

--- a/tripal/src/Entity/TripalEntityTypeInterface.php
+++ b/tripal/src/Entity/TripalEntityTypeInterface.php
@@ -29,7 +29,7 @@ interface TripalEntityTypeInterface extends ConfigEntityInterface {
   public function setID($id);
 
   /**
-   * Gets the machine name of the Tripal Entity Type (e.g. bio_data_1).
+   * Gets the machine name of the Tripal Entity Type (e.g. organism).
    *
    * @return string
    *   Machine name of the Tripal Entity Type.

--- a/tripal/src/Entity/TripalEntityTypeInterface.php
+++ b/tripal/src/Entity/TripalEntityTypeInterface.php
@@ -9,43 +9,6 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  */
 interface TripalEntityTypeInterface extends ConfigEntityInterface {
 
-  /**
-   * Gets the index of the machine name (e.g. 1).
-   *
-   * @return string
-   *   Index of the machine name of the Tripal Entity Type.
-   */
-  public function getID();
-
-  /**
-   * Sets the index of the machine name.
-   *
-   * @param integer $id
-   *   The index of the machine name of the Tripal Entity Type.
-   *
-   * @return \Drupal\tripal\Entity\TripalEntityTypeInterface
-   *   The called Tripal Entity Type entity.
-   */
-  public function setID($id);
-
-  /**
-   * Gets the machine name of the Tripal Entity Type (e.g. organism).
-   *
-   * @return string
-   *   Machine name of the Tripal Entity Type.
-   */
-  public function getName();
-
-  /**
-   * Sets the machine name of the Tripal Entity Type.
-   *
-   * @param string $name
-   *   The machine name of the Tripal Entity Type.
-   *
-   * @return \Drupal\tripal\Entity\TripalEntityTypeInterface
-   *   The called Tripal Entity Type entity.
-   */
-  public function setName($name);
 
   /**
    * Gets the Tripal Entity Type label (e.g. gene).

--- a/tripal/src/Form/TripalEntityForm.php
+++ b/tripal/src/Form/TripalEntityForm.php
@@ -40,7 +40,7 @@ class TripalEntityForm extends ContentEntityForm {
     $entity->setTitle($values['title'][0]['value']);
     $entity->setOwnerId($values['uid'][0]['target_id']);
     $status = parent::save($form, $form_state);
-    // $entity->setAlias();
+    $entity->setAlias();
 
     switch ($status) {
       case SAVED_NEW:

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -22,7 +22,7 @@ class TripalEntityTypeForm extends EntityForm {
 
     $tripal_entity_type = $this->entity;
     $tripal_entity_type->setDefaults();
-    $machine_name = $tripal_entity_type->getName();
+    $machine_name = preg_replace('[^\w]','_', ucwords($tripal_entity_type->label()));
 
 
     // We need to choose a term if this is a new content type.
@@ -88,11 +88,14 @@ class TripalEntityTypeForm extends EntityForm {
     $form['name'] = [
       '#type' => 'machine_name',
       '#default_value' => $machine_name,
+      '#description' => $this->t('A unique name for this content type. It must only contain lowercase ' .
+          'letters, numbers, and underscores.'),
+      '#maxlength' => 64,
       '#required' => TRUE,
       '#machine_name' => [
         'exists' => '\Drupal\tripal\Entity\TripalEntityType::load',
       ],
-      '#disabled' => TRUE,
+      '#disabled' => !$this->entity->isNew(),
     ];
 
     $form['term'] = [

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -22,20 +22,8 @@ class TripalEntityTypeForm extends EntityForm {
 
     $tripal_entity_type = $this->entity;
     $tripal_entity_type->setDefaults();
+    $machine_name = $tripal_entity_type->getName();
 
-    // Determine the machine name for the content type.
-    // Note, there may be some discrepancy here if others happen to be creating
-    // content types at the same time. Here we are making a prediction but
-    // the TripalEntityType->save() method will create the id at the time of
-    // saving, not based on what we provide it here.
-    if ($tripal_entity_type->isNew()) {
-      $config = \Drupal::config('tripal.settings');
-      $max_index = $config->get('tripal_entity_type.max_id');
-      $machine_name = 'bio_data_' . ($max_index + 1);
-    }
-    else {
-      $machine_name = $tripal_entity_type->id();
-    }
 
     // We need to choose a term if this is a new content type.
     // The term cannot be changed later!

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -22,8 +22,6 @@ class TripalEntityTypeForm extends EntityForm {
 
     $tripal_entity_type = $this->entity;
     $tripal_entity_type->setDefaults();
-    $machine_name = preg_replace('[^\w]','_', ucwords($tripal_entity_type->label()));
-
 
     // We need to choose a term if this is a new content type.
     // The term cannot be changed later!
@@ -85,9 +83,9 @@ class TripalEntityTypeForm extends EntityForm {
       '#required' => TRUE,
     ];
 
-    $form['name'] = [
+    $form['id'] = [
       '#type' => 'machine_name',
-      '#default_value' => $machine_name,
+      '#default_value' => $tripal_entity_type->id(),
       '#description' => $this->t('A unique name for this content type. It must only contain lowercase ' .
           'letters, numbers, and underscores.'),
       '#maxlength' => 64,
@@ -95,7 +93,7 @@ class TripalEntityTypeForm extends EntityForm {
       '#machine_name' => [
         'exists' => '\Drupal\tripal\Entity\TripalEntityType::load',
       ],
-      '#disabled' => !$this->entity->isNew(),
+      '#disabled' => TRUE,
     ];
 
     $form['term'] = [
@@ -223,14 +221,17 @@ class TripalEntityTypeForm extends EntityForm {
     $values = $form_state->getValues();
     $tripal_entity_type = $this->entity;
 
-    // Ensure the label is not already taken.
-    $entities = \Drupal::entityTypeManager()
-      ->getStorage('tripal_entity_type')
-      ->loadByProperties(['label' => $values['label']]);
-    unset($entities[ $values['name'] ]);
-    if (!empty($entities)) {
-      $form_state->setErrorByName('label',
-        $this->t('A Tripal Content type with the label :label already exists. Please choose a unique label.', [':label' => $values['label']]));
+    if ($tripal_entity_type->getLabel() != $values['label']) {
+
+      // Ensure the label is not already taken.
+      $entities = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->loadByProperties(['label' => $values['label']]);
+      unset($entities[ $values['label'] ]);
+      if (!empty($entities)) {
+        $form_state->setErrorByName('label',
+          $this->t('A Tripal Content type with the label :label already exists. Please choose a unique label.', [':label' => $values['label']]));
+      }
     }
 
     $term_str = $form_state->getValue('term');

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -93,7 +93,8 @@ class TripalEntityTypeForm extends EntityForm {
       '#machine_name' => [
         'exists' => '\Drupal\tripal\Entity\TripalEntityType::load',
       ],
-      '#disabled' => TRUE,
+      '#source' => 'label',
+      '#disabled' => !$tripal_entity_type->isNew(),
     ];
 
     $form['term'] = [
@@ -299,12 +300,14 @@ class TripalEntityTypeForm extends EntityForm {
     // Note: we have to reprocess the term ID Space + Accession because we can't
     // save what we learned in validate. We do not use an if around the preg_replace()
     // because in order to get here, this pattern has to work.
+    $matches = [];
     preg_match('/(.+?) \((.+?):(.+?)\)/', $values['term'], $matches);
     $idSpace = $matches[2];
     $accession = $matches[3];
 
     // Set the properties for the new Tripal Content Type
     // using those set in the form state.
+    $tripal_entity_type->setOriginalId($values['id']);
     $tripal_entity_type->setLabel($values['label']);
     $tripal_entity_type->setHelpText($values['help']);
     $tripal_entity_type->setTermIdSpace($idSpace);

--- a/tripal/src/Plugin/Block/ContentBarChartBlock.php
+++ b/tripal/src/Plugin/Block/ContentBarChartBlock.php
@@ -16,7 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class ContentBarChartBlock extends BlockBase implements BlockPluginInterface {
-  
+
   /**
    * {@inheritdoc}
    */
@@ -33,7 +33,7 @@ class ContentBarChartBlock extends BlockBase implements BlockPluginInterface {
     $entity_count_listing = [];
     while (($entity_type = $entity_types->fetchObject())) {
       $entity_count_listing[] = [
-        'name' => \Drupal::config('tripal.bio_data.' . $entity_type->type)->get('label'),
+        'name' => \Drupal::config('tripal.content_type.' . $entity_type->type)->get('label'),
         'count' => $entity_type->count,
       ];
     }

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -100,15 +100,15 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
    */
   public function validate($details) {
 
-    if (!array_key_exists('name', $details) or !$details['name']) {
-      $this->logger->error(t('Creation of content type, "@type", failed. No name provided.',
+    if (!array_key_exists('id', $details) or !$details['id']) {
+      $this->logger->error(t('Creation of content type, "@type", failed. No id provided.',
           ['@type' => $details['label']]));
       return FALSE;
     }
 
     if (!array_key_exists('label', $details) or !$details['label']) {
-      $this->logger->error(t('Creation of content name, "@name", failed. No label provided.',
-          ['@name' => $details['name']]));
+      $this->logger->error(t('Creation of content name, "@id", failed. No label provided.',
+          ['@id' => $details['id']]));
       return FALSE;
     }
 
@@ -198,7 +198,7 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
         $entityType->save();
         $this->logger->notice(t('Content type, "@type", created.',
             ['@type' => $details['label']]));
-        $bundle = $entityType->getName();
+        $bundle = $entityType->id();
       }
       else {
         $this->logger->error(t('Creation of content type, "@type", failed. The provided details were: ',

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -100,13 +100,11 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
    */
   public function validate($details) {
 
-    ## Name is currently autocreated as bio_data_#
-    ## but we will want to change this in a future PR.
-    # if (!array_key_exists('name', $details) or !$details['name']) {
-    #   $this->logger->error(t('Creation of content type, "@type", failed. No name provided.',
-    #       ['@type' => $details['label']]));
-    #   return FALSE;
-    # }
+    if (!array_key_exists('name', $details) or !$details['name']) {
+       $this->logger->error(t('Creation of content type, "@type", failed. No name provided.',
+           ['@type' => $details['label']]));
+       return FALSE;
+     }
 
     if (!array_key_exists('label', $details) or !$details['label']) {
       $this->logger->error(t('Creation of content type with failed since no label provided.'));
@@ -143,13 +141,11 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
       return FALSE;
     }
 
-    ## This will be added in a future PR
-    ## to keep track of the old bio_data_# used in previous versions of Tripal.
-    # if (array_key_exists('synonyms', $details) and !is_array($details['synonyms'])) {
-    #   $this->logger->error(t('Creation of content type, "@type", failed. The synonyms should be an array.',
-    #       ['@type' => $details['label']]));
-    #   return FALSE;
-    # }
+    if (array_key_exists('synonyms', $details) and !is_array($details['synonyms'])) {
+       $this->logger->error(t('Creation of content type, "@type", failed. The synonyms should be an array.',
+           ['@type' => $details['label']]));
+       return FALSE;
+    }
 
     return TRUE;
   }

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -303,7 +303,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
    * Adds a field to a Tripal entity type.
    *
    * @param string $bundle
-   *   The bundle name (e.g. bio_data_1).
+   *   The bundle name (e.g. organism).
    * @param array $field_def
    *   An associative array providing the necessary information about a field
    *   instance for this entity type. The following key/values are supported
@@ -409,7 +409,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     $field_def = $this->setFieldDefDefaults($field_def);
 
     // Get the bundle and field id.
-    $field_id = 'tripal_entity' . '.' . 'bio_data_' . $entity_type->getId() . '.' . $field_def['name'];
+    $field_id = 'tripal_entity' . '.' . $entity_type->getName() . '.' . $field_def['name'];
 
     try {
 
@@ -445,7 +445,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
 
         // Add field to the default display modes.
         $entity_display = \Drupal::service('entity_display.repository');
-        $bundle_id = 'bio_data_' . $entity_type->getId();
+        $bundle_id = $entity_type->getName();
         $view_modes = $entity_display->getViewModeOptionsByBundle('tripal_entity', $bundle_id);
         foreach (array_keys($view_modes) as $view_mode) {
           \Drupal::service('entity_display.repository')

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -217,7 +217,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     // Check if the type already exists.
     $entityTypes = \Drupal::entityTypeManager()
       ->getStorage('tripal_entity_type')
-      ->loadByProperties(['name' => $field_def['content_type']]);
+      ->loadByProperties(['id' => $field_def['content_type']]);
     if (empty($entityTypes)) {
       $this->logger->error('The specified entity type, "' . $field_def['content_type'] . '", for field "' . $field_def['name'] . '", does not exist.');
       return FALSE;
@@ -402,14 +402,14 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     // Get the entitytype
     $entity_types = \Drupal::entityTypeManager()
       ->getStorage('tripal_entity_type')
-      ->loadByProperties(['name' => $field_def['content_type']]);
+      ->loadByProperties(['id' => $field_def['content_type']]);
     $entity_type = array_pop($entity_types);
 
     // Set defaults for the field if they are not already set.
     $field_def = $this->setFieldDefDefaults($field_def);
 
     // Get the bundle and field id.
-    $field_id = 'tripal_entity' . '.' . $entity_type->getName() . '.' . $field_def['name'];
+    $field_id = 'tripal_entity' . '.' . $entity_type->id() . '.' . $field_def['name'];
 
     try {
 
@@ -445,7 +445,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
 
         // Add field to the default display modes.
         $entity_display = \Drupal::service('entity_display.repository');
-        $bundle_id = $entity_type->getName();
+        $bundle_id = $entity_type->id();
         $view_modes = $entity_display->getViewModeOptionsByBundle('tripal_entity', $bundle_id);
         foreach (array_keys($view_modes) as $view_mode) {
           \Drupal::service('entity_display.repository')
@@ -462,18 +462,18 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
         }
 
         $this->logger->notice(t('Added field, "@field", to content type: "@type".',
-            ['@field' => $field_def['name'], '@type' => $entity_type->getName()]));
+            ['@field' => $field_def['name'], '@type' => $entity_type->id()]));
       }
       else {
         $this->logger->notice(t('Skipping addition of field, "@field", to content type: "@type" as it is already added.',
-            ['@field' => $field_def['name'], '@type' => $entity_type->getName()]));
+            ['@field' => $field_def['name'], '@type' => $entity_type->id()]));
       }
     }
     catch (\Exception $e) {
       print_r([$e->getMessage()]);
       $this->logger->error(t('Error adding field, "@field_name", to "@bundle": @error', [
          '@field_name' => $field_def['name'],
-         '@bundle' => $entity_type->getName(),
+         '@bundle' => $entity_type->id(),
          '@error' => $e->getMessage(),
       ]));
       return FALSE;

--- a/tripal/src/api/tripal.entities.api.php
+++ b/tripal/src/api/tripal.entities.api.php
@@ -155,9 +155,6 @@ function theme_token_list($tokens) {
  * Refreshes the bundle such that new fields added by modules will be found
  * during cron.
  *
- * @param $bundle_name
- *   The name of the bundle to refresh (e.g. bio_data_4).
- *
  * @ingroup tripal_entities_api
  */
 function tripal_tripal_cron_notification() {

--- a/tripal/tests/src/Functional/Entity/EntityAccessTest.php
+++ b/tripal/tests/src/Functional/Entity/EntityAccessTest.php
@@ -53,7 +53,7 @@ class EntityAccessTest extends BrowserTestBase {
     // -- Content Type.
     $values = [];
     $values['label'] = 'Freddyopolis-' . uniqid();
-    $values['name'] = 'freddy';
+    $values['id'] = 'freddy';
     $values['url_format'] = 'freddy/TripalEntity__entity_id';
     $values['title_format'] = '[freddy_name]';
     $values['termIdSpace'] = 'FRED';

--- a/tripal/tests/src/Functional/Entity/EntityAccessTest.php
+++ b/tripal/tests/src/Functional/Entity/EntityAccessTest.php
@@ -53,6 +53,9 @@ class EntityAccessTest extends BrowserTestBase {
     // -- Content Type.
     $values = [];
     $values['label'] = 'Freddyopolis-' . uniqid();
+    $values['name'] = 'freddy';
+    $values['url_format'] = 'freddy/TripalEntity__entity_id';
+    $values['title_format'] = '[freddy_name]';
     $values['termIdSpace'] = 'FRED';
     $values['termAccession'] = '1g2h3j4k5';
     $values['help_text'] = 'This is just random text to meet the requirement of this field.';

--- a/tripal/tests/src/Functional/Entity/TripalContentTest.php
+++ b/tripal/tests/src/Functional/Entity/TripalContentTest.php
@@ -23,7 +23,7 @@ class TripalContentTest extends TripalTestBrowserBase {
     // Provides a title with ~8 latin capitalized words.
     $values['label'] = $random->sentences(8,TRUE);
     // Provides a machine name for the content type.
-    $values['name'] = $random->sentences(8,TRUE);
+    $values['id'] = $random->sentences(1,TRUE);
     // Provides a category with ~3 latin capitalized words.
     $values['category'] = $random->sentences(3,TRUE);
     // Provides a title with ~8 latin capitalized words.

--- a/tripal/tests/src/Functional/Entity/TripalContentTest.php
+++ b/tripal/tests/src/Functional/Entity/TripalContentTest.php
@@ -65,9 +65,9 @@ class TripalContentTest extends TripalTestBrowserBase {
     ]);
 
     $urls = [
-      'Tripal Content Listing' => 'admin/content/bio_data',
-      'Tripal Content Type Listing' => 'admin/structure/bio_data',
-      'Add Tripal Content Listing/Form' => 'bio_data/add',
+      'Tripal Content Listing' => 'admin/content/tripal',
+      'Tripal Content Type Listing' => 'admin/structure/tripal',
+      'Add Tripal Content Listing/Form' => 'tripal/add',
     ];
 
     // Anonymous User should not be able to see any of these urls.

--- a/tripal/tests/src/Functional/Entity/TripalContentTest.php
+++ b/tripal/tests/src/Functional/Entity/TripalContentTest.php
@@ -22,6 +22,8 @@ class TripalContentTest extends TripalTestBrowserBase {
     $random = $this->getRandomGenerator();
     // Provides a title with ~8 latin capitalized words.
     $values['label'] = $random->sentences(8,TRUE);
+    // Provides a machine name for the content type.
+    $values['name'] = $random->sentences(8,TRUE);
     // Provides a category with ~3 latin capitalized words.
     $values['category'] = $random->sentences(3,TRUE);
     // Provides a title with ~8 latin capitalized words.

--- a/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
+++ b/tripal/tests/src/Functional/Services/TripalContentTypesTest.php
@@ -42,7 +42,7 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      'name' => 'organism',
+      'id' => 'organism',
       'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
       'url_format' => "organism/[TripalEntity__entity_id]",
       'synonyms' => ['bio_data_1']
@@ -68,11 +68,11 @@ class TripalContentTypesTest extends TripalTestBrowserBase {
 
 
     $bad = $good;
-    unset($bad['name']);
+    unset($bad['id']);
     $is_valid = $content_type_service->validate($bad);
-    $this->assertFalse($is_valid, "A content type definition missing the 'name' should fail the validation check but it passed.");
+    $this->assertFalse($is_valid, "A content type definition missing the 'id' should fail the validation check but it passed.");
     $content_type = $content_type_service->createContentType($bad);
-    $this->assertTrue(is_null($content_type), "Created a content type when the name is incorrect.");
+    $this->assertTrue(is_null($content_type), "Created a content type when the id is incorrect.");
 
 
     $bad = $good;

--- a/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
@@ -44,10 +44,10 @@ class TripalEntityTypeCollectionTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      # 'name' => 'organism',
+      'name' => 'organism',
       # 'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
       # 'url_format' => "organism/[TripalEntity__entity_id]",
-      # 'synonyms' => ['bio_data_1']
+      'synonyms' => ['bio_data_1']
     ];
 
     /** @var \Drupal\tripal\Services\TripalEntityTypeCollection $content_type_service **/

--- a/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
@@ -44,7 +44,7 @@ class TripalEntityTypeCollectionTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      'name' => 'organism',
+      'id' => 'organism',
       'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
       'url_format' => "organism/[TripalEntity__entity_id]",
       'synonyms' => ['bio_data_1']

--- a/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalEntityTypeCollectionTest.php
@@ -46,7 +46,7 @@ class TripalEntityTypeCollectionTest extends TripalTestBrowserBase {
       'category' => 'General',
       'name' => 'organism',
       # 'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
-      # 'url_format' => "organism/[TripalEntity__entity_id]",
+      'url_format' => "organism/[TripalEntity__entity_id]",
       'synonyms' => ['bio_data_1']
     ];
 

--- a/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
@@ -43,10 +43,10 @@ class TripalFieldCollectionTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      'name' => 'bio_data_1',
+      'name' => 'organism',
       #'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
       #'url_format' => "organism/[TripalEntity__entity_id]",
-      #'synonyms' => ['bio_data_1']
+      'synonyms' => ['bio_data_1']
     ];
     /** @var \Drupal\tripal\Services\TripalContentTypes $content_type_setup **/
     $content_type_service = \Drupal::service('tripal.tripalentitytype_collection');

--- a/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
@@ -43,8 +43,8 @@ class TripalFieldCollectionTest extends TripalTestBrowserBase {
       'term' => $term,
       'help_text' => 'Use the organism page for an individual living system, such as animal, plant, bacteria or virus,',
       'category' => 'General',
-      'name' => 'organism',
-      #'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
+      'id' => 'organism',
+      'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
       'url_format' => "organism/[TripalEntity__entity_id]",
       'synonyms' => ['bio_data_1']
     ];

--- a/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
+++ b/tripal/tests/src/Functional/Services/TripalFieldColectionTest.php
@@ -45,7 +45,7 @@ class TripalFieldCollectionTest extends TripalTestBrowserBase {
       'category' => 'General',
       'name' => 'organism',
       #'title_format' => "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]",
-      #'url_format' => "organism/[TripalEntity__entity_id]",
+      'url_format' => "organism/[TripalEntity__entity_id]",
       'synonyms' => ['bio_data_1']
     ];
     /** @var \Drupal\tripal\Services\TripalContentTypes $content_type_setup **/
@@ -69,7 +69,7 @@ class TripalFieldCollectionTest extends TripalTestBrowserBase {
     $idspace->saveTerm($term);
     $field_def = [
       'name' => 'organism_genus',
-      'content_type' => 'bio_data_1',
+      'content_type' => 'organism',
       'label' => 'Genus',
       'type' => 'tripal_string_type',
       'description' => "The genus name of the organism.",

--- a/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
+++ b/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
@@ -236,6 +236,7 @@ class TripalRoutePermissionsTest extends BrowserTestBase {
     // -- Content Type.
     $values = [];
     $values['label'] = 'Freddyopolis-' . uniqid();
+    $values['id'] = 'freddy';
     $values['termIdSpace'] = 'FRED';
     $values['termAccession'] = '1g2h3j4k5';
     $values['help_text'] = 'This is just random text to meet the requirement of this field.';

--- a/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
+++ b/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
@@ -255,21 +255,21 @@ class TripalRoutePermissionsTest extends BrowserTestBase {
 
     // The URLs to check.
     $urls = [
-      'entity-canonical' => 'bio_data/' . $entity_id,
-      'entity-add-page' => 'bio_data/add',
-      'entity-add-form' => 'bio_data/add/' . $content_type,
-      'entity-edit-form' => 'bio_data/' . $entity_id . '/edit',
-      'entity-delete-form' => 'bio_data/' . $entity_id . '/delete',
-      'entity-collection' => 'admin/content/bio_data',
+      'entity-canonical' => 'tripal/' . $entity_id,
+      'entity-add-page' => 'tripal/add',
+      'entity-add-form' => 'tripal/add/' . $content_type,
+      'entity-edit-form' => 'tripal/' . $entity_id . '/edit',
+      'entity-delete-form' => 'tripal/' . $entity_id . '/delete',
+      'entity-collection' => 'admin/content/tripal',
       //'publish-content' => '',
-      'unpublish-content' => 'admin/content/bio_data/unpublish',
-      'entitytype-add-form' => 'admin/structure/bio_data/add',
-      'entitytype-edit-form' => 'admin/structure/bio_data/manage/' . $content_type,
-      'entitytype-delete-form' => 'admin/structure/bio_data/manage/' . $content_type . '/delete',
-      'entitytype-manage-fields' => 'admin/structure/bio_data/manage/' . $content_type . '/fields',
-      'entitytype-manage-form' => 'admin/structure/bio_data/manage/' . $content_type . '/form-display',
-      'entitytype-manage-display' => 'admin/structure/bio_data/manage/' . $content_type . '/display',
-      'entitytype-collection' => 'admin/structure/bio_data',
+      'unpublish-content' => 'admin/content/tripal/unpublish',
+      'entitytype-add-form' => 'admin/structure/tripal/add',
+      'entitytype-edit-form' => 'admin/structure/tripal/manage/' . $content_type,
+      'entitytype-delete-form' => 'admin/structure/tripal/manage/' . $content_type . '/delete',
+      'entitytype-manage-fields' => 'admin/structure/tripal/manage/' . $content_type . '/fields',
+      'entitytype-manage-form' => 'admin/structure/tripal/manage/' . $content_type . '/form-display',
+      'entitytype-manage-display' => 'admin/structure/tripal/manage/' . $content_type . '/display',
+      'entitytype-collection' => 'admin/structure/tripal',
     ];
 
     // Keys in the array are pages which that permission SHOULD be able to access.

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -187,6 +187,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
     $random = $this->getRandomGenerator();
     // Provides a title with ~8 latin capitalized words.
     $values['title'] = $values['title'] ?? $random->sentences(8, TRUE);
+    $values['id'] = $values['id'] ?? $random->sentences(1, TRUE);
 
     // Creates a type if one is not provided.
     if (!isset($values['type'])) {

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -39,7 +39,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
    * Creates a Tripal Field for testing purposes.
    *
    * @param string $entity_type
-   *   The machine name of the entity to add the field to (i.e. bio_data_5)
+   *   The machine name of the entity to add the field to (e.g., organism)
    * @param array $values
    *   These values are passed directly to the create() method. Suggested values are:
    *    - field_name (string)

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -214,8 +214,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
    *
    * @param array $values
    *   These values are passed directly to the create() method. Suggested values are:
-   *    -     id (integer)
-   *    -     name (string)
+   *    -     id (string)
    *    -     label (label; string)
    *    -     termIdSpace (string)
    *    -     termAccession (string)
@@ -232,6 +231,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
     $random = $this->getRandomGenerator();
     // Provides a title with ~3 latin capitalized words.
     $values['label'] = $values['label'] ?? $random->sentences(3,TRUE);
+    $values['id'] = $values['id'] ?? $random->sentences(1,TRUE);
     // Provides a random non-unique 4 character string.
     $values['termIdSpace'] = $values['termIdSpace'] ?? $random->string(4);
     // Provides a random non-unique 10 character string.

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -177,7 +177,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
    * @param array $values
    *   These values are passed directly to the create() method. Suggested values are:
    *    - title (string)
-   *    - type (string; eg. bio_data_5)
+   *    - type (string; eg. organism)
    *    - user_id (integer)
    *    - status (boolean; TRUE if published)
    */

--- a/tripal/tripal.links.action.yml
+++ b/tripal/tripal.links.action.yml
@@ -11,8 +11,8 @@ entity.tripal_entity.add_page:
     - entity.tripal_entity.collection
 
 # -- Remove orphaned content (i.e missing non-drupal record) link on Content Listing page.
-tripal.content_bio_data_unpublish:
-  route_name: tripal.content_bio_data_unpublish
+tripal.content_type_unpublish:
+  route_name: tripal.content_type_unpublish
   title: 'Unpublish Orphaned Content'
   weight: 100
   appears_on:
@@ -26,8 +26,8 @@ entity.tripal_entity_type.add_form:
     - entity.tripal_entity_type.collection
 
 # -- Check for new fields link on the Manage Fields page.
-tripal.content_bio_data_field_check:
-  route_name: 'tripal.content_bio_data_field_check'
+tripal.content_type_field_check:
+  route_name: 'tripal.content_type_field_check'
   title: 'Check for new fields'
   appears_on:
     - entity.tripal_entity.field_ui_fields

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -432,7 +432,7 @@ function tripal_shortcut_default_set($account) {
   //       'weight' => -25,
   //     ),
   //     array(
-  //       'link_path' => 'admin/content/bio_data',
+  //       'link_path' => 'admin/content/tripal',
   //       'link_title' => 'Find Tripal Content',
   //       'weight' => -20,
   //     ),

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -378,8 +378,8 @@ function tripal_access_user_data($uid) {
 function tripal_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   // Add an "Add Tripal Content" action link to the Admin >> Content >>
   // Biological Content page.
-  if ($root_path == 'admin/content/bio_data') {
-    $item = menu_get_item('bio_data/add');
+  if ($root_path == 'admin/content/tripal') {
+    $item = menu_get_item('tripal/add');
     if ($item['access']) {
       $data['actions']['output'][] = array(
         '#theme' => 'menu_local_task',
@@ -422,7 +422,7 @@ function tripal_shortcut_default_set($account) {
   //       'weight' => -35,
   //     ),
   //     array(
-  //       'link_path' => 'bio_data/add',
+  //       'link_path' => 'tripal/add',
   //       'link_title' => 'Add Tripal Content',
   //       'weight' => -30,
   //     ),
@@ -540,7 +540,7 @@ function tripal_check_new_fields($bundle_name) {
     \Drupal::messenger()->addStatus(t('Added field: ' . $field_name));
   }
 
-  $response = new RedirectResponse("admin/structure/bio_data/manage/$bundle_name/fields");
+  $response = new RedirectResponse("admin/structure/tripal/manage/$bundle_name/fields");
   $response->send();
 }
 

--- a/tripal/tripal.routing.yml
+++ b/tripal/tripal.routing.yml
@@ -128,39 +128,14 @@ tripal.dashboard_admin_notification_field:
 
 ##
 # Tripal Content
-##
+## 
 
-# Tripal Content:
-
-# entity.tripal_entity_type.canonical:
-#   path: "/bio_data/{tripal_entity}",
-# entity.tripal_entity_type.add-page:
-#   path: "/bio_data/add",
-# entity.tripal_entity_type.add-form:
-#   path: "/bio_data/add/{tripal_entity_type}",
-# entity.tripal_entity_type.edit-form:
-#   path: "/bio_data/{tripal_entity}/edit",
-# entity.tripal_entity_type.delete-form:
-#   path: "/bio_data/{tripal_entity}/delete",
-# entity.tripal_entity_type.collection:
-#   path: "/admin/content/bio_data",
-
-# Tripal Content Types:
-
-# entity.tripal_entity_type.canonical:
-#   path: '/admin/structure/bio_data/{tripal_entity_type}'
-# entity.tripal_entity_type.add-form:
-#   path: '/admin/structure/bio_data/add'
-# entity.tripal_entity_type.edit-form:
-#   path: '/admin/structure/bio_data/manage/{tripal_entity_type}'
-# entity.tripal_entity_type.delete-form:
-#   path: '/admin/structure/bio_data/manage/{tripal_entity_type}/delete'
-
+# Override the default entity listing page for a more informative page.
 entity.tripal_entity.add_page:
-  path: bio_data/add
+  path: tripal/add
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalEntityUIController::tripalContentAddPage'
-    _title: 'Add Biological Data'
+    _title: 'Add Tripal Content'
     _description: 'Add biological data provided by Tripal.'
   options:
     _admin_route: 'TRUE'
@@ -169,7 +144,7 @@ entity.tripal_entity.add_page:
 
 # tripal_unpublish_orphans_form
 tripal.content_bio_data_unpublish:
-  path: 'admin/content/bio_data/unpublish'
+  path: 'admin/content/tripal/unpublish'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalController::tripalContentUnpublishOrphans'
     _title: 'Unpublish Orphaned Content'
@@ -179,7 +154,7 @@ tripal.content_bio_data_unpublish:
 
 # Bio Data Ajax Callbacks
 tripal.content_bio_data_field_attach:
-  path: 'bio_data/ajax/field_attach/{id}'
+  path: 'tripal/ajax/field_attach/{id}'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalController::tripalAttachField'
     _title: 'Attach a Field to a Content Type'
@@ -188,7 +163,7 @@ tripal.content_bio_data_field_attach:
 
 # Adds a +Check for new fields link on the 'Tripal Content Types' page.
 tripal.content_bio_data_field_check:
-  path: 'admin/structure/bio_data/manage/{tripal_entity_type}/fields/check'
+  path: 'admin/structure/tripal/manage/{tripal_entity_type}/fields/check'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalEntityUIController::tripalCheckForFields'
     _title: 'Check for new fields'

--- a/tripal/tripal.routing.yml
+++ b/tripal/tripal.routing.yml
@@ -143,7 +143,7 @@ entity.tripal_entity.add_page:
     _permission: 'administer tripal content'
 
 # tripal_unpublish_orphans_form
-tripal.content_bio_data_unpublish:
+tripal.content_type_unpublish:
   path: 'admin/content/tripal/unpublish'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalController::tripalContentUnpublishOrphans'
@@ -153,7 +153,7 @@ tripal.content_bio_data_unpublish:
     _permission: 'publish tripal content+administer tripal content'
 
 # Bio Data Ajax Callbacks
-tripal.content_bio_data_field_attach:
+tripal.content_type_field_attach:
   path: 'tripal/ajax/field_attach/{id}'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalController::tripalAttachField'
@@ -162,7 +162,7 @@ tripal.content_bio_data_field_attach:
     _permission: 'administer tripal'
 
 # Adds a +Check for new fields link on the 'Tripal Content Types' page.
-tripal.content_bio_data_field_check:
+tripal.content_type_field_check:
   path: 'admin/structure/tripal/manage/{tripal_entity_type}/fields/check'
   defaults:
     _controller: '\Drupal\tripal\Controller\TripalEntityUIController::tripalCheckForFields'

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
@@ -7,7 +7,7 @@ content_types:
         term: OBI:0100026
         help_text: Use the organism page for an individual living system, such as animal, plant, bacteria or virus,
         category: General
-        name: organism
+        id: organism
         title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
         url_format: "organism/[TripalEntity__entity_id]"
         synonyms:
@@ -17,7 +17,7 @@ content_types:
         term: operation:2945
         help_text: Use the analysis page to for an individual analysis, workflow or pipeline that was performed using statistical or computational means.
         category: General
-        name: analysis
+        id: analysis
         title_format: "[analysis_name]"
         url_format: "analysis/[TripalEntity__entity_id]"
         synonyms:
@@ -27,7 +27,7 @@ content_types:
         term: NCIT:C47885
         help_text: Use the project page to provide information about a project that many be linked to multiple sub components such as studies or analyses.
         category: General
-        name: project
+        id: project
         title_format: "[project_name]"
         url_format: "project/[TripalEntity__entity_id]"
         synonyms:
@@ -37,7 +37,7 @@ content_types:
         term: SIO:001066
         help_text: Use the study page for a systematic investigation.
         category: General
-        name: study
+        id: study
         title_format: "[study_name]"
         url_format: "study/[TripalEntity__entity_id]"
         synonyms:
@@ -47,7 +47,7 @@ content_types:
         term: local:contact
         help_text: Use the contage page a person or institution that can be linked as a responsible party for data or results.
         category: General
-        name: contact
+        id: contact
         title_format: "[contact_name]"
         url_format: "contact/[TripalEntity__entity_id]"
         synonyms:
@@ -57,7 +57,7 @@ content_types:
         term: TPUB:0000002
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
-        name: pub
+        id: pub
         title_format: "[publication_title]"
         url_format: "pub/[TripalEntity__entity_id]"
         synonyms:
@@ -67,7 +67,7 @@ content_types:
         term: sep:00101
         help_text: Use the protocol page for a parameterizable description of a process.
         category: General
-        name: protocol
+        id: protocol
         title_format: "[protocol_name]"
         url_format: "protocol/[TripalEntity__entity_id]"
         synonyms:
@@ -77,7 +77,7 @@ content_types:
         term: SO:0000704
         help_text: Use the gene page for a region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.
         category: Genomic
-        name: gene
+        id: gene
         title_format: "[gene_name]"
         url_format: "gene/[TripalEntity__entity_id]"
         synonyms:
@@ -87,7 +87,7 @@ content_types:
         term: SO:0000234
         help_text: Use the mRNA page for a messenger RNA whic is the intermediate molecule between DNA and protein. It includes UTR and coding sequences. It does not contain introns.
         category: Genomic
-        name: mRNA
+        id: mRNA
         title_format: "[mrna_name]"
         url_format: "mRNA/[TripalEntity__entity_id]"
         synonyms:
@@ -97,7 +97,7 @@ content_types:
         term: data:0872
         help_text: Use the phylogenetic tree page for data or plotting of phylogenetic trees. Usually includes information such as topology, lengths (in time or in expected amounts of variance) and a confidence interval for each length.
         category: Genomic
-        name: phylotree
+        id: phylotree
         title_format: "[phylotree_name]"
         url_format: "phylotree/[TripalEntity__entity_id]"
         synonyms:
@@ -107,7 +107,7 @@ content_types:
         term: data:1280
         help_text: Use the physical map page for a map of annotated with physical features or landmarks such as restriction sites, cloned DNA fragments, genes or genetic markers, along with the physical distances between them. Distance in a physical map is measured in base pairs. A physical map might be ordered relative to a reference map (typically a genetic map) in the process of genome sequencing.
         category: Genomic 
-        name: physical_map
+        id: physical_map
         title_format: "[physical_map_name]"
         url_format: "physical_map/[TripalEntity__entity_id]"
         synonyms:
@@ -117,7 +117,7 @@ content_types:
         term: NCIT:C16223
         help_text: Use the DNA library page for a collection of DNA molecules that have been cloned in vectors.
         category: Genomic
-        name: dna_library
+        id: dna_library
         title_format: "[dna_library_name]"
         url_format: "dna_library/[TripalEntity__entity_id]"
         synonyms:
@@ -127,7 +127,7 @@ content_types:
         term: operation:0525
         help_text: Use the genome assembly page for an analyses specifcally for genome assembly. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the assembly.
         category: Genomic
-        name:  genome_assembly
+        id:  genome_assembly
         title_format: "[genome_assembly_name]"
         url_format: "genome_assembly/[TripalEntity__entity_id]"
         synonyms:
@@ -137,7 +137,7 @@ content_types:
         term: operation:0362
         help_text: Use the genome annotation page for an analyses specifcally for genome annotation. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the structural and functional annotations of the genome.
         category: Genomic
-        name: genome_annotation
+        id: genome_annotation
         title_format: "[genome_annotation_name]"
         url_format: "genome_annotation/[TripalEntity__entity_id]"
         synonyms:
@@ -147,7 +147,7 @@ content_types:
         term: local:Genome Project
         help_text: Use the genome project page to provide information about a genome assembly and annotation project that many be linked to multiple sub analyses.
         category: Genomic
-        name: genome_project
+        id: genome_project
         title_format: "[genome_project_name]"
         url_format: "genome_project/[TripalEntity__entity_id]"
         synonyms:
@@ -157,7 +157,7 @@ content_types:
         term: data:1278
         help_text: Use a genetic map page for a map showing the relative positions of genetic markers in a nucleic acid sequence, based on estimation of non-physical distance such as recombination frequencies.
         category: Genetic
-        name: genetic_map
+        id: genetic_map
         title_format: "[genetic_map_name]"
         url_format: "genetic_map/[TripalEntity__entity_id]"
         synonyms:
@@ -167,7 +167,7 @@ content_types:
         term: SO:0000771
         help_text: Use a QTL page for a quantitative trait locus (QTL), which is a polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait. Usually it is a marker described by statistical association to quantitative variation in the particular phenotypic trait that is thought to be controlled by the cumulative action of alleles at multiple loci.
         category: Genetic
-        name: QTL
+        id: QTL
         title_format: "[qtl_name]"
         url_format: "QTL/[TripalEntity__entity_id]"
         synonyms:
@@ -177,7 +177,7 @@ content_types:
         term: SO:0001060
         help_text: Use the sequence variant page for a non exact copy of a sequence feature or genome exhibiting one or more sequence alteration.
         category: Genetic
-        name: sequence_variant
+        id: sequence_variant
         title_format: "[sequence_variant_name]"
         url_format: "sequence_variant/[TripalEntity__entity_id]"
         synonyms:
@@ -187,7 +187,7 @@ content_types:
         term: SO:0001645
         help_text: Use the genetic marker page for a measurable sequence feature that varies within a population.
         category: Genetic
-        name: genetic_marker
+        id: genetic_marker
         title_format: "[genetic_marker_name]"
         url_format: "genetic_marker/[TripalEntity__entity_id]"
         synonyms:
@@ -197,7 +197,7 @@ content_types:
         term: SO:0001500
         help_text: Use the heritable phenotypic marker page for a sequence region characterized as a single heritable trait in a phenotype screen. The heritable phenotype may be mapped to a chromosome but generally has not been characterized to a specific gene locus.
         category: Genetic
-        name: phenotypic_marker
+        id: phenotypic_marker
         title_format: "[phenotypic_marker_name]"
         url_format: "phenotypic_marker/[TripalEntity__entity_id]"
         synonyms:
@@ -207,7 +207,7 @@ content_types:
         term: CO_010:0000044
         help_text: Use the germplasm accession page for a living genetic resources such as seeds or tissues that are maintained for the purpose of animal and plant breeding, and preservation.
         category: Germplasm
-        name: germplasm
+        id: germplasm
         title_format: "[germplasm_name]"
         url_format: "germplasm/[TripalEntity__entity_id]"
         synonyms:
@@ -217,7 +217,7 @@ content_types:
         term: CO_010:0000255
         help_text: Use the breeding cross page for information about a cross between two germplasm in a breeding application.
         category: Germplasm
-        name: breeding_cross
+        id: breeding_cross
         title_format: "[breeding_cross_name]"
         url_format: "breeding_cross/[TripalEntity__entity_id]"
         synonyms:
@@ -227,7 +227,7 @@ content_types:
         term: CO_010:0000029
         help_text: Use the germplasm variety page for information about specific variety of germplasm.
         category: Germplasm
-        name: germplasm_variety
+        id: germplasm_variety
         title_format: "[germplasm_variety_name]"
         url_format: "germplasm_variety/[TripalEntity__entity_id]"
         synonyms:
@@ -237,7 +237,7 @@ content_types:
         term: CO_010:0000162
         help_text: Use the recombinant inbred line page to describe a collection of germplasm that were created by crossing and can be used to map quantitative trait loci.
         category: Germplasm
-        name: RIL
+        id: RIL
         title_format: "[ril_name]"
         url_format: "RIL/[TripalEntity__entity_id]"
         synonyms:
@@ -247,7 +247,7 @@ content_types:
         term: sep:00195
         help_text: Use the biological sample page for any material taken from a biological system for use in a systematic study.
         category: Expression
-        name: biosample
+        id: biosample
         title_format: "[biosample_name]"
         url_format: "biosample/[TripalEntity__entity_id]"
         synonyms:
@@ -257,7 +257,7 @@ content_types:
         term: OBI:0000070
         help_text: Use the assay page to describe an experimental approach used to measure the characteristics of an item.
         category: Expression
-        name: assay
+        id: assay
         title_format: "[assay_name]"
         url_format: "assay/[TripalEntity__entity_id]"
         synonyms:
@@ -267,7 +267,7 @@ content_types:
         term: EFO:0000269
         help_text: Use the array design page to describe the systematic arrangement of similar objects, usually in rows and columns, used by intstrument to perform an assay.
         category: Expression
-        name: array_design
+        id: array_design
         title_format: "[array_design_name]"
         url_format: "array_design/[TripalEntity__entity_id]"
         synonyms:

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
@@ -9,7 +9,7 @@ content_types:
         category: General
         name: organism
         # title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
-        # url_format: "organism/[TripalEntity__entity_id]"
+        url_format: "organism/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_1
 
@@ -19,7 +19,7 @@ content_types:
         category: General
         name: analysis
         # title_format: "[analysis_name]"
-        # url_format: "analysis/[TripalEntity__entity_id]"
+        url_format: "analysis/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_2
 
@@ -29,7 +29,7 @@ content_types:
         category: General
         name: project
         # title_format: "[project_name]"
-        # url_format: "project/[TripalEntity__entity_id]"
+        url_format: "project/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_3
               
@@ -39,7 +39,7 @@ content_types:
         category: General
         name: study
         # title_format: "[study_name]"
-        # url_format: "study/[TripalEntity__entity_id]"
+        url_format: "study/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_4
         
@@ -49,7 +49,7 @@ content_types:
         category: General
         name: contact
         # title_format: "[contact_name]"
-        # url_format: "contact/[TripalEntity__entity_id]"
+        url_format: "contact/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_5        
 
@@ -59,7 +59,7 @@ content_types:
         category: General
         name: pub
         # title_format: "[publication_title]"
-        # url_format: "pub/[TripalEntity__entity_id]"
+        url_format: "pub/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_6
 
@@ -69,7 +69,7 @@ content_types:
         category: General
         name: protocol
         # title_format: "[protocol_name]"
-        # url_format: "protocol/[TripalEntity__entity_id]"
+        url_format: "protocol/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_7
         
@@ -79,7 +79,7 @@ content_types:
         category: Genomic
         name: gene
         # title_format: "[gene_name]"
-        # url_format: "gene/[TripalEntity__entity_id]"
+        url_format: "gene/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_8
 
@@ -89,7 +89,7 @@ content_types:
         category: Genomic
         name: mRNA
         # title_format: "[mrna_name]"
-        # url_format: "mRNA/[TripalEntity__entity_id]"
+        url_format: "mRNA/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_9
             
@@ -99,7 +99,7 @@ content_types:
         category: Genomic
         name: phylotree
         # title_format: "[phylotree_name]"
-        # url_format: "phylotree/[TripalEntity__entity_id]"
+        url_format: "phylotree/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_10
               
@@ -109,7 +109,7 @@ content_types:
         category: Genomic  
         name: physical_map 
         # title_format: "[physical_map_name]"
-        # url_format: "physical_map/[TripalEntity__entity_id]"
+        url_format: "physical_map/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_11    
               
@@ -119,7 +119,7 @@ content_types:
         category: Genomic
         name: dna_library
         # title_format: "[dna_library_name]"
-        # url_format: "dna_library/[TripalEntity__entity_id]"
+        url_format: "dna_library/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_12
         
@@ -129,7 +129,7 @@ content_types:
         category: Genomic 
         name:  genome_assembly
         # title_format: "[genome_assembly_name]"
-        # url_format: "genome_assembly/[TripalEntity__entity_id]"
+        url_format: "genome_assembly/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_13     
 
@@ -139,7 +139,7 @@ content_types:
         category: Genomic
         name: genome_annotation
         # title_format: "[genome_annotation_name]"
-        # url_format: "genome_annotation/[TripalEntity__entity_id]"
+        url_format: "genome_annotation/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_14
         
@@ -149,7 +149,7 @@ content_types:
         category: Genomic
         name: genome_project
         # title_format: "[genome_project_name]"
-        # url_format: "genome_project/[TripalEntity__entity_id]"
+        url_format: "genome_project/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_15
             
@@ -159,7 +159,7 @@ content_types:
         category: Genetic
         name: genetic_map
         # title_format: "[genetic_map_name]"
-        # url_format: "genetic_map/[TripalEntity__entity_id]"
+        url_format: "genetic_map/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_16
             
@@ -169,7 +169,7 @@ content_types:
         category: Genetic
         name: QTL
         # title_format: "[qtl_name]"
-        # url_format: "QTL/[TripalEntity__entity_id]"
+        url_format: "QTL/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_17
         
@@ -179,7 +179,7 @@ content_types:
         category: Genetic
         name: sequence_variant
         # title_format: "[sequence_variant_name]"
-        # url_format: "sequence_variant/[TripalEntity__entity_id]"
+        url_format: "sequence_variant/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_18
 
@@ -189,7 +189,7 @@ content_types:
         category: Genetic
         name: genetic_marker
         # title_format: "[genetic_marker_name]"
-        # url_format: "genetic_marker/[TripalEntity__entity_id]"
+        url_format: "genetic_marker/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_19
         
@@ -199,7 +199,7 @@ content_types:
         category: Genetic
         name: phenotypic_marker 
         # title_format: "[phenotypic_marker_name]"
-        # url_format: "phenotypic_marker/[TripalEntity__entity_id]"
+        url_format: "phenotypic_marker/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_20
         
@@ -209,7 +209,7 @@ content_types:
         category: Germplasm
         name: germplasm
         # title_format: "[germplasm_name]"
-        # url_format: "germplasm/[TripalEntity__entity_id]"
+        url_format: "germplasm/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_21
         
@@ -219,7 +219,7 @@ content_types:
         category: Germplasm
         name: breeding_cross
         # title_format: "[breeding_cross_name]"
-        # url_format: "breeding_cross/[TripalEntity__entity_id]"
+        url_format: "breeding_cross/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_22
         
@@ -229,7 +229,7 @@ content_types:
         category: Germplasm
         name: germplasm_variety
         # title_format: "[germplasm_variety_name]"
-        # url_format: "germplasm_variety/[TripalEntity__entity_id]"
+        url_format: "germplasm_variety/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_23
         
@@ -239,7 +239,7 @@ content_types:
         category: Germplasm
         name: RIL
         # title_format: "[ril_name]"
-        # url_format: "RIL/[TripalEntity__entity_id]"
+        url_format: "RIL/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_24
         
@@ -249,7 +249,7 @@ content_types:
         category: Expression
         name: biosample
         # title_format: "[biosample_name]"
-        # url_format: "biosample/[TripalEntity__entity_id]"
+        url_format: "biosample/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_25
         
@@ -259,7 +259,7 @@ content_types:
         category: Expression
         name: assay
         # title_format: "[assay_name]"
-        # url_format: "assay/[TripalEntity__entity_id]"
+        url_format: "assay/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_26
         
@@ -269,7 +269,7 @@ content_types:
         category: Expression
         name: array_design
         # title_format: "[array_design_name]"
-        # url_format: "array_design/[TripalEntity__entity_id]"
+        url_format: "array_design/[TripalEntity__entity_id]"
         synonyms: 
              - bio_data_27
         

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.default_chado.yml
@@ -7,269 +7,269 @@ content_types:
         term: OBI:0100026
         help_text: Use the organism page for an individual living system, such as animal, plant, bacteria or virus, 
         category: General
-        # name: organism
+        name: organism
         # title_format: "[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]"
         # url_format: "organism/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_1
+        synonyms: 
+             - bio_data_1
 
     -   label:  Analysis
         term: operation:2945
         help_text: Use the analysis page to for an individual analysis, workflow or pipeline that was performed using statistical or computational means.
         category: General
-        # name: analysis
+        name: analysis
         # title_format: "[analysis_name]"
         # url_format: "analysis/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_2
+        synonyms: 
+             - bio_data_2
 
     -   label: Project
         term: NCIT:C47885
         help_text: Use the project page to provide information about a project that many be linked to multiple sub components such as studies or analyses.
         category: General
-        # name: project
+        name: project
         # title_format: "[project_name]"
         # url_format: "project/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_3
+        synonyms: 
+             - bio_data_3
               
     -   label: Study
         term: SIO:001066
         help_text: Use the study page for a systematic investigation.
         category: General
-        # name: study
+        name: study
         # title_format: "[study_name]"
         # url_format: "study/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_4
+        synonyms: 
+             - bio_data_4
         
     -   label: Contact
         term: local:contact
         help_text: Use the contage page a person or institution that can be linked as a responsible party for data or results.
         category: General
-        # name: contact
+        name: contact
         # title_format: "[contact_name]"
         # url_format: "contact/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_5        
+        synonyms: 
+             - bio_data_5        
 
     -   label: Publication
         term: TPUB:0000002
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
-        # name: pub
+        name: pub
         # title_format: "[publication_title]"
         # url_format: "pub/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_6
+        synonyms: 
+             - bio_data_6
 
     -   label: Protocol
         term: sep:00101
         help_text: Use the protocol page for a parameterizable description of a process.
         category: General
-        # name: protocol
+        name: protocol
         # title_format: "[protocol_name]"
         # url_format: "protocol/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_7
+        synonyms: 
+             - bio_data_7
         
     -   label: Gene
         term: SO:0000704
         help_text: Use the gene page for a region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.
         category: Genomic
-        # name: gene
+        name: gene
         # title_format: "[gene_name]"
         # url_format: "gene/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_8
+        synonyms: 
+             - bio_data_8
 
     -   label: mRNA
         term: SO:0000234
         help_text: Use the mRNA page for a messenger RNA whic is the intermediate molecule between DNA and protein. It includes UTR and coding sequences. It does not contain introns.
         category: Genomic
-        # name: mRNA
+        name: mRNA
         # title_format: "[mrna_name]"
         # url_format: "mRNA/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_9
+        synonyms: 
+             - bio_data_9
             
     -   label: Phylogenetic Tree
         term: data:0872
         help_text: Use the phylogenetic tree page for data or plotting of phylogenetic trees. Usually includes information such as topology, lengths (in time or in expected amounts of variance) and a confidence interval for each length.
         category: Genomic
-        # name: phylotree
+        name: phylotree
         # title_format: "[phylotree_name]"
         # url_format: "phylotree/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_10
+        synonyms: 
+             - bio_data_10
               
     -   label: Physical Map
         term: data:1280
         help_text: Use the physical map page for a map of annotated with physical features or landmarks such as restriction sites, cloned DNA fragments, genes or genetic markers, along with the physical distances between them. Distance in a physical map is measured in base pairs. A physical map might be ordered relative to a reference map (typically a genetic map) in the process of genome sequencing.
         category: Genomic  
-        # name: physical_map 
+        name: physical_map 
         # title_format: "[physical_map_name]"
         # url_format: "physical_map/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_11    
+        synonyms: 
+             - bio_data_11    
               
     -   label: DNA Library
         term: NCIT:C16223
         help_text: Use the DNA library page for a collection of DNA molecules that have been cloned in vectors.
         category: Genomic
-        # name: dna_library
+        name: dna_library
         # title_format: "[dna_library_name]"
         # url_format: "dna_library/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_12
+        synonyms: 
+             - bio_data_12
         
     -   label: Genome Assembly
         term: operation:0525
         help_text: Use the genome assembly page for an analyses specifcally for genome assembly. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the assembly.
         category: Genomic 
-        # name:  genome_assembly
+        name:  genome_assembly
         # title_format: "[genome_assembly_name]"
         # url_format: "genome_assembly/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_13     
+        synonyms: 
+             - bio_data_13     
 
     -   label: Genome Annotation
         term: operation:0362
         help_text: Use the genome annotation page for an analyses specifcally for genome annotation. Such an analysis typically involves one or more workflows of bioinormatics tools to generate the structural and functional annotations of the genome.
         category: Genomic
-        # name: genome_annotation
+        name: genome_annotation
         # title_format: "[genome_annotation_name]"
         # url_format: "genome_annotation/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_14
+        synonyms: 
+             - bio_data_14
         
     -   label: Genome Project
         term: local:Genome Project
         help_text: Use the genome project page to provide information about a genome assembly and annotation project that many be linked to multiple sub analyses.
         category: Genomic
-        # name: genome_project
+        name: genome_project
         # title_format: "[genome_project_name]"
         # url_format: "genome_project/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_15
+        synonyms: 
+             - bio_data_15
             
     -   label: Genetic Map
         term: data:1278
         help_text: Use a genetic map page for a map showing the relative positions of genetic markers in a nucleic acid sequence, based on estimation of non-physical distance such as recombination frequencies.
         category: Genetic
-        # name: genetic_map
+        name: genetic_map
         # title_format: "[genetic_map_name]"
         # url_format: "genetic_map/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_16
+        synonyms: 
+             - bio_data_16
             
     -   label: QTL
         term: SO:0000771
         help_text: Use a QTL page for a quantitative trait locus (QTL), which is a polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait. Usually it is a marker described by statistical association to quantitative variation in the particular phenotypic trait that is thought to be controlled by the cumulative action of alleles at multiple loci.
         category: Genetic
-        # name: QTL
+        name: QTL
         # title_format: "[qtl_name]"
         # url_format: "QTL/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_17
+        synonyms: 
+             - bio_data_17
         
     -   label: Sequence Variant
         term: SO:0001060
         help_text: Use the sequence variant page for a non exact copy of a sequence feature or genome exhibiting one or more sequence alteration.
         category: Genetic
-        # name: sequence_variant
+        name: sequence_variant
         # title_format: "[sequence_variant_name]"
         # url_format: "sequence_variant/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_18
+        synonyms: 
+             - bio_data_18
 
     -   label: Genetic Marker
         term: SO:0001645
         help_text: Use the genetic marker page for a measurable sequence feature that varies within a population.
         category: Genetic
-        # name: genetic_marker
+        name: genetic_marker
         # title_format: "[genetic_marker_name]"
         # url_format: "genetic_marker/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_19
+        synonyms: 
+             - bio_data_19
         
     -   label: Heritable Phenotypic Marker
         term: SO:0001500
         help_text: Use the heritable phenotypic marker page for a sequence region characterized as a single heritable trait in a phenotype screen. The heritable phenotype may be mapped to a chromosome but generally has not been characterized to a specific gene locus.
         category: Genetic
-        # name: phenotypic_marker 
+        name: phenotypic_marker 
         # title_format: "[phenotypic_marker_name]"
         # url_format: "phenotypic_marker/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_20
+        synonyms: 
+             - bio_data_20
         
     -   label: Germplasm Accession
         term: CO_010:0000044
         help_text: Use the germplasm accession page for a living genetic resources such as seeds or tissues that are maintained for the purpose of animal and plant breeding, and preservation.
         category: Germplasm
-        # name: germplasm
+        name: germplasm
         # title_format: "[germplasm_name]"
         # url_format: "germplasm/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_21
+        synonyms: 
+             - bio_data_21
         
     -   label: Breeding Cross
         term: CO_010:0000255
         help_text: Use the breeding cross page for information about a cross between two germplasm in a breeding application.
         category: Germplasm
-        # name: breeding_cross
+        name: breeding_cross
         # title_format: "[breeding_cross_name]"
         # url_format: "breeding_cross/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_22
+        synonyms: 
+             - bio_data_22
         
     -   label: Germplasm Variety
         term: CO_010:0000029
         help_text: Use the germplasm variety page for information about specific variety of germplasm.
         category: Germplasm
-        # name: germplasm_variety
+        name: germplasm_variety
         # title_format: "[germplasm_variety_name]"
         # url_format: "germplasm_variety/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_23
+        synonyms: 
+             - bio_data_23
         
     -   label: Recombinant Inbred Line
         term: CO_010:0000162
         help_text: Use the recombinant inbred line page to describe a collection of germplasm that were created by crossing and can be used to map quantitative trait loci.
         category: Germplasm
-        # name: RIL
+        name: RIL
         # title_format: "[ril_name]"
         # url_format: "RIL/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_24
+        synonyms: 
+             - bio_data_24
         
     -   label: Biological Sample
         term: sep:00195
         help_text: Use the biological sample page for any material taken from a biological system for use in a systematic study.
         category: Expression
-        # name: biosample
+        name: biosample
         # title_format: "[biosample_name]"
         # url_format: "biosample/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_25
+        synonyms: 
+             - bio_data_25
         
     -   label: Assay
         term: OBI:0000070
         help_text: Use the assay page to describe an experimental approach used to measure the characteristics of an item. 
         category: Expression
-        # name: assay
+        name: assay
         # title_format: "[assay_name]"
         # url_format: "assay/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_26
+        synonyms: 
+             - bio_data_26
         
     -   label: Array Design
         term: EFO:0000269
         help_text: Use the array design page to describe the systematic arrangement of similar objects, usually in rows and columns, used by intstrument to perform an assay.
         category: Expression
-        # name: array_design
+        name: array_design
         # title_format: "[array_design_name]"
         # url_format: "array_design/[TripalEntity__entity_id]"
-        # synonyms: 
-        #     - bio_data_27
+        synonyms: 
+             - bio_data_27
         

--- a/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.default_chado.yml
@@ -4,7 +4,7 @@ description: 'Default fields configurations provided by the Tripal Chado module'
 fields:
 
     -   name: organism_abbreviation
-        content_type: bio_data_1
+        content_type: organism
         label: Abbreviation
         type: chado_string_type
         description: A shortened name (or abbreviation) for the organism (e.g. O. sativa).
@@ -31,7 +31,7 @@ fields:
                     weight: 10
 
     -   name: organism_genus
-        content_type: bio_data_1
+        content_type: organism
         label: Genus
         type: chado_string_type
         description: "The genus name of the organism."
@@ -58,7 +58,7 @@ fields:
                     weight: 15
 
     -   name: organism_species
-        content_type: bio_data_1
+        content_type: organism
         label: Species
         type: chado_string_type
         description: "The species name of the organism."
@@ -85,7 +85,7 @@ fields:
                     weight: 20
 
     -   name: organism_common_name
-        content_type: bio_data_1
+        content_type: organism
         label: Common Name
         type: chado_string_type
         description: "The common name for the organism."
@@ -112,7 +112,7 @@ fields:
                     weight: 25
 
     -   name: organism_infraspecific_name
-        content_type: bio_data_1
+        content_type: organism
         label: Infraspecies
         type: chado_string_type
         description: "The infraspecfic name for the organism."
@@ -139,7 +139,7 @@ fields:
                     weight: 30
 
     -   name: organism_comment
-        content_type: bio_data_1
+        content_type: organism
         label: Description
         type: chado_text_type
         description: A description of the organism.
@@ -165,7 +165,7 @@ fields:
               weight: 35
 
     -   name: organism_infraspecific_type
-        content_type: bio_data_1
+        content_type: organism
         label: Infraspecific Type
         type: chado_additional_type_default
         description: The connector type (e.g. subspecies, varietas, forma, etc.) for the infraspecific name.
@@ -193,7 +193,7 @@ fields:
 
 
     -   name: analysis_name
-        content_type: bio_data_2
+        content_type: analysis
         label: Name
         type: chado_string_type
         description: The name of the analysis.
@@ -220,7 +220,7 @@ fields:
               weight: 10
 
     -   name: analysis_description
-        content_type: bio_data_2
+        content_type: analysis
         label: Description
         type: chado_text_type
         description: A description of the analysis.
@@ -246,7 +246,7 @@ fields:
               weight: 15
 
     -   name: analysis_software
-        content_type: bio_data_2
+        content_type: analysis
         label: Program, Pipeline, Workflow or Method Name
         type: chado_string_type
         description: The program name (e.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
@@ -273,7 +273,7 @@ fields:
               weight: 20
 
     -   name: analysis_program_version
-        content_type: bio_data_2
+        content_type: analysis
         label: Software Version
         type: chado_string_type
         description: The version of the program, pipeline or method used to perform this analysis. (e.g. TBLASTX 2.0MP-WashU [09-Nov-2000]. Enter "n/a" if no version is available or applicable.
@@ -300,7 +300,7 @@ fields:
               weight: 25
 
     -   name: analysis_algorithm
-        content_type: bio_data_2
+        content_type: analysis
         label: Algorithm
         type: chado_string_type
         description: The name of the algorithm used to produce the dataset if different from the program.
@@ -327,7 +327,7 @@ fields:
               weight: 30
 
     -   name: analysis_source
-        content_type: bio_data_2
+        content_type: analysis
         label: Data Source Name
         type: chado_string_type
         description: The name of the source where data was obtained for this analysis.
@@ -354,7 +354,7 @@ fields:
               weight: 35
 
     -   name: analysis_source_version
-        content_type: bio_data_2
+        content_type: analysis
         label: Data Source Version
         type: chado_string_type
         description: The version number of the data source (if applicable).
@@ -381,7 +381,7 @@ fields:
               weight: 40
 
     -   name: analysis_source_uri
-        content_type: bio_data_2
+        content_type: analysis
         label: Data Source URI
         type: chado_text_type
         description: The URI (e.g. web URL) where the source data can be retrieved.
@@ -407,7 +407,7 @@ fields:
               weight: 45
 
     -   name: project_name
-        content_type: bio_data_3
+        content_type: project
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -434,7 +434,7 @@ fields:
               weight: 10
 
     -   name: project_description
-        content_type: bio_data_3
+        content_type: project
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -460,7 +460,7 @@ fields:
               weight: 15
 
     -   name: study_name
-        content_type: bio_data_4
+        content_type: study
         label: Name
         type: chado_text_type
         description: The name of the item.
@@ -486,7 +486,7 @@ fields:
               weight: 10
 
     -   name: study_description
-        content_type: bio_data_4
+        content_type: study
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -512,7 +512,7 @@ fields:
               weight: 15
 
     -   name: contact_name
-        content_type: bio_data_5
+        content_type: contact
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -539,7 +539,7 @@ fields:
               weight: 10
 
     -   name: contact_description
-        content_type: bio_data_5
+        content_type: contact
         label: Description
         type: chado_string_type
         description: A description of the item.
@@ -566,7 +566,7 @@ fields:
               weight: 15
 
     -   name: contact_type
-        content_type: bio_data_5
+        content_type: contact
         label: Contact Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -593,7 +593,7 @@ fields:
               weight: 10
 
     -   name: protocol_name
-        content_type: bio_data_7
+        content_type: protocol
         label: Name
         type: chado_text_type
         description: The name of the item.
@@ -619,7 +619,7 @@ fields:
               weight: 10
 
     -   name: protocol_uri
-        content_type: bio_data_7
+        content_type: protocol
         label: URI
         type: chado_text_type
         description: The name of a biological or bioinformatics database.
@@ -645,7 +645,7 @@ fields:
               weight: 15
 
     -   name: protocol_description
-        content_type: bio_data_7
+        content_type: protocol
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -671,7 +671,7 @@ fields:
               weight: 20
 
     -   name: protocol_instrument
-        content_type: bio_data_7
+        content_type: protocol
         label: Instrument
         type: chado_text_type
         description: An instrument is a device which provides a mechanical or electronic function.
@@ -697,7 +697,7 @@ fields:
               weight: 25
 
     -   name: protocol_software
-        content_type: bio_data_7
+        content_type: protocol
         label: Software
         type: chado_text_type
         description: Computer software, or generally just software, is any set of machine-readable instructions (most often in the form of a computer program) that conform to a given syntax (sometimes referred to as a language) that is interpretable by a given processor and that directs a computer's processor to perform specific operations.
@@ -723,7 +723,7 @@ fields:
               weight: 30
 
     -   name: protocol_type
-        content_type: bio_data_7
+        content_type: protocol
         label: Protocol Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -750,7 +750,7 @@ fields:
               weight: 10
 
     -   name: gene_name
-        content_type: bio_data_8
+        content_type: gene
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -777,7 +777,7 @@ fields:
               weight: 10
 
     -   name: gene_uniquename
-        content_type: bio_data_8
+        content_type: gene
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the gene within the organism.
@@ -803,7 +803,7 @@ fields:
               weight: 15
 
     -   name: gene_sequence
-        content_type: bio_data_8
+        content_type: gene
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -829,7 +829,7 @@ fields:
               weight: 20
 
     -   name: gene_length
-        content_type: bio_data_8
+        content_type: gene
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.
@@ -855,7 +855,7 @@ fields:
               weight: 25
 
     -   name: gene_organism
-        content_type: bio_data_8
+        content_type: gene
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -881,7 +881,7 @@ fields:
               weight: 10
 
     -   name: gene_type
-        content_type: bio_data_8
+        content_type: gene
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -909,7 +909,7 @@ fields:
               weight: 10
 
     -   name: gene_is_analysis
-        content_type: bio_data_8
+        content_type: gene
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -936,7 +936,7 @@ fields:
               weight: 90
 
     -   name: gene_is_obsolete
-        content_type: bio_data_8
+        content_type: gene
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -963,7 +963,7 @@ fields:
               weight: 90
 
     -   name: mrna_name
-        content_type: bio_data_9
+        content_type: mRNA
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -990,7 +990,7 @@ fields:
               weight: 10
 
     -   name: mrna_uniquename
-        content_type: bio_data_9
+        content_type: mRNA
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the mRNA within the organism.
@@ -1016,7 +1016,7 @@ fields:
               weight: 15
 
     -   name: mrna_sequence
-        content_type: bio_data_9
+        content_type: mRNA
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -1042,7 +1042,7 @@ fields:
               weight: 20
 
     -   name: mrna_sequence_length
-        content_type: bio_data_9
+        content_type: mRNA
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.
@@ -1068,7 +1068,7 @@ fields:
               weight: 25
 
     -   name: mrna_organism
-        content_type: bio_data_9
+        content_type: mRNA
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -1094,7 +1094,7 @@ fields:
               weight: 10
 
     -   name: mrna_type
-        content_type: bio_data_9
+        content_type: mRNA
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1122,7 +1122,7 @@ fields:
               weight: 10
 
     -   name: mrna_is_analysis
-        content_type: bio_data_9
+        content_type: mRNA
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -1149,7 +1149,7 @@ fields:
               weight: 90
 
     -   name: mrna_is_obsolete
-        content_type: bio_data_9
+        content_type: mRNA
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -1176,7 +1176,7 @@ fields:
               weight: 90
 
     -   name: phylotree_name
-        content_type: bio_data_10
+        content_type: phylotree
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1203,7 +1203,7 @@ fields:
               weight: 10
 
     -   name: phylotree_comment
-        content_type: bio_data_10
+        content_type: phylotree
         label: Notes
         type: chado_text_type
         description: Comments, typically from users.
@@ -1229,7 +1229,7 @@ fields:
               weight: 15
 
     -   name: phylotree_type
-        content_type: bio_data_10
+        content_type: phylotree
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1257,7 +1257,7 @@ fields:
               weight: 10
 
     -   name: physical_map_name
-        content_type: bio_data_11
+        content_type: physical_map
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1284,7 +1284,7 @@ fields:
               weight: 10
 
     -   name: physical_map_description
-        content_type: bio_data_11
+        content_type: physical_map
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -1310,7 +1310,7 @@ fields:
               weight: 15
 
     -   name: physical_map_unit_type
-        content_type: bio_data_11
+        content_type: physical_map
         label: Unit Type
         type: chado_additional_type_default
         description: A unit of measurement is a standardized quantity of a physical quality.
@@ -1337,7 +1337,7 @@ fields:
               weight: 10
 
     -   name: dna_library_name
-        content_type: bio_data_12
+        content_type: dna_library
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1364,7 +1364,7 @@ fields:
               weight: 10
 
     -   name: dna_library_uniquename
-        content_type: bio_data_12
+        content_type: dna_library
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the DNA library on this site.
@@ -1390,7 +1390,7 @@ fields:
               weight: 15
 
     -   name: dna_library_type
-        content_type: bio_data_12
+        content_type: dna_library
         label: Library Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1418,7 +1418,7 @@ fields:
               weight: 10
 
     -   name: dna_library_organism
-        content_type: bio_data_12
+        content_type: dna_library
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -1444,7 +1444,7 @@ fields:
               weight: 20
 
     -   name: genome_assembly_name
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1471,7 +1471,7 @@ fields:
               weight: 10
 
     -   name: genome_assembly_description
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -1497,7 +1497,7 @@ fields:
               weight: 15
 
     -   name: genome_assembly_software
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Program, Pipeline, Workflow or Method Name
         type: chado_string_type
         description: The program name (e.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
@@ -1524,7 +1524,7 @@ fields:
               weight: 20
 
     -   name: genome_assembly_program_version
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Program Version
         type: chado_string_type
         description: The version of the program, pipeline, workflow or method used to perform this analysis. (e.g. TBLASTX 2.0MP-WashU [09-Nov-2000]. Enter "n/a" if no version is available or applicable.
@@ -1552,7 +1552,7 @@ fields:
 
 
     -   name: genome_assembly_source_name
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Data Source Name
         type: chado_string_type
         description: The name of the source where data was obtained for this analysis.
@@ -1579,7 +1579,7 @@ fields:
               weight: 35
 
     -   name: genome_assembly_source_version
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Data Source Version
         type: chado_string_type
         description: The version number of the data source (if applicable).
@@ -1606,7 +1606,7 @@ fields:
               weight: 40
 
     -   name: genome_assembly_uri
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Data Source URI
         type: chado_text_type
         description: The URI (e.g. web URL) where the source data can be retrieved.
@@ -1632,7 +1632,7 @@ fields:
               weight: 45
 
     -   name: genome_assembly_type
-        content_type: bio_data_13
+        content_type: genome_assembly
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1660,7 +1660,7 @@ fields:
               weight: 10
 
     -   name: genome_annotation_name
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1687,7 +1687,7 @@ fields:
               weight: 10
 
     -   name: genome_annotation_description
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -1713,7 +1713,7 @@ fields:
               weight: 15
 
     -   name: genome_annotation_software
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Program, Pipeline, Workflow or Method Name
         type: chado_string_type
         description: The program name (e.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
@@ -1740,7 +1740,7 @@ fields:
               weight: 20
 
     -   name: genome_annotation_prog_version
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Program Version
         type: chado_string_type
         description: The version of the program, pipeline, workflow or method used to perform this analysis. (e.g. TBLASTX 2.0MP-WashU [09-Nov-2000]. Enter "n/a" if no version is available or applicable.
@@ -1767,7 +1767,7 @@ fields:
               weight: 25
 
     -   name: genome_annotation_src_name
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Name
         type: chado_string_type
         description: The name of the source where data was obtained for this analysis.
@@ -1794,7 +1794,7 @@ fields:
               weight: 35
 
     -   name: genome_annotation_src_version
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Data Source Version
         type: chado_string_type
         description: The version number of the data source (if applicable).
@@ -1821,7 +1821,7 @@ fields:
               weight: 40
 
     -   name: genome_annotation_uri
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Data Source URI
         type: chado_text_type
         description: The URI (e.g. web URL) where the source data can be retrieved.
@@ -1847,7 +1847,7 @@ fields:
               weight: 45
 
     -   name: genome_annotation_type
-        content_type: bio_data_14
+        content_type: genome_annotation
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1875,7 +1875,7 @@ fields:
               weight: 10
 
     -   name: genome_project_name
-        content_type: bio_data_15
+        content_type: genome_project
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1902,7 +1902,7 @@ fields:
               weight: 10
 
     -   name: genome_project_description
-        content_type: bio_data_15
+        content_type: genome_project
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -1928,7 +1928,7 @@ fields:
               weight: 15
 
     -   name: genome_project_type
-        content_type: bio_data_15
+        content_type: genome_project
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -1956,7 +1956,7 @@ fields:
               weight: 10
 
     -   name: genetic_map_name
-        content_type: bio_data_16
+        content_type: genetic_map
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -1983,7 +1983,7 @@ fields:
               weight: 10
 
     -   name: genetic_map_description
-        content_type: bio_data_16
+        content_type: genetic_map
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -2009,7 +2009,7 @@ fields:
               weight: 15
 
     -   name: genetic_map_unit_type
-        content_type: bio_data_16
+        content_type: genetic_map
         label: Unit Type
         type: chado_additional_type_default
         description: A unit of measurement is a standardized quantity of a physical quality.
@@ -2036,7 +2036,7 @@ fields:
               weight: 10
 
     -   name: qtl_name
-        content_type: bio_data_17
+        content_type: QTL
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -2063,7 +2063,7 @@ fields:
               weight: 10
 
     -   name: qtl_unique_name
-        content_type: bio_data_17
+        content_type: QTL
         label: Uniquen Name
         type: chado_text_type
         description: A name that uniquely identifies the QTL within the organism.
@@ -2089,7 +2089,7 @@ fields:
               weight: 15
 
     -   name: qtl_sequence
-        content_type: bio_data_17
+        content_type: QTL
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -2115,7 +2115,7 @@ fields:
               weight: 20
 
     -   name: qtl_sequence_length
-        content_type: bio_data_17
+        content_type: QTL
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.
@@ -2141,7 +2141,7 @@ fields:
               weight: 25
 
     -   name: qtl_organism
-        content_type: bio_data_17
+        content_type: QTL
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -2167,7 +2167,7 @@ fields:
               weight: 10
 
     -   name: qtl_type
-        content_type: bio_data_17
+        content_type: QTL
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -2195,7 +2195,7 @@ fields:
               weight: 10
 
     -   name: qtl_is_analysis
-        content_type: bio_data_17
+        content_type: QTL
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -2222,7 +2222,7 @@ fields:
               weight: 90
 
     -   name: qtl_is_obsolete
-        content_type: bio_data_17
+        content_type: QTL
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -2249,7 +2249,7 @@ fields:
               weight: 90
 
     -   name: sequence_variant_name
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -2276,7 +2276,7 @@ fields:
               weight: 10
 
     -   name: sequence_variant_uniquene_name
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the sequence variant within the organism.
@@ -2302,7 +2302,7 @@ fields:
               weight: 15
 
     -   name: sequence_variant_sequence
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -2328,7 +2328,7 @@ fields:
               weight: 20
 
     -   name: sequence_variant_sequence_length
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.
@@ -2354,7 +2354,7 @@ fields:
               weight: 25
 
     -   name: sequence_variant_organism
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -2380,7 +2380,7 @@ fields:
               weight: 10
 
     -   name: sequence_variant_type
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -2408,7 +2408,7 @@ fields:
               weight: 10
 
     -   name: sequence_variant_is_analysis
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -2435,7 +2435,7 @@ fields:
               weight: 90
 
     -   name: sequence_variant_is_obsolete
-        content_type: bio_data_18
+        content_type: sequence_variant
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -2462,7 +2462,7 @@ fields:
               weight: 90
 
     -   name: genetic_marker_name
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -2489,7 +2489,7 @@ fields:
               weight: 10
 
     -   name: genetic_marker_unique_name
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the genetic marker within the organism.
@@ -2515,7 +2515,7 @@ fields:
               weight: 15
 
     -   name: genetic_marker_sequence
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -2541,7 +2541,7 @@ fields:
               weight: 20
 
     -   name: genetic_marker_sequence_length
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence,or range(s) of lengths.
@@ -2567,7 +2567,7 @@ fields:
               weight: 25
 
     -   name: genetic_marker_organism
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -2593,7 +2593,7 @@ fields:
               weight: 10
 
     -   name: genetic_marker_type
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -2621,7 +2621,7 @@ fields:
               weight: 10
 
     -   name: genetic_marker_is_analysis
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -2648,7 +2648,7 @@ fields:
               weight: 90
 
     -   name: genetic_marker_is_obsolete
-        content_type: bio_data_19
+        content_type: genetic_marker
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -2675,7 +2675,7 @@ fields:
               weight: 90
 
     -   name: phenotypic_marker_name
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -2702,7 +2702,7 @@ fields:
               weight: 10
 
     -   name: phenotypic_marker_unique_name
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Uniquen Name
         type: chado_text_type
         description: A name that uniquely identifies the heritable phenotypic marker within the organism.
@@ -2728,7 +2728,7 @@ fields:
               weight: 15
 
     -   name: phenotypic_marker_sequence
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Sequence
         type: chado_text_type
         description: One or more molecular sequences, possibly with associated annotation.
@@ -2754,7 +2754,7 @@ fields:
               weight: 20
 
     -   name: phenotypic_marker_seqlen
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Sequence Length
         type: chado_integer_type
         description: The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.
@@ -2780,7 +2780,7 @@ fields:
               weight: 25
 
     -   name: phenotypic_marker_organism
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Organism
         type: chado_organism_default
         description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
@@ -2806,7 +2806,7 @@ fields:
               weight: 10
 
     -   name: phenotypic_marker_type
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -2834,7 +2834,7 @@ fields:
               weight: 10
 
     -   name: phenotypic_marker_is_analysis
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Is Analysis
         type: chado_boolean_type
         description: Indicates if this feature was predicted computationally using another feature.
@@ -2861,7 +2861,7 @@ fields:
               weight: 90
 
     -   name: phenotypic_marker_is_obsolete
-        content_type: bio_data_20
+        content_type: phenotypic_marker
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -2888,7 +2888,7 @@ fields:
               weight: 90
 
     -   name: germplasm_name
-        content_type: bio_data_21
+        content_type: germplasm
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -2915,7 +2915,7 @@ fields:
               weight: 10
 
     -   name: germplasm_unique_name
-        content_type: bio_data_21
+        content_type: germplasm
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the germplasm within this organism.
@@ -2941,7 +2941,7 @@ fields:
               weight: 15
 
     -   name: germplasm_description
-        content_type: bio_data_21
+        content_type: germplasm
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -2967,7 +2967,7 @@ fields:
               weight: 20
 
     -   name: germplasm_type
-        content_type: bio_data_21
+        content_type: germplasm
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -2995,7 +2995,7 @@ fields:
               weight: 10
 
     -   name: germplasm_is_obsolete
-        content_type: bio_data_21
+        content_type: germplasm
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -3022,7 +3022,7 @@ fields:
               weight: 90
 
     -   name: breeding_cross_name
-        content_type: bio_data_22
+        content_type: breeding_cross
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -3049,7 +3049,7 @@ fields:
               weight: 10
 
     -   name: breeding_cross_unique_name
-        content_type: bio_data_22
+        content_type: breeding_cross
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the breeding cross within this organism.
@@ -3075,7 +3075,7 @@ fields:
               weight: 15
 
     -   name: breeding_cross_description
-        content_type: bio_data_22
+        content_type: breeding_cross
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3101,7 +3101,7 @@ fields:
               weight: 20
 
     -   name: breeding_cross_type
-        content_type: bio_data_22
+        content_type: breeding_cross
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -3129,7 +3129,7 @@ fields:
               weight: 10
 
     -   name: breeding_cross_is_obsolete
-        content_type: bio_data_22
+        content_type: breeding_cross
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -3156,7 +3156,7 @@ fields:
               weight: 90
 
     -   name: germplasm_variety_name
-        content_type: bio_data_23
+        content_type: germplasm_variety
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -3183,7 +3183,7 @@ fields:
               weight: 10
 
     -   name: germplasm_variety_unique_name
-        content_type: bio_data_23
+        content_type: germplasm_variety
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the germplasm variety within this organism.
@@ -3209,7 +3209,7 @@ fields:
               weight: 15
 
     -   name: germplasm_variety_description
-        content_type: bio_data_23
+        content_type: germplasm_variety
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3235,7 +3235,7 @@ fields:
               weight: 20
 
     -   name: germplasm_variety_type
-        content_type: bio_data_23
+        content_type: germplasm_variety
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -3263,7 +3263,7 @@ fields:
               weight: 10
 
     -   name: germplasm_variety_is_obsolete
-        content_type: bio_data_23
+        content_type: germplasm_variety
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -3290,7 +3290,7 @@ fields:
               weight: 90
 
     -   name: ril_name
-        content_type: bio_data_24
+        content_type: RIL
         label: Name
         type: chado_string_type
         description: The name of the item.
@@ -3317,7 +3317,7 @@ fields:
               weight: 10
 
     -   name: ril_unique_name
-        content_type: bio_data_24
+        content_type: RIL
         label: Unique Name
         type: chado_text_type
         description: A name that uniquely identifies the RIL within this organism.
@@ -3343,7 +3343,7 @@ fields:
               weight: 15
 
     -   name: ril_description
-        content_type: bio_data_24
+        content_type: RIL
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3369,7 +3369,7 @@ fields:
               weight: 20
 
     -   name: ril_type
-        content_type: bio_data_24
+        content_type: RIL
         label: Type
         type: chado_additional_type_default
         description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
@@ -3397,7 +3397,7 @@ fields:
               weight: 10
 
     -   name: ril_is_obsolete
-        content_type: bio_data_24
+        content_type: RIL
         label: Is Obsolete
         type: chado_boolean_type
         description: Indicates if this record is obsolete.
@@ -3424,7 +3424,7 @@ fields:
               weight: 90
 
     -   name: biosample_name
-        content_type: bio_data_25
+        content_type: biosample
         label: Name
         type: chado_text_type
         description: The name of the item.
@@ -3450,7 +3450,7 @@ fields:
               weight: 10
 
     -   name: biosample_description
-        content_type: bio_data_25
+        content_type: biosample
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3476,7 +3476,7 @@ fields:
               weight: 15
 
     -   name: assay_unique_name
-        content_type: bio_data_26
+        content_type: assay
         label: Unique Name
         type: chado_text_type
         description: A text token, number or something else which identifies an entity, but which may not be persistent (stable) or unique (the same identifier may identify multiple things).
@@ -3502,7 +3502,7 @@ fields:
               weight: 10
 
     -   name: assay_batch_id
-        content_type: bio_data_26
+        content_type: assay
         label: Array Batch Identifier
         type: chado_text_type
         description: A unique identifier for an array batch.
@@ -3528,7 +3528,7 @@ fields:
               weight: 15
 
     -   name: assay_name
-        content_type: bio_data_26
+        content_type: assay
         label: Name
         type: chado_text_type
         description: The name of the item.
@@ -3554,7 +3554,7 @@ fields:
               weight: 20
 
     -   name: assay_description
-        content_type: bio_data_26
+        content_type: assay
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3581,7 +3581,7 @@ fields:
 
 
     -   name: array_design_name
-        content_type: bio_data_27
+        content_type: array_design
         label: Name
         type: chado_text_type
         description: The name of the item.
@@ -3607,7 +3607,7 @@ fields:
               weight: 10
 
     -   name: array_design_version_num
-        content_type: bio_data_27
+        content_type: array_design
         label: Array Version
         type: chado_text_type
         description: A version number is an information content entity which is a sequence of characters borne by part of each of a class of manufactured products or its packaging and indicates its order within a set of other products having the same name.
@@ -3633,7 +3633,7 @@ fields:
               weight: 15
 
     -   name: array_design_description
-        content_type: bio_data_27
+        content_type: array_design
         label: Description
         type: chado_text_type
         description: A description of the item.
@@ -3659,7 +3659,7 @@ fields:
               weight: 20
 
     -   name: array_design_dimensions
-        content_type: bio_data_27
+        content_type: array_design
         label: Array Dimensions
         type: chado_text_type
         description: The dimensions of an array.
@@ -3685,7 +3685,7 @@ fields:
               weight: 25
 
     -   name: array_design_element_dims
-        content_type: bio_data_27
+        content_type: array_design
         label: Element Dimensions
         type: chado_text_type
         description: The dimensions of an element.
@@ -3711,7 +3711,7 @@ fields:
               weight: 30
 
     -   name: array_design_substrate_type
-        content_type: bio_data_27
+        content_type: array_design
         label: Substrate Type
         type: chado_additional_type_default
         description: Controlled terms for descriptors of types of array substrates.
@@ -3738,7 +3738,7 @@ fields:
               weight: 10
 
     -   name: array_design_platform_type
-        content_type: bio_data_27
+        content_type: array_design
         label: Platform Type
         type: chado_additional_type_default
         description: The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -157,7 +157,7 @@ class ChadoPreparer extends ChadoTaskBase {
       $this->logger->notice("Loading Terms and Ontologies...");
       $terms_setup = \Drupal::service('tripal_chado.terms_init');
       $terms_setup->installTerms();
-      $this->importOntologies();
+      //$this->importOntologies();
 
       $this->setProgress(0.5);
       $this->logger->notice("Creating default content types...");

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -157,7 +157,7 @@ class ChadoPreparer extends ChadoTaskBase {
       $this->logger->notice("Loading Terms and Ontologies...");
       $terms_setup = \Drupal::service('tripal_chado.terms_init');
       $terms_setup->installTerms();
-      //$this->importOntologies();
+      $this->importOntologies();
 
       $this->setProgress(0.5);
       $this->logger->notice("Creating default content types...");

--- a/tripal_chado/tests/fixtures/fill_public_test_prepare.sql
+++ b/tripal_chado/tests/fixtures/fill_public_test_prepare.sql
@@ -241,4102 +241,4102 @@ COMMENT ON COLUMN public.tripal_entity.uid IS 'The ID of the target entity.';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_10_schema_comment (
+CREATE TABLE public.tripal_entity__phylotree_schema_comment (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_10_schema_comment_value text,
-    bio_data_10_schema_comment_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_10_schema_comment_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_10_schema_comment_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_10_schema_comment_revision_id_check CHECK ((revision_id >= 0))
+    phylotree_schema_comment_value text,
+    phylotree_schema_comment_record_id integer,
+    CONSTRAINT tripal_entity__phylotree_schema_comment_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phylotree_schema_comment_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phylotree_schema_comment_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_10_schema_comment OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phylotree_schema_comment OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_10_schema_comment IS 'Data storage for tripal_entity field bio_data_10_schema_comment.';
+COMMENT ON TABLE public.tripal_entity__phylotree_schema_comment IS 'Data storage for tripal_entity field phylotree_schema_comment.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_comment.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_comment.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_10_schema_name (
+CREATE TABLE public.tripal_entity__phylotree_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_10_schema_name_value character varying(255),
-    bio_data_10_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_10_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_10_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_10_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    phylotree_schema_name_value character varying(255),
+    phylotree_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__phylotree_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phylotree_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phylotree_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_10_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phylotree_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_10_schema_name IS 'Data storage for tripal_entity field bio_data_10_schema_name.';
+COMMENT ON TABLE public.tripal_entity__phylotree_schema_name IS 'Data storage for tripal_entity field phylotree_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_10_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phylotree_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_11_schema_description (
+CREATE TABLE public.tripal_entity__physical_map_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_11_schema_description_value text,
-    bio_data_11_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_11_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_11_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_11_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    physical_map_schema_description_value text,
+    physical_map_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__physical_map_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__physical_map_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__physical_map_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_11_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__physical_map_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_11_schema_description IS 'Data storage for tripal_entity field bio_data_11_schema_description.';
+COMMENT ON TABLE public.tripal_entity__physical_map_schema_description IS 'Data storage for tripal_entity field physical_map_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_11_schema_name (
+CREATE TABLE public.tripal_entity__physical_map_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_11_schema_name_value character varying(255),
-    bio_data_11_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_11_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_11_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_11_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    physical_map_schema_name_value character varying(255),
+    physical_map_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__physical_map_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__physical_map_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__physical_map_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_11_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__physical_map_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_11_schema_name IS 'Data storage for tripal_entity field bio_data_11_schema_name.';
+COMMENT ON TABLE public.tripal_entity__physical_map_schema_name IS 'Data storage for tripal_entity field physical_map_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_11_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__physical_map_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_12_data_0842 (
+CREATE TABLE public.tripal_entity__dna_library_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_12_data_0842_value text,
-    bio_data_12_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_12_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_12_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_12_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    dna_library_data_0842_value text,
+    dna_library_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__dna_library_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__dna_library_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__dna_library_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_12_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__dna_library_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_12_data_0842 IS 'Data storage for tripal_entity field bio_data_12_data_0842.';
+COMMENT ON TABLE public.tripal_entity__dna_library_data_0842 IS 'Data storage for tripal_entity field dna_library_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__dna_library_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_12_schema_name (
+CREATE TABLE public.tripal_entity__dna_library_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_12_schema_name_value character varying(255),
-    bio_data_12_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_12_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_12_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_12_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    dna_library_schema_name_value character varying(255),
+    dna_library_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__dna_library_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__dna_library_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__dna_library_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_12_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__dna_library_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_12_schema_name IS 'Data storage for tripal_entity field bio_data_12_schema_name.';
+COMMENT ON TABLE public.tripal_entity__dna_library_schema_name IS 'Data storage for tripal_entity field dna_library_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_12_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__dna_library_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_data_1047 (
+CREATE TABLE public.tripal_entity__genome_assembly_data_1047 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_data_1047_value text,
-    bio_data_13_data_1047_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_data_1047_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_data_1047_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_data_1047_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_data_1047_value text,
+    genome_assembly_data_1047_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_data_1047_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_data_1047_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_data_1047_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_data_1047 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_data_1047 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_data_1047 IS 'Data storage for tripal_entity field bio_data_13_data_1047.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_data_1047 IS 'Data storage for tripal_entity field genome_assembly_data_1047.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_iao_0000064 (
+CREATE TABLE public.tripal_entity__genome_assembly_iao_0000064 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_iao_0000064_value character varying(255),
-    bio_data_13_iao_0000064_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000064_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_iao_0000064_value character varying(255),
+    genome_assembly_iao_0000064_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000064_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_iao_0000064 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_iao_0000064 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_iao_0000064 IS 'Data storage for tripal_entity field bio_data_13_iao_0000064.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_iao_0000064 IS 'Data storage for tripal_entity field genome_assembly_iao_0000064.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_iao_0000129 (
+CREATE TABLE public.tripal_entity__genome_assembly_iao_0000129 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_iao_0000129_value character varying(255),
-    bio_data_13_iao_0000129_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000129_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_iao_0000129_value character varying(255),
+    genome_assembly_iao_0000129_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000129_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_iao_0000129 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_iao_0000129 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_iao_0000129 IS 'Data storage for tripal_entity field bio_data_13_iao_0000129.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_iao_0000129 IS 'Data storage for tripal_entity field genome_assembly_iao_0000129.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_schema_description (
+CREATE TABLE public.tripal_entity__genome_assembly_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_schema_description_value text,
-    bio_data_13_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_schema_description_value text,
+    genome_assembly_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_schema_description IS 'Data storage for tripal_entity field bio_data_13_schema_description.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_schema_description IS 'Data storage for tripal_entity field genome_assembly_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_schema_name (
+CREATE TABLE public.tripal_entity__genome_assembly_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_schema_name_value character varying(255),
-    bio_data_13_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_schema_name_value character varying(255),
+    genome_assembly_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_schema_name IS 'Data storage for tripal_entity field bio_data_13_schema_name.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_schema_name IS 'Data storage for tripal_entity field genome_assembly_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_13_swo_0000001 (
+CREATE TABLE public.tripal_entity__genome_assembly_swo_0000001 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_13_swo_0000001_value character varying(255),
-    bio_data_13_swo_0000001_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_13_swo_0000001_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_13_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
+    genome_assembly_swo_0000001_value character varying(255),
+    genome_assembly_swo_0000001_record_id integer,
+    CONSTRAINT tripal_entity__genome_assembly_swo_0000001_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_assembly_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_13_swo_0000001 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_assembly_swo_0000001 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_13_swo_0000001 IS 'Data storage for tripal_entity field bio_data_13_swo_0000001.';
+COMMENT ON TABLE public.tripal_entity__genome_assembly_swo_0000001 IS 'Data storage for tripal_entity field genome_assembly_swo_0000001.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_13_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_assembly_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_data_1047 (
+CREATE TABLE public.tripal_entity__genome_annotation_data_1047 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_data_1047_value text,
-    bio_data_14_data_1047_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_data_1047_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_data_1047_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_data_1047_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_data_1047_value text,
+    genome_annotation_data_1047_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_data_1047_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_data_1047_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_data_1047_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_data_1047 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_data_1047 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_data_1047 IS 'Data storage for tripal_entity field bio_data_14_data_1047.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_data_1047 IS 'Data storage for tripal_entity field genome_annotation_data_1047.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_iao_0000064 (
+CREATE TABLE public.tripal_entity__genome_annotation_iao_0000064 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_iao_0000064_value character varying(255),
-    bio_data_14_iao_0000064_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000064_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_iao_0000064_value character varying(255),
+    genome_annotation_iao_0000064_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000064_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_iao_0000064 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_iao_0000064 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_iao_0000064 IS 'Data storage for tripal_entity field bio_data_14_iao_0000064.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_iao_0000064 IS 'Data storage for tripal_entity field genome_annotation_iao_0000064.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_iao_0000129 (
+CREATE TABLE public.tripal_entity__genome_annotation_iao_0000129 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_iao_0000129_value character varying(255),
-    bio_data_14_iao_0000129_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000129_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_iao_0000129_value character varying(255),
+    genome_annotation_iao_0000129_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000129_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_iao_0000129 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_iao_0000129 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_iao_0000129 IS 'Data storage for tripal_entity field bio_data_14_iao_0000129.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_iao_0000129 IS 'Data storage for tripal_entity field genome_annotation_iao_0000129.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_schema_description (
+CREATE TABLE public.tripal_entity__genome_annotation_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_schema_description_value text,
-    bio_data_14_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_schema_description_value text,
+    genome_annotation_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_schema_description IS 'Data storage for tripal_entity field bio_data_14_schema_description.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_schema_description IS 'Data storage for tripal_entity field genome_annotation_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_schema_name (
+CREATE TABLE public.tripal_entity__genome_annotation_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_schema_name_value character varying(255),
-    bio_data_14_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_schema_name_value character varying(255),
+    genome_annotation_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_schema_name IS 'Data storage for tripal_entity field bio_data_14_schema_name.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_schema_name IS 'Data storage for tripal_entity field genome_annotation_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_14_swo_0000001 (
+CREATE TABLE public.tripal_entity__genome_annotation_swo_0000001 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_14_swo_0000001_value character varying(255),
-    bio_data_14_swo_0000001_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_14_swo_0000001_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_14_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
+    genome_annotation_swo_0000001_value character varying(255),
+    genome_annotation_swo_0000001_record_id integer,
+    CONSTRAINT tripal_entity__genome_annotation_swo_0000001_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_annotation_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_14_swo_0000001 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_annotation_swo_0000001 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_14_swo_0000001 IS 'Data storage for tripal_entity field bio_data_14_swo_0000001.';
+COMMENT ON TABLE public.tripal_entity__genome_annotation_swo_0000001 IS 'Data storage for tripal_entity field genome_annotation_swo_0000001.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_14_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_annotation_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_15_schema_description (
+CREATE TABLE public.tripal_entity__genome_project_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_15_schema_description_value text,
-    bio_data_15_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_15_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_15_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_15_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    genome_project_schema_description_value text,
+    genome_project_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__genome_project_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_project_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_project_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_15_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_project_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_15_schema_description IS 'Data storage for tripal_entity field bio_data_15_schema_description.';
+COMMENT ON TABLE public.tripal_entity__genome_project_schema_description IS 'Data storage for tripal_entity field genome_project_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_15_schema_name (
+CREATE TABLE public.tripal_entity__genome_project_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_15_schema_name_value character varying(255),
-    bio_data_15_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_15_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_15_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_15_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    genome_project_schema_name_value character varying(255),
+    genome_project_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__genome_project_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genome_project_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genome_project_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_15_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genome_project_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_15_schema_name IS 'Data storage for tripal_entity field bio_data_15_schema_name.';
+COMMENT ON TABLE public.tripal_entity__genome_project_schema_name IS 'Data storage for tripal_entity field genome_project_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_15_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genome_project_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_16_schema_description (
+CREATE TABLE public.tripal_entity__genetic_map_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_16_schema_description_value text,
-    bio_data_16_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_16_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_16_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_16_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    genetic_map_schema_description_value text,
+    genetic_map_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__genetic_map_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_map_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_map_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_16_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_map_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_16_schema_description IS 'Data storage for tripal_entity field bio_data_16_schema_description.';
+COMMENT ON TABLE public.tripal_entity__genetic_map_schema_description IS 'Data storage for tripal_entity field genetic_map_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_16_schema_name (
+CREATE TABLE public.tripal_entity__genetic_map_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_16_schema_name_value character varying(255),
-    bio_data_16_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_16_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_16_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_16_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    genetic_map_schema_name_value character varying(255),
+    genetic_map_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__genetic_map_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_map_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_map_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_16_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_map_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_16_schema_name IS 'Data storage for tripal_entity field bio_data_16_schema_name.';
+COMMENT ON TABLE public.tripal_entity__genetic_map_schema_name IS 'Data storage for tripal_entity field genetic_map_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_16_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_map_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_17_data_0842 (
+CREATE TABLE public.tripal_entity__QTL_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_17_data_0842_value text,
-    bio_data_17_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_17_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    QTL_data_0842_value text,
+    QTL_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__QTL_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_17_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__QTL_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_17_data_0842 IS 'Data storage for tripal_entity field bio_data_17_data_0842.';
+COMMENT ON TABLE public.tripal_entity__QTL_data_0842 IS 'Data storage for tripal_entity field QTL_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_17_data_1249 (
+CREATE TABLE public.tripal_entity__QTL_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_17_data_1249_value integer,
-    bio_data_17_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_17_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    QTL_data_1249_value integer,
+    QTL_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__QTL_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_17_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__QTL_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_17_data_1249 IS 'Data storage for tripal_entity field bio_data_17_data_1249.';
+COMMENT ON TABLE public.tripal_entity__QTL_data_1249 IS 'Data storage for tripal_entity field QTL_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_17_data_2044 (
+CREATE TABLE public.tripal_entity__QTL_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_17_data_2044_value text,
-    bio_data_17_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_17_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    QTL_data_2044_value text,
+    QTL_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__QTL_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__QTL_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_17_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__QTL_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_17_data_2044 IS 'Data storage for tripal_entity field bio_data_17_data_2044.';
+COMMENT ON TABLE public.tripal_entity__QTL_data_2044 IS 'Data storage for tripal_entity field QTL_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__QTL_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_17_schema_name (
+CREATE TABLE public.tripal_entity__QTL_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_17_schema_name_value character varying(255),
-    bio_data_17_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_17_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_17_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    QTL_schema_name_value character varying(255),
+    QTL_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__QTL_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__QTL_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__QTL_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_17_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__QTL_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_17_schema_name IS 'Data storage for tripal_entity field bio_data_17_schema_name.';
+COMMENT ON TABLE public.tripal_entity__QTL_schema_name IS 'Data storage for tripal_entity field QTL_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_17_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__QTL_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_18_data_0842 (
+CREATE TABLE public.tripal_entity__sequence_variant_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_18_data_0842_value text,
-    bio_data_18_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_18_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    sequence_variant_data_0842_value text,
+    sequence_variant_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__sequence_variant_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_18_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__sequence_variant_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_18_data_0842 IS 'Data storage for tripal_entity field bio_data_18_data_0842.';
+COMMENT ON TABLE public.tripal_entity__sequence_variant_data_0842 IS 'Data storage for tripal_entity field sequence_variant_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_18_data_1249 (
+CREATE TABLE public.tripal_entity__sequence_variant_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_18_data_1249_value integer,
-    bio_data_18_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_18_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    sequence_variant_data_1249_value integer,
+    sequence_variant_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__sequence_variant_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_18_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__sequence_variant_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_18_data_1249 IS 'Data storage for tripal_entity field bio_data_18_data_1249.';
+COMMENT ON TABLE public.tripal_entity__sequence_variant_data_1249 IS 'Data storage for tripal_entity field sequence_variant_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_18_data_2044 (
+CREATE TABLE public.tripal_entity__sequence_variant_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_18_data_2044_value text,
-    bio_data_18_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_18_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    sequence_variant_data_2044_value text,
+    sequence_variant_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__sequence_variant_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_18_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__sequence_variant_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_18_data_2044 IS 'Data storage for tripal_entity field bio_data_18_data_2044.';
+COMMENT ON TABLE public.tripal_entity__sequence_variant_data_2044 IS 'Data storage for tripal_entity field sequence_variant_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_18_schema_name (
+CREATE TABLE public.tripal_entity__sequence_variant_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_18_schema_name_value character varying(255),
-    bio_data_18_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_18_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_18_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    sequence_variant_schema_name_value character varying(255),
+    sequence_variant_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__sequence_variant_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__sequence_variant_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_18_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__sequence_variant_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_18_schema_name IS 'Data storage for tripal_entity field bio_data_18_schema_name.';
+COMMENT ON TABLE public.tripal_entity__sequence_variant_schema_name IS 'Data storage for tripal_entity field sequence_variant_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_18_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__sequence_variant_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_19_data_0842 (
+CREATE TABLE public.tripal_entity__genetic_marker_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_19_data_0842_value text,
-    bio_data_19_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_19_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    genetic_marker_data_0842_value text,
+    genetic_marker_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__genetic_marker_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_19_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_marker_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_19_data_0842 IS 'Data storage for tripal_entity field bio_data_19_data_0842.';
+COMMENT ON TABLE public.tripal_entity__genetic_marker_data_0842 IS 'Data storage for tripal_entity field genetic_marker_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_19_data_1249 (
+CREATE TABLE public.tripal_entity__genetic_marker_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_19_data_1249_value integer,
-    bio_data_19_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_19_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    genetic_marker_data_1249_value integer,
+    genetic_marker_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__genetic_marker_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_19_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_marker_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_19_data_1249 IS 'Data storage for tripal_entity field bio_data_19_data_1249.';
+COMMENT ON TABLE public.tripal_entity__genetic_marker_data_1249 IS 'Data storage for tripal_entity field genetic_marker_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_19_data_2044 (
+CREATE TABLE public.tripal_entity__genetic_marker_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_19_data_2044_value text,
-    bio_data_19_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_19_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    genetic_marker_data_2044_value text,
+    genetic_marker_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__genetic_marker_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_19_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_marker_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_19_data_2044 IS 'Data storage for tripal_entity field bio_data_19_data_2044.';
+COMMENT ON TABLE public.tripal_entity__genetic_marker_data_2044 IS 'Data storage for tripal_entity field genetic_marker_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_19_schema_name (
+CREATE TABLE public.tripal_entity__genetic_marker_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_19_schema_name_value character varying(255),
-    bio_data_19_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_19_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_19_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    genetic_marker_schema_name_value character varying(255),
+    genetic_marker_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__genetic_marker_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__genetic_marker_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_19_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__genetic_marker_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_19_schema_name IS 'Data storage for tripal_entity field bio_data_19_schema_name.';
+COMMENT ON TABLE public.tripal_entity__genetic_marker_schema_name IS 'Data storage for tripal_entity field genetic_marker_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_19_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__genetic_marker_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_local_abbreviation (
+CREATE TABLE public.tripal_entity__organism_local_abbreviation (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_local_abbreviation_value character varying(255),
-    bio_data_1_local_abbreviation_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_local_abbreviation_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_local_abbreviation_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_local_abbreviation_revision_id_check CHECK ((revision_id >= 0))
+    organism_local_abbreviation_value character varying(255),
+    organism_local_abbreviation_record_id integer,
+    CONSTRAINT tripal_entity__organism_local_abbreviation_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_local_abbreviation_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__organism_local_abbreviation_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_local_abbreviation OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_local_abbreviation OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_local_abbreviation IS 'Data storage for tripal_entity field bio_data_1_local_abbreviation.';
+COMMENT ON TABLE public.tripal_entity__organism_local_abbreviation IS 'Data storage for tripal_entity field organism_local_abbreviation.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_local_abbreviation.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_local_abbreviation.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_ncbitaxon_common_name (
+CREATE TABLE public.tripal_entity__organism_ncbitaxon_common_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_ncbitaxon_common_name_value character varying(255),
-    bio_data_1_ncbitaxon_common_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_ncbitaxon_common_na_revision_id_check CHECK ((revision_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_ncbitaxon_common_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_ncbitaxon_common_name_entity_id_check CHECK ((entity_id >= 0))
+    organism_ncbitaxon_common_name_value character varying(255),
+    organism_ncbitaxon_common_name_record_id integer,
+    CONSTRAINT tripal_entity__organism_ncbitaxon_common_na_revision_id_check CHECK ((revision_id >= 0)),
+    CONSTRAINT tripal_entity__organism_ncbitaxon_common_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_ncbitaxon_common_name_entity_id_check CHECK ((entity_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_ncbitaxon_common_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_ncbitaxon_common_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_ncbitaxon_common_name IS 'Data storage for tripal_entity field bio_data_1_ncbitaxon_common_name.';
+COMMENT ON TABLE public.tripal_entity__organism_ncbitaxon_common_name IS 'Data storage for tripal_entity field organism_ncbitaxon_common_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_ncbitaxon_common_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_ncbitaxon_common_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_schema_description (
+CREATE TABLE public.tripal_entity__organism_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_schema_description_value text,
-    bio_data_1_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    organism_schema_description_value text,
+    organism_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__organism_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__organism_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_schema_description IS 'Data storage for tripal_entity field bio_data_1_schema_description.';
+COMMENT ON TABLE public.tripal_entity__organism_schema_description IS 'Data storage for tripal_entity field organism_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_taxrank_0000005 (
+CREATE TABLE public.tripal_entity__organism_taxrank_0000005 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_taxrank_0000005_value character varying(255),
-    bio_data_1_taxrank_0000005_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000005_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000005_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000005_revision_id_check CHECK ((revision_id >= 0))
+    organism_taxrank_0000005_value character varying(255),
+    organism_taxrank_0000005_record_id integer,
+    CONSTRAINT tripal_entity__organism_taxrank_0000005_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000005_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000005_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_taxrank_0000005 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_taxrank_0000005 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_taxrank_0000005 IS 'Data storage for tripal_entity field bio_data_1_taxrank_0000005.';
+COMMENT ON TABLE public.tripal_entity__organism_taxrank_0000005 IS 'Data storage for tripal_entity field organism_taxrank_0000005.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000005.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000005.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_taxrank_0000006 (
+CREATE TABLE public.tripal_entity__organism_taxrank_0000006 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_taxrank_0000006_value character varying(255),
-    bio_data_1_taxrank_0000006_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000006_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000006_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000006_revision_id_check CHECK ((revision_id >= 0))
+    organism_taxrank_0000006_value character varying(255),
+    organism_taxrank_0000006_record_id integer,
+    CONSTRAINT tripal_entity__organism_taxrank_0000006_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000006_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000006_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_taxrank_0000006 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_taxrank_0000006 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_taxrank_0000006 IS 'Data storage for tripal_entity field bio_data_1_taxrank_0000006.';
+COMMENT ON TABLE public.tripal_entity__organism_taxrank_0000006 IS 'Data storage for tripal_entity field organism_taxrank_0000006.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000006.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000006.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_1_taxrank_0000045 (
+CREATE TABLE public.tripal_entity__organism_taxrank_0000045 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_1_taxrank_0000045_value character varying(1024),
-    bio_data_1_taxrank_0000045_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000045_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000045_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_1_taxrank_0000045_revision_id_check CHECK ((revision_id >= 0))
+    organism_taxrank_0000045_value character varying(1024),
+    organism_taxrank_0000045_record_id integer,
+    CONSTRAINT tripal_entity__organism_taxrank_0000045_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000045_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__organism_taxrank_0000045_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_1_taxrank_0000045 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__organism_taxrank_0000045 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_1_taxrank_0000045 IS 'Data storage for tripal_entity field bio_data_1_taxrank_0000045.';
+COMMENT ON TABLE public.tripal_entity__organism_taxrank_0000045 IS 'Data storage for tripal_entity field organism_taxrank_0000045.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_1_taxrank_0000045.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__organism_taxrank_0000045.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_20_data_0842 (
+CREATE TABLE public.tripal_entity__phenotypic_marker_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_20_data_0842_value text,
-    bio_data_20_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_20_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    phenotypic_marker_data_0842_value text,
+    phenotypic_marker_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__phenotypic_marker_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_20_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phenotypic_marker_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_20_data_0842 IS 'Data storage for tripal_entity field bio_data_20_data_0842.';
+COMMENT ON TABLE public.tripal_entity__phenotypic_marker_data_0842 IS 'Data storage for tripal_entity field phenotypic_marker_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_20_data_1249 (
+CREATE TABLE public.tripal_entity__phenotypic_marker_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_20_data_1249_value integer,
-    bio_data_20_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_20_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    phenotypic_marker_data_1249_value integer,
+    phenotypic_marker_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__phenotypic_marker_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_20_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phenotypic_marker_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_20_data_1249 IS 'Data storage for tripal_entity field bio_data_20_data_1249.';
+COMMENT ON TABLE public.tripal_entity__phenotypic_marker_data_1249 IS 'Data storage for tripal_entity field phenotypic_marker_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_20_data_2044 (
+CREATE TABLE public.tripal_entity__phenotypic_marker_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_20_data_2044_value text,
-    bio_data_20_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_20_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    phenotypic_marker_data_2044_value text,
+    phenotypic_marker_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__phenotypic_marker_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_20_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phenotypic_marker_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_20_data_2044 IS 'Data storage for tripal_entity field bio_data_20_data_2044.';
+COMMENT ON TABLE public.tripal_entity__phenotypic_marker_data_2044 IS 'Data storage for tripal_entity field phenotypic_marker_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_20_schema_name (
+CREATE TABLE public.tripal_entity__phenotypic_marker_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_20_schema_name_value character varying(255),
-    bio_data_20_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_20_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_20_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    phenotypic_marker_schema_name_value character varying(255),
+    phenotypic_marker_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__phenotypic_marker_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__phenotypic_marker_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_20_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__phenotypic_marker_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_20_schema_name IS 'Data storage for tripal_entity field bio_data_20_schema_name.';
+COMMENT ON TABLE public.tripal_entity__phenotypic_marker_schema_name IS 'Data storage for tripal_entity field phenotypic_marker_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_20_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__phenotypic_marker_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_21_data_0842 (
+CREATE TABLE public.tripal_entity__germplasm_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_21_data_0842_value text,
-    bio_data_21_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_21_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_data_0842_value text,
+    germplasm_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_21_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_21_data_0842 IS 'Data storage for tripal_entity field bio_data_21_data_0842.';
+COMMENT ON TABLE public.tripal_entity__germplasm_data_0842 IS 'Data storage for tripal_entity field germplasm_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_21_schema_description (
+CREATE TABLE public.tripal_entity__germplasm_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_21_schema_description_value text,
-    bio_data_21_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_21_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_schema_description_value text,
+    germplasm_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_21_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_21_schema_description IS 'Data storage for tripal_entity field bio_data_21_schema_description.';
+COMMENT ON TABLE public.tripal_entity__germplasm_schema_description IS 'Data storage for tripal_entity field germplasm_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_21_schema_name (
+CREATE TABLE public.tripal_entity__germplasm_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_21_schema_name_value character varying(255),
-    bio_data_21_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_21_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_21_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_schema_name_value character varying(255),
+    germplasm_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_21_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_21_schema_name IS 'Data storage for tripal_entity field bio_data_21_schema_name.';
+COMMENT ON TABLE public.tripal_entity__germplasm_schema_name IS 'Data storage for tripal_entity field germplasm_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_21_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_22_data_0842 (
+CREATE TABLE public.tripal_entity__breeding_cross_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_22_data_0842_value text,
-    bio_data_22_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_22_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    breeding_cross_data_0842_value text,
+    breeding_cross_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__breeding_cross_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_22_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__breeding_cross_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_22_data_0842 IS 'Data storage for tripal_entity field bio_data_22_data_0842.';
+COMMENT ON TABLE public.tripal_entity__breeding_cross_data_0842 IS 'Data storage for tripal_entity field breeding_cross_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_22_schema_description (
+CREATE TABLE public.tripal_entity__breeding_cross_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_22_schema_description_value text,
-    bio_data_22_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_22_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    breeding_cross_schema_description_value text,
+    breeding_cross_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__breeding_cross_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_22_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__breeding_cross_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_22_schema_description IS 'Data storage for tripal_entity field bio_data_22_schema_description.';
+COMMENT ON TABLE public.tripal_entity__breeding_cross_schema_description IS 'Data storage for tripal_entity field breeding_cross_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_22_schema_name (
+CREATE TABLE public.tripal_entity__breeding_cross_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_22_schema_name_value character varying(255),
-    bio_data_22_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_22_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_22_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    breeding_cross_schema_name_value character varying(255),
+    breeding_cross_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__breeding_cross_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__breeding_cross_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_22_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__breeding_cross_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_22_schema_name IS 'Data storage for tripal_entity field bio_data_22_schema_name.';
+COMMENT ON TABLE public.tripal_entity__breeding_cross_schema_name IS 'Data storage for tripal_entity field breeding_cross_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_22_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__breeding_cross_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_23_data_0842 (
+CREATE TABLE public.tripal_entity__germplasm_variety_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_23_data_0842_value text,
-    bio_data_23_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_23_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_variety_data_0842_value text,
+    germplasm_variety_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_variety_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_23_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_variety_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_23_data_0842 IS 'Data storage for tripal_entity field bio_data_23_data_0842.';
+COMMENT ON TABLE public.tripal_entity__germplasm_variety_data_0842 IS 'Data storage for tripal_entity field germplasm_variety_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_23_schema_description (
+CREATE TABLE public.tripal_entity__germplasm_variety_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_23_schema_description_value text,
-    bio_data_23_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_23_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_variety_schema_description_value text,
+    germplasm_variety_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_variety_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_23_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_variety_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_23_schema_description IS 'Data storage for tripal_entity field bio_data_23_schema_description.';
+COMMENT ON TABLE public.tripal_entity__germplasm_variety_schema_description IS 'Data storage for tripal_entity field germplasm_variety_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_23_schema_name (
+CREATE TABLE public.tripal_entity__germplasm_variety_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_23_schema_name_value character varying(255),
-    bio_data_23_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_23_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_23_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    germplasm_variety_schema_name_value character varying(255),
+    germplasm_variety_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__germplasm_variety_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__germplasm_variety_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_23_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__germplasm_variety_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_23_schema_name IS 'Data storage for tripal_entity field bio_data_23_schema_name.';
+COMMENT ON TABLE public.tripal_entity__germplasm_variety_schema_name IS 'Data storage for tripal_entity field germplasm_variety_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_23_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__germplasm_variety_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_24_data_0842 (
+CREATE TABLE public.tripal_entity__RIL_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_24_data_0842_value text,
-    bio_data_24_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_24_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    RIL_data_0842_value text,
+    RIL_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__RIL_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__RIL_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__RIL_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_24_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__RIL_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_24_data_0842 IS 'Data storage for tripal_entity field bio_data_24_data_0842.';
+COMMENT ON TABLE public.tripal_entity__RIL_data_0842 IS 'Data storage for tripal_entity field RIL_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__RIL_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_24_schema_description (
+CREATE TABLE public.tripal_entity__RIL_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_24_schema_description_value text,
-    bio_data_24_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_24_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    RIL_schema_description_value text,
+    RIL_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__RIL_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__RIL_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__RIL_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_24_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__RIL_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_24_schema_description IS 'Data storage for tripal_entity field bio_data_24_schema_description.';
+COMMENT ON TABLE public.tripal_entity__RIL_schema_description IS 'Data storage for tripal_entity field RIL_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_24_schema_name (
+CREATE TABLE public.tripal_entity__RIL_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_24_schema_name_value character varying(255),
-    bio_data_24_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_24_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_24_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    RIL_schema_name_value character varying(255),
+    RIL_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__RIL_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__RIL_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__RIL_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_24_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__RIL_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_24_schema_name IS 'Data storage for tripal_entity field bio_data_24_schema_name.';
+COMMENT ON TABLE public.tripal_entity__RIL_schema_name IS 'Data storage for tripal_entity field RIL_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_24_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__RIL_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_25_schema_description (
+CREATE TABLE public.tripal_entity__biosample_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_25_schema_description_value text,
-    bio_data_25_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_25_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_25_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_25_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    biosample_schema_description_value text,
+    biosample_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__biosample_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__biosample_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__biosample_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_25_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__biosample_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_25_schema_description IS 'Data storage for tripal_entity field bio_data_25_schema_description.';
+COMMENT ON TABLE public.tripal_entity__biosample_schema_description IS 'Data storage for tripal_entity field biosample_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_25_schema_name (
+CREATE TABLE public.tripal_entity__biosample_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_25_schema_name_value text,
-    bio_data_25_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_25_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_25_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_25_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    biosample_schema_name_value text,
+    biosample_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__biosample_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__biosample_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__biosample_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_25_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__biosample_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_25_schema_name IS 'Data storage for tripal_entity field bio_data_25_schema_name.';
+COMMENT ON TABLE public.tripal_entity__biosample_schema_name IS 'Data storage for tripal_entity field biosample_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_25_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__biosample_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_27_iao_0000129 (
+CREATE TABLE public.tripal_entity__array_design_iao_0000129 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_27_iao_0000129_value text,
-    bio_data_27_iao_0000129_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_27_iao_0000129_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
+    array_design_iao_0000129_value text,
+    array_design_iao_0000129_record_id integer,
+    CONSTRAINT tripal_entity__array_design_iao_0000129_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__array_design_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__array_design_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_27_iao_0000129 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__array_design_iao_0000129 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_27_iao_0000129 IS 'Data storage for tripal_entity field bio_data_27_iao_0000129.';
+COMMENT ON TABLE public.tripal_entity__array_design_iao_0000129 IS 'Data storage for tripal_entity field array_design_iao_0000129.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__array_design_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_27_local_array_dimensio (
+CREATE TABLE public.tripal_entity__array_design_local_array_dimensio (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_27_local_array_dimensio_value text,
-    bio_data_27_local_array_dimensio_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_27_local_array_dimens_revision_id_check CHECK ((revision_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_local_array_dimensio_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_local_array_dimensio_entity_id_check CHECK ((entity_id >= 0))
+    array_design_local_array_dimensio_value text,
+    array_design_local_array_dimensio_record_id integer,
+    CONSTRAINT tripal_entity__array_design_local_array_dimens_revision_id_check CHECK ((revision_id >= 0)),
+    CONSTRAINT tripal_entity__array_design_local_array_dimensio_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__array_design_local_array_dimensio_entity_id_check CHECK ((entity_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_27_local_array_dimensio OWNER TO drupal;
+ALTER TABLE public.tripal_entity__array_design_local_array_dimensio OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_27_local_array_dimensio IS 'Data storage for tripal_entity field bio_data_27_local_array_dimensio.';
+COMMENT ON TABLE public.tripal_entity__array_design_local_array_dimensio IS 'Data storage for tripal_entity field array_design_local_array_dimensio.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_array_dimensio.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_array_dimensio.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_27_local_element_dimens (
+CREATE TABLE public.tripal_entity__array_design_local_element_dimens (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_27_local_element_dimens_value text,
-    bio_data_27_local_element_dimens_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_27_local_element_dime_revision_id_check CHECK ((revision_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_local_element_dimens_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_local_element_dimens_entity_id_check CHECK ((entity_id >= 0))
+    array_design_local_element_dimens_value text,
+    array_design_local_element_dimens_record_id integer,
+    CONSTRAINT tripal_entity__array_design_local_element_dime_revision_id_check CHECK ((revision_id >= 0)),
+    CONSTRAINT tripal_entity__array_design_local_element_dimens_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__array_design_local_element_dimens_entity_id_check CHECK ((entity_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_27_local_element_dimens OWNER TO drupal;
+ALTER TABLE public.tripal_entity__array_design_local_element_dimens OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_27_local_element_dimens IS 'Data storage for tripal_entity field bio_data_27_local_element_dimens.';
+COMMENT ON TABLE public.tripal_entity__array_design_local_element_dimens IS 'Data storage for tripal_entity field array_design_local_element_dimens.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_local_element_dimens.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__array_design_local_element_dimens.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_27_schema_description (
+CREATE TABLE public.tripal_entity__array_design_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_27_schema_description_value text,
-    bio_data_27_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_27_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    array_design_schema_description_value text,
+    array_design_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__array_design_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__array_design_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__array_design_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_27_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__array_design_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_27_schema_description IS 'Data storage for tripal_entity field bio_data_27_schema_description.';
+COMMENT ON TABLE public.tripal_entity__array_design_schema_description IS 'Data storage for tripal_entity field array_design_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_27_schema_name (
+CREATE TABLE public.tripal_entity__array_design_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_27_schema_name_value text,
-    bio_data_27_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_27_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_27_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    array_design_schema_name_value text,
+    array_design_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__array_design_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__array_design_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__array_design_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_27_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__array_design_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_27_schema_name IS 'Data storage for tripal_entity field bio_data_27_schema_name.';
+COMMENT ON TABLE public.tripal_entity__array_design_schema_name IS 'Data storage for tripal_entity field array_design_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_27_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__array_design_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_data_1047 (
+CREATE TABLE public.tripal_entity__analysis_data_1047 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_data_1047_value text,
-    bio_data_2_data_1047_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_data_1047_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_data_1047_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_data_1047_revision_id_check CHECK ((revision_id >= 0))
+    analysis_data_1047_value text,
+    analysis_data_1047_record_id integer,
+    CONSTRAINT tripal_entity__analysis_data_1047_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_data_1047_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_data_1047_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_data_1047 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_data_1047 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_data_1047 IS 'Data storage for tripal_entity field bio_data_2_data_1047.';
+COMMENT ON TABLE public.tripal_entity__analysis_data_1047 IS 'Data storage for tripal_entity field analysis_data_1047.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_iao_0000064 (
+CREATE TABLE public.tripal_entity__analysis_iao_0000064 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_iao_0000064_value character varying(255),
-    bio_data_2_iao_0000064_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000064_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
+    analysis_iao_0000064_value character varying(255),
+    analysis_iao_0000064_record_id integer,
+    CONSTRAINT tripal_entity__analysis_iao_0000064_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_iao_0000064_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_iao_0000064_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_iao_0000064 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_iao_0000064 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_iao_0000064 IS 'Data storage for tripal_entity field bio_data_2_iao_0000064.';
+COMMENT ON TABLE public.tripal_entity__analysis_iao_0000064 IS 'Data storage for tripal_entity field analysis_iao_0000064.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000064.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_iao_0000129 (
+CREATE TABLE public.tripal_entity__analysis_iao_0000129 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_iao_0000129_value character varying(255),
-    bio_data_2_iao_0000129_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000129_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
+    analysis_iao_0000129_value character varying(255),
+    analysis_iao_0000129_record_id integer,
+    CONSTRAINT tripal_entity__analysis_iao_0000129_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_iao_0000129_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_iao_0000129_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_iao_0000129 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_iao_0000129 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_iao_0000129 IS 'Data storage for tripal_entity field bio_data_2_iao_0000129.';
+COMMENT ON TABLE public.tripal_entity__analysis_iao_0000129 IS 'Data storage for tripal_entity field analysis_iao_0000129.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_iao_0000129.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_schema_description (
+CREATE TABLE public.tripal_entity__analysis_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_schema_description_value text,
-    bio_data_2_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    analysis_schema_description_value text,
+    analysis_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__analysis_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_schema_description IS 'Data storage for tripal_entity field bio_data_2_schema_description.';
+COMMENT ON TABLE public.tripal_entity__analysis_schema_description IS 'Data storage for tripal_entity field analysis_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_schema_name (
+CREATE TABLE public.tripal_entity__analysis_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_schema_name_value character varying(255),
-    bio_data_2_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    analysis_schema_name_value character varying(255),
+    analysis_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__analysis_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_schema_name IS 'Data storage for tripal_entity field bio_data_2_schema_name.';
+COMMENT ON TABLE public.tripal_entity__analysis_schema_name IS 'Data storage for tripal_entity field analysis_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_2_swo_0000001 (
+CREATE TABLE public.tripal_entity__analysis_swo_0000001 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_2_swo_0000001_value character varying(255),
-    bio_data_2_swo_0000001_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_2_swo_0000001_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_2_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
+    analysis_swo_0000001_value character varying(255),
+    analysis_swo_0000001_record_id integer,
+    CONSTRAINT tripal_entity__analysis_swo_0000001_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__analysis_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__analysis_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_2_swo_0000001 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__analysis_swo_0000001 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_2_swo_0000001 IS 'Data storage for tripal_entity field bio_data_2_swo_0000001.';
+COMMENT ON TABLE public.tripal_entity__analysis_swo_0000001 IS 'Data storage for tripal_entity field analysis_swo_0000001.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_2_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__analysis_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_3_schema_description (
+CREATE TABLE public.tripal_entity__project_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_3_schema_description_value text,
-    bio_data_3_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_3_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_3_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_3_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    project_schema_description_value text,
+    project_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__project_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__project_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__project_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_3_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__project_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_3_schema_description IS 'Data storage for tripal_entity field bio_data_3_schema_description.';
+COMMENT ON TABLE public.tripal_entity__project_schema_description IS 'Data storage for tripal_entity field project_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__project_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_3_schema_name (
+CREATE TABLE public.tripal_entity__project_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_3_schema_name_value character varying(255),
-    bio_data_3_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_3_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_3_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_3_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    project_schema_name_value character varying(255),
+    project_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__project_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__project_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__project_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_3_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__project_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_3_schema_name IS 'Data storage for tripal_entity field bio_data_3_schema_name.';
+COMMENT ON TABLE public.tripal_entity__project_schema_name IS 'Data storage for tripal_entity field project_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_3_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__project_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_4_schema_description (
+CREATE TABLE public.tripal_entity__study_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_4_schema_description_value text,
-    bio_data_4_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_4_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_4_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_4_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    study_schema_description_value text,
+    study_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__study_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__study_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__study_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_4_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__study_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_4_schema_description IS 'Data storage for tripal_entity field bio_data_4_schema_description.';
+COMMENT ON TABLE public.tripal_entity__study_schema_description IS 'Data storage for tripal_entity field study_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__study_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_4_schema_name (
+CREATE TABLE public.tripal_entity__study_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_4_schema_name_value text,
-    bio_data_4_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_4_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_4_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_4_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    study_schema_name_value text,
+    study_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__study_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__study_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__study_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_4_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__study_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_4_schema_name IS 'Data storage for tripal_entity field bio_data_4_schema_name.';
+COMMENT ON TABLE public.tripal_entity__study_schema_name IS 'Data storage for tripal_entity field study_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_4_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__study_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_5_schema_description (
+CREATE TABLE public.tripal_entity__contact_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_5_schema_description_value character varying(255),
-    bio_data_5_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_5_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_5_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_5_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    contact_schema_description_value character varying(255),
+    contact_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__contact_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__contact_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__contact_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_5_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__contact_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_5_schema_description IS 'Data storage for tripal_entity field bio_data_5_schema_description.';
+COMMENT ON TABLE public.tripal_entity__contact_schema_description IS 'Data storage for tripal_entity field contact_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_5_schema_name (
+CREATE TABLE public.tripal_entity__contact_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_5_schema_name_value character varying(255),
-    bio_data_5_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_5_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_5_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_5_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    contact_schema_name_value character varying(255),
+    contact_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__contact_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__contact_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__contact_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_5_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__contact_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_5_schema_name IS 'Data storage for tripal_entity field bio_data_5_schema_name.';
+COMMENT ON TABLE public.tripal_entity__contact_schema_name IS 'Data storage for tripal_entity field contact_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_5_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__contact_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_7_data_1047 (
+CREATE TABLE public.tripal_entity__protocol_data_1047 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_7_data_1047_value text,
-    bio_data_7_data_1047_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_7_data_1047_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_data_1047_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_data_1047_revision_id_check CHECK ((revision_id >= 0))
+    protocol_data_1047_value text,
+    protocol_data_1047_record_id integer,
+    CONSTRAINT tripal_entity__protocol_data_1047_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__protocol_data_1047_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__protocol_data_1047_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_7_data_1047 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__protocol_data_1047 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_7_data_1047 IS 'Data storage for tripal_entity field bio_data_7_data_1047.';
+COMMENT ON TABLE public.tripal_entity__protocol_data_1047 IS 'Data storage for tripal_entity field protocol_data_1047.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__protocol_data_1047.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_7_efo_0000548 (
+CREATE TABLE public.tripal_entity__protocol_efo_0000548 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_7_efo_0000548_value text,
-    bio_data_7_efo_0000548_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_7_efo_0000548_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_efo_0000548_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_efo_0000548_revision_id_check CHECK ((revision_id >= 0))
+    protocol_efo_0000548_value text,
+    protocol_efo_0000548_record_id integer,
+    CONSTRAINT tripal_entity__protocol_efo_0000548_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__protocol_efo_0000548_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__protocol_efo_0000548_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_7_efo_0000548 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__protocol_efo_0000548 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_7_efo_0000548 IS 'Data storage for tripal_entity field bio_data_7_efo_0000548.';
+COMMENT ON TABLE public.tripal_entity__protocol_efo_0000548 IS 'Data storage for tripal_entity field protocol_efo_0000548.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_efo_0000548.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__protocol_efo_0000548.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_7_schema_description (
+CREATE TABLE public.tripal_entity__protocol_schema_description (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_7_schema_description_value text,
-    bio_data_7_schema_description_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_7_schema_description_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_schema_description_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_schema_description_revision_id_check CHECK ((revision_id >= 0))
+    protocol_schema_description_value text,
+    protocol_schema_description_record_id integer,
+    CONSTRAINT tripal_entity__protocol_schema_description_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__protocol_schema_description_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__protocol_schema_description_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_7_schema_description OWNER TO drupal;
+ALTER TABLE public.tripal_entity__protocol_schema_description OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_7_schema_description IS 'Data storage for tripal_entity field bio_data_7_schema_description.';
+COMMENT ON TABLE public.tripal_entity__protocol_schema_description IS 'Data storage for tripal_entity field protocol_schema_description.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_description.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_7_schema_name (
+CREATE TABLE public.tripal_entity__protocol_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_7_schema_name_value text,
-    bio_data_7_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_7_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    protocol_schema_name_value text,
+    protocol_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__protocol_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__protocol_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__protocol_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_7_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__protocol_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_7_schema_name IS 'Data storage for tripal_entity field bio_data_7_schema_name.';
+COMMENT ON TABLE public.tripal_entity__protocol_schema_name IS 'Data storage for tripal_entity field protocol_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__protocol_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_7_swo_0000001 (
+CREATE TABLE public.tripal_entity__protocol_swo_0000001 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_7_swo_0000001_value text,
-    bio_data_7_swo_0000001_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_7_swo_0000001_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_7_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
+    protocol_swo_0000001_value text,
+    protocol_swo_0000001_record_id integer,
+    CONSTRAINT tripal_entity__protocol_swo_0000001_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__protocol_swo_0000001_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__protocol_swo_0000001_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_7_swo_0000001 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__protocol_swo_0000001 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_7_swo_0000001 IS 'Data storage for tripal_entity field bio_data_7_swo_0000001.';
+COMMENT ON TABLE public.tripal_entity__protocol_swo_0000001 IS 'Data storage for tripal_entity field protocol_swo_0000001.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_7_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__protocol_swo_0000001.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_8_data_0842 (
+CREATE TABLE public.tripal_entity__gene_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_8_data_0842_value text,
-    bio_data_8_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_8_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    gene_data_0842_value text,
+    gene_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__gene_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__gene_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__gene_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_8_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__gene_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_8_data_0842 IS 'Data storage for tripal_entity field bio_data_8_data_0842.';
+COMMENT ON TABLE public.tripal_entity__gene_data_0842 IS 'Data storage for tripal_entity field gene_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__gene_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_8_data_1249 (
+CREATE TABLE public.tripal_entity__gene_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_8_data_1249_value integer,
-    bio_data_8_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_8_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    gene_data_1249_value integer,
+    gene_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__gene_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__gene_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__gene_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_8_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__gene_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_8_data_1249 IS 'Data storage for tripal_entity field bio_data_8_data_1249.';
+COMMENT ON TABLE public.tripal_entity__gene_data_1249 IS 'Data storage for tripal_entity field gene_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__gene_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_8_data_2044 (
+CREATE TABLE public.tripal_entity__gene_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_8_data_2044_value text,
-    bio_data_8_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_8_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    gene_data_2044_value text,
+    gene_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__gene_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__gene_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__gene_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_8_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__gene_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_8_data_2044 IS 'Data storage for tripal_entity field bio_data_8_data_2044.';
+COMMENT ON TABLE public.tripal_entity__gene_data_2044 IS 'Data storage for tripal_entity field gene_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__gene_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_8_obi_0100026 (
+CREATE TABLE public.tripal_entity__gene_obi_0100026 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_8_obi_0100026_value integer,
-    bio_data_8_obi_0100026_rdfs_label character varying(2558),
-    "bio_data_8_obi_0100026_TAXRANK_0000005" character varying(255),
-    "bio_data_8_obi_0100026_TAXRANK_0000006" character varying(255),
-    "bio_data_8_obi_0100026_TAXRANK_0000045" character varying(1024),
-    bio_data_8_obi_0100026_local_infraspecific_type integer,
-    bio_data_8_obi_0100026_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_8_obi_0100026_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_obi_0100026_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_obi_0100026_revision_id_check CHECK ((revision_id >= 0))
+    gene_obi_0100026_value integer,
+    gene_obi_0100026_rdfs_label character varying(2558),
+    "gene_obi_0100026_TAXRANK_0000005" character varying(255),
+    "gene_obi_0100026_TAXRANK_0000006" character varying(255),
+    "gene_obi_0100026_TAXRANK_0000045" character varying(1024),
+    gene_obi_0100026_local_infraspecific_type integer,
+    gene_obi_0100026_record_id integer,
+    CONSTRAINT tripal_entity__gene_obi_0100026_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__gene_obi_0100026_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__gene_obi_0100026_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_8_obi_0100026 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__gene_obi_0100026 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_8_obi_0100026 IS 'Data storage for tripal_entity field bio_data_8_obi_0100026.';
+COMMENT ON TABLE public.tripal_entity__gene_obi_0100026 IS 'Data storage for tripal_entity field gene_obi_0100026.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_obi_0100026.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__gene_obi_0100026.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_8_schema_name (
+CREATE TABLE public.tripal_entity__gene_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_8_schema_name_value character varying(255),
-    bio_data_8_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_8_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_8_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    gene_schema_name_value character varying(255),
+    gene_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__gene_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__gene_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__gene_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_8_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__gene_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_8_schema_name IS 'Data storage for tripal_entity field bio_data_8_schema_name.';
+COMMENT ON TABLE public.tripal_entity__gene_schema_name IS 'Data storage for tripal_entity field gene_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_8_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__gene_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_9_data_0842 (
+CREATE TABLE public.tripal_entity__mRNA_data_0842 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_9_data_0842_value text,
-    bio_data_9_data_0842_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_9_data_0842_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_0842_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_0842_revision_id_check CHECK ((revision_id >= 0))
+    mRNA_data_0842_value text,
+    mRNA_data_0842_record_id integer,
+    CONSTRAINT tripal_entity__mRNA_data_0842_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_0842_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_0842_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_9_data_0842 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__mRNA_data_0842 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_9_data_0842 IS 'Data storage for tripal_entity field bio_data_9_data_0842.';
+COMMENT ON TABLE public.tripal_entity__mRNA_data_0842 IS 'Data storage for tripal_entity field mRNA_data_0842.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_0842.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_9_data_1249 (
+CREATE TABLE public.tripal_entity__mRNA_data_1249 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_9_data_1249_value integer,
-    bio_data_9_data_1249_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_9_data_1249_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_1249_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_1249_revision_id_check CHECK ((revision_id >= 0))
+    mRNA_data_1249_value integer,
+    mRNA_data_1249_record_id integer,
+    CONSTRAINT tripal_entity__mRNA_data_1249_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_1249_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_1249_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_9_data_1249 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__mRNA_data_1249 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_9_data_1249 IS 'Data storage for tripal_entity field bio_data_9_data_1249.';
+COMMENT ON TABLE public.tripal_entity__mRNA_data_1249 IS 'Data storage for tripal_entity field mRNA_data_1249.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_1249.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_9_data_2044 (
+CREATE TABLE public.tripal_entity__mRNA_data_2044 (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_9_data_2044_value text,
-    bio_data_9_data_2044_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_9_data_2044_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_2044_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_data_2044_revision_id_check CHECK ((revision_id >= 0))
+    mRNA_data_2044_value text,
+    mRNA_data_2044_record_id integer,
+    CONSTRAINT tripal_entity__mRNA_data_2044_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_2044_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__mRNA_data_2044_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_9_data_2044 OWNER TO drupal;
+ALTER TABLE public.tripal_entity__mRNA_data_2044 OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_9_data_2044 IS 'Data storage for tripal_entity field bio_data_9_data_2044.';
+COMMENT ON TABLE public.tripal_entity__mRNA_data_2044 IS 'Data storage for tripal_entity field mRNA_data_2044.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__mRNA_data_2044.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 
-CREATE TABLE public.tripal_entity__bio_data_9_schema_name (
+CREATE TABLE public.tripal_entity__mRNA_schema_name (
     bundle character varying(128) DEFAULT ''::character varying NOT NULL,
     deleted smallint DEFAULT 0 NOT NULL,
     entity_id bigint NOT NULL,
     revision_id bigint NOT NULL,
     langcode character varying(32) DEFAULT ''::character varying NOT NULL,
     delta bigint NOT NULL,
-    bio_data_9_schema_name_value character varying(255),
-    bio_data_9_schema_name_record_id integer,
-    CONSTRAINT tripal_entity__bio_data_9_schema_name_delta_check CHECK ((delta >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_schema_name_entity_id_check CHECK ((entity_id >= 0)),
-    CONSTRAINT tripal_entity__bio_data_9_schema_name_revision_id_check CHECK ((revision_id >= 0))
+    mRNA_schema_name_value character varying(255),
+    mRNA_schema_name_record_id integer,
+    CONSTRAINT tripal_entity__mRNA_schema_name_delta_check CHECK ((delta >= 0)),
+    CONSTRAINT tripal_entity__mRNA_schema_name_entity_id_check CHECK ((entity_id >= 0)),
+    CONSTRAINT tripal_entity__mRNA_schema_name_revision_id_check CHECK ((revision_id >= 0))
 );
 
 
-ALTER TABLE public.tripal_entity__bio_data_9_schema_name OWNER TO drupal;
+ALTER TABLE public.tripal_entity__mRNA_schema_name OWNER TO drupal;
 
 
-COMMENT ON TABLE public.tripal_entity__bio_data_9_schema_name IS 'Data storage for tripal_entity field bio_data_9_schema_name.';
+COMMENT ON TABLE public.tripal_entity__mRNA_schema_name IS 'Data storage for tripal_entity field mRNA_schema_name.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.bundle IS 'The field instance bundle to which this row belongs, used when deleting a field instance';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.deleted IS 'A boolean indicating whether this data item has been deleted';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.entity_id IS 'The entity id this data is attached to';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.entity_id IS 'The entity id this data is attached to';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.revision_id IS 'The entity revision id this data is attached to, which for an unversioned entity type is the same as the entity id';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.langcode IS 'The language code for this data item.';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.langcode IS 'The language code for this data item.';
 
 
 
-COMMENT ON COLUMN public.tripal_entity__bio_data_9_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
+COMMENT ON COLUMN public.tripal_entity__mRNA_schema_name.delta IS 'The sequence number for this data item, used for multi-value fields';
 
 
 

--- a/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
+++ b/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
@@ -105,12 +105,12 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       'termIdSpace' => 'OBI',
       'termAccession' => '0100026',
       'category' => 'General',
-      'name' => 'organism',
+      'id' => 'organism',
       'help_text' => 'A material entity that is an individual living system, ' .
-      'such as animal, plant, bacteria or virus, that is capable of replicating ' .
-      'or reproducing, growth and maintenance in the right environment. An ' .
-      'organism may be unicellular or made up, like humans, of many billions ' .
-      'of cells divided into specialized tissues and organs.',
+        'such as animal, plant, bacteria or virus, that is capable of replicating ' .
+        'or reproducing, growth and maintenance in the right environment. An ' .
+        'organism may be unicellular or made up, like humans, of many billions ' .
+        'of cells divided into specialized tissues and organs.',
     ]);
 
     // Create the terms that are needed for this field.

--- a/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
+++ b/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
@@ -85,7 +85,7 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
    * This function creates the Organism content type, adds all of the default
    * fields used by Chado for an organism (including the controlled vocabulary
    * terms for the field) and then creates an organism entity. It uses
-   * `bio_data_1` as the entity type ID.
+   * `organism` as the entity type ID.
    *
    * @param string $genus
    *   The genus name
@@ -105,7 +105,7 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       'termIdSpace' => 'OBI',
       'termAccession' => '0100026',
       'category' => 'General',
-      'name' => 'bio_data_1',
+      'name' => 'organism',
       'help_text' => 'A material entity that is an individual living system, ' .
       'such as animal, plant, bacteria or virus, that is capable of replicating ' .
       'or reproducing, growth and maintenance in the right environment. An ' .
@@ -181,8 +181,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
     // We need these because the content type won't save properly. Technically,
     // we only need the required fields, but to mimic reality we'll add them
     // all.
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_taxrank_0000005',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_taxrank_0000005',
       'field_type' => 'chado_string_type',
       'term' => $genus_term,
       'is_required' => TRUE,
@@ -193,8 +193,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       ],
     ]);
 
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_taxrank_0000006',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_taxrank_0000006',
       'field_type' => 'chado_string_type',
       'term' => $species_term,
       'is_required' => TRUE,
@@ -205,8 +205,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       ],
     ]);
 
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_taxrank_0000045',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_taxrank_0000045',
       'field_type' => 'chado_string_type',
       'term' => $infraspecies_term,
       'is_required' => FALSE,
@@ -217,8 +217,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       ],
     ]);
 
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_schema_description',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_schema_description',
       'field_type' => 'chado_text_type',
       'term' => $description_term,
       'is_required' => FALSE,
@@ -229,8 +229,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       ],
     ]);
 
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_local_abbreviation',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_local_abbreviation',
       'field_type' => 'chado_string_type',
       'term' => $abbreviation_term,
       'is_required' => FALSE,
@@ -241,8 +241,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       ],
     ]);
 
-    $this->createTripalField('bio_data_1', [
-      'field_name' => 'bio_data_1_ncbitaxon_common_name',
+    $this->createTripalField('organism', [
+      'field_name' => 'organism_ncbitaxon_common_name',
       'field_type' => 'chado_string_type',
       'term' => $common_name_term,
       'is_required' => FALSE,
@@ -260,23 +260,23 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
      */
     $entity = $this->createTripalContent([
       'title' => $genus . '_' . $species,
-      'type' => 'bio_data_1',
+      'type' => 'organism',
       'user_id' => 0,
       'status' => TRUE,
     ]);
 
 
 //     // Make sure that the entity has all of the fields.
-//     $this->assertTrue($entity->hasField('bio_data_1_taxrank_0000005'), "The organism entity is missing the bio_data_1_taxrank_0000005 field");
-//     $this->assertTrue($entity->hasField('bio_data_1_taxrank_0000006'), "The organism entity is missing the bio_data_1_taxrank_0000006 field");
-//     $this->assertTrue($entity->hasField('bio_data_1_taxrank_0000045'), "The organism entity is missing the bio_data_1_taxrank_0000045 field");
-//     $this->assertTrue($entity->hasField('bio_data_1_local_abbreviation'), "The organism entity is missing the bio_data_1_local_abbreviation field");
-//     $this->assertTrue($entity->hasField('bio_data_1_ncbitaxon_common_name'), "The organism entity is missing the bio_data_1_ncbitaxon_common_name field");
-//     $this->assertTrue($entity->hasField('bio_data_1_schema_description'), "The organism entity is missing the bio_data_1_schema_description field");
+//     $this->assertTrue($entity->hasField('organism_taxrank_0000005'), "The organism entity is missing the organism_taxrank_0000005 field");
+//     $this->assertTrue($entity->hasField('organism_taxrank_0000006'), "The organism entity is missing the organism_taxrank_0000006 field");
+//     $this->assertTrue($entity->hasField('organism_taxrank_0000045'), "The organism entity is missing the organism_taxrank_0000045 field");
+//     $this->assertTrue($entity->hasField('organism_local_abbreviation'), "The organism entity is missing the organism_local_abbreviation field");
+//     $this->assertTrue($entity->hasField('organism_ncbitaxon_common_name'), "The organism entity is missing the organism_ncbitaxon_common_name field");
+//     $this->assertTrue($entity->hasField('organism_schema_description'), "The organism entity is missing the organism_schema_description field");
 
 //     // Set field property values.
-//     $entity->bio_data_1_taxrank_0000005->value =  $genus;
-//     $entity->bio_data_1_taxrank_0000006->value =  $species;
+//     $entity->organism_taxrank_0000005->value =  $genus;
+//     $entity->organism_taxrank_0000006->value =  $species;
 
 //     // Save the entity.
 //     $entity->enforceIsNew();


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Tripal 4 Core Dev Task

Issue #1565 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The goal of this PR is to remove the use of the word `bio_data` in Tripal. As part of Tripal3 it was used as an equilvalent of `node` but for Tripal content types.   The goal was to use the bundle name (e.g. organism, analysis, contact, etc.) instread of `bio_data`.   After digging through the code I found this wasn't easily doable.  I got part of the way there, but hit on problems when creating brand new content items.  So, instead, I opted for using `tripal` instead of `bio_data` and I enabled the automatic creation of URL aliases using the `url_format` setting for content types.  So, all tripal entities will get a default URL of something like `tripal/1`, `tripal/2`, etc. but with the URL alias will appear to the user as something like `organism/1`, `project/2`, etc.  

The best benefit for this change is that content type are no longer referred to as `bio_data_1` and `bio_data_2` but rather by a more human-readable name (e.g. `organism`, `contact`, etc.).

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
There are two items to test.
1. Entity Creation: To  test this, simply update your Drupal installation to include this branch, install Drupal and create tripal an organism, project, analysis... whatever you like.  After creation, they should have URL aliases appropraite for the content type and you should be able to get to the same entity by changing the URL to have `tripal\<num>` where `<num>` is the same ID in the original URL (e..g `organism\1`)
2. Content Type Creation:  Now that we no longer use `bio_data` for the name of content types, you can create a new content type and it will use as a name a lowercase version of the label you give it.  Go to Admin > Structure > Tripal Content Types  and click the `Add Tripal Content Type` button at the top.  You should be able to create a new content type. Notice the machine name in the form (to the right of the label field), it should be a lowercase version of whatever you type in.  Any non alphanumeric values get converted to underscores.  
