### PR TITLE
Ability to Disable TripalImporter submit button

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -130,10 +130,20 @@ class TripalImporterForm implements FormInterface {
     // We should only add a submit button if this importer uses a button.
     // Examples of importers who don't use this button are multi-page forms.
     if (array_key_exists('use_button', $importer_def) AND $importer_def['use_button'] !== FALSE) {
+
+      // We will allow specific importers to disable this button based on the state of the form.
+      // By default it is enabled.
+      $disabled = FALSE;
+      // But if they set the storage to indicate we should disable it then we will.
+      $storage = $form_state->getStorage();
+      if (array_key_exists('disable_TripalImporter_submit', $storage)) {
+        $disabled = $storage['disable_TripalImporter_submit'];
+      }
       $form['button'] = [
         '#type' => 'submit',
         '#value' => $importer_def['button_text'],
         '#weight' => 10,
+        '#disabled' => $disabled,
       ];
     }
 

--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -134,7 +134,12 @@ class TripalImporterForm implements FormInterface {
       // We will allow specific importers to disable this button based on the state of the form.
       // By default it is enabled.
       $disabled = FALSE;
-      // But if they set the storage to indicate we should disable it then we will.
+      // Unless the annotation says it should be disabled by default..
+      if (array_key_exists('submit_disabled', $importer_def) AND $importer_def['submit_disabled'] === TRUE) {
+        $disabled = TRUE;
+      }
+      // But if they set the storage to indicate we should disable/enable it
+      // then we will do whatever they say ;-).
       $storage = $form_state->getStorage();
       if (array_key_exists('disable_TripalImporter_submit', $storage)) {
         $disabled = $storage['disable_TripalImporter_submit'];

--- a/tripal/src/TripalImporter/Annotation/TripalImporter.php
+++ b/tripal/src/TripalImporter/Annotation/TripalImporter.php
@@ -97,6 +97,22 @@ class TripalImporter extends Plugin {
   public $use_button = TRUE;
 
   /**
+   * Indicated whether the base importer added submit button should be disabled
+   * when the form is first loaded (i.e when the user clicks the link for the
+   * importer). The form can then be programatically enabled via AJAX once
+   * certain criteria is set by setting the form state storage.
+   *
+   * Example of programatically enabling the button via the form state
+   * on an importer where this annotation is set to TRUE.
+   * @code
+      $storage = $form_state->getStorage();
+      $storage['disable_TripalImporter_submit'] = FALSE;
+      $form_state->setStorage($storage);
+   * @endcode
+   */
+  public $submit_disabled = FALSE;
+
+  /**
    * Text that should appear on the button at the bottom of the importer form.
    *
    * @var \Drupal\Core\Annotation\Translation

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -463,7 +463,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
    * Confirm that importers can indicate they want the form submit button
    * disabled using a particular key in the form state.
    */
-  public function testTripalImporterFormDisableButton() {
+  public function testTripalImporterFormDisableButtonFormStateOnly() {
 
     $container = \Drupal::getContainer();
     $form_builder = \Drupal::formBuilder();
@@ -473,7 +473,6 @@ class TripalImporterFormBuildTest extends KernelTestBase {
 
     // CASE 1: No Form State
     $expected = $this->definitions[$plugin_id];
-    // @todo not implemented yet $expected['disable_submit'] = FALSE;
     $manager = $this->setMockManager([$plugin_id => $expected]);
     $container->set('tripal.importer', $manager);
 
@@ -534,5 +533,83 @@ class TripalImporterFormBuildTest extends KernelTestBase {
       "The submit button should have the disabled key set.");
     $this->assertFalse($form['button']['#disabled'],
       "The submit button should BE ENABLED when the form is built with the form state disable_TripalImporter_submit set to FALSE.");
+  }
+
+  /**
+   * Confirm that importers can indicate they want the form submit button
+   * disabled via annotation and change it via form state.
+   */
+  public function testTripalImporterFormDisableButtonAnnotation() {
+
+    $container = \Drupal::getContainer();
+    $form_builder = \Drupal::formBuilder();
+    $plugin_id = 'fakeImporterName';
+    $form_id = 'tripal_admin_form_tripalimporter';
+    $form_class = 'Drupal\tripal\Form\TripalImporterForm';
+
+    // CASE 1: No Form State
+    $expected = $this->definitions[$plugin_id];
+    $expected['submit_disabled'] = TRUE;
+    $manager = $this->setMockManager([$plugin_id => $expected]);
+    $container->set('tripal.importer', $manager);
+
+    // Build the form using the Drupal form builder.
+    // and confirm that when the form is built with no Form State that
+    // the button is enabled.
+    $form = $form_builder->getForm(
+      'Drupal\tripal\Form\TripalImporterForm',
+      $plugin_id,
+    );
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertTrue($form['button']['#disabled'],
+      "The submit button should BE DISABLED when the form is built without a specific form state but annotation says it should be.");
+
+    // CASE 2: Form State[disable_submit] = FALSE when form rebuilt.
+    $form_state = new FormState();
+    $form_state->addBuildInfo('args', [$plugin_id]);
+    $form_state->setStorage(['disable_TripalImporter_submit' => FALSE]);
+    $form = $form_builder->buildForm($form_class, $form_state);
+
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertFalse($form['button']['#disabled'],
+      "The submit button should BE ENABLED when the form is built with the form state disable_TripalImporter_submit set to FALSE.");
+
+    // CASE 3: Form State[disable_submit] = TRUE when form rebuilt.
+    $form_state = new FormState();
+    $form_state->addBuildInfo('args', [$plugin_id]);
+    $form_state->setStorage(['disable_TripalImporter_submit' => TRUE]);
+    $form = $form_builder->buildForm($form_class, $form_state);
+
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertTrue($form['button']['#disabled'],
+      "The submit button should BE DISABLED when the form is built with the form state disable_TripalImporter_submit set to TRUE.");
+
   }
 }

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\tripal\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Core\Form\FormState;
 
 /**
  * Tests the base functionality for importers.
@@ -456,5 +457,82 @@ class TripalImporterFormBuildTest extends KernelTestBase {
     $this->assertArrayNotHasKey('button', $form,
       "We should not have a submit button if our annotation sets use_button to FALSE but we do.");
 
+  }
+
+  /**
+   * Confirm that importers can indicate they want the form submit button
+   * disabled using a particular key in the form state.
+   */
+  public function testTripalImporterFormDisableButton() {
+
+    $container = \Drupal::getContainer();
+    $form_builder = \Drupal::formBuilder();
+    $plugin_id = 'fakeImporterName';
+    $form_id = 'tripal_admin_form_tripalimporter';
+    $form_class = 'Drupal\tripal\Form\TripalImporterForm';
+
+    // CASE 1: No Form State
+    $expected = $this->definitions[$plugin_id];
+    // @todo not implemented yet $expected['disable_submit'] = FALSE;
+    $manager = $this->setMockManager([$plugin_id => $expected]);
+    $container->set('tripal.importer', $manager);
+
+    // Build the form using the Drupal form builder.
+    // and confirm that when the form is built with no Form State that
+    // the button is enabled.
+    $form = $form_builder->getForm(
+      'Drupal\tripal\Form\TripalImporterForm',
+      $plugin_id,
+    );
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertFalse($form['button']['#disabled'],
+      "The submit button should BE ENABLED when the form is built without a specific form state.");
+
+    // CASE 2: Form State[disable_submit] = TRUE when form rebuilt.
+    $form_state = new FormState();
+    $form_state->addBuildInfo('args', [$plugin_id]);
+    $form_state->setStorage(['disable_TripalImporter_submit' => TRUE]);
+    $form = $form_builder->buildForm($form_class, $form_state);
+
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertTrue($form['button']['#disabled'],
+      "The submit button should BE DISABLED when the form is built with the form state disable_TripalImporter_submit set to TRUE.");
+
+    // CASE 3: Form State[disable_submit] = FALSE when form rebuilt.
+    $form_state = new FormState();
+    $form_state->addBuildInfo('args', [$plugin_id]);
+    $form_state->setStorage(['disable_TripalImporter_submit' => FALSE]);
+    $form = $form_builder->buildForm($form_class, $form_state);
+
+    $this->assertIsArray($form,
+      'The form builder should return a form array.');
+    $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
+      'We did not get the form id we expected.');
+
+    // check that our button element is in the form.
+    $this->assertArrayHasKey('button', $form,
+      "We should have a submit button.");
+    $this->assertArrayHasKey('#disabled', $form['button'],
+      "The submit button should have the disabled key set.");
+    $this->assertFalse($form['button']['#disabled'],
+      "The submit button should BE ENABLED when the form is built with the form state disable_TripalImporter_submit set to FALSE.");
   }
 }


### PR DESCRIPTION

# Tripal 4 Core Dev Task

### Issue #1652 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The Tripal Importer form takes complete control over the file and submit elements in such a way that Importer implementations (e.g. GFF3 loader) cannot modify these elements.

In some cases, this is problematic -especially for the submit button. For example, if an importer wants to do in page AJAX validation before allowing submit such as validating the file via a Tripal Job, developers of the importer have no way to stop submission of the form via the submit button. Additionally, Drupal updates the DOM after ajax submission by appending unique codes to the IDs which makes targetting these ids via javascript alone difficult. Another example if so a multi-stage form or a form using an accordion.

This PR adds two pieces of functionality to allow TripalImporter implementations to disable the submit button.
1. A new property in the annotation `submit_disabled`. When set to true for an importer, the submit button will be disabled when a user first loads the form.
2. A key in the form_state storage `disable_TripalImporter_submit` that when true the submit button is disabled and when false, the submit button is enabled. Since this is in the form_state it can be set via AJAX or via the form itself.

An example of using these two additions is in the importer attached to the testing section. This example has `submit_disabled: True` in the annotation. The form on first load shows the submit button disabled and a selection of form elements. AJAX is triggered once the user selects something from the select list which rebuilds the entire form. On rebuild, the form sees the select list element has a value and sets the form_state storage `disable_TripalImporter_submit` to FALSE. Since TripalImporterForm adds the button after it pulls in the implementation form elements, it sees the form state set to FALSE and renders the button as enabled.

Here is a code snippet of changing the value of the form state. This is done using the Storage of the form which stores random information about the state. This ensures we are following Drupal Standards :-)

```php
$storage = $form_state->getStorage();
$storage['disable_TripalImporter_submit'] = FALSE;
$form_state->setStorage($storage);
```

Also this change is backwards compatible as when I added `submit_disabled` to the annotation, I set a default of FALSE.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Check Backwards compatibility.
Load the existing importers and ensure the submit button is not disabled ;-)

### Check current Functionality.
1. Download my [example importer class](https://github.com/tripal/tripal/files/12730176/TestImporter.txt) and change the file ending to php. Place this class in the `tripal/src/Plugin/TripalImporter` directory.
2. Clear the cache. This is needed for new importers to be found. You may need to clear the cache 2X if the routing isn't picked up the first time.
3. Go to the importer listing Tripal > Data Loaders > Test Disable Button
4. Ensure the import button is disabled!
5. Select anything from the drop down list.
6. Ensure that the button is now enabled! Also enjoy the reply to your selection <3 
