### PR TITLE
TripalStorage doesn't support Tripal fields using Drupal Storage

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -480,6 +480,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $tsid = $item->tripalStorageId();
 
 
+        // For basic Tripal fields, developers may want to use the standard
+        // Drupal storage only. In this case, the tsid would be empty.
+        if (empty($tsid)) {
+          continue;
+        }
+
         // Create instance of the storage plugin so we can add the properties
         // to it as we go.
         if (!array_key_exists($tsid, $tripal_storages)) {
@@ -579,6 +585,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $delta = $item->getName();
         $tsid = $item->tripalStorageId();
 
+        // Some simple Tripal fields may only want to use the Drupal storage
+        // In this case the tsid will be empty.
+        if (empty($tsid)) {
+          continue;
+        }
+
         // Load into the entity the properties that are to be stored in Drupal.
         $prop_values = [];
         $prop_types = [];
@@ -670,6 +682,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           }
           $delta = $item->getName();
           $tsid = $item->tripalStorageId();
+
+          // Some simple Tripal fields may only want to use the Drupal storage
+          // In this case the tsid will be empty.
+          if (empty($tsid)) {
+            continue;
+          }
 
           // Create a new properties array for this field item.
           $prop_values = [];


### PR DESCRIPTION
# Bug Fix

Issue #1611

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR simply allows TripalStorage to be bypassed for Tripal Fields which do not specify a backend storage. This allows developers to create simple visualization fields, etc which use the Drupal Storage backend while still taking advantage of the benefits of Tripal Fields.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Create a fresh docker image + container based on this branch ([see these instructions if needed](https://tripaldoc.readthedocs.io/en/latest/contributing/docker-for-testing.html#testing-an-unmerged-pull-request)).
2. Copy the following field class files into the Tripal/src/Plugin/Field/FieldType, FieldWidget and FieldFormatter folders and replace `.txt` with `.php`: 
[TripalExampleSimpleStringTypeItem.txt](https://github.com/tripal/tripal/files/12388873/TripalExampleSimpleStringTypeItem.txt), [TripalExampleSimpleStringWidget.txt](https://github.com/tripal/tripal/files/12388874/TripalExampleSimpleStringWidget.txt),  [TripalExampleSimpleStringFormatter.txt](https://github.com/tripal/tripal/files/12388875/TripalExampleSimpleStringFormatter.txt)
3. Go to Tripal > Page Structure > Organism > Manage Fields and click on "Add Field"
4. Select "Tripal Example Simple String Field Type" from the "Add a new field" drop-down. Enter a label for the field and click "Save and Continue".
5. Use the default field settings and click Save. Set a Term and click Save.
6. Now create an organism by going to Admin > Tripal > Content and clicking "Add Tripal Content". This branch should show you a form element for the new field you added with no errors. Fill out this field and all required fields and click save.
7. The view page should show the value of the field just as you entered it.
8. Edit the page and change the field value then click save. It should be updated as expected with no errors.
