### PR TITLE
Tripal 4 php8.2 deprecations (part 4)

### DIFF
--- a/tripal_chado/src/ChadoCustomTables/ChadoMview.php
+++ b/tripal_chado/src/ChadoCustomTables/ChadoMview.php
@@ -28,9 +28,7 @@ class ChadoMview extends ChadoCustomTable {
 
     parent::__construct($table_name, $chado_schema);
 
-    $this->custom_table = NULL;
     $this->mview_id = NULL;
-
 
     if (!$table_name) {
       throw new \Exception('Please provide a value for the $table_name argument');

--- a/tripal_chado/src/api/tripal_chado.query.api.php
+++ b/tripal_chado/src/api/tripal_chado.query.api.php
@@ -651,7 +651,7 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
   $ivalues = [];       // Contains the values of the fields.
   foreach ($insert_values as $field => $value) {
     $ifields[] = $field;
-    if (strcmp($value, '__NULL__') == 0) {
+    if (is_string($value) and (strcmp($value, '__NULL__') == 0)) {
       $itypes[] = "NULL";
     }
     else {
@@ -917,7 +917,7 @@ function chado_update_record($table, $match, $values, $options = NULL, $chado_sc
   $sql = 'UPDATE {' . $table . '} SET ';
   $args = [];        // Arguments passed to chado_query.
   foreach ($update_values as $field => $value) {
-    if (strcmp($value, '__NULL__') == 0) {
+    if (is_string($value) and (strcmp($value, '__NULL__') == 0)) {
       $sql .= " $field = NULL, ";
     }
     else {
@@ -929,7 +929,7 @@ function chado_update_record($table, $match, $values, $options = NULL, $chado_sc
 
   $sql .= " WHERE ";
   foreach ($update_matches as $field => $value) {
-    if (strcmp($value, '__NULL__') == 0) {
+    if (is_string($value) and (strcmp($value, '__NULL__') == 0)) {
       $sql .= " $field = NULL AND ";
     }
     else {
@@ -1115,7 +1115,7 @@ function chado_delete_record($table, $match, $options = NULL, $chado_schema_name
       $sql .= ") AND ";
     }
     else {
-      if (strcmp($value, '__NULL__') == 0) {
+      if (is_string($value) and (strcmp($value, '__NULL__') == 0)) {
         $sql .= " $field = NULL AND ";
       }
       else {


### PR DESCRIPTION
# Tripal 4 Core Dev Task 

## Issue #1520

### Tripal Version: 4

## Description
Deprecation warnings under PHP8.2 for dynamically created properties

## Testing?
- Build a docker with PHP8.2 and Drupal 10.0:
`docker build --tag=tripaldocker:testing-1520 --build-arg drupalversion="10.0.x-dev" --file tripaldocker/Dockerfile-php8.2-pgsql13 ./`

- Start up a container:
`docker run --publish=80:80 -tid --name=1520 --volume=/home/admin/git/tripal:/var/www/drupal9/web/modules/contrib/tripal --volume=/home/admin/docker_prepare:/usr/local/bin/docker_common tripaldocker:testing-1520`

- Run this test group:
`docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal 1520 phpunit --group 'Tripal Chado Preparer' --debug`

- Before commit https://github.com/tripal/tripal/pull/1617/commits/687ad575365b0c604e5e617428d899c5fcc493ff
```
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Testing 
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testChadoPreparer' started

Deprecated: a:5:{s:11:"deprecation";s:106:"Creation of dynamic property Drupal\tripal_chado\ChadoCustomTables\ChadoMview::$custom_table is deprecated";s:5:"class";s:59:"Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest";s:6:"method";s:17:"testChadoPreparer";s:15:"triggering_file";s:93:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/ChadoCustomTables/ChadoMview.php";s:11:"files_stack";a:12:{i:0;s:93:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/ChadoCustomTables/ChadoMview.php";i:1;s:92:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Services/ChadoMviewsManager.php";i:2;s:83:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Task/ChadoPreparer.php";i:3;s:83:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Task/ChadoPreparer.php";i:4;s:83:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Task/ChadoPreparer.php";i:5;s:104:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/tests/src/Functional/Task/ChadoPreparerTest.php";i:6;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:7;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:8;s:68:"/var/www/drupal9/vendor/phpunit/phpunit/src/Framework/TestResult.php";i:9;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:10;s:19:"Standard input code";i:11;s:19:"Standard input code";}} in /var/www/drupal9/vendor/symfony/phpunit-bridge/Legacy/SymfonyTestsListenerTrait.php on line 284
...
(multiple instances of the warning above)
...
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testChadoPreparer' ended
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testPrepareTestChadoSimulation' started
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testPrepareTestChadoSimulation' ended


Time: 06:41.674, Memory: 14.00 MB

OK (2 tests, 67 assertions)
```

- Output after this PR is applied
```
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Testing 
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testChadoPreparer' started
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testChadoPreparer' ended
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testPrepareTestChadoSimulation' started
Test 'Drupal\Tests\tripal_chado\Functional\Task\ChadoPreparerTest::testPrepareTestChadoSimulation' ended


Time: 06:51.896, Memory: 14.00 MB

OK (2 tests, 67 assertions)
```

- Run this test group:
`docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal 1520 phpunit --group 'taxonomy' --debug`

- Before commit https://github.com/tripal/tripal/pull/1617/commits/b6688e60e1df3538eb75265a19e1f5c3ac3ebc82
```
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Testing 
Test 'Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest::testTaxonomyImporterSimpleTest' started

Deprecated: a:5:{s:11:"deprecation";s:78:"strcmp(): Passing null to parameter #1 ($string1) of type string is deprecated";s:5:"class";s:57:"Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest";s:6:"method";s:30:"testTaxonomyImporterSimpleTest";s:15:"triggering_file";s:91:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.query.api.php";s:11:"files_stack";a:11:{i:0;s:91:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.query.api.php";i:1;s:95:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.phylotree.api.php";i:2;s:103:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php";i:3;s:103:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php";i:4;s:109:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php";i:5;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:6;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:7;s:68:"/var/www/drupal9/vendor/phpunit/phpunit/src/Framework/TestResult.php";i:8;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:9;s:19:"Standard input code";i:10;s:19:"Standard input code";}} in /var/www/drupal9/vendor/symfony/phpunit-bridge/Legacy/SymfonyTestsListenerTrait.php on line 284
Test 'Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest::testTaxonomyImporterSimpleTest' ended
PHP Deprecated:  a:5:{s:11:"deprecation";s:78:"strcmp(): Passing null to parameter #1 ($string1) of type string is deprecated";s:5:"class";s:57:"Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest";s:6:"method";s:30:"testTaxonomyImporterSimpleTest";s:15:"triggering_file";s:91:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.query.api.php";s:11:"files_stack";a:11:{i:0;s:91:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.query.api.php";i:1;s:95:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/api/tripal_chado.phylotree.api.php";i:2;s:103:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php";i:3;s:103:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php";i:4;s:109:"/var/www/drupal9/web/modules/contrib/tripal/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php";i:5;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:6;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:7;s:68:"/var/www/drupal9/vendor/phpunit/phpunit/src/Framework/TestResult.php";i:8;s:50:"/var/www/drupal9/web/sites/simpletest/TestCase.php";i:9;s:19:"Standard input code";i:10;s:19:"Standard input code";}} in /var/www/drupal9/vendor/symfony/phpunit-bridge/Legacy/SymfonyTestsListenerTrait.php on line 284
```

- Output after this PR is applied
```
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Testing 
Test 'Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest::testTaxonomyImporterSimpleTest' started
Test 'Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest::testTaxonomyImporterSimpleTest' ended


Time: 08:56.892, Memory: 14.00 MB

OK (1 test, 21 assertions)
```