### PR TITLE
TripalImporter support for use_button is false

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -129,7 +129,7 @@ class TripalImporterForm implements FormInterface {
 
     // We should only add a submit button if this importer uses a button.
     // Examples of importers who don't use this button are mutl-page forms.
-    if (array_key_exists('use_button', $importer_def) AND $importer_def['use_button'] != FALSE) {
+    if (array_key_exists('use_button', $importer_def) AND $importer_def['use_button'] !== FALSE) {
       $form['button'] = [
         '#type' => 'submit',
         '#value' => $importer_def['button_text'],

--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -127,12 +127,15 @@ class TripalImporterForm implements FormInterface {
       $form = array_merge($form, $importer_form);
     }
 
-
-    $form['button'] = [
-      '#type' => 'submit',
-      '#value' => $importer_def['button_text'],
-      '#weight' => 10,
-    ];
+    // We should only add a submit button if this importer uses a button.
+    // Examples of importers who don't use this button are mutl-page forms.
+    if (array_key_exists('use_button', $importer_def) AND $importer_def['use_button'] != FALSE) {
+      $form['button'] = [
+        '#type' => 'submit',
+        '#value' => $importer_def['button_text'],
+        '#weight' => 10,
+      ];
+    }
 
     return $form;
   }

--- a/tripal/src/TripalImporter/Annotation/TripalImporter.php
+++ b/tripal/src/TripalImporter/Annotation/TripalImporter.php
@@ -88,6 +88,15 @@ class TripalImporter extends Plugin {
   public $require_analysis;
 
   /**
+   * Indicates whether the base importer should add a submit button or not.
+   * This should only be used in situations were you need multiple buttons
+   * or control over the submit process (e.g. multi-page forms).
+   *
+   * @var bool
+   */
+  public $use_button = TRUE;
+
+  /**
    * Text that should appear on the button at the bottom of the importer form.
    *
    * @var \Drupal\Core\Annotation\Translation

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -147,8 +147,6 @@ class TripalImporterFormBuildTest extends KernelTestBase {
 
   /**
    * Tests focusing on the Tripal importer form.
-   *
-   * @group tripal_importer
    */
   public function testTripalImporterForm() {
 
@@ -224,8 +222,6 @@ class TripalImporterFormBuildTest extends KernelTestBase {
   /**
    * Confirm that the file-related form elements are added to the form
    * as expected based on plugin annotation.
-   *
-   * @group tripal_importer
    */
   public function testTripalImporterFormFiles() {
 
@@ -399,8 +395,6 @@ class TripalImporterFormBuildTest extends KernelTestBase {
     /**
    * Confirm that the file-related form elements are added to the form
    * as expected based on plugin annotation.
-   *
-   * @group tripal_importer
    */
   public function testTripalImporterFormAnalysis() {
 
@@ -430,5 +424,36 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       "The title for our analysis element did not match what we expected.");
     $this->assertCount(4, $form['analysis_method']['#options'],
       "There were not the expected number of options including the empty option that we expected for our analysis.");
+  }
+
+  /**
+   * Confirm that importers whose annotation indicates they do not want a submit
+   * button, do not get a submit button forced on them.
+   */
+  public function testTripalImporterFormNoButton() {
+
+    $container = \Drupal::getContainer();
+    $plugin_id = 'fakeImporterName';
+    $expected = $this->definitions[$plugin_id];
+
+    // -- Indicate to use an analysis elements.
+    $expected['use_button'] = FALSE;
+    $manager = $this->setMockManager([$plugin_id => $expected]);
+    $container->set('tripal.importer', $manager);
+
+    // Build the form using the Drupal form builder.
+    $form = \Drupal::formBuilder()->getForm(
+      'Drupal\tripal\Form\TripalImporterForm',
+      $plugin_id,
+    );
+    $this->assertIsArray($form,
+      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our analysis element is in the form.
+    $this->assertArrayNotHasKey('button', $form,
+      "We should not have a submit button if our annotation sets use_button to FALSE but we do.");
+
   }
 }

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -46,6 +46,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       'upload_title' => 'Gemstone Descriptions',
       'use_analysis' => FALSE,
       'require_analysis' => FALSE,
+      'use_button' => TRUE,
       'button_text' => 'Import file',
       'file_upload' => FALSE,
       'file_load' => FALSE,
@@ -201,7 +202,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       "The importer_plugin_id[#value] should be set to our fake plugin_id.");
     // a submit button.
     $this->assertArrayHasKey('button', $form,
-      "The form should not have a submit button since we indicated a specific importer.");
+      "The form should have a submit button since we indicated a specific importer.");
 
     // We should also have our importer specific form elements added to the form!
     $this->assertArrayHasKey('gemstone_composition', $form,


### PR DESCRIPTION
# Bug Fix

### Issue #1580 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Simple PR ensuring that the TripalImporter only adds it's own submit button if the specific importer has not indicated `use_button` = FALSE. This allows importers to take control of the submit button if needed (e.g. multi-page forms).

## Testing?
I also added an automated test to confirm this works!

That said, if you want to confirm yourself manually, just edit and existing importer and add the following into the annotation (or replace this line if it already exists).

Then refresh the importer page, scroll to the bottom and confirm that there is no submit button 🙃 Check an unaltered importer who doesn't define use_button in the annotation and ensure they do have a button (default set in annotation class).

```
 *    use_button = False,
```

For example,
<img width="509" alt="Screenshot 2023-09-18 at 5 12 00 PM" src="https://github.com/tripal/tripal/assets/1566301/0d32a8eb-6d2d-4c3f-a90d-b4d54c276422">
