### PR TITLE
Drush command to create Tripal + Chado Fields

### DIFF
--- a/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
@@ -36,9 +36,9 @@ final class TripalFieldFormatterGenerator extends BaseGenerator {
     $vars['formatter_label'] = $prompt->ask('Field Formatter Label', Utils::machine2human($vars['formatter_id'], TRUE), $label_validator);
     $vars['formatter_description'] = $prompt->ask('Field Formatter Description');
     $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['formatter_id'], '_formatter'), $id_validator);
-    $vars['class'] = $prompt->askClass(default: '{formatter_id|camelize}');
+    $vars['formatter_class'] = $prompt->askClass(default: '{formatter_id|camelize}');
 
-    $assets->addFile('src/Plugin/Field/FieldFormatter/{class}.php', 'tripal-field-formatter.twig');
+    $assets->addFile('src/Plugin/Field/FieldFormatter/{formatter_class}.php', 'tripal-field-formatter.twig');
   }
 
 }

--- a/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal:field-formatter',
+  description: 'Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class TripalFieldFormatterGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Formatter
+    $vars['formatter_id'] = $prompt->ask('Field Formatter ID', '{machine_name}_example_formatter', $id_validator);
+    $vars['formatter_label'] = $prompt->ask('Field Formatter Label', Utils::machine2human($vars['formatter_id'], TRUE), $label_validator);
+    $vars['formatter_description'] = $prompt->ask('Field Formatter Description');
+    $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['formatter_id'], '_formatter'), $id_validator);
+    $vars['class'] = $prompt->askClass(default: '{formatter_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldFormatter/{class}.php', 'tripal-field-formatter.twig');
+  }
+
+}

--- a/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldFormatterGenerator.php
@@ -12,7 +12,7 @@ use DrupalCodeGenerator\Utils;
 
 #[Generator(
   name: 'tripal:field-formatter',
-  description: 'Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.',
+  description: 'Generates a Tripal Formatter to be used with an existing Tripal Field.',
   templatePath: __DIR__ . '/../../../templates/generator',
   type: GeneratorType::MODULE_COMPONENT,
 )]

--- a/tripal/src/Drush/Generators/TripalFieldGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldGenerator.php
@@ -12,7 +12,7 @@ use DrupalCodeGenerator\Utils;
 
 #[Generator(
   name: 'tripal:field',
-  description: 'Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.',
+  description: 'Generates a Tripal Field Type, Widget and Formatter for fields not interacting with Chado.',
   templatePath: __DIR__ . '/../../../templates/generator',
   type: GeneratorType::MODULE_COMPONENT,
 )]

--- a/tripal/src/Drush/Generators/TripalFieldGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldGenerator.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal:field',
+  description: 'Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class TripalFieldGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+    $term_validator = new RegExp('/:/', 'The value must be an ID Space and Accession defining the term with a : separating them (e.g. rdfs:type).');
+
+    // Field Type
+    $vars['field_id'] = $prompt->ask('Field Type | ID', '{machine_name}_example', $id_validator);
+    $vars['field_label'] = $prompt->ask('Field Type | Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
+    $vars['field_description'] = $prompt->ask('Field Type | Description');
+    $vars['field_term'] = $prompt->ask('Field Type | Term (IdSpace:Accession)', 'rdfs:type', $term_validator);
+    $vars['field_class'] = $prompt->askClass('Field Type | Class', '{field_id|camelize}TypeItem');
+
+    // Field Widget
+    $vars['widget_id'] = $prompt->ask('Field Widget | ID', '{field_id}_widget', $id_validator);
+    $vars['widget_label'] = $prompt->ask('Field Widget | Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
+    $vars['widget_description'] = $prompt->ask('Field Widget | Description');
+    $vars['widget_class'] = $prompt->askClass('Field Widget | Class', '{widget_id|camelize}');
+
+    // Field Formatter
+    $vars['formatter_id'] = $prompt->ask('Field Formatter | ID', '{field_id}_formatter', $id_validator);
+    $vars['formatter_label'] = $prompt->ask('Field Formatter | Label', Utils::machine2human($vars['formatter_id'], TRUE), $label_validator);
+    $vars['formatter_description'] = $prompt->ask('Field Formatter | Description');
+    $vars['formatter_class'] = $prompt->askClass('Field Formatter | Class', '{formatter_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldType/{field_class}.php', 'tripal-field-type.twig');
+    $assets->addFile('src/Plugin/Field/FieldWidget/{widget_class}.php', 'tripal-field-widget.twig');
+
+    $assets->addFile('src/Plugin/Field/FieldFormatter/{formatter_class}.php', 'tripal-field-formatter.twig');
+  }
+
+}

--- a/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+
+#[Generator(
+  name: 'tripal:field-type',
+  description: 'Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class TripalFieldTypeGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Type
+    $vars['field_id'] = $prompt->ask('FieldType id', '{machine_name}_example', $id_validator);
+    $vars['field_label'] = $prompt->ask('FieldType label', '{machine_name|camelize} Example Field Type', $label_validator);
+    $vars['description'] = $prompt->ask('FieldType description');
+    $vars['widget_id'] = $prompt->ask('Default Field Widget id', '{machine_name}_example_widget', $id_validator);
+    $vars['formatter_id'] = $prompt->ask('Default Field Formatter id', '{machine_name}_example_formatter', $id_validator);
+    $vars['class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');
+
+    $assets->addFile('src/Plugin/Field/FieldType/{class}.php', 'tripal-field-type.twig');
+  }
+
+}

--- a/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
@@ -6,6 +6,7 @@ use DrupalCodeGenerator\Asset\AssetCollection as Assets;
 use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Utils;
 use DrupalCodeGenerator\Validator\RegExp;
 use DrupalCodeGenerator\Validator\Required;
 
@@ -31,11 +32,12 @@ final class TripalFieldTypeGenerator extends BaseGenerator {
     $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
 
     // Field Type
-    $vars['field_id'] = $prompt->ask('FieldType id', '{machine_name}_example', $id_validator);
-    $vars['field_label'] = $prompt->ask('FieldType label', '{machine_name|camelize} Example Field Type', $label_validator);
-    $vars['description'] = $prompt->ask('FieldType description');
-    $vars['widget_id'] = $prompt->ask('Default Field Widget id', '{machine_name}_example_widget', $id_validator);
-    $vars['formatter_id'] = $prompt->ask('Default Field Formatter id', '{machine_name}_example_formatter', $id_validator);
+    $vars['field_id'] = $prompt->ask('Field Type ID', '{machine_name}_example', $id_validator);
+
+    $vars['field_label'] = $prompt->ask('Field Type Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
+    $vars['description'] = $prompt->ask('Field Type Description');
+    $vars['widget_id'] = $prompt->ask('Default Field Widget ID', '{field_id}_widget', $id_validator);
+    $vars['formatter_id'] = $prompt->ask('Default Field Formatter ID', '{field_id}_formatter', $id_validator);
     $vars['class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');
 
     $assets->addFile('src/Plugin/Field/FieldType/{class}.php', 'tripal-field-type.twig');

--- a/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
@@ -36,13 +36,13 @@ final class TripalFieldTypeGenerator extends BaseGenerator {
     $vars['field_id'] = $prompt->ask('Field Type ID', '{machine_name}_example', $id_validator);
 
     $vars['field_label'] = $prompt->ask('Field Type Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
-    $vars['description'] = $prompt->ask('Field Type Description');
+    $vars['field_description'] = $prompt->ask('Field Type Description');
     $vars['field_term'] = $prompt->ask('Field Term (IdSpace:Accession)', 'rdfs:type', $term_validator);
     $vars['widget_id'] = $prompt->ask('Default Field Widget ID', '{field_id}_widget', $id_validator);
     $vars['formatter_id'] = $prompt->ask('Default Field Formatter ID', '{field_id}_formatter', $id_validator);
-    $vars['class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');
+    $vars['field_class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');
 
-    $assets->addFile('src/Plugin/Field/FieldType/{class}.php', 'tripal-field-type.twig');
+    $assets->addFile('src/Plugin/Field/FieldType/{field_class}.php', 'tripal-field-type.twig');
   }
 
 }

--- a/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldTypeGenerator.php
@@ -30,12 +30,14 @@ final class TripalFieldTypeGenerator extends BaseGenerator {
     // Validators
     $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
     $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+    $term_validator = new RegExp('/:/', 'The value must be an ID Space and Accession defining the term with a : separating them (e.g. rdfs:type).');
 
     // Field Type
     $vars['field_id'] = $prompt->ask('Field Type ID', '{machine_name}_example', $id_validator);
 
     $vars['field_label'] = $prompt->ask('Field Type Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
     $vars['description'] = $prompt->ask('Field Type Description');
+    $vars['field_term'] = $prompt->ask('Field Term (IdSpace:Accession)', 'rdfs:type', $term_validator);
     $vars['widget_id'] = $prompt->ask('Default Field Widget ID', '{field_id}_widget', $id_validator);
     $vars['formatter_id'] = $prompt->ask('Default Field Formatter ID', '{field_id}_formatter', $id_validator);
     $vars['class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');

--- a/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
@@ -31,14 +31,14 @@ final class TripalFieldWidgetGenerator extends BaseGenerator {
     $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
     $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
 
-    // Field Type
+    // Field Widget
     $vars['widget_id'] = $prompt->ask('Field Widget ID', '{machine_name}_example_widget', $id_validator);
-    $vars['field_label'] = $prompt->ask('Field Widget Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
-    $vars['description'] = $prompt->ask('Field Widget Description');
+    $vars['widget_label'] = $prompt->ask('Field Widget Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
+    $vars['widget_description'] = $prompt->ask('Field Widget Description');
     $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['widget_id'], '_widget'), $id_validator);
-    $vars['class'] = $prompt->askClass(default: '{widget_id|camelize}');
+    $vars['widget_class'] = $prompt->askClass(default: '{widget_id|camelize}');
 
-    $assets->addFile('src/Plugin/Field/FieldWidget/{class}.php', 'tripal-field-widget.twig');
+    $assets->addFile('src/Plugin/Field/FieldWidget/{widget_class}.php', 'tripal-field-widget.twig');
   }
 
 }

--- a/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal:field-widget',
+  description: 'Generates a Tripal Field Widget for developing Tripal fields with no interactiion with Chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class TripalFieldWidgetGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Type
+    $vars['widget_id'] = $prompt->ask('Field Widget ID', '{machine_name}_example_widget', $id_validator);
+    $vars['field_label'] = $prompt->ask('Field Widget Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
+    $vars['description'] = $prompt->ask('Field Widget Description');
+    $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['widget_id'], '_widget'), $id_validator);
+    $vars['class'] = $prompt->askClass(default: '{widget_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldWidget/{class}.php', 'tripal-field-widget.twig');
+  }
+
+}

--- a/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
+++ b/tripal/src/Drush/Generators/TripalFieldWidgetGenerator.php
@@ -12,7 +12,7 @@ use DrupalCodeGenerator\Utils;
 
 #[Generator(
   name: 'tripal:field-widget',
-  description: 'Generates a Tripal Field Widget for developing Tripal fields with no interactiion with Chado.',
+  description: 'Generates a Tripal Widget to be used with an existing Tripal Field.',
   templatePath: __DIR__ . '/../../../templates/generator',
   type: GeneratorType::MODULE_COMPONENT,
 )]

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -480,6 +480,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $tsid = $item->tripalStorageId();
 
 
+        // For basic Tripal fields, developers may want to use the standard
+        // Drupal storage only. In this case, the tsid would be empty.
+        if (empty($tsid)) {
+          continue;
+        }
+
         // Create instance of the storage plugin so we can add the properties
         // to it as we go.
         if (!array_key_exists($tsid, $tripal_storages)) {
@@ -579,6 +585,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $delta = $item->getName();
         $tsid = $item->tripalStorageId();
 
+        // Some simple Tripal fields may only want to use the Drupal storage
+        // In this case the tsid will be empty.
+        if (empty($tsid)) {
+          continue;
+        }
+
         // Load into the entity the properties that are to be stored in Drupal.
         $prop_values = [];
         $prop_types = [];
@@ -670,6 +682,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           }
           $delta = $item->getName();
           $tsid = $item->tripalStorageId();
+
+          // Some simple Tripal fields may only want to use the Drupal storage
+          // In this case the tsid will be empty.
+          if (empty($tsid)) {
+            continue;
+          }
 
           // Create a new properties array for this field item.
           $prop_values = [];

--- a/tripal/templates/generator/tripal-field-formatter.twig
+++ b/tripal/templates/generator/tripal-field-formatter.twig
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldFormatter;
+
+use Drupal\tripal\TripalField\TripalFormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the '{{ formatter_id }}' field formatter for '{{ field_id }}'.
+ *
+ * @FieldFormatter(
+ *   id = "{{ formatter_id }}",
+ *   label = @Translation("{{ formatter_label }}"),
+ *   description = @Translation("{{ formatter_description }}"),
+ *   field_types = {
+ *     "{{ field_id }}"
+ *   }
+ * )
+ */
+class {{ class }} extends TripalFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach($items as $delta => $item) {
+      $elements[$delta] = [
+        "#markup" => $item->get("value")->getString(),
+      ];
+    }
+
+    return $elements;
+  }
+
+}
+

--- a/tripal/templates/generator/tripal-field-formatter.twig
+++ b/tripal/templates/generator/tripal-field-formatter.twig
@@ -18,7 +18,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class {{ class }} extends TripalFormatterBase {
+class {{ formatter_class }} extends TripalFormatterBase {
 
   /**
    * {@inheritdoc}

--- a/tripal/templates/generator/tripal-field-type.twig
+++ b/tripal/templates/generator/tripal-field-type.twig
@@ -16,12 +16,12 @@ use Drupal\core\Field\FieldDefinitionInterface;
  * @FieldType(
  *   id = "{{ field_id }}",
  *   label = @Translation("{{ field_label }}"),
- *   description = @Translation("{{ description }}"),
+ *   description = @Translation("{{ field_description }}"),
  *   default_widget = "{{ widget_id }}",
  *   default_formatter = "{{ formatter_id }}"
  * )
  */
-class {{ class }} extends TripalFieldItemBase {
+class {{ field_class }} extends TripalFieldItemBase {
 
   public static $id = "{{ field_id }}";
 

--- a/tripal/templates/generator/tripal-field-type.twig
+++ b/tripal/templates/generator/tripal-field-type.twig
@@ -33,8 +33,11 @@ class {{ class }} extends TripalFieldItemBase {
     // Use the field settings to extract information we need to make generic fields.
     $entity_type_id = $field_definition->getTargetEntityTypeId();
     $storage_settings = $field_definition->getSettings();
-    $termIdSpace = $storage_settings['termIdSpace'];
-    $termAccession = $storage_settings['termAccession'];
+    $termIdSpace = '{{ field_term|split(':')[0] }}';
+    $termAccession = '{{ field_term|split(':')[1] }}';
+
+    // Here we set the max length to the typical size of a Drupal postgresql varchar column.
+    $max_length = 255;
 
     return [
       // Example Property Type for strings.

--- a/tripal/templates/generator/tripal-field-type.twig
+++ b/tripal/templates/generator/tripal-field-type.twig
@@ -5,7 +5,7 @@ namespace Drupal\{{ machine_name }}\Plugin\Field\FieldType;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
 // Make sure to include the Property type class you are going to create
 // in your addTypes() method below.
-// use Drupal\tripal\TripalStorage\IntStoragePropertyType;
+use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
 use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\core\Field\FieldDefinitionInterface;
@@ -29,14 +29,16 @@ class {{ class }} extends TripalFieldItemBase {
    * {@inheritdoc}
    */
   public static function tripalTypes($field_definition) {
+
+    // Use the field settings to extract information we need to make generic fields.
     $entity_type_id = $field_definition->getTargetEntityTypeId();
     $storage_settings = $field_definition->getSettings();
     $termIdSpace = $storage_settings['termIdSpace'];
     $termAccession = $storage_settings['termAccession'];
 
     return [
-      // Example Property Type for integers.
-      // new IntStoragePropertyType($entity_type_id, self::$id, "value", $termIdSpace . ':' . $termAccession),
+      // Example Property Type for strings.
+      new VarCharStoragePropertyType($entity_type_id, self::$id, "value", $termIdSpace . ':' . $termAccession, $max_length),
     ];
   }
 

--- a/tripal/templates/generator/tripal-field-type.twig
+++ b/tripal/templates/generator/tripal-field-type.twig
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldType;
+
+use Drupal\tripal\TripalField\TripalFieldItemBase;
+// Make sure to include the Property type class you are going to create
+// in your addTypes() method below.
+// use Drupal\tripal\TripalStorage\IntStoragePropertyType;
+use Drupal\tripal\TripalStorage\StoragePropertyValue;
+use Drupal\core\Form\FormStateInterface;
+use Drupal\core\Field\FieldDefinitionInterface;
+
+/**
+ * Plugin implementation of the '{{ field_id }}' field type.
+ *
+ * @FieldType(
+ *   id = "{{ field_id }}",
+ *   label = @Translation("{{ field_label }}"),
+ *   description = @Translation("{{ description }}"),
+ *   default_widget = "{{ widget_id }}",
+ *   default_formatter = "{{ formatter_id }}"
+ * )
+ */
+class {{ class }} extends TripalFieldItemBase {
+
+  public static $id = "{{ field_id }}";
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $storage_settings = $field_definition->getSettings();
+    $termIdSpace = $storage_settings['termIdSpace'];
+    $termAccession = $storage_settings['termAccession'];
+
+    return [
+      // Example Property Type for integers.
+      // new IntStoragePropertyType($entity_type_id, self::$id, "value", $termIdSpace . ':' . $termAccession),
+    ];
+  }
+
+}
+

--- a/tripal/templates/generator/tripal-field-widget.twig
+++ b/tripal/templates/generator/tripal-field-widget.twig
@@ -18,7 +18,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class {{ class }} extends TripalWidgetBase {
+class {{ widget_class }} extends TripalWidgetBase {
 
   /**
    * {@inheritdoc}

--- a/tripal/templates/generator/tripal-field-widget.twig
+++ b/tripal/templates/generator/tripal-field-widget.twig
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the '{{ widget_id }}' field widget for '{{ field_id }}'.
+ *
+ * @FieldWidget(
+ *   id = "{{ widget_id }}",
+ *   label = @Translation("{{ widget_label }}"),
+ *   description = @Translation("{{ widget_description }}"),
+ *   field_types = {
+ *     "{{ field_id }}"
+ *   }
+ * )
+ */
+class {{ class }} extends TripalWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Define your form elements here.
+    // If you have chosen to make a widget which does not allow editing of the
+    // data then you should display it in disabled elements.
+    $element['value'] = $element + [
+      '#type' => 'textfield',
+      '#default_value' => $items[$delta]->value ?? '',
+      '#attributes' => ['class' => ['js-text-full', 'text-full']],
+    ];
+
+    return $element;
+  }
+
+}
+

--- a/tripal_chado/src/Drush/Generators/ChadoFieldFormatterGenerator.php
+++ b/tripal_chado/src/Drush/Generators/ChadoFieldFormatterGenerator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal_chado\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal-chado:field-formatter',
+  description: 'Generates a Chado Formatter to be used with an existing Chado Field.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class ChadoFieldFormatterGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Formatter
+    $vars['formatter_id'] = $prompt->ask('Field Formatter ID', 'chado_example_formatter', $id_validator);
+    $vars['formatter_label'] = $prompt->ask('Field Formatter Label', Utils::machine2human($vars['formatter_id'], TRUE), $label_validator);
+    $vars['formatter_description'] = $prompt->ask('Field Formatter Description');
+    $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['formatter_id'], '_formatter'), $id_validator);
+    $vars['formatter_class'] = $prompt->askClass(default: '{formatter_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldFormatter/{formatter_class}.php', 'chado-field-formatter.twig');
+  }
+
+}

--- a/tripal_chado/src/Drush/Generators/ChadoFieldGenerator.php
+++ b/tripal_chado/src/Drush/Generators/ChadoFieldGenerator.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal_chado\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal-chado:field',
+  description: 'Generates a Chado Field Type, Widget and Formatter for fields who store their data in Chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class ChadoFieldGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+    $term_validator = new RegExp('/:/', 'The value must be an ID Space and Accession defining the term with a : separating them (e.g. rdfs:type).');
+
+    // Field Type
+    $vars['field_id'] = $prompt->ask('Field Type | ID', 'chado_example', $id_validator);
+    $vars['field_label'] = $prompt->ask('Field Type | Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
+    $vars['field_description'] = $prompt->ask('Field Type | Description');
+    $vars['field_class'] = $prompt->askClass('Field Type | Class', '{field_id|camelize}TypeItem');
+
+    // Field Widget
+    $vars['widget_id'] = $prompt->ask('Field Widget | ID', '{field_id}_widget', $id_validator);
+    $vars['widget_label'] = $prompt->ask('Field Widget | Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
+    $vars['widget_description'] = $prompt->ask('Field Widget | Description');
+    $vars['widget_class'] = $prompt->askClass('Field Widget | Class', '{widget_id|camelize}');
+
+    // Field Formatter
+    $vars['formatter_id'] = $prompt->ask('Field Formatter | ID', '{field_id}_formatter', $id_validator);
+    $vars['formatter_label'] = $prompt->ask('Field Formatter | Label', Utils::machine2human($vars['formatter_id'], TRUE), $label_validator);
+    $vars['formatter_description'] = $prompt->ask('Field Formatter | Description');
+    $vars['formatter_class'] = $prompt->askClass('Field Formatter | Class', '{formatter_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldType/{field_class}.php', 'chado-field-type.twig');
+    $assets->addFile('src/Plugin/Field/FieldWidget/{widget_class}.php', 'chado-field-widget.twig');
+
+    $assets->addFile('src/Plugin/Field/FieldFormatter/{formatter_class}.php', 'chado-field-formatter.twig');
+  }
+
+}

--- a/tripal_chado/src/Drush/Generators/ChadoFieldTypeGenerator.php
+++ b/tripal_chado/src/Drush/Generators/ChadoFieldTypeGenerator.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal_chado\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Utils;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+
+#[Generator(
+  name: 'tripal-chado:field-type',
+  description: 'Generates a Chado Field Type for developing fields which store their data in chado.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class ChadoFieldTypeGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Type
+    $vars['field_id'] = $prompt->ask('Field Type ID', 'chado_example', $id_validator);
+    $vars['field_label'] = $prompt->ask('Field Type Label', Utils::machine2human($vars['field_id'], TRUE) . ' Field Type', $label_validator);
+    $vars['field_description'] = $prompt->ask('Field Type Description');
+    $vars['widget_id'] = $prompt->ask('Default Field Widget ID', '{field_id}_widget', $id_validator);
+    $vars['formatter_id'] = $prompt->ask('Default Field Formatter ID', '{field_id}_formatter', $id_validator);
+    $vars['field_class'] = $prompt->askClass(default: '{field_id|camelize}TypeItem');
+
+    $assets->addFile('src/Plugin/Field/FieldType/{field_class}.php', 'chado-field-type.twig');
+  }
+
+}

--- a/tripal_chado/src/Drush/Generators/ChadoFieldWidgetGenerator.php
+++ b/tripal_chado/src/Drush/Generators/ChadoFieldWidgetGenerator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal_chado\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+use DrupalCodeGenerator\Validator\RegExp;
+use DrupalCodeGenerator\Validator\Required;
+use DrupalCodeGenerator\Utils;
+
+#[Generator(
+  name: 'tripal-chado:field-widget',
+  description: 'Generates a Chado Field Widget to be used with an existing Chado Field.',
+  templatePath: __DIR__ . '/../../../templates/generator',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class ChadoFieldWidgetGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $prompt = $this->createInterviewer($vars);
+
+    // Module Machine Name
+    $vars['machine_name'] = $prompt->askMachineName();
+
+    // Validators
+    $id_validator = new RegExp('/^[a-z][a-z0-9_]*[a-z0-9]$/', 'The value must consist of only lower case alphanumeric characters and underscores. It should start with a letter and not end with an underscore.');
+    $label_validator = new RegExp('/^[a-zA-Z][a-zA-Z0-9- ]*[a-zA-Z0-9]$/', 'The value must be alphanumeric. We suggest focusing on a title-case human-readable name for your field.');
+
+    // Field Widget
+    $vars['widget_id'] = $prompt->ask('Field Widget ID', 'chado_example_widget', $id_validator);
+    $vars['widget_label'] = $prompt->ask('Field Widget Label', Utils::machine2human($vars['widget_id'], TRUE), $label_validator);
+    $vars['widget_description'] = $prompt->ask('Field Widget Description');
+    $vars['field_id'] = $prompt->ask('Default Field Type id', Utils::removeSuffix($vars['widget_id'], '_widget'), $id_validator);
+    $vars['widget_class'] = $prompt->askClass(default: '{widget_id|camelize}');
+
+    $assets->addFile('src/Plugin/Field/FieldWidget/{widget_class}.php', 'chado-field-widget.twig');
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoExampleFormatter.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoExampleFormatter.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\tripal\TripalField\TripalFormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of the 'chado_example_formatter' field formatter for 'chado_example'.
+ *
+ * @FieldFormatter(
+ *   id = "chado_example_formatter",
+ *   label = @Translation("Chado Example Formatter"),
+ *   description = @Translation(""),
+ *   field_types = {
+ *     "chado_example"
+ *   }
+ * )
+ */
+class ChadoExampleFormatter extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    // Rather than displaying the primary key value to the page,
+    // you should either change it to be a user-sharable value
+    // or you should do something with it (e.g. pass to an API or micro-service).
+    foreach($items as $delta => $item) {
+      $elements[$delta] = [
+        "#markup" => $item->get("value")->getString(),
+      ];
+    }
+
+    return $elements;
+  }
+
+}
+

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoExampleTypeItem.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoExampleTypeItem.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Drupal\{{ machine_name }}\Plugin\Field\FieldType;
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 
 use Drupal\tripal\TripalField\TripalFieldItemBase;
@@ -13,19 +13,19 @@ use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 
 /**
- * Plugin implementation of the '{{ field_id }}' field type.
+ * Plugin implementation of the 'chado_example' field type.
  *
  * @FieldType(
- *   id = "{{ field_id }}",
- *   label = @Translation("{{ field_label }}"),
- *   description = @Translation("{{ field_description }}"),
- *   default_widget = "{{ widget_id }}",
- *   default_formatter = "{{ formatter_id }}"
+ *   id = "chado_example",
+ *   label = @Translation("Chado Example Field Type"),
+ *   description = @Translation(""),
+ *   default_widget = "chado_example_widget",
+ *   default_formatter = "chado_example_formatter"
  * )
  */
-class {{ field_class }} extends ChadoFieldItemBase {
+class ChadoExampleTypeItem extends ChadoFieldItemBase {
 
-  public static $id = "{{ field_id }}";
+  public static $id = "chado_example";
 
   /**
    * {@inheritdoc}
@@ -38,7 +38,6 @@ class {{ field_class }} extends ChadoFieldItemBase {
 
     return [
       // Add your chado property types here.
-      // This is REQUIRED before you can test this field through the UI.
     ];
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoExampleWidget.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoExampleWidget.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Drupal\{{ machine_name }}\Plugin\Field\FieldWidget;
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
 use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -8,18 +8,18 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**
- * Plugin implementation of the '{{ widget_id }}' field widget for '{{ field_id }}'.
+ * Plugin implementation of the 'chado_example_widget' field widget for 'chado_example'.
  *
  * @FieldWidget(
- *   id = "{{ widget_id }}",
- *   label = @Translation("{{ widget_label }}"),
- *   description = @Translation("{{ widget_description }}"),
+ *   id = "chado_example_widget",
+ *   label = @Translation("Chado Example Widget"),
+ *   description = @Translation(""),
  *   field_types = {
- *     "{{ field_id }}"
+ *     "chado_example"
  *   }
  * )
  */
-class {{ widget_class }} extends ChadoWidgetBase {
+class ChadoExampleWidget extends ChadoWidgetBase {
 
   /**
    * {@inheritdoc}
@@ -29,13 +29,13 @@ class {{ widget_class }} extends ChadoWidgetBase {
     // Grab the values for our properties based on the passed in delta.
     // For fields with a cardinality above 1, this is called one per record
     // with the delta indicating the current record.
-    // $item_vals = $items[$delta]->getValue();
+    $item_vals = $items[$delta]->getValue();
 
-    // Define your form elements here.
-    // $element['value'] = [
-    //   '#type' => 'value',
-    //   '#default_value' => $item_vals['value'] ?? 0,
-    // ];
+    // Define your form elements here.=
+    $element['value'] = [
+      '#type' => 'value',
+      '#default_value' => $item_vals['value'] ?? 0,
+    ];
 
     return $element;
   }

--- a/tripal_chado/templates/generator/chado-field-formatter.twig
+++ b/tripal_chado/templates/generator/chado-field-formatter.twig
@@ -27,11 +27,12 @@ class {{ formatter_class }} extends ChadoFormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
-    foreach($items as $delta => $item) {
-      $elements[$delta] = [
-        "#markup" => $item->get("value")->getString(),
-      ];
-    }
+    // Use render arrays to generate markup for your field.
+    // foreach($items as $delta => $item) {
+    //   $elements[$delta] = [
+    //     "#markup" => $item->get("value")->getString(),
+    //   ];
+    // }
 
     return $elements;
   }

--- a/tripal_chado/templates/generator/chado-field-formatter.twig
+++ b/tripal_chado/templates/generator/chado-field-formatter.twig
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldFormatter;
+
+use Drupal\tripal\TripalField\TripalFormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of the '{{ formatter_id }}' field formatter for '{{ field_id }}'.
+ *
+ * @FieldFormatter(
+ *   id = "{{ formatter_id }}",
+ *   label = @Translation("{{ formatter_label }}"),
+ *   description = @Translation("{{ formatter_description }}"),
+ *   field_types = {
+ *     "{{ field_id }}"
+ *   }
+ * )
+ */
+class {{ formatter_class }} extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach($items as $delta => $item) {
+      $elements[$delta] = [
+        "#markup" => $item->get("value")->getString(),
+      ];
+    }
+
+    return $elements;
+  }
+
+}
+

--- a/tripal_chado/templates/generator/chado-field-type.twig
+++ b/tripal_chado/templates/generator/chado-field-type.twig
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldType;
+
+
+use Drupal\tripal\TripalField\TripalFieldItemBase;
+use Drupal\tripal\TripalStorage\StoragePropertyValue;
+use Drupal\core\Form\FormStateInterface;
+use Drupal\core\Field\FieldDefinitionInterface;
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+// Make sure to include the Property type class you are going to create
+// in your addTypes() method below.
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of the '{{ field_id }}' field type.
+ *
+ * @FieldType(
+ *   id = "{{ field_id }}",
+ *   label = @Translation("{{ field_label }}"),
+ *   description = @Translation("{{ field_description }}"),
+ *   default_widget = "{{ widget_id }}",
+ *   default_formatter = "{{ formatter_id }}"
+ * )
+ */
+class {{ field_class }} extends ChadoFieldItemBase {
+
+  public static $id = "{{ field_id }}";
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Use the field settings to extract information we need to make generic fields.
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $storage_settings = $field_definition->getSettings();
+
+    // Get the base table columns needed for this field.
+    // These will be set automatically based on the content type this field is added to.
+    $base_table = $settings['base_table'];
+    $base_column = 'name';
+    $schema = \Drupal::service('tripal_chado.database')->schema();
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Get the property terms by using the Chado table columns they map to.
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+
+    $record_id_term = 'SIO:000729';
+    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+
+    return [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id,'record_id', $record_id_term, [
+        'action' => 'store_id',
+        'drupal_store' => TRUE,
+        'chado_table' => $base_table,
+        'chado_column' => $base_pkey_col
+      ]),
+      new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, "value", $value_term, 255, [
+        'action' => 'store',
+        'chado_table' => $base_table,
+        'chado_column' => $base_column,
+      ]),
+    ];
+  }
+
+}
+

--- a/tripal_chado/templates/generator/chado-field-widget.twig
+++ b/tripal_chado/templates/generator/chado-field-widget.twig
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\{{ machine_name }}\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of the '{{ widget_id }}' field widget for '{{ field_id }}'.
+ *
+ * @FieldWidget(
+ *   id = "{{ widget_id }}",
+ *   label = @Translation("{{ widget_label }}"),
+ *   description = @Translation("{{ widget_description }}"),
+ *   field_types = {
+ *     "{{ field_id }}"
+ *   }
+ * )
+ */
+class {{ widget_class }} extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Grab the values for our properties based on the passed in delta.
+    // For fields with a cardinality above 1, this is called one per record
+    // with the delta indicating the current record.
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $name = $item_vals['name'] ?? '';
+
+    // Define your form elements here.
+    // If you have chosen to make a widget which does not allow editing of the
+    // data then you should display it in disabled elements.
+    // You must have an element in your form for each property type registered in the field type.
+    $elements['record_id'] = $element + [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $element['value'] = [
+      '#type' => 'textfield',
+      '#default_value' => $name,
+      '#attributes' => ['class' => ['js-text-full', 'text-full']],
+      '#disabled' => TRUE,
+    ];
+
+    return $element;
+  }
+
+}
+


### PR DESCRIPTION

# Tripal 4 Core Dev Task

**DEPENDANT ON PR #1612**

Issue #1606

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds 8 Drush generators for Tripal/Chado Fields. Specifically, it adds

```
  tripal:field            Generates a Tripal Field Type, Widget and Formatter for fields not interacting with Chado.
  tripal:field-formatter  Generates a Tripal Formatter to be used with an existing Tripal Field.
  tripal:field-type       Generates a Tripal Field Type for developing Tripal fields with no interactiion with Chado.
  tripal:field-widget     Generates a Tripal Widget to be used with an existing Tripal Field.
  tripal-chado:field            Generates a Chado Field Type, Widget and Formatter for fields who store their data in Chado.
  tripal-chado:field-formatter  Generates a Chado Formatter to be used with an existing Chado Field.
  tripal-chado:field-type       Generates a Chado Field Type for developing fields which store their data in chado.
  tripal-chado:field-widget     Generates a Chado Field Widget to be used with an existing Chado Field.
```

Once this PR is merged, any developer can generate the skeletons of these field types by entering `drush generate ` followed by one of the generators listed above.  Then they enter the prompts and the generator will generate the files using the values they put in.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Switch to this branch on a fresh Tripal clone.
2. Rebuild the cache using `drush cr`
3. Execute `drush generate tripal` and confirm you see 4 Tripal field generators.
4. Execute `drush generate tripal-chado` and confirm you see 4 Chado field generators.
5. Test each of the generators by running the command, entering the criteria and then testing the generated field.

NOTE: The Tripal generator default generate a completely functioning field. However, the Chado field generators do not... to test these fully you will have to add at least one property to the generated field type class. This was done because there wasn't a simple example to generate that did not cause unexpected results.
