### PR TITLE
Tripal 4 Assorted typo fixes

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -128,7 +128,7 @@ class TripalImporterForm implements FormInterface {
     }
 
     // We should only add a submit button if this importer uses a button.
-    // Examples of importers who don't use this button are mutl-page forms.
+    // Examples of importers who don't use this button are multi-page forms.
     if (array_key_exists('use_button', $importer_def) AND $importer_def['use_button'] !== FALSE) {
       $form['button'] = [
         '#type' => 'submit',

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -62,7 +62,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
    *
    * This function will only add defaults if the value is not already present
    * in the $field_def array. You can retrieve a fully populated definition
-   * array, with derfaults, by not passing an argument.  This function will
+   * array, with defaults, by not passing an argument.  This function will
    * remove any keys in the definition array that are not supported.
    *
    * @return array $field_def
@@ -201,7 +201,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
    * Validates a field definition array.
    *
    * This function can be used to check a field definition prior to adding
-   * the field to a Tripal content type..
+   * the field to a Tripal content type.
    *
    * @param array $field_def
    *   A definition array for the field.
@@ -321,7 +321,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
    *     - storage_plugin_id: the name of the storage plugin
    *       (e.g. 'chado_storage').
    *     - storage_plugin_setings: an array of any settings that the storage
-   *       plugin expects for the field..
+   *       plugin expects for the field.
    *   - settings: (array) Any other settings needed for the field. Every
    *     field can have different settings.
    *   - display: Provides details for display of the field. By default it
@@ -413,7 +413,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
 
     try {
 
-      // Check if field storage exists for this field. If not, add it..
+      // Check if field storage exists for this field. If not, add it.
       $field_storage = FieldStorageConfig::loadByName('tripal_entity', $field_def['name']);
       if (!$field_storage) {
         $field_storage = FieldStorageConfig::create([

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -744,7 +744,7 @@ EOD;
    *   -'name': table name
    *   -'type': one of 'table', 'view', 'partition' and 'materialized view' for
    *     PostgreSQL materialized views.
-   *   -'status': either 'base' for base a table, or 'custom' for a custom table
+   *   -'status': either 'base' for a base table, or 'custom' for a custom table
    *     or a tripal materialized view, or 'other' for other elements.
    */
   public function getTables(

--- a/tripal/src/TripalStorage/StoragePropertyBase.php
+++ b/tripal/src/TripalStorage/StoragePropertyBase.php
@@ -63,7 +63,7 @@ class StoragePropertyBase {
       }
     }
     else {
-      throw new \Exception('Cannot create a StorageProperty object without a property formatted term: ' . $term_id);
+      throw new \Exception('Cannot create a StorageProperty object without a properly formatted term: ' . $term_id);
     }
 
     // Ensure we have required values.

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -818,7 +818,7 @@ class TripalTerm {
    * An array of synonyms.
    *
    * For easy lookup, this is an associative array where
-   * the key is the synonym and the value is the type term..
+   * the key is the synonym and the value is the type term.
    * Using the synonym as the key also prevents duplication.
    *
    * @var array

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
@@ -142,7 +142,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($selected_args,
       "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguments we expected.");
+      "We did not retrieve the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -153,7 +153,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($retrieved_args,
       "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguments we expected after loading.");
+      "We did not retrieve the arguments we expected after loading.");
 
     // CASE --- Exception Expected
     // -- Empty run args, no file when file required.
@@ -216,7 +216,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($selected_args,
       "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguments we expected.");
+      "We did not retrieve the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -227,7 +227,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($retrieved_args,
       "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguments we expected after loading.");
+      "We did not retrieve the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + remote file.
@@ -264,7 +264,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($selected_args,
       "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguments we expected.");
+      "We did not retrieve the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -275,7 +275,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($retrieved_args,
       "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguments we expected after loading.");
+      "We did not retrieve the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + file upload (single file).
@@ -315,7 +315,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($selected_args,
       "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguments we expected.");
+      "We did not retrieve the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -326,7 +326,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($retrieved_args,
       "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguments we expected after loading.");
+      "We did not retrieve the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + file upload (multiple files).
@@ -369,7 +369,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($selected_args,
       "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguments we expected.");
+      "We did not retrieve the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -380,7 +380,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $this->assertIsArray($retrieved_args,
       "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguments we expected after loading.");
+      "We did not retrieve the arguments we expected after loading.");
 
     // CASE --- Exception Expected
     // -- Load non-existant importer.

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
@@ -140,9 +140,9 @@ class TripalImporterBaseTest extends KernelTestBase {
       "The class should match our fake plugin name.");
     $selected_args = unserialize(base64_decode($records[0]->arguments));
     $this->assertIsArray($selected_args,
-      "Unable to retrieve arguements after creating tripal importer record.");
+      "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguements we expected.");
+      "We did not retreive the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -151,9 +151,9 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importerTestLoad->load($import_id);
     $retrieved_args = $importerTestLoad->getArguments();
     $this->assertIsArray($retrieved_args,
-      "Unable to retrieve arguements after loading tripal importer.");
+      "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguements we expected after loading.");
+      "We did not retreive the arguments we expected after loading.");
 
     // CASE --- Exception Expected
     // -- Empty run args, no file when file required.
@@ -214,9 +214,9 @@ class TripalImporterBaseTest extends KernelTestBase {
       "The class should match our fake plugin name.");
     $selected_args = unserialize(base64_decode($records[0]->arguments));
     $this->assertIsArray($selected_args,
-      "Unable to retrieve arguements after creating tripal importer record.");
+      "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguements we expected.");
+      "We did not retreive the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -225,9 +225,9 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importerTestLoad->load($import_id);
     $retrieved_args = $importerTestLoad->getArguments();
     $this->assertIsArray($retrieved_args,
-      "Unable to retrieve arguements after loading tripal importer.");
+      "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguements we expected after loading.");
+      "We did not retreive the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + remote file.
@@ -262,9 +262,9 @@ class TripalImporterBaseTest extends KernelTestBase {
       "The class should match our fake plugin name.");
     $selected_args = unserialize(base64_decode($records[0]->arguments));
     $this->assertIsArray($selected_args,
-      "Unable to retrieve arguements after creating tripal importer record.");
+      "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguements we expected.");
+      "We did not retreive the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -273,9 +273,9 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importerTestLoad->load($import_id);
     $retrieved_args = $importerTestLoad->getArguments();
     $this->assertIsArray($retrieved_args,
-      "Unable to retrieve arguements after loading tripal importer.");
+      "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguements we expected after loading.");
+      "We did not retreive the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + file upload (single file).
@@ -313,9 +313,9 @@ class TripalImporterBaseTest extends KernelTestBase {
       "The class should match our fake plugin name.");
     $selected_args = unserialize(base64_decode($records[0]->arguments));
     $this->assertIsArray($selected_args,
-      "Unable to retrieve arguements after creating tripal importer record.");
+      "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguements we expected.");
+      "We did not retreive the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -324,9 +324,9 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importerTestLoad->load($import_id);
     $retrieved_args = $importerTestLoad->getArguments();
     $this->assertIsArray($retrieved_args,
-      "Unable to retrieve arguements after loading tripal importer.");
+      "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguements we expected after loading.");
+      "We did not retreive the arguments we expected after loading.");
 
     // CASE --- Valid
     // -- run args + file upload (multiple files).
@@ -367,9 +367,9 @@ class TripalImporterBaseTest extends KernelTestBase {
       "The class should match our fake plugin name.");
     $selected_args = unserialize(base64_decode($records[0]->arguments));
     $this->assertIsArray($selected_args,
-      "Unable to retrieve arguements after creating tripal importer record.");
+      "Unable to retrieve arguments after creating tripal importer record.");
     $this->assertEquals($expected_args, $selected_args,
-      "We did not retreive the arguements we expected.");
+      "We did not retreive the arguments we expected.");
 
     $importerTestLoad = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
@@ -378,9 +378,9 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importerTestLoad->load($import_id);
     $retrieved_args = $importerTestLoad->getArguments();
     $this->assertIsArray($retrieved_args,
-      "Unable to retrieve arguements after loading tripal importer.");
+      "Unable to retrieve arguments after loading tripal importer.");
     $this->assertEquals($expected_args, $retrieved_args,
-      "We did not retreive the arguements we expected after loading.");
+      "We did not retreive the arguments we expected after loading.");
 
     // CASE --- Exception Expected
     // -- Load non-existant importer.
@@ -522,7 +522,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importer->prepareFiles();
     $retrieved_args = $importer->getArguments();
     $this->assertIsArray($retrieved_args,
-      "We could not retrieve arguements after preparing files");
+      "We could not retrieve arguments after preparing files");
     $this->assertArrayHasKey('file_path', $retrieved_args['files'][0],
       "The file_path should have been set during prepareFiles().");
 
@@ -549,7 +549,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importer->prepareFiles();
     $retrieved_args = $importer->getArguments();
     $this->assertIsArray($retrieved_args,
-      "We could not retrieve arguements after preparing files");
+      "We could not retrieve arguments after preparing files");
     $this->assertArrayHasKey('file_path', $retrieved_args['files'][0],
       "The file_path should have been set during prepareFiles().");
 

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -163,7 +163,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
 
     // Ensure we are able to build the form.
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -245,7 +245,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -299,7 +299,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -334,7 +334,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -369,7 +369,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -414,7 +414,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
@@ -448,7 +448,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       $plugin_id,
     );
     $this->assertIsArray($form,
-      'We still expect the form builder to return a form array even without a plguin_id but it did not.');
+      'We still expect the form builder to return a form array even without a plugin_id but it did not.');
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 

--- a/tripal/tests/src/Kernel/TripalStorage/PropertyBaseClassTest.php
+++ b/tripal/tests/src/Kernel/TripalStorage/PropertyBaseClassTest.php
@@ -96,7 +96,7 @@ class PropertyBaseClassTest extends KernelTestBase {
     catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
-    $this->assertStringContainsString('property formatted term', $exception_message,
+    $this->assertStringContainsString('properly formatted term', $exception_message,
       "We did not get the exception message we expected for passing in a badly formatted term.");
 
     // Test passing in a term whose ID Space doesn't exist in our mock.

--- a/tripal/tripal.views.inc
+++ b/tripal/tripal.views.inc
@@ -137,7 +137,7 @@ function tripal_views_data_jobs(&$data) {
 
   // Arguments
   $data['tripal_jobs']['arguments'] = [
-    'title' => t('Arguements'),
+    'title' => t('Arguments'),
     'help' => t('Any arguments passed to the callback.'),
     'field' => [
       'id' => 'standard',

--- a/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
+++ b/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
@@ -221,7 +221,7 @@ vocabularies:
                 description: 'A version number is an information content entity which is a sequence of characters borne by part of each of a class of manufactured products or its packaging and indicates its order within a set of other products having the same name.'
             -   id: 'IAO:0000064'
                 name: 'algorithm'
-                description: 'An algorithm is a set of instructions for performing a paticular calculation.'
+                description: 'An algorithm is a set of instructions for performing a particular calculation.'
 
     -   name: 'null'
         label: 'No vocabulary'

--- a/tripal_chado/config/install/views.view.chado_mviews.yml
+++ b/tripal_chado/config/install/views.view.chado_mviews.yml
@@ -794,7 +794,7 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: false
-          content: '<a class="button button-action button--primary button--small" href="[site:url]admin/tripal/storage/chado/mview">Add Materilaized View</a>'
+          content: '<a class="button button-action button--primary button--small" href="[site:url]admin/tripal/storage/chado/mview">Add Materialized View</a>'
           tokenize: false
       footer: {  }
       display_extenders: {  }

--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -87,7 +87,7 @@ class ChadoSchema extends TripalDbxSchema {
    *  include linker tables (which link two or more base tables), property
    * tables, and relationship tables.  These provide additional information
    * about primary data records and are therefore not base tables.  This
-   * function retreives only the list of tables that are considered 'base'
+   * function retrieves only the list of tables that are considered 'base'
    * tables.
    *
    * @return

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -39,7 +39,7 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
     $results = $chado->query($sql, []);
 
     while ($contact = $results->fetchObject()) {
-      // Change the non-user-friendly 'null' contact, which is spedified by chado.
+      // Change the non-user-friendly 'null' contact, which is specified by chado.
       if ($contact->name == 'null') {
         $contact->name = '-- Unknown --';  // This will sort to the top.
       }

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -984,7 +984,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
   }
 
   /**
-   * Retrieves from the Drupal cache the default vocabulary for this space..
+   * Retrieves from the Drupal cache the default vocabulary for this space.
    *
    * @return string
    *   The deffault vocabulary name.

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2731,7 +2731,7 @@ class OBOImporter extends ChadoImporterBase {
    *   The name of the vocabulary to add.
    *
    * @return object|NULL
-   *   The newly inserted CV object..
+   *   The newly inserted CV object.
    */
   private function insertChadoCv($cvname) {
     $chado = $this->getChadoConnection();

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -351,7 +351,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
         }
       }
 
-      // Now insert all new values for nor the non-base table records.
+      // Now insert all new values for the non-base table records.
       foreach ($records as $chado_table => $deltas) {
         foreach ($deltas as $delta => $record) {
 
@@ -393,7 +393,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     }
 
     // If we are selecting on the base table and we don't have a proper
-    // condition then throw and error.
+    // condition then throw an error.
     if (!$this->hasValidConditions($record)) {
       throw new \Exception($this->t('Cannot select record in the Chado "@table" table due to unset conditions. Record: @record',
           ['@table' => $chado_table, '@record' => print_r($record, TRUE)]));
@@ -983,7 +983,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       ];
     }
 
-    // Get then current number of joins to the right table.
+    // Get the current number of joins to the right table.
     $num_left = 0;
     if (array_key_exists($left_table,$records[$parent_table][$delta]['joins'])) {
       $num_left = count($records[$parent_table][$delta]['joins'][$left_table]) - 1;

--- a/tripal_chado/src/Services/ChadoFieldDebugger.php
+++ b/tripal_chado/src/Services/ChadoFieldDebugger.php
@@ -182,7 +182,7 @@ class ChadoFieldDebugger {
      * We would like to complete print out the query with subbed in parameters
      * but it's driving me crazy.
      *
-     * Usually we would use $query->arguments() to get the arguements with
+     * Usually we would use $query->arguments() to get the arguments with
      * placeholders but there are a number of bugs here:
      *  - in Drupal 10 $insertQuery->arguments() provides a scope error.
      *  - $updateQuery->arguments() only provides the conditional arguments,

--- a/tripal_chado/src/api/ChadoSchema.php
+++ b/tripal_chado/src/api/ChadoSchema.php
@@ -324,7 +324,7 @@ class ChadoSchema {
    *  include linker tables (which link two or more base tables), property
    * tables, and relationship tables.  These provide additional information
    * about primary data records and are therefore not base tables.  This
-   * function retreives only the list of tables that are considered 'base'
+   * function retrieves only the list of tables that are considered 'base'
    * tables.
    *
    * @return

--- a/tripal_chado/src/api/ChadoSchema.php
+++ b/tripal_chado/src/api/ChadoSchema.php
@@ -531,7 +531,7 @@ class ChadoSchema {
    * Check that any given column in a Chado table exists.
    *
    * This function is necessary because Drupal's db_field_exists() will not
-   * look in any other schema but the one were Drupal is installed
+   * look in any other schema but the one where Drupal is installed
    *
    * @param $table
    *   The name of the chado table.
@@ -611,7 +611,7 @@ class ChadoSchema {
    * Check that any given column in a Chado table exists.
    *
    * This function is necessary because Drupal's db_field_exists() will not
-   * look in any other schema but the one were Drupal is installed
+   * look in any other schema but the one where Drupal is installed
    *
    * @param $table
    *   The name of the chado table.

--- a/tripal_chado/src/api/tripal_chado.db.api.php
+++ b/tripal_chado/src/api/tripal_chado.db.api.php
@@ -161,7 +161,7 @@ function chado_get_db_select_options($schema_name = NULL) {
 
   $dbs = chado_query(
     "SELECT db_id, name FROM {db} ORDER BY name",
-    [], // Arguements.
+    [], // Arguments.
     [], // Options.
     $schema_name
   );

--- a/tripal_chado/src/api/tripal_chado.query.api.php
+++ b/tripal_chado/src/api/tripal_chado.query.api.php
@@ -402,7 +402,7 @@ function chado_set_active($dbname = 'default', $chado_schema_name = NULL) {
  *
  * Use this function to insert a record into any Chado table.  The first
  * argument specifies the table for inserting and the second is an array
- * of values to be inserted.  The array is mutli-dimensional such that
+ * of values to be inserted.  The array is multi-dimensional such that
  * foreign key lookup values can be specified.
  *
  * @param $table
@@ -706,7 +706,7 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
  * Use this function to update a record in any Chado table.  The first
  * argument specifies the table for inserting, the second is an array
  * of values to matched for locating the record for updating, and the third
- * argument give the values to update.  The arrays are mutli-dimensional such
+ * argument give the values to update.  The arrays are multi-dimensional such
  * that foreign key lookup values can be specified.
  *
  * @param string $table
@@ -980,7 +980,7 @@ function chado_update_record($table, $match, $values, $options = NULL, $chado_sc
  * Use this function to delete a record(s) in any Chado table.  The first
  * argument specifies the table to delete from and the second is an array
  * of values to match for locating the record(s) to be deleted.  The arrays
- * are mutli-dimensional such that foreign key lookup values can be specified.
+ * are multi-dimensional such that foreign key lookup values can be specified.
  *
  * @param string $table
  *  The name of the chado table for inserting.

--- a/tripal_chado/src/api/tripal_chado.query.api.php
+++ b/tripal_chado/src/api/tripal_chado.query.api.php
@@ -1766,7 +1766,7 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
   }
   // -- Args should be an array.
   if (!is_array($args)) {
-    $msg = t('chado_query; Arguements should be an array. Query: @query; Arguements: @values',
+    $msg = t('chado_query; Arguments should be an array. Query: @query; Arguments: @values',
       ['@values' => print_r($args, TRUE), '@query' => $sql]);
     \Drupal::logger('tripal_chado')->error($msg);
     return FALSE;
@@ -1777,7 +1777,7 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
   $tokens_in_sql = $matches[0];
   $tokens_in_args = array_keys($args);
   if (count($tokens_in_sql) !== count($tokens_in_args)) {
-    $msg = t('chado_query; There should be the same number of tokens in the arguements as in the SQL. Tokens provided: @args, Tokens in SQL: @sql',
+    $msg = t('chado_query; There should be the same number of tokens in the arguments as in the SQL. Tokens provided: @args, Tokens in SQL: @sql',
       ['@args' => print_r($tokens_in_args,TRUE), '@sql' => print_r($tokens_in_sql,TRUE)]);
     \Drupal::logger('tripal_chado')->error($msg);
     return FALSE;

--- a/tripal_chado/src/api/tripal_chado.schema.api.php
+++ b/tripal_chado/src/api/tripal_chado.schema.api.php
@@ -557,7 +557,7 @@ function chado_get_custom_table_schema($table, $chado_schema = NULL) {
  *  include linker tables (which link two or more base tables), property tables,
  *  and relationship tables.  These provide additional information about
  *  primary data records and are therefore not base tables.  This function
- *  retreives only the list of tables that are considered 'base' tables.
+ *  retrieves only the list of tables that are considered 'base' tables.
  *
  * @param string $chado_schema
  *   The chado schema you are interested in.

--- a/tripal_chado/src/api/tripal_chado.schema.api.php
+++ b/tripal_chado/src/api/tripal_chado.schema.api.php
@@ -39,7 +39,7 @@ use Drupal\Core\Database\Database;
  * Check that any given Chado table exists.
  *
  * This function is necessary because Drupal's db_table_exists() function will
- * not look in any other schema but the one were Drupal is installed
+ * not look in any other schema but the one where Drupal is installed
  *
  * @param string $table
  *   The name of the chado table whose existence should be checked.
@@ -69,7 +69,7 @@ function chado_table_exists($table, $chado_schema = NULL) {
  * Check that any given column in a Chado table exists.
  *
  * This function is necessary because Drupal's db_field_exists() will not
- * look in any other schema but the one were Drupal is installed
+ * look in any other schema but the one where Drupal is installed
  *
  * @param string $table
  *   The name of the chado table.
@@ -102,7 +102,7 @@ function chado_column_exists($table, $column, $chado_schema = NULL) {
  * Check that any given column in a Chado table exists.
  *
  * This function is necessary because Drupal's db_field_exists() will not
- * look in any other schema but the one were Drupal is installed
+ * look in any other schema but the one where Drupal is installed
  *
  * @param string $sequence
  *   The name of the sequence.
@@ -605,6 +605,7 @@ function chado_get_base_tables($chado_schema = NULL) {
  *
  * @upgrade
  *
+ */
 function chado_get_cvterm_mapping($params) {
   $cvterm_id = array_key_exists('cvterm_id', $params) ? $params['cvterm_id'] : NULL;
   $vocabulary = array_key_exists('vocabulary', $params) ? $params['vocabulary'] : NULL;
@@ -641,4 +642,3 @@ function chado_get_cvterm_mapping($params) {
   }
   return NULL;
 }
-*/

--- a/tripal_chado/src/api/tripal_chado.variables.api.php
+++ b/tripal_chado/src/api/tripal_chado.variables.api.php
@@ -1027,7 +1027,7 @@ function chado_expand_var($object, $type, $to_expand, $table_options = [], $sche
   if (property_exists($object, 'expanded')) {
 
     // If so, then remove the expanded identifier from the correct expandable
-    // array..
+    // array.
     $expandable_name = 'expandable_' . $type . 's';
     if (property_exists($object, $expandable_name) and $object->{$expandable_name}) {
       $key_to_remove = array_search($object->expanded, $object->{$expandable_name});

--- a/tripal_chado/tests/fixtures/fill_chado_test_prepare.sql
+++ b/tripal_chado/tests/fixtures/fill_chado_test_prepare.sql
@@ -3603,7 +3603,7 @@ INSERT INTO chado.cvterm VALUES (42, 11, 'assay', 'A planned process with the ob
 INSERT INTO chado.cvterm VALUES (43, 12, 'location on map', '', 43, 0, 0);
 INSERT INTO chado.cvterm VALUES (44, 13, 'definition', 'The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.', 44, 0, 0);
 INSERT INTO chado.cvterm VALUES (45, 13, 'version number', 'A version number is an information content entity which is a sequence of characters borne by part of each of a class of manufactured products or its packaging and indicates its order within a set of other products having the same name.', 45, 0, 0);
-INSERT INTO chado.cvterm VALUES (46, 13, 'algorithm', 'An algorithm is a set of instructions for performing a paticular calculation.', 46, 0, 0);
+INSERT INTO chado.cvterm VALUES (46, 13, 'algorithm', 'An algorithm is a set of instructions for performing a particular calculation.', 46, 0, 0);
 INSERT INTO chado.cvterm VALUES (47, 2, 'property', 'A generic term indicating that represents an attribute, quality or characteristic of something.', 47, 0, 0);
 INSERT INTO chado.cvterm VALUES (48, 2, 'time_last_modified', 'The time at which the record was last modified.', 48, 0, 0);
 INSERT INTO chado.cvterm VALUES (49, 2, 'time_accessioned', 'The time at which the record was first added.', 49, 0, 0);

--- a/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
+++ b/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
@@ -6,7 +6,7 @@ use Drupal\tripal\TripalDBX\TripalDbx;
 use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
- * This is a base class for Chado tests that need a full Drupal install..
+ * This is a base class for Chado tests that need a full Drupal install.
  *
  * It enables Chado tests schemas and helper functions to efficiently perform
  * tests.

--- a/tripal_chado/tests/src/Functional/api/ChadoQueryAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoQueryAPITest.php
@@ -53,12 +53,12 @@ class ChadoQueryAPITest extends BrowserTestBase {
 		$dbq = chado_query($sql, $args);
 		$this->assertEquals(FALSE, $dbq);
 
-		// -- Arguements must be an array.
+		// -- Arguments must be an array.
 		$sql = $args = 'SELECT * FROM {organism}';
 		$dbq = chado_query($sql, $args);
 		$this->assertEquals(FALSE, $dbq);
 
-		// -- Arguements should be in the SQL string.
+		// -- Arguments should be in the SQL string.
 		$sql = 'SELECT * FROM {organism} WHERE genus=:genus';
 		$args = [':genus' => 'Tripalus', ':species' => 'databasica'];
 		$dbq = chado_query($sql, $args);


### PR DESCRIPTION
# Bug Fix

### Issue #1389

### Tripal Version: 4.x

## Description
Spelling and typo fixes.

## Testing?
There is only one fix that would affect an automated test (`tripal/src/TripalStorage/StoragePropertyBase.php`), but it is fixed in the test too.
Code review and automated testing should be sufficient?
