### PR TITLE
Tripal 4 importer logging updates

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -259,8 +259,8 @@ class TripalImporterForm implements FormInterface {
 
     // How many methods were specified for the source of the file?
     $n_methods = ($file_local?1:0) + ($file_remote?1:0) + (($file_upload or $file_existing)?1:0);
-    // The user must provide at least one file source method.
-    if ($n_methods == 0) {
+    // If a file is required, the user must provide at least one file source method.
+    if (array_key_exists('file_required', $importer_def) and ($importer_def['file_required'] == TRUE) and ($n_methods == 0)) {
       $form_state->setErrorByName('file_local', t('You must provide a file location or upload a file.'));
     }
     // No more than one method can be specified.

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -35,68 +35,6 @@ use Drupal\Core\Ajax\ReplaceCommand;
  */
 class FASTAImporter extends ChadoImporterBase {
   /**
-   * The name of this loader.  This name will be presented to the site
-   * user.
-   */
-  public static $name = 'Chado FASTA Loader';
-
-  /**
-   * The machine name for this loader. This name will be used to construct
-   * the URL for the loader.
-   */
-  public static $machine_name = 'chado_fasta_loader';
-
-  /**
-   * A brief description for this loader.  This description will be
-   * presented to the site user.
-   */
-  public static $description = 'Load sequences from a multi-FASTA file into Chado';
-
-  /**
-   * An array containing the extensions of allowed file types.
-   */
-  public static $file_types = [
-    'fasta',
-    'txt',
-    'fa',
-    'aa',
-    'pep',
-    'nuc',
-    'faa',
-    'fna',
-  ];
-
-
-  /**
-   * Provides information to the user about the file upload.  Typically this
-   * may include a description of the file types allowed.
-   */
-  public static $upload_description = 'Please provide the FASTA file. The file must have a .fasta extension.';
-
-  /**
-   * The title that should appear above the file upload section.
-   */
-  public static $upload_title = 'FASTA Upload';
-
-  /**
-   * Text that should appear on the button at the bottom of the importer
-   * form.
-   */
-  public static $button_text = 'Import FASTA file';
-
-  /**
-   * Indicates the methods that the file uploader will support.
-   */
-  public static $methods = [
-    // Allow the user to upload a file to the server.
-    'file_upload' => TRUE,
-    // Allow the user to provide the path on the Tripal server for the file.
-    'file_local' => TRUE,
-    // Allow the user to provide a remote URL for the file.
-    'file_remote' => TRUE,
-  ];
-
-  /**
    * @see TripalImporter::form()
    */
   public function form($form, &$form_state) {
@@ -505,8 +443,8 @@ class FASTAImporter extends ChadoImporterBase {
       ':cvterm_id' => $cvterm_id,
     ])->fetchObject();
     if (!$cvterm) {
-      $this->logger->error("Cannot find the term type: ':type'",
-        [':type' => $type]
+      $this->logger->error("Cannot find the term type: '@type'",
+        ['@type' => $type]
       );
       return 0;
     }

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -592,7 +592,9 @@ class FASTAImporter extends ChadoImporterBase {
     $filesize = filesize($file_path);
     $fh = fopen($file_path, 'r');
     if (!$fh) {
-      throw new \Exception(t("Cannot open file: !dfile", ['!dfile' => $file_path]));
+      $this->logger->error("Cannot open file: @dfile",
+        ['@dfile' => $file_path]
+      );
     }
     $num_read = 0;
 

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -343,33 +343,14 @@ class FASTAImporter extends ChadoImporterBase {
       $match_type = 'Unique name';
     }
 
-    $file_existing = false;
-    if ($file_upload_existing == "0" || $file_upload_existing == "" || $file_upload_existing == null) {
-      // this means no existing file
-    }
-    else {
-      $file_existing = true;
-    }
-
-    $file_uploaded = false;
-    // If there is no file upload
-    if($file_upload == "" || $file_upload == "0") {
-
-    }
-    else {
-      $file_uploaded = true;
-    }
-
-    if ($file_uploaded == false and $file_existing == false and !$file_local and !$file_remote) {
-      $form_state->setErrorByName('file_local', t('You must upload a FASTA file or choose an existing FASTA file'));
-    }
+    // The parent class will validate that a file has been specified and is valid.
 
     if ($re_name and !$re_uname and strcmp($match_type, 'Unique name') == 0) {
-      $form_state->setErrorByName('re_uname', t('You must provide a regular expression to identify the sequence unique name'));
+      $form_state->setErrorByName('re_name', t('You should not specify a regular expression for name if you are matching to sequence unique name'));
     }
 
     if (!$re_name and $re_uname and strcmp($match_type, 'Name') == 0) {
-      $form_state->setErrorByName('re_name', t('You must provide a regular expression to identify the sequence name'));
+      $form_state->setErrorByName('re_uname', t('You should not specify a regular expression for unique name if you are matching to sequence name'));
     }
 
     // make sure if a relationship is specified that all fields are provided.

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -361,71 +361,60 @@ class FASTAImporter extends ChadoImporterBase {
     }
 
     if ($file_uploaded == false and $file_existing == false and !$file_local and !$file_remote) {
-      \Drupal::messenger()->addError(t("You must upload a FASTA file or choose an existing FASTA file"));
+      $form_state->setErrorByName('file_local', t('You must upload a FASTA file or choose an existing FASTA file'));
     }
 
     if ($re_name and !$re_uname and strcmp($match_type, 'Unique name') == 0) {
-      // form_set_error('re_uname', t("You must provide a regular expression to identify the sequence unique name"));
-      \Drupal::messenger()->addError(t("You must provide a regular expression to identify the sequence unique name"));
+      $form_state->setErrorByName('re_uname', t('You must provide a regular expression to identify the sequence unique name'));
     }
 
     if (!$re_name and $re_uname and strcmp($match_type, 'Name') == 0) {
-      // form_set_error('re_name', t("You must provide a regular expression to identify the sequence name"));
-      \Drupal::messenger()->addError(t("You must provide a regular expression to identify the sequence name"));
+      $form_state->setErrorByName('re_name', t('You must provide a regular expression to identify the sequence name'));
     }
 
     // make sure if a relationship is specified that all fields are provided.
-
     if (($rel_type or $re_subject) and !$parent_type) {
-      // form_set_error('parent_type', t("Please provide a SO term for the parent"));
-      \Drupal::messenger()->addError(t("Please provide a SO term for the parent"));
+      $form_state->setErrorByName('parent_type', t('Please provide a Sequence Ontology (SO) term for the parent'));
     }
     if (($parent_type or $re_subject) and !$rel_type) {
-      // form_set_error('rel_type', t("Please select a relationship type"));
-      \Drupal::messenger()->addError(t("Please select a relationship type"));
+      $form_state->setErrorByName('rel_type', t('Please select a relationship type'));
     }
 
     // make sure if a database is specified that all fields are provided
     if ($db_id and !$re_accession) {
-      // form_set_error('re_accession', t("Please provide a regular expression for the accession"));
-      \Drupal::messenger()->addError(t("Please provide a regular expression for the accession"));
+      $form_state->setErrorByName('re_accession', t('Please provide a regular expression for the accession'));
     }
     if ($re_accession and !$db_id) {
-      // form_set_error('db_id', t("Please select a database"));
-      \Drupal::messenger()->addError(t("Please select a database"));
+      $form_state->setErrorByName('db_id', t('Please select a database'));
     }
 
     // Check to make sure the regexps are valid.
     if ($re_name && @preg_match("/$re_name/", null) === false) {
-      // form_set_error('re_name', t("please provide a valid regular expression for the feature name."));
-      \Drupal::messenger()->addError(t("please provide a valid regular expression for the feature name."));
+      $form_state->setErrorByName('re_name', t('Please provide a valid regular expression for the feature name'));
     }
     if ($re_uname && @preg_match("/$re_uname/", null) === false) {
-      // form_set_error('re_uname', t("please provide a valid regular expression for the feature unique name."));
-      \Drupal::messenger()->addError(t("please provide a valid regular expression for the feature unique name."));
+      $form_state->setErrorByName('re_uname', t('Please provide a valid regular expression for the feature unique name'));
     }
     if ($re_accession && @preg_match("/$re_accession/", null) === false) {
-      // form_set_error('re_accession', t("please provide a valid regular expression for the external database accession."));
-      \Drupal::messenger()->addError(t("please provide a valid regular expression for the external database accession."));
+      $form_state->setErrorByName('re_accession', t('Please provide a valid regular expression for the external database accession'));
     }
     if ($re_subject && @preg_match("/$re_subject/", null) === false) {
-      // form_set_error('re_subject', t("please provide a valid regular expression for the relationship parent."));
-      \Drupal::messenger()->addError(t("please provide a valid regular expression for the relationship parent."));
+      $form_state->setErrorByName('re_subject', t('Please provide a valid regular expression for the relationship parent'));
     }
 
     // check to make sure the types exists
     $cv_autocomplete = new ChadoCVTermAutocompleteController();
     $cvterm_id = $cv_autocomplete->getCVtermId($type, 'sequence');
     if (!$cvterm_id) {
-      // form_set_error('type', t("The Sequence Ontology (SO) term selected for the sequence type is not available in the database. Please check spelling or select another."));
-      \Drupal::messenger()->addError(t("The Sequence Ontology (SO) term selected for the sequence type is not available in the database. Please check spelling or select another."));
+      $form_state->setErrorByName('type', t('The Sequence Ontology (SO) term selected for the sequence'
+        . ' type is not available in the database. Please check the spelling or select another.'));
     }
 
     if ($rel_type) {
       $cvterm_id = $cv_autocomplete->getCVtermId($parent_type, 'sequence');
       if (!$cvterm_id) {
-        // form_set_error('parent_type', t("The Sequence Ontology (SO) term selected for the parent relationship is not available in the database. Please check spelling or select another."));
-        \Drupal::messenger()->addError(t("The Sequence Ontology (SO) term selected for the parent relationship is not available in the database. Please check spelling or select another."));
+        $form_state->setErrorByName('parent_type', t('The Sequence Ontology (SO) term selected for the parent'
+          . ' relationship is not available in the database. Please check the spelling or select another.'));
       }
     }
   }

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -145,7 +145,7 @@ class FASTAImporter extends ChadoImporterBase {
          exists with the same name or unique name and type then it is skipped.
          Select "Update only" to only update featues that already exist in the
          database.  Select "Insert and Update" to insert features that do
-         not exist and upate those that do.'),
+         not exist and update those that do.'),
       '#default_value' => 2,
     ];
 
@@ -163,9 +163,9 @@ class FASTAImporter extends ChadoImporterBase {
         a human-readable name then select the "Name" button. If your features are
         uniquely identified using the unique name then select the "Unique name" button.  If you
         loaded your features first using the GFF loader then the unique name of each
-        features were indicated by the "ID=" attribute and the name by the "Name=" attribute.
+        feature was indicated by the "ID=" attribute and the name by the "Name=" attribute.
         By default, the FASTA loader will use the first word (character string
-        before the first space) as  the name for your feature. If
+        before the first space) as the name for your feature. If
         this does not uniquely identify your feature consider specifying a regular expression in the advanced section below.
         Additionally, you may import both a name and a unique name for each sequence using the advanced options.'),
       '#default_value' => 1,
@@ -870,12 +870,6 @@ class FASTAImporter extends ChadoImporterBase {
           // First check to make sure that by changing the unique name of this
           // feature that we won't conflict with another existing feature of
           // the same name
-          // $values = [
-          //   'organism_id' => $organism_id,
-          //   'uniquename' => $uname,
-          //   'type_id' => $cvterm->cvterm_id,
-          // ];
-          // $results = chado_select_record('feature', ['feature_id'], $values);
           $results_query = $chado->select('1:feature', 'feature')
             ->fields('feature')
             ->condition('organism_id', $organism_id)
@@ -939,11 +933,6 @@ class FASTAImporter extends ChadoImporterBase {
     // add in the analysis link
     if ($analysis_id) {
       // if the association doesn't already exist then add one
-      // $values = [
-      //   'analysis_id' => $analysis_id,
-      //   'feature_id' => $feature->feature_id,
-      // ];
-      // $results = chado_select_record('analysisfeature', ['analysisfeature_id'], $values);
       $results_query = $chado->select('1:analysisfeature', 'analysisfeature')
         ->fields('analysisfeature')
         ->condition('analysis_id', $analysis_id)
@@ -951,7 +940,6 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count == 0) {
-        // $success = chado_insert_record('analysisfeature', $values);
         $values = [
           'analysis_id' => $analysis_id,
           'feature_id' => $feature->feature_id,
@@ -968,12 +956,6 @@ class FASTAImporter extends ChadoImporterBase {
 
     // now add the database cross reference
     if ($db_id) {
-      // check to see if this accession reference exists, if not add it
-      // $values = [
-      //   'db_id' => $db_id,
-      //   'accession' => $accession,
-      // ];
-      // $results = chado_select_record('dbxref', ['dbxref_id'], $values);
       $results_query = $chado->select('1:dbxref', 'dbxref')
         ->fields('dbxref')
         ->condition('db_id', $db_id)
@@ -982,7 +964,6 @@ class FASTAImporter extends ChadoImporterBase {
       $results_count = $results_query->countQuery()->execute()->fetchField();
       // if the accession doesn't exist then add it
       if ($results_count == 0) {
-        // $results = chado_insert_record('dbxref', $values);
         $values = [
           'db_id' => $db_id,
           'accession' => $accession,
@@ -1015,12 +996,6 @@ class FASTAImporter extends ChadoImporterBase {
         $dbxref = $results[0];
       }
 
-      // Check to see if the feature dbxref record exists. If not, then add it.
-      // $values = [
-      //   'feature_id' => $feature->feature_id,
-      //   'dbxref_id' => $dbxref->dbxref_id,
-      // ];
-      // $results = chado_select_record('feature_dbxref', ['feature_dbxref_id'], $values);
       $results_query = $chado->select('1:feature_dbxref', 'feature_dbxref')
         ->fields('feature_dbxref')
         ->condition('feature_id', $feature->feature_id)
@@ -1028,7 +1003,6 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count == 0) {
-        // $success = chado_insert_record('feature_dbxref', $values);
         $values = [
           'feature_id' => $feature->feature_id,
           'dbxref_id' => $dbxref->dbxref_id,
@@ -1045,12 +1019,6 @@ class FASTAImporter extends ChadoImporterBase {
 
     // Now add in the relationship if one exists.
     if ($rel_type) {
-      // $values = [
-      //   'organism_id' => $organism_id,
-      //   'uniquename' => $parent,
-      //   'type_id' => $parentcvterm->cvterm_id,
-      // ];
-      // $results = chado_select_record('feature', ['feature_id'], $values);
       $results_query = $chado->select('1:feature', 'feature')
         ->fields('feature')
         ->condition('organism_id', $organism_id)
@@ -1064,16 +1032,9 @@ class FASTAImporter extends ChadoImporterBase {
         );
         return 0;
       }
-      // $parent_feature = $results[0];
       $parent_feature = $results->fetchObject();
 
       // Check to see if the relationship already exists. If not, then add it.
-      // $values = [
-      //   'subject_id' => $feature->feature_id,
-      //   'object_id' => $parent_feature->feature_id,
-      //   'type_id' => $relcvterm->cvterm_id,
-      // ];
-      // $results = chado_select_record('feature_relationship', ['feature_relationship_id'], $values);
       $results_query = $chado->select('1:feature_relationship', 'feature_relationship')
         ->fields('feature_relationship')
         ->condition('subject_id', $feature->feature_id)
@@ -1082,7 +1043,6 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count == 0) {
-        // $success = chado_insert_record('feature_relationship', $values);
         $values = [
           'subject_id' => $feature->feature_id,
           'object_id' => $parent_feature->feature_id,

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -519,9 +519,9 @@ class FASTAImporter extends ChadoImporterBase {
     $cv_autocomplete = new ChadoCVTermAutocompleteController();
     $cvterm_id = $cv_autocomplete->getCVtermId($type, 'sequence');
     if (!$cvterm_id) {
-      // $this->logMessage("Cannot find the term type: '!type'", ['!type' => $type], TRIPAL_ERROR);
-      $this->logger->error("Cannot find the term type: ':type'",
-          [':type' => $type]);
+      $this->logger->error("Cannot find the term type: '@type'",
+        ['@type' => $type]
+      );
       return 0;
     }
     $cvtermsql = "
@@ -536,7 +536,8 @@ class FASTAImporter extends ChadoImporterBase {
     ])->fetchObject();
     if (!$cvterm) {
       $this->logger->error("Cannot find the term type: ':type'",
-          [':type' => $type]);
+        [':type' => $type]
+      );
       return 0;
     }
 
@@ -545,17 +546,17 @@ class FASTAImporter extends ChadoImporterBase {
     if (isset($parent_type) && $parent_type != "") {
       $parentcvterm_id = $cv_autocomplete->getCVtermId($parent_type, 'sequence');
       if (!$parentcvterm_id) {
-        $this->logger->error("Cannot find the parent term type: ':parent_type'",
-            [':parent_type' => $parent_type]);
+        $this->logger->error("Cannot find the parent term type: '@parent_type'",
+           ['@parent_type' => $parent_type]
+        );
       }
       $parentcvterm = $chado->query($cvtermsql, [
         ':cvterm_id' => $parentcvterm_id,
       ])->fetchObject();
       if (!isset($parentcvterm)) {
-        // $this->logMessage("Cannot find the parent term type: '!type'",
-        //   ['!type' => $parentcvterm], TRIPAL_ERROR);
-        $this->logger->error("Cannot find the parent term type: ':parent_type'",
-            [':parent_type' => $parent_type]);
+        $this->logger->error("Cannot find the parent term type: '@parent_type'",
+           ['@parent_type' => $parent_type]
+        );
         return 0;
       }
     }
@@ -575,10 +576,9 @@ class FASTAImporter extends ChadoImporterBase {
         ':name' => $rel_type,
       ])->fetchObject();
       if (!$relcvterm) {
-        // $this->logMessage("Cannot find the relationship term type: '!type'",
-        //   ['!type' => $relcvterm], TRIPAL_ERROR);
-        $this->logger->error("Cannot find the relationship term type: ':relcvterm'",
-            [':relcvterm' => $rel_type]);
+        $this->logger->error("Cannot find the relationship term type: '@type'",
+          ['@type' => $rel_type]
+        );
         return 0;
       }
     }
@@ -588,7 +588,6 @@ class FASTAImporter extends ChadoImporterBase {
     $feature_tbl = chado_get_schema('feature', $chado->getSchemaName());
     $dbxref_tbl = chado_get_schema('dbxref', $chado->getSchemaName());
 
-    // $this->logMessage(t("Step 1: Finding sequences..."));
     $this->logger->notice("Step 1: Finding sequences...");
     $filesize = filesize($file_path);
     $fh = fopen($file_path, 'r');
@@ -621,16 +620,16 @@ class FASTAImporter extends ChadoImporterBase {
         // if ($re_name) { // OLD T3 code that does not work as intended
         if (isset($re_name) && $re_name != "") {
           if (!preg_match("/$re_name/", $defline, $matches)) {
-            // $this->logMessage("Regular expression for the feature name finds nothing. Line !line.",
-            //   ['!line' => $i], TRIPAL_ERROR);
-            $this->logger->error("Regular expression for the feature name finds nothing. Line $i.");
+            $this->logger->error("Regular expression for the feature name finds nothing. Line @line.",
+              ['@line' => $i]
+            );
           }
           // OLD TRIPAL 3 CODE
           // elseif (strlen($matches[1]) > $feature_tbl['fields']['name']['length']) {
           elseif (strlen($matches[1]) > $feature_tbl['fields']['name']['size']) {
-            // $this->logMessage("Regular expression retrieves a value too long for the feature name. Line !line.",
-            //   ['!line' => $i], TRIPAL_WARNING);
-            $this->logger->warning("Regular expression retrieves a value too long for the feature name. Line $i.");
+            $this->logger->warning("Regular expression retrieves a value too long for the feature name. Line @line.",
+              ['@line' => $i]
+            );
           }
           else {
             $name = trim($matches[1]);
@@ -644,17 +643,18 @@ class FASTAImporter extends ChadoImporterBase {
             // OLD TRIPAL 3 CODE
             // if (strlen($matches[1]) > $feature_tbl['fields']['name']['length']) {
             if (strlen($matches[1]) > $feature_tbl['fields']['name']['size']) {
-              // $this->logMessage("Regular expression retrieves a feature name too long for the feature name. Line !line.",
-              //   ['!line' => $i], TRIPAL_WARNING);
-              $this->logger->warning("Regular expression retrieves a feature name too long for the feature name. Line $i.");
+              $this->logger->warning("Regular expression retrieves a feature name too long for the feature name. Line @line.",
+                ['@line' => $i]
+              );
             }
             else {
               $name = trim($matches[1]);
             }
           }
           else {
-            // $this->logMessage("Cannot find a feature name. Line !line.", ['!line' => $i], TRIPAL_WARNING);
-            $this->logger->warning("Cannot find a feature name. Line $i.");
+            $this->logger->warning("Cannot find a feature name. Line @line.",
+              ['@line' => $i]
+            );
           }
         }
 
@@ -662,9 +662,9 @@ class FASTAImporter extends ChadoImporterBase {
         $uname = "";
         if ($re_uname) {
           if (!preg_match("/$re_uname/", $defline, $matches)) {
-            // $this->logMessage("Regular expression for the feature unique name finds nothing. Line !line.",
-            //   ['!line' => $i], TRIPAL_ERROR);
-            $this->logger->error("Regular expression for the feature unique name finds nothing. Line $i.");
+            $this->logger->error("Regular expression for the feature unique name finds nothing. Line @line.",
+              ['@line' => $i]
+            );
           }
           $uname = trim($matches[1]);
         }
@@ -676,9 +676,9 @@ class FASTAImporter extends ChadoImporterBase {
             $uname = trim($matches[1]);
           }
           else {
-            // $this->logMessage("Cannot find a feature unique name. Line !line.",
-            //   ['!line' => $i], TRIPAL_ERROR);
-            $this->logger->error("Cannot find a feature unique name. Line $i.");
+            $this->logger->error("Cannot find a feature unique name. Line @line.",
+              ['@line' => $i]
+            );
           }
         }
 
@@ -689,11 +689,10 @@ class FASTAImporter extends ChadoImporterBase {
           // OLD TRIPAL 3 CODE
           // if (strlen($matches[1]) > $dbxref_tbl['fields']['accession']['length']) {
           if (strlen($matches[1]) > $dbxref_tbl['fields']['accession']['size']) {
-            // tripal_report_error('trp-fasta', TRIPAL_WARNING, "WARNING: Regular expression retrieves an accession too long for the feature name. " .
-            //   "Cannot add cross reference. Line %line.", [
-            //   '%line' => $i,
-            // ]);
-            $this->logger->error("WARNING: Regular expression retrieves an accession too long for the feature name. Cannot add cross reference. Line $i.");
+            $this->logger->warning("WARNING: Regular expression retrieves an accession too long for"
+                                 . " the feature name. Cannot add cross reference. Line @line.",
+              ['@line' => $i]
+            );
           }
           else {
             $accession = trim($matches[1]);
@@ -733,15 +732,12 @@ class FASTAImporter extends ChadoImporterBase {
     $seqs[$num_seqs - 1]['seq_end'] = $num_read - strlen($line);
 
     // Now that we know where the sequences are in the file we need to add them.
-    // $this->logMessage("Step 2: Importing sequences...");
     $this->logger->notice("Step 2: Importing sequences...");
-    // $this->logMessage("Found !num_seqs sequence(s).", ['!num_seqs' => $num_seqs]);
-    $this->logger->notice("Found $num_seqs sequence(s).");
+    $this->logger->notice("Found @num_seqs sequence(s).", ['@num_seqs' => $num_seqs]);
     $this->setTotalItems($num_seqs);
     $this->setItemsHandled(0);
     for ($j = 0; $j < $num_seqs; $j++) {
       $seq = $seqs[$j];
-      //$this->logMessage("Importing !seqname.", array('!seqname' => $seq['name']));
       $source = NULL;
       $this->loadFastaFeature($fh, $seq['name'], $seq['uname'], $db_id,
         $seq['accession'], $seq['subject'], $rel_type, $parent_type,
@@ -766,14 +762,6 @@ class FASTAImporter extends ChadoImporterBase {
     $chado = $this->getChadoConnection();
     // Check to see if this feature already exists if the match_type is 'Name'.
     if (strcmp($match_type, 'Name') == 0) {
-      // $values = [
-      //   'organism_id' => $organism_id,
-      //   'name' => $name,
-      //   'type_id' => $cvterm->cvterm_id,
-      // ];
-      // $results = chado_select_record('feature', [
-      //   'feature_id',
-      // ], $values);
       $results_query = $chado->select('1:feature', 'feature')
         ->fields('feature')
         ->condition('organism_id', $organism_id)
@@ -782,26 +770,18 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count > 1) {
-        // $this->logMessage("Multiple features exist with the name '!name' of type '!type' for the organism.  skipping",
-        //   ['!name' => $name, '!type' => $cvterm->name], TRIPAL_ERROR);
-        $this->logger->error("Multiple features exist with the name '$name' of type '" .
-          $cvterm->name . "' for the organism.  skipping");
+        $this->logger->error("Multiple features exist with the name '@name' of type '@type' for the organism.  skipping",
+          ['@name' => $name, '@type' => $cvterm->name]
+        );
         return 0;
       }
       if ($results_count == 1) {
-        // $feature = $results[0];
         $feature = $results->fetchObject();
       }
     }
 
     // Check if this feature already exists if the match_type is 'Unique Name'.
     if (strcmp($match_type, 'Unique name') == 0) {
-      // $values = [
-      //   'organism_id' => $organism_id,
-      //   'uniquename' => $uname,
-      //   'type_id' => $cvterm->cvterm_id,
-      // ];
-      // $results = chado_select_record('feature', ['feature_id'], $values);
       $results_query = $chado->select('1:feature', 'feature')
         ->fields('feature')
         ->condition('organism_id', $organism_id)
@@ -810,27 +790,20 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count > 1) {
-        // $this->logMessage("Multiple features exist with the name '!name' of type '!type' for the organism.  skipping",
-        //   ['!name' => $name, '!type' => $cvterm->name], TRIPAL_WARNING);
-        $this->logger->error("Multiple features exist with the name '$name' of type '" .
-          $cvterm->name . "' for the organism.  skipping");
+        $this->logger->error("Multiple features exist with the name '@name' of type '@type' for the organism.  skipping",
+          ['@name' => $name, '@type' => $cvterm->name]
+        );
         return 0;
       }
       if ($results_count == 1) {
-        // $feature = $results[0];
         $feature = $results->fetchObject();
       }
 
       // If the feature exists but this is an "insert only" then skip.
       if (isset($feature) and (strcmp($method, 'Insert only') == 0)) {
-        // $this->logMessage("Feature already exists '!name' ('!uname') while matching on !type. Skipping insert.",
-        //   [
-        //     '!name' => $name,
-        //     '!uname' => $uname,
-        //     '!type' => drupal_strtolower($match_type),
-        //   ], TRIPAL_WARNING);
-        $this->logger->error("Feature already exists '$name' ('$uname') while matching on " .
-          strtolower($match_type) . ". Skipping insert.");
+        $this->logger->error("Feature already exists '@name' ('@uname') while matching on @type. Skipping insert.",
+          ['@name' => $name, '@uname' => $uname, '@type' => strtolower($match_type)]
+        );
         return 0;
       }
     }
@@ -853,23 +826,15 @@ class FASTAImporter extends ChadoImporterBase {
         'uniquename' => $uname,
         'type_id' => $cvterm->cvterm_id,
       ];
-      // $success = chado_insert_record('feature', $values);
       $success = $chado->insert('1:feature')->fields($values)->execute();
       if (!$success) {
-        $this->logMessage("Failed to insert feature '!name (!uname)'", [
-          '!name' => $name,
-          '!uname' => $uname,
-        ], TRIPAL_ERROR);
+        $this->logger->error("Failed to insert feature '@name (@uname)'",
+          ['@name' => $name, '@uname' => $uname]
+        );
         return 0;
       }
 
       // now get the feature we just inserted
-      // $values = [
-      //   'organism_id' => $organism_id,
-      //   'uniquename' => $uname,
-      //   'type_id' => $cvterm->cvterm_id,
-      // ];
-      // $results = chado_select_record('feature', ['feature_id'], $values);
       $results_query = $chado->select('1:feature', 'feature')
         ->fields('feature')
         ->condition('organism_id', $organism_id)
@@ -879,15 +844,12 @@ class FASTAImporter extends ChadoImporterBase {
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count == 1) {
         $inserted = 1;
-        // $feature = $results[0];
         $feature = $results->fetchObject();
       }
       else {
-        // $this->logMessage("Failed to retrieve newly inserted feature '!name (!uname)'", [
-        //   '!name' => $name,
-        //   '!uname' => $uname,
-        // ], TRIPAL_ERRORR);
-        $this->logger->error("Failed to retrieve newly inserted feature '$name ($uname)'");
+        $this->logger->error("Failed to retrieve newly inserted feature '@name (@uname)'",
+          ['@name' => $name, '@uname' => $uname]
+        );
         return 0;
       }
 
@@ -897,9 +859,9 @@ class FASTAImporter extends ChadoImporterBase {
 
     // if we don't have a feature and the user wants to do an update then fail
     if (!isset($feature) and (strcmp($method, 'Update only') == 0 or strcmp($method, 'Insert and update') == 0)) {
-      // $this->logMessage("Failed to find feature '!name' ('!uname') while matching on " . drupal_strtolower($match_type) . ".",
-      //   ['!name' => $name, '!uname' => $uname], TRIPAL_ERROR);
-      $this->logger->error("Failed to find feature '$name' ('$uname') while matching on " . strtolower($match_type) . ".");
+      $this->logger->error("Failed to find feature '@name' ('@uname') while matching on @match_type.",
+        ['@name' => $name, '@uname' => $uname, '@match_type' => strtolower($match_type)]
+      );
       return 0;
     }
 
@@ -931,16 +893,10 @@ class FASTAImporter extends ChadoImporterBase {
           $results = $results_query->execute();
           $results_count = $results_query->countQuery()->execute()->fetchField();
           if ($results_count > 0) {
-            // $this->logMessage("Cannot update the feature '!name' with a uniquename of '!uname' and type of '!type' as it " .
-            //   "conflicts with an existing feature with the same uniquename and type.",
-            //   [
-            //     '!name' => $name,
-            //     '!uname' => $uname,
-            //     '!type' => $cvterm->name,
-            //   ], TRIPAL_ERROR);
-            $this->logger->error("Cannot update the feature '$name' with a uniquename of '$uname' and type of '" .
-              $cvterm->name . "' as it " .
-              "conflicts with an existing feature with the same uniquename and type.");
+            $this->logger->error("Cannot update the feature '@name' with a uniquename of '@uname' and type of '@type'"
+                               . " as it conflicts with an existing feature with the same uniquename and type.",
+              ['@name' => $name, '@uname' => $uname, '@type' => $cvterm->name]
+            );
             return 0;
           }
 
@@ -956,7 +912,8 @@ class FASTAImporter extends ChadoImporterBase {
           $success = chado_update_record('feature', $match, $values);
           if (!$success) {
             $this->logger->error("Failed to update feature '@name' ('@uname')",
-              ['!name' => $name, '!uname' => $uname]);
+              ['@name' => $name, '@uname' => $uname]
+            );
             return 0;
           }
         }
@@ -977,7 +934,8 @@ class FASTAImporter extends ChadoImporterBase {
           $success = chado_update_record('feature', $match, $values);
           if (!$success) {
             $this->logger->error("Failed to update feature '@name' ('@uname')",
-              ['!name' => $name, '!uname' => $uname]);
+              ['@name' => $name, '@uname' => $uname]
+            );
             return 0;
           }
         }
@@ -1009,9 +967,9 @@ class FASTAImporter extends ChadoImporterBase {
         ];
         $success = $chado->insert('1:analysisfeature')->fields($values)->execute();
         if (!$success) {
-          // $this->logMessage("Failed to associate analysis and feature '!name' ('!name')",
-          //   ['!name' => $name, '!uname' => $uname], TRIPAL_ERROR);
-          $this->logger->error("Failed to associate analysis and feature '$name' ('$name')");
+          $this->logger->error("Failed to associate analysis and feature '@name' ('@name')",
+            ['@name' => $name, '@uname' => $uname]
+          );
           return 0;
         }
       }
@@ -1040,26 +998,25 @@ class FASTAImporter extends ChadoImporterBase {
         ];
         $success = $chado->insert('1:dbxref')->fields($values)->execute();
         if (!$results) {
-          // $this->logMessage("Failed to add database accession '!accession'",
-          //   ['!accession' => $accession], TRIPAL_ERROR);
-          $this->logger->error("Failed to add database accession '$accession'");
+          $this->logger->error("Failed to add database accession '@accession'",
+            ['@accession' => $accession]
+          );
           return 0;
         }
-        // $results = chado_select_record('dbxref', ['dbxref_id'], $values);
+
         $results_query = $chado->select('1:dbxref', 'dbxref')
-        ->fields('dbxref')
-        ->condition('db_id', $db_id)
-        ->condition('accession', $accession);
+          ->fields('dbxref')
+          ->condition('db_id', $db_id)
+          ->condition('accession', $accession);
         $results = $results_query->execute();
         $results_count = $results_query->countQuery()->execute()->fetchField();
         if ($results_count == 1) {
-          // $dbxref = $results[0];
           $dbxref = $results->fetchObject();
         }
         else {
-          // $this->logMessage("Failed to retrieve newly inserted dbxref '!name (!uname)'",
-          //   ['!name' => $name, '!uname' => $uname], TRIPAL_ERROR);
-          $this->logger->error("Failed to retrieve newly inserted dbxref '$name ($uname)'");
+          $this->logger->error("Failed to retrieve newly inserted dbxref '@name (@uname)'",
+            ['@name' => $name, '@uname' => $uname]
+          );
           return 0;
         }
       }
@@ -1087,9 +1044,9 @@ class FASTAImporter extends ChadoImporterBase {
         ];
         $success = $chado->insert('1:feature_dbxref')->fields($values)->execute();
         if (!$success) {
-          // $this->logMessage("Failed to add associate database accession '!accession' with feature",
-          //   ['!accession' => $accession], TRIPAL_ERROR);
-          $this->logger->error("Failed to add associate database accession '$accession' with feature");
+          $this->logger->error("Failed to associate database accession '@accession' with feature",
+            ['@accession' => $accession]
+          );
           return 0;
         }
       }
@@ -1111,9 +1068,9 @@ class FASTAImporter extends ChadoImporterBase {
       $results = $results_query->execute();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count != 1) {
-        // $this->logMessage("Cannot find a unique feature for the parent '!parent' of type '!type' for the feature.",
-        //   ['!parent' => $parent, '!type' => $parent_type], TRIPAL_ERROR);
-        $this->logger->error("Cannot find a unique feature for the parent '$parent' of type '$parent_type' for the feature.");
+        $this->logger->error("Cannot find a unique feature for the parent '@parent' of type '@type' for the feature.",
+          ['@parent' => $parent, '@type' => $parent_type]
+        );
         return 0;
       }
       // $parent_feature = $results[0];
@@ -1142,9 +1099,9 @@ class FASTAImporter extends ChadoImporterBase {
         ];
         $success = $chado->insert('1:feature_relationship')->fields($values)->execute();
         if (!$success) {
-          // $this->logMessage("Failed to add associate database accession '!accession' with feature",
-          //   ['!accession' => $accession], TRIPAL_ERROR);
-          $this->logger->error("Failed to add associate database accession '$accession' with feature");
+          $this->logger->error("Failed to associate database accession '@accession' with feature",
+            ['@accession' => $accession]
+          );
           return 0;
         }
       }

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -955,9 +955,8 @@ class FASTAImporter extends ChadoImporterBase {
           // perform the update
           $success = chado_update_record('feature', $match, $values);
           if (!$success) {
-            // $this->logMessage("Failed to update feature '!name' ('!name')",
-            //   ['!name' => $name, '!uiname' => $uname], TRIPAL_ERROR);
-            $this->logger->error("Failed to update feature '$name' ('$name')");
+            $this->logger->error("Failed to update feature '@name' ('@uname')",
+              ['!name' => $name, '!uname' => $uname]);
             return 0;
           }
         }
@@ -977,9 +976,8 @@ class FASTAImporter extends ChadoImporterBase {
           ];
           $success = chado_update_record('feature', $match, $values);
           if (!$success) {
-            // $this->logMessage("Failed to update feature '!name' ('!name')",
-            //   ['!name' => $name, '!uiname' => $uname], TRIPAL_ERROR);
-            $this->logger->error("Failed to update feature '$name' ('$name')");
+            $this->logger->error("Failed to update feature '@name' ('@uname')",
+              ['!name' => $name, '!uname' => $uname]);
             return 0;
           }
         }

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -703,7 +703,7 @@ class GFF3Importer extends ChadoImporterBase {
     // Load the GFF3.
     try {
 
-      $this->logger->notice("Step  1 of 27: Caching GFF3 file...                             ");
+      $this->logger->notice("Step  1 of 27: Caching GFF3 file...                                ");
       $this->parseGFF3();
 
       // Prep the database for necessary records.
@@ -711,95 +711,99 @@ class GFF3Importer extends ChadoImporterBase {
       $this->prepNullPub();
       $this->prepDBs();
 
-      $this->logger->notice("Step  2 of 27: Find existing landmarks...                         ");
+      $this->logger->notice("Step  2 of 27: Find existing landmarks...                          ");
       $this->findLandmarks();
 
-      $this->logger->notice("Step  3 of 27: Insert new landmarks (if needed)...                ");
+      $this->logger->notice("Step  3 of 27: Insert new landmarks (if needed)...                 ");
       $this->insertLandmarks();
 
       if (!$this->skip_protein) {
-        $this->logger->notice("Step  4 of 27: Find missing proteins...                           ");
+        $this->logger->notice("Step  4 of 27: Find missing proteins...                            ");
         $this->findMissingProteins();
 
-        $this->logger->notice("Step  5 of 27: Add missing proteins to list of features...        ");
+        $this->logger->notice("Step  5 of 27: Add missing proteins to list of features...         ");
         $this->addMissingProteins();
       }
       else {
-        $this->logger->notice("Step  4 of 27: Find missing proteins (Skipped)...                ");
-        $this->logger->notice("Step  5 of 27: Add missing proteins to list of features (Skipped)...");
+        $this->logger->notice("Step  4 of 27: Find missing proteins (Skipped)                     ");
+        $this->logger->notice("Step  5 of 27: Add missing proteins to list of features (Skipped)  ");
       }
 
-      $this->logger->notice("Step  6 of 27: Find existing features...                          ");
+      $this->logger->notice("Step  6 of 27: Find existing features...                           ");
       $this->findFeatures();
 
       $this->logger->notice("Step  7 of 27: Clear attributes of existing features...            ");
       $this->deleteFeatureData();
 
-      $this->logger->notice("Step  8 of 27: Processing @num_features features...               ",
-      ['@num_features' => number_format(count(array_keys($this->features)))]);
+      $this->logger->notice("Step  8 of 27: Processing @num_features features...                ",
+        ['@num_features' => number_format(count(array_keys($this->features)))]
+      );
 
       $this->insertFeatures();
       $this->logger->notice("Step  9 of 27: Processing @num_features feature Names to update...               ",
-      ['@num_features' =>  number_format(count(array_keys($this->update_names)))]);
+        ['@num_features' =>  number_format(count(array_keys($this->update_names)))]
+      );
 
       $this->updateFeatureNames();
 
-      $this->logger->notice("Step  10 of 27: Get new feature IDs...                             ");
+      $this->logger->notice("Step 10 of 27: Get new feature IDs...                              ");
       $this->findFeatures();
 
-      $this->logger->notice("Step 11 of 27: Insert locations...                               ");
+      $this->logger->notice("Step 11 of 27: Insert locations...                                 ");
       $this->insertFeatureLocs();
 
-      $this->logger->notice("Step 12 of 27: Associate parents and children...                 ");
+      $this->logger->notice("Step 12 of 27: Associate parents and children...                   ");
       $this->associateChildren();
 
-      $this->logger->notice("Step 13 of 27: Calculate child ranks...                          ");
+      $this->logger->notice("Step 13 of 27: Calculate child ranks...                            ");
       $this->calculateChildRanks();
 
-      $this->logger->notice("Step 14 of 27: Add child-parent relationships...                 ");
+      $this->logger->notice("Step 14 of 27: Add child-parent relationships...                   ");
       $this->insertFeatureParents();
 
-      $this->logger->notice("Step 15 of 27: Insert properties...                               ");
+      $this->logger->notice("Step 15 of 27: Insert properties...                                ");
       $this->insertFeatureProps();
 
-      $this->logger->notice("Step 16 of 27: Find synonyms (aliases)...                         ");
+      $this->logger->notice("Step 16 of 27: Find synonyms (aliases)...                          ");
       $this->findSynonyms();
 
-      $this->logger->notice("Step 17 of 27: Insert new synonyms (aliases)...                  ");
+      $this->logger->notice("Step 17 of 27: Insert new synonyms (aliases)...                    ");
       $this->insertSynonyms();
 
-      $this->logger->notice("Step 18 of 27: Insert feature synonyms (aliases)...              ");
+      $this->logger->notice("Step 18 of 27: Insert feature synonyms (aliases)...                ");
       $this->insertFeatureSynonyms();
 
-      $this->logger->notice("Step 19 of 27: Find cross references...                          ");
+      $this->logger->notice("Step 19 of 27: Find cross references...                            ");
       $this->findDbxrefs();
 
-      $this->logger->notice("Step 20 of 27: Insert new cross references...                    ");
+      $this->logger->notice("Step 20 of 27: Insert new cross references...                      ");
       $this->insertDbxrefs();
 
-      $this->logger->notice("Step 21 of 27: Get new cross references IDs...                   ");
+      $this->logger->notice("Step 21 of 27: Get new cross references IDs...                     ");
       $this->findDbxrefs();
 
-      $this->logger->notice("Step 22 of 27: Insert feature cross references...                ");
+      $this->logger->notice("Step 22 of 27: Insert feature cross references...                  ");
       $this->insertFeatureDbxrefs();
 
-      $this->logger->notice("Step 23 of 27: Insert feature ontology terms...                  ");
+      $this->logger->notice("Step 23 of 27: Insert feature ontology terms...                    ");
       $this->insertFeatureCVterms();
 
-      $this->logger->notice("Step 24 of 27: Insert 'derives_from' relationships...            ");
+      $this->logger->notice("Step 24 of 27: Insert 'derives_from' relationships...              ");
       $this->insertFeatureDerivesFrom();
 
-      $this->logger->notice("Step 25 of 27: Insert Targets...                                 ");
+      $this->logger->notice("Step 25 of 27: Insert Targets...                                   ");
       $this->insertFeatureTargets();
 
-      $this->logger->notice("Step 26 of 27: Associate features with analysis....              ");
+      $this->logger->notice("Step 26 of 27: Associate features with analysis...                 ");
       $this->insertFeatureAnalysis();
 
       if (!empty($this->residue_index)) {
-        $this->logger->notice("Step 27 of 27: Adding sequences data...                        ");
+        $this->logger->notice("Step 27 of 27: Adding sequences data...                            ");
         $this->insertFeatureSeqs();
       }
-      $this->logger->notice("Step 27 of 27: Adding sequences data (Skipped: none available)...");
+      else {
+        $this->logger->notice("Step 27 of 27: Adding sequences data (Skipped: none available)     ");
+      }
     }
     // On exception, catch the error, clean up the cache file and rethrow
     catch (\Exception $e) {
@@ -902,9 +906,6 @@ class GFF3Importer extends ChadoImporterBase {
           'name' => 'synonym_type',
           'definition' => 'vocabulary for synonym types',
       ];
-      // $success = chado_insert_record('cv', $values, array(
-      //     'skip_validation' => TRUE,
-      // ), $this->chado_schema_main);
       $success = $chado->insert('1:cv')
         ->fields($values)
         ->execute();
@@ -916,8 +917,8 @@ class GFF3Importer extends ChadoImporterBase {
       // now that we've added the cv we need to get the record
       // $results = chado_select_record('cv', ['*'], $select, NULL, $this->chado_schema_main);
       $results_query = $chado->select('1:cv', 'cv')
-      ->fields('cv')
-      ->condition('name', 'synonym_type');
+        ->fields('cv')
+        ->condition('name', 'synonym_type');
       $results = $results_query->execute()->fetchObject();
       $results_count = $results_query->countQuery()->execute()->fetchField();
       if ($results_count > 0) {
@@ -935,7 +936,6 @@ class GFF3Importer extends ChadoImporterBase {
         'name' => 'synonym_type',
       ],
     ];
-    // $result = chado_select_record('cvterm', ['*'], $select, NULL, $this->chado_schema_main);
     $result_cv = $chado->select('1:cv', 'cv')
       ->fields('cv')
       ->condition('name', 'synonym_type')
@@ -962,7 +962,6 @@ class GFF3Importer extends ChadoImporterBase {
         'is_relationship' => FALSE,
       ];
       $syntype = chado_insert_cvterm($term, ['update_existing' => TRUE], $this->chado_schema_main);
-      // $syntype = $this->insert_cvterm($term, ['update_existing' => TRUE]);
       if (!$syntype) {
         $this->logger->warning("Cannot add synonym type: synonym_type:exact");
         return 0;
@@ -982,7 +981,6 @@ class GFF3Importer extends ChadoImporterBase {
     // Check to see if we have a NULL publication in the pub table.  If not,
     // then add one.
     $select = ['uniquename' => 'null'];
-    // $result = chado_select_record('pub', ['*'], $select, NULL, $this->chado_schema_main);
     $result_query = $chado->select('1:pub', 'pub')
       ->fields('pub')
       ->condition('uniquename', 'null');
@@ -1003,21 +1001,10 @@ class GFF3Importer extends ChadoImporterBase {
         ':type_id' => 'null',
       ]);
       if (!$status) {
-        $this->logger->warning("Cannot prepare statement 'ins_pub_uniquename_typeid.");
+        $this->logger->error("Cannot add null publication needed for setup of alias.");
         return 0;
       }
 
-      // Insert the null pub.
-      // $result = $chado->query($pub_sql, [
-      //     ':uname' => 'null',
-      //     ':type_id' => 'null',
-      // ])->fetchObject();
-      // if (!$result) {
-      //   $this->logger->warning("Cannot add null publication needed for setup of alias.");
-      //   return 0;
-      // }
-
-      // $result = chado_select_record('pub', ['*'], $select, NULL, $this->chado_schema_main);
       $result_query = $chado->select('1:pub','pub')
         ->fields('pub')
         ->condition('uniquename','null');
@@ -1091,7 +1078,9 @@ class GFF3Importer extends ChadoImporterBase {
           $db = $db_query->execute()->fetchObject();
         }
         else {
-          $this->logger->warning("Cannot find or add the database $dbname.");
+          $this->logger->warning('Cannot find or add the database "@dbname".',
+            ['@dbname' => $dbname]
+          );
           return 0;
         }
       }
@@ -1476,8 +1465,11 @@ class GFF3Importer extends ChadoImporterBase {
       // or landmark name.
       if (!(array_key_exists($uniquename, $this->features) and $this->features[$uniquename]) and
           !(array_key_exists($uniquename, $this->landmarks) and $this->landmarks[$uniquename])) {
-        $this->logger->warning('Assigning Sequence: cannot find a feature with a unique name of: "@uname". Please ensure the sequence names in the ##FASTA section use the same name as the ID in the feature in the GFF file. ',
-        ['@uname' => $uniquename]);
+        $this->logger->warning('Assigning Sequence: cannot find a feature with a unique name of: "@uname".'
+                             . ' Please ensure the sequence names in the ##FASTA section use the same name'
+                             . ' as the ID in the feature in the GFF file.',
+          ['@uname' => $uniquename]
+        );
         $count++;
         continue;
       }
@@ -1932,7 +1924,8 @@ class GFF3Importer extends ChadoImporterBase {
     $this->gff_cache_file_name = \Drupal::service('file_system')->realpath($temp_file);
 
     $this->logger->notice("Opening temporary cache file: @cfile",
-    ['@cfile' => $this->gff_cache_file_name]);
+      ['@cfile' => $this->gff_cache_file_name]
+    );
     $this->gff_cache_file = fopen($this->gff_cache_file_name, "r+");
   }
 
@@ -1942,7 +1935,8 @@ class GFF3Importer extends ChadoImporterBase {
   private function closeCacheFile() {
     fclose($this->gff_cache_file);
     $this->logger->notice("Removing temporary cache file: @cfile",
-    ['@cfile' => $this->gff_cache_file_name]);
+      ['@cfile' => $this->gff_cache_file_name]
+    );
     unlink($this->gff_cache_file_name);
   }
 
@@ -2898,9 +2892,10 @@ class GFF3Importer extends ChadoImporterBase {
       if (!$feature['skipped'] and $feature['derives_from']) {
         $object_id = $this->features[$feature['derives_from']]['feature_id'];
         if (!$object_id) {
-          $this->logger->warning("Skipping 'derives_from' relationship for feature @feature_name. " .
-            "Could not find the derives_from feature: @derives_from.",
-            ['@feature_name' => $feature['uniquename'], '@derives_from' => $feature['derives_from']]);
+          $this->logger->warning("Skipping 'derives_from' relationship for feature @feature_name. "
+                               . "Could not find the derives_from feature: @derives_from.",
+            ['@feature_name' => $feature['uniquename'], '@derives_from' => $feature['derives_from']]
+          );
           continue;
         }
         $sql .= "(:subject_id_$i, :object_id_$i, :type_id_$i, 0),\n";

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -524,13 +524,14 @@ class GFF3Importer extends ChadoImporterBase {
     $re_mrna = trim($form_state_values['re_mrna']);
     $re_protein = trim($form_state_values['re_protein']);
 
+    // The parent class will validate that a file has been specified and is valid.
 
     if ($line_number and !is_numeric($line_number) or $line_number < 0) {
-      \Drupal::messenger()->addError(t("Please provide an integer line number greater than zero."));
+      $form_state->setErrorByName('line_number', t('Please provide an integer line number greater than zero'));
     }
 
     if (!($re_mrna and $re_protein) and ($re_mrna or $re_protein)) {
-      \Drupal::messenger()->addError(t("You must provide both a regular expression for mRNA and a replacement string for protein"));
+      $form_state->setErrorByName('re_mrna', t('You must provide both a regular expression for mRNA and a replacement string for protein'));
     }
 
     // check the regular expression to make sure it is valid
@@ -539,24 +540,24 @@ class GFF3Importer extends ChadoImporterBase {
     $result = preg_replace("/" . $re_mrna . "/", $re_protein, "");
     restore_error_handler();
     if ($result_re === FALSE) {
-      \Drupal::messenger()->addError('Invalid regular expression.');
+      $form_state->setErrorByName('re_mrna', t('Invalid regular expression'));
     }
-    else {
-      if ($result === FALSE) {
-        \Drupal::messenger()->addError('Invalid replacement string.');
-      }
+    elseif ($result === FALSE) {
+      $form_state->setErrorByName('re_protein', t('Invalid replacement string'));
     }
 
     // check to make sure the types exists
     $cv_autocomplete = new ChadoCVTermAutocompleteController();
     $landmark_cvterm_id = $cv_autocomplete->getCVtermId($landmark_type, 'sequence');
     if (!$landmark_cvterm_id) {
-      \Drupal::messenger()->addError(t("The Sequence Ontology (SO) term selected for the landmark type is not available in the database. Please check spelling or select another."));
+      $form_state->setErrorByName('landmark_type', t('The Sequence Ontology (SO) term selected for the landmark type is not'
+                                                   . ' available in the database. Please check the spelling or select another'));
     }
     if ($target_type) {
       $target_type_id = $cv_autocomplete->getCVtermId($target_type, 'sequence');
       if (!$target_type_id) {
-        \Drupal::messenger()->addError(t("The Sequence Ontology (SO) term selected for the target type is not available in the database. Please check spelling or select another."));
+        $form_state->setErrorByName('target_type', t('The Sequence Ontology (SO) term selected for the target type is not'
+                                                   . ' available in the database. Please check the spelling or select another'));
       }
     }
 

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -36,46 +36,6 @@ use Drupal\Core\Ajax\ReplaceCommand;
  */
 class GFF3Importer extends ChadoImporterBase {
   /**
-   * The name of this loader.  This name will be presented to the site
-   * user.
-   */
-  public static $name = 'Chado GFF3 File Loader';
-
-  /**
-   * The machine name for this loader. This name will be used to construct
-   * the URL for the loader.
-   */
-  public static $machine_name = 'chado_gff3_loader';
-
-  /**
-   * A brief description for this loader.  This description will be
-   * presented to the site user.
-   */
-  public static $description = 'Import a GFF3 file into Chado';
-
-  /**
-   * An array containing the extensions of allowed file types.
-   */
-  public static $file_types = ['gff', 'gff3'];
-
-  /**
-   * Provides information to the user about the file upload.  Typically this
-   * may include a description of the file types allowed.
-   */
-  public static $upload_description = 'Please provide the GFF3 file.';
-
-  /**
-   * The title that should appear above the upload button.
-   */
-  public static $upload_title = 'GFF3 File';
-
-  /**
-   * Text that should appear on the button at the bottom of the importer
-   * form.
-   */
-  public static $button_text = 'Import GFF3 file';
-
-  /**
    * A handle to a temporary file for caching the GFF features. This allows for
    * quick lookup of parsed features without having to store it in RAM.
    */

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -106,7 +106,7 @@ class NewickImporter extends ChadoImporterBase {
     $so_cv = chado_get_cv(['name' => 'sequence']);
     $cv_id = $so_cv->cv_id;
     if (!$so_cv) {
-      \Drupal::messenger()->addError(t("The Sequence Ontolgoy does not appear to be imported.
+      \Drupal::messenger()->addError(t("The Sequence Ontology does not appear to be imported.
          Please import the Sequence Ontology before adding a tree."));
     }
 

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -195,6 +195,8 @@ class NewickImporter extends ChadoImporterBase {
     $errors = [];
     $warnings = [];
 
+    // The parent class will validate that a file has been specified and is valid.
+
     // Validate DBXREF
     if ($options['dbxref'] and ($options['dbxref'] != "null:local:null")) {
       // The db in a dbxref must already exist, the accession can be new.
@@ -215,12 +217,6 @@ class NewickImporter extends ChadoImporterBase {
         $form_state->setErrorByName('dbxref', "The DB \"$db\" in the dbxref value does not exist, specify a valid dbxref value.");
         return;
       }
-    }
-
-    // Verify that a file has been supplied.
-    if ((!array_key_exists('tree_file', $options) or $options['tree_file'] == null) && $values['file_upload_existing'] <= 0) {
-      $form_state->setErrorByName('file_upload_existing', t('No tree file was submitted, please upload a file or choose one if it exists'));
-      return;
     }
 
     // Perform API validation.

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -258,12 +258,8 @@ class TaxonomyImporter extends ChadoImporterBase {
         }
       }
       if (count($bad_ids) > 0) {
-        // form_set_error('taxonomy_ids',
-        //   t('Taxonomy IDs must be numeric. The following are not valid: "@ids".',
-        //     ['@ids' => implode('", "', $bad_ids)]));
-        \Drupal::messenger()->addError(
-          t('Taxonomy IDs must be numeric. The following are not valid: "@ids".',
-          ['@ids' => implode('", "', $bad_ids)])
+        $form_state->setErrorByName('taxonomy_ids', t('Taxonomy IDs must be numeric. The following are not valid: "@ids".'),
+          ['@ids' => implode('", "', $bad_ids)]
         );
       }
     }

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -666,8 +666,9 @@ class TaxonomyImporter extends ChadoImporterBase {
           $rfh = fopen($search_url, "r");
           // If error, delay then retry
           if ((!$rfh) and ($retries)) {
-            $this->logger->warning("Error contacting NCBI to look up %sci_name, will retry",
-                              ['%sci_name' => $sci_name_escaped]);
+            $this->logger->warning("Error contacting NCBI to look up @sci_name, will retry",
+              ['@sci_name' => $sci_name_escaped]
+            );
           }
           $retries--;
           $remaining_sleep = $sleep_time - ((int) (1e6 * (microtime(TRUE) - $start)));
@@ -677,7 +678,9 @@ class TaxonomyImporter extends ChadoImporterBase {
         }
 
         if (!$rfh) {
-          $this->logger->warning("Could not look up %sci_name", ['%sci_name' => $sci_name_escaped]);
+          $this->logger->warning("Could not look up @sci_name",
+            ['@sci_name' => $sci_name_escaped]
+          );
           continue;
         }
         $xml_text = '';
@@ -701,8 +704,9 @@ class TaxonomyImporter extends ChadoImporterBase {
               $taxid = (string) $xml->IdList->Id;
             }
             else {
-              $this->logger->warning("Partial match \"%matched\" to query \"%query\", no taxid available",
-                ['%matched' => $matched, '%query' => $sci_name]);
+              $this->logger->warning("Partial match \"@matched\" to query \"@query\", no taxid available",
+                ['@matched' => $matched, '@query' => $sci_name]
+              );
             }
           }
         }
@@ -724,10 +728,10 @@ class TaxonomyImporter extends ChadoImporterBase {
     }
     if (count($omitted_organisms)) {
       $omitted_list = implode('", "', $omitted_organisms);
-      $this->logger->warning('The following %count organisms do not have an NCBI taxonomy ID, '
-                        . 'and have not been included in the tree: "@omitted_list"',
-                        ['%count' => count($omitted_organisms),
-                         '@omitted_list' => $omitted_list]);
+      $this->logger->warning('The following @count organisms do not have an NCBI taxonomy ID,'
+                           . ' and have not been included in the tree: "@omitted_list"',
+        ['@count' => count($omitted_organisms), '@omitted_list' => $omitted_list]
+      );
     }
   }
 
@@ -923,8 +927,9 @@ class TaxonomyImporter extends ChadoImporterBase {
         $xml = new \SimpleXMLElement($xml_text);
       }
       else {
-        $this->logger->warning("Error contacting NCBI to look up taxid %taxid, will retry",
-                               ['%taxid' => $taxid]);
+        $this->logger->warning("Error contacting NCBI to look up @taxid, will retry",
+          ['@taxid' => $taxid]
+        );
       }
       $retries--;
       $remaining_sleep = $sleep_time - ((int) (1e6 * (microtime(TRUE) - $start)));
@@ -960,9 +965,10 @@ class TaxonomyImporter extends ChadoImporterBase {
         $chado_name = chado_get_organism_scientific_name($organism, $this->chado_schema_main);
         if ($chado_name != $sci_name) {
           $this->logger->warning("Substituting site taxon \"@chado_name\" for NCBI taxon \"@sci_name\","
-                            . " taxid @taxid, organism_id @organism_id",
+                               . " taxid @taxid, organism_id @organism_id",
             ['@chado_name' => $chado_name, '@sci_name' => $sci_name,
-             '@taxid' => $taxid, '@organism_id' => $organism->organism_id]);
+             '@taxid' => $taxid, '@organism_id' => $organism->organism_id]
+          );
           $sci_name = $chado_name;
         }
       }
@@ -1104,8 +1110,9 @@ class TaxonomyImporter extends ChadoImporterBase {
       return TRUE;
     }
     else {
-      $this->logger->warning("Error contacting NCBI to look up taxid %taxid",
-                        ['%taxid' => $taxid]);
+      $this->logger->warning("Error contacting NCBI to look up taxid @taxid",
+        ['@taxid' => $taxid]
+      );
       return FALSE;
     }
   }


### PR DESCRIPTION
# Bug Fix

### Closes #1579
### Closes #1651

### Tripal Version: 4.x

## Description

 * logger warnings and errors should all use variable substitution, for example
`$this->logger->error("Regular expression for the feature name finds nothing. Line $i.");`
becomes
```
$this->logger->error("Regular expression for the feature name finds nothing. Line @line.",
  ['@line' => $i]
);
```

 * A number of updates from Drupal messenger to setErrorByName in validation functions. The primary problem is that messenger allows the import job to proceed. setErrorByName will highlight the faulty field and require edit and then resubmission. For example
`\Drupal::messenger()->addError(t("You must provide a regular expression to identify the sequence unique name"));`
becomes
`$form_state->setErrorByName('re_name', t('You should not specify a regular expression for name if you are matching 
to sequence unique name'));`

 * Remove some variables used by Tripal 3 but now in the object header comment definitions. https://github.com/tripal/tripal/pull/1644/commits/c12382d9f4f25b2a2cebdba7630fcd4ba06a63d6

 * A few typos fixed

 * A few bugs fixed seen in the code review. Some of these are backported to Tripal 3 in Issue #1643 pull #1645

## Testing?
Manual testing involves trying to run importers and leave fields out or enter bogus values in fields.
 * Fasta importer select "Name" but put a regex in "Unique name" or vice versa. 
Before these changes, there was an error, but the job was submitted anyway.
![fasta-regex0](https://github.com/tripal/tripal/assets/8419404/2304d5a3-61fb-48c6-aa29-26bf17bf6213)

After this PR it will be validated thusly:
![fasta-regex1](https://github.com/tripal/tripal/assets/8419404/47387819-a6ea-480a-8824-0bf8aa5d363d)
![fasta-regex2](https://github.com/tripal/tripal/assets/8419404/660bb9ec-d293-47ff-95c3-11e945bca3dc)

 * enter non-existing cv term names (type in a value and don't use the ajax list provided) and verify error is shown, e.g. for the GFF3 importer:
![CV1](https://github.com/tripal/tripal/assets/8419404/29228b5f-d0e7-4162-bbd9-40bd723b90a8)
![CV2](https://github.com/tripal/tripal/assets/8419404/d403bda0-3111-40ce-8e51-1b33d1da0b6b)

