### PR TITLE
Add a Tripal 4 Pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 ### Issue #
 
 <!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
-## Tripal Version:
+### Tripal Version: 
 
 ## Description
 <!--- Describe your changes in detail -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Thank you for contributing! -->
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- See our Contribution Guidelines here:
+          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
+
+
+<!---  Please set the header below based on the PR type:
+# New Feature
+# Bug Fix
+# Tripal 4 Core Dev Task  --->
+
+#
+
+Issue #
+
+<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
+### Tripal Version: 
+
+## Description
+<!--- Describe your changes in detail -->
+<!--- Why is this change required? What problem does it solve? -->
+
+## Testing?
+<!--- Please describe in detail how to test these changes. -->
+<!--- Reviewers will use this section to test the submission! -->
+<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--- Thank you for contributing! -->
 <!--- Provide a general summary of your changes in the Title above -->
 <!--- See our Contribution Guidelines here:
-          https://github.com/tripal/tripal/blob/7.x-3.x/CONTRIBUTING.md -->
+          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->
 
 
 <!---  Please set the header below based on the PR type:
@@ -11,10 +11,10 @@
 
 #
 
-Issue #
+### Issue #
 
 <!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
-### Tripal Version: 
+## Tripal Version:
 
 ## Description
 <!--- Describe your changes in detail -->


### PR DESCRIPTION
# New Feature

### Closes #1614 

## Tripal Version: 4.x

## Description

This is the Tripal 7.x-3.x pull request template, with an updated contributing link, and a couple of minor edits just based on my own preference 😆 You can see just these changes in commit https://github.com/tripal/tripal/pull/1633/commits/25434c2211c0a7406a60619147129e3f6b23a001 and then I removed one https://github.com/tripal/tripal/pull/1633/commits/354d8b7649f2caa177c8042d38e473933e16090d

Apparently for pull requests you can't use the nice YAML method that Sean used for the issue templates.

## Testing
Preview at https://github.com/tripal/tripal/blob/354d8b7649f2caa177c8042d38e473933e16090d/.github/PULL_REQUEST_TEMPLATE.md