### PR TITLE
Tv4g0 issue1614 issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report (Form)
+name: Bug Report
 description: Create a report to help us improve Tripal
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report (Form)
+description: Create a report to help us improve Tripal
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # BUG/ERROR report
+
+        ## System Information
+        All information is available in your site's administrator report area
+        (Administration Toolbar > Reports > Status Report)
+  - type: input
+    id: tripal_version
+    attributes:
+      label: Tripal Version
+  - type: input
+    id: drupal_version
+    attributes:
+      label: Drupal Version
+  - type: input
+    id: postgresql_version
+    attributes:
+      label: PostgreSQL Version
+  - type: input
+    id: php_version
+    attributes:
+      label: PHP Version
+  - type: markdown
+    attributes:
+      value: |
+        ## Issue Description
+        Please describe your issue here. Some information you might want to include:
+          - the page you're seeing the issue on
+          - what behavior you're experiencing versus what you expect
+          - really anything you think might best help us help you!
+        For required fields that do not make sense for this issue, please enter **n/a**.
+  - type: textarea
+    id: general_issue_description
+    attributes:
+      label: General Description
+      description: A general description of the issue
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: What steps are necessary to recreate the bug/error?  Clear instructions here will make it easier for us to fix the problem!
+    validations:
+      required: true
+  - type: textarea
+    id: error_messages
+    attributes:
+      label: Error messages
+      description: Please include any error messages you find.
+      placeholder: Pasted text is automatically formatted cleanly, no need for backticks.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Upload screenshots into this field, and optionally provide a description of each.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/core_development_task.yml
+++ b/.github/ISSUE_TEMPLATE/core_development_task.yml
@@ -1,4 +1,4 @@
-name: Core Development Task (Form)
+name: Core Development Task
 description: For keeping track of Tripal 4 core development.
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/core_development_task.yml
+++ b/.github/ISSUE_TEMPLATE/core_development_task.yml
@@ -1,0 +1,24 @@
+name: Core Development Task (Form)
+description: For keeping track of Tripal 4 core development.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Core Tripal 4 Development Task
+        Remember to tag this issue with 1 or more groups that it relates to.
+
+        I suggest using the "Development Branch" section to the right once you create the issue.
+        This links the branch to the issue and will automatically close the issue when the PR is merged.
+  - type: textarea
+    id: task_description
+    attributes:
+      label: Task Description
+      description: Describe the core development task.
+    validations:
+        required: true
+  - type: input
+    id: branch_name
+    attributes:
+      label: Branch Name
+      description: Fill this in after submitting this issue and opening a new branch.
+      value: tv4g[0-9]-issue\d+-[optional short descriptor]

--- a/.github/ISSUE_TEMPLATE/discussion_question.yml
+++ b/.github/ISSUE_TEMPLATE/discussion_question.yml
@@ -1,0 +1,20 @@
+name: Discussion / Question (Form)
+description: Discuss a topic / Ask for help.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Instructions
+        Our intent is to use Github as an open forum to help community members connect.
+        If you are looking to do any of the following, you are in the right place! and Thank You!
+          - Ask for help/documentation/clarification of Tripal Functionality and Site Building/Management
+          - Discuss controlled vocabulary terms for your data
+          - Ask for input on site/module design questions
+          - State your intent to develop a specific extension module
+          - Really any type of discussion or question -we want to hear from you!
+  - type: textarea
+    id: discussion_question
+    attributes:
+      label: Discussion or Question
+    validations:
+        required: true

--- a/.github/ISSUE_TEMPLATE/discussion_question.yml
+++ b/.github/ISSUE_TEMPLATE/discussion_question.yml
@@ -1,4 +1,4 @@
-name: Discussion / Question (Form)
+name: Discussion / Question
 description: Discuss a topic / Ask for help.
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
@@ -1,4 +1,4 @@
-name: Tripal 4 Feature Request (Form)
+name: Tripal 4 Feature Request
 description: Suggest an idea for this project
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
@@ -9,7 +9,7 @@ body:
         The following template is meant to structure your feature request.
         Please keep in mind, this issue may evolve into discussion for an extension module if it's decided that the feature is not a good fit for Tripal Core.
 
-        Go over all the follwoing points, and select the options that best apply to you.
+        Go over all the following points, and select the options that best apply to you.
   - type: dropdown
     id: existing_problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/tripal_4_feature_request.yml
@@ -1,0 +1,55 @@
+name: Tripal 4 Feature Request (Form)
+description: Suggest an idea for this project
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        # Tripal 4 Feature Request
+        ## Instructions
+        The following template is meant to structure your feature request.
+        Please keep in mind, this issue may evolve into discussion for an extension module if it's decided that the feature is not a good fit for Tripal Core.
+
+        Go over all the follwoing points, and select the options that best apply to you.
+  - type: dropdown
+    id: existing_problem
+    attributes:
+      label: This feature attempts to solve an existing problem
+      options:
+        - "Yes"
+        - "No"
+  - type: dropdown
+    id: open_to_develop_or_collab_extensino
+    attributes:
+      label: I am open to developing or collaborating on an extension module if this is not a good fit for Tripal Core
+      description: No pressure here, just good to know upfront :-)
+      options:
+        - "Yes"
+        - "No"
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Is this feature urgent?
+      options:
+        - "Yes"
+        - "No"
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and conccise description of what you want to happen.
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Your specific use case
+      description: Please describe how you would use this feature in your own Tripal site and why you need it.
+  - type: textarea
+    id: generally_applicable
+    attributes:
+      label: Generally Applicable
+      description: Why do you feel this is generally applicable? 
+      placeholder: Suggest other use cases if possible.
+  - type: textarea
+    id: additional_information_screenshots
+    attributes:
+      label: Additional information/screenshots
+      description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Now that we've switched 4.x to the main branch, we are without issue templates! These new ones are yml and utilize Github's [Issue form templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates). They provide users with nice forms to fill out.

We can/should adjust them as needed, they were created to mimic our old issue templates as closely as possible. 