### PR TITLE
Tripal 4 content terms route fix

### DIFF
--- a/tripal/src/Entity/TripalContentTerms.php
+++ b/tripal/src/Entity/TripalContentTerms.php
@@ -39,8 +39,8 @@ use Drupal\tripal\TripalContentTermsInterface;
  *   },
  *   links = {
  *     "add-form" = "/admin/tripal/config/terms/add",
- *     "edit-form" = "/admin/tripal/config/terms/{config}",
- *     "delete-form" = "/admin/tripal/config/terms/{config}/delete",
+ *     "edit-form" = "/admin/tripal/config/terms/{tripal_content_terms}",
+ *     "delete-form" = "/admin/tripal/config/terms/{tripal_content_terms}/delete",
  *   }
  * )
  */

--- a/tripal/src/Entity/TripalEntityTypeCollection.php
+++ b/tripal/src/Entity/TripalEntityTypeCollection.php
@@ -38,7 +38,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "content_types"
  *   },
  *   links = {
- *     "delete-form" = "/admin/tripal/config/tripalentitytype-collection/{config}/delete",
+ *     "delete-form" = "/admin/tripal/config/tripalentitytype-collection/{tripalentitytype_collection}/delete",
  *     "collection" = "/admin/tripal/config/tripalentitytype-collection"
  *   }
  * )

--- a/tripal/src/Entity/TripalFieldCollection.php
+++ b/tripal/src/Entity/TripalFieldCollection.php
@@ -35,7 +35,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *   },
  *   links = {
  *     "collection" = "/admin/tripal/config/tripalfield-collection",
- *     "delete-form" = "/admin/tripal/config/tripalfield-collection/{config}/delete"
+ *     "delete-form" = "/admin/tripal/config/tripalfield-collection/{tripalfield_collection}/delete"
  *   }
  * )
  */


### PR DESCRIPTION
# Bug Fix

## Issue #1518 

### Tripal Version: 4.0.alpha1

## Description
Placeholder `{config}` should instead contain the value from the `id` field.

## Testing?
1. `git checkout tv4g1-issue1518-tripal-content-terms-route-fix`
2. Rebuild cache `drush cache:rebuild` (won't work without this)
3. Go to the "Tripal Content Terms" page at
`/admin/tripal/config/terms`
and you should now see the page displayed without errors.
4. Test the "Delete" button. (**yes, you will destroy your docker!**)
5. For good measure, go to `/admin/tripal/config/tripalentitytype-collection` and test the "Delete" button. This one worked before this pull request, but changing it here for correctness.
6. Go to `/admin/tripal/config/tripalfield-collection` and test the "Delete" button. Also worked before, but changing for correctness.
