### PR TITLE
Removes duplicated importer metadata

### DIFF
--- a/tripal/src/TripalImporter/Annotation/TripalImporter.php
+++ b/tripal/src/TripalImporter/Annotation/TripalImporter.php
@@ -45,8 +45,7 @@ class TripalImporter extends Plugin {
    *
    * @var array
    */
-  public $file_types;
-
+  public $file_types = ['txt'];
 
   /**
    * Provides information to the user about the file upload.
@@ -77,7 +76,7 @@ class TripalImporter extends Plugin {
    *
    * @var bool
    */
-  public $use_analysis;
+  public $use_analysis = TRUE;
 
   /**
    * If the $use_analysis value is set above then this value indicates if the
@@ -85,7 +84,7 @@ class TripalImporter extends Plugin {
    *
    * @var bool
    */
-  public $require_analysis;
+  public $require_analysis = FALSE;
 
   /**
    * Indicates whether the base importer should add a submit button or not.
@@ -103,29 +102,28 @@ class TripalImporter extends Plugin {
    *
    * @ingroup plugin_translatable
    */
-  public $button_text;
+  public $button_text = 'Import';
 
   /**
    * Indicates if the loader should provide a file upload form element.
    *
    * @var bool
    */
-  public $file_upload;
+  public $file_upload = TRUE;
 
   /**
    * Indicates if the loader should provide a local file form element.
    *
    * @var bool
    */
-  public $file_local;
+  public $file_local = TRUE;
 
   /**
    * Indicates if the loader should provide a remote file form element.
    *
    * @var bool
    */
-  public $file_remote;
-
+  public $file_remote = TRUE;
 
   /**
    * Indicates if the file must be provided.
@@ -137,8 +135,7 @@ class TripalImporter extends Plugin {
    *
    * @var bool
    */
-  public $file_required;
-
+  public $file_required = TRUE;
 
   /**
    * The array of arguments used for this loader.
@@ -151,7 +148,6 @@ class TripalImporter extends Plugin {
    */
   public $argument_list = [];
 
-
   /**
    * Indicates how many files are allowed to be uploaded.
    *
@@ -160,8 +156,7 @@ class TripalImporter extends Plugin {
    *
    * @var int
    */
-  public $cardinality;
-
+  public $cardinality = 1;
 
   /**
    * Be default, all loaders are automaticlly added to the Admin >
@@ -172,7 +167,6 @@ class TripalImporter extends Plugin {
    * @var string
    */
   public $menu_path;
-
 
   /**
    * If your importer requires more flexibility and advanced features than

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -22,79 +22,12 @@ use Drupal\Core\Ajax\ReplaceCommand;
  *    require_analysis = True,
  *    button_text = @Translation("Import FASTA file"),
  *    file_upload = True,
- *    file_load = True,
  *    file_remote = True,
  *    file_local = True,
  *    file_required = True,
- *    cardinality = 1,
- *    menu_path = "",
- *    callback = "",
- *    callback_module = "",
- *    callback_path = "",
  *  )
  */
 class FASTAImporter extends ChadoImporterBase {
-  /**
-   * The name of this loader.  This name will be presented to the site
-   * user.
-   */
-  public static $name = 'Chado FASTA Loader';
-
-  /**
-   * The machine name for this loader. This name will be used to construct
-   * the URL for the loader.
-   */
-  public static $machine_name = 'chado_fasta_loader';
-
-  /**
-   * A brief description for this loader.  This description will be
-   * presented to the site user.
-   */
-  public static $description = 'Load sequences from a multi-FASTA file into Chado';
-
-  /**
-   * An array containing the extensions of allowed file types.
-   */
-  public static $file_types = [
-    'fasta',
-    'txt',
-    'fa',
-    'aa',
-    'pep',
-    'nuc',
-    'faa',
-    'fna',
-  ];
-
-
-  /**
-   * Provides information to the user about the file upload.  Typically this
-   * may include a description of the file types allowed.
-   */
-  public static $upload_description = 'Please provide the FASTA file. The file must have a .fasta extension.';
-
-  /**
-   * The title that should appear above the file upload section.
-   */
-  public static $upload_title = 'FASTA Upload';
-
-  /**
-   * Text that should appear on the button at the bottom of the importer
-   * form.
-   */
-  public static $button_text = 'Import FASTA file';
-
-  /**
-   * Indicates the methods that the file uploader will support.
-   */
-  public static $methods = [
-    // Allow the user to upload a file to the server.
-    'file_upload' => TRUE,
-    // Allow the user to provide the path on the Tripal server for the file.
-    'file_local' => TRUE,
-    // Allow the user to provide a remote URL for the file.
-    'file_remote' => TRUE,
-  ];
 
   /**
    * @see TripalImporter::form()

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -23,57 +23,12 @@ use Drupal\Core\Ajax\ReplaceCommand;
  *    require_analysis = True,
  *    button_text = @Translation("Import GFF3 file"),
  *    file_upload = True,
- *    file_load = True,
  *    file_remote = True,
  *    file_local = True,
  *    file_required = True,
- *    cardinality = 1,
- *    menu_path = "",
- *    callback = "",
- *    callback_module = "",
- *    callback_path = "",
  *  )
  */
 class GFF3Importer extends ChadoImporterBase {
-  /**
-   * The name of this loader.  This name will be presented to the site
-   * user.
-   */
-  public static $name = 'Chado GFF3 File Loader';
-
-  /**
-   * The machine name for this loader. This name will be used to construct
-   * the URL for the loader.
-   */
-  public static $machine_name = 'chado_gff3_loader';
-
-  /**
-   * A brief description for this loader.  This description will be
-   * presented to the site user.
-   */
-  public static $description = 'Import a GFF3 file into Chado';
-
-  /**
-   * An array containing the extensions of allowed file types.
-   */
-  public static $file_types = ['gff', 'gff3'];
-
-  /**
-   * Provides information to the user about the file upload.  Typically this
-   * may include a description of the file types allowed.
-   */
-  public static $upload_description = 'Please provide the GFF3 file.';
-
-  /**
-   * The title that should appear above the upload button.
-   */
-  public static $upload_title = 'GFF3 File';
-
-  /**
-   * Text that should appear on the button at the bottom of the importer
-   * form.
-   */
-  public static $button_text = 'Import GFF3 file';
 
   /**
    * A handle to a temporary file for caching the GFF features. This allows for
@@ -136,12 +91,10 @@ class GFF3Importer extends ChadoImporterBase {
    */
   private $update = TRUE;
 
-
-    /**
+  /**
    * A list of features to have names updated.
    */
   private $update_names = [];
-
 
   /**
    * If the GFF file contains a 'Target' attribute then the feature and the
@@ -211,7 +164,6 @@ class GFF3Importer extends ChadoImporterBase {
    * The cvterm_id for the landmark type cvterm.
    */
   private $landmark_cvterm_id = NULL;
-
 
   /**
    * Regular expression to pull out the mRNA name.

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -24,17 +24,12 @@ use Drupal\Core\Url;
  *    require_analysis = True,
  *    button_text = @Translation("Import Newick Tree file"),
  *    file_upload = True,
- *    file_load = False,
  *    file_remote = False,
  *    file_required = False,
- *    cardinality = 1,
- *    menu_path = "",
- *    callback = "",
- *    callback_module = "",
- *    callback_path = "",
  *  )
  */
 class NewickImporter extends ChadoImporterBase {
+
   /**
    * @see TripalImporter::form()
    */

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -21,14 +21,8 @@ use Drupal\Core\Ajax\ReplaceCommand;
  *    require_analysis = True,
  *    button_text = @Translation("Import OBO File"),
  *    file_upload = False,
- *    file_load = False,
  *    file_remote = False,
  *    file_required = False,
- *    cardinality = 1,
- *    menu_path = "",
- *    callback = "",
- *    callback_module = "",
- *    callback_path = "",
  *  )
  */
 class OBOImporter extends ChadoImporterBase {
@@ -39,7 +33,6 @@ class OBOImporter extends ChadoImporterBase {
    * @var array
    */
   private $obo_namespaces = [];
-
 
   /**
    * Holds the list of all CVs on this site. By storing them here it saves
@@ -67,7 +60,6 @@ class OBOImporter extends ChadoImporterBase {
     'narrow' => NULL,
     'related' => NULL,
   ];
-
 
   // An alternative cache to the temp_obo table.
   private $termStanzaCache = [
@@ -101,7 +93,6 @@ class OBOImporter extends ChadoImporterBase {
    */
   private $default_namespace = '';
 
-
   /**
    * Holds the idspace elements from the header. These will correspond
    * to the accession prefixes, or short names (e.g. GO) for the terms. For
@@ -117,13 +108,11 @@ class OBOImporter extends ChadoImporterBase {
    */
   private $default_db = '';
 
-
   /**
    * An array of used cvterm objects so that we don't have to look them
    * up repeatedly.
    */
   private $used_terms = [];
-
 
   /**
    * An array of base IRIs returned from the EBI OLS lookup service.  We
@@ -156,7 +145,6 @@ class OBOImporter extends ChadoImporterBase {
    * @var array
    */
   private $term_names = [];
-
 
   /**
    * {@inheritdoc}

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -24,113 +24,11 @@ use Drupal\Core\Url;
  *    require_analysis = False,
  *    button_text = @Translation("Import Taxonomy file"),
  *    file_upload = False,
- *    file_load = False,
  *    file_remote = False,
  *    file_required = False,
- *    cardinality = 1,
- *    menu_path = "",
- *    callback = "",
- *    callback_module = "",
- *    callback_path = "",
  *  )
  */
 class TaxonomyImporter extends ChadoImporterBase {
-
-  /**
-   * The name of this loader.  This name will be presented to the site
-   * user.
-   */
-  public static $name = 'Chado NCBI Taxonomy Loader';
-
-  /**
-   * The machine name for this loader. This name will be used to construct
-   * the URL for the loader.
-   */
-  public static $machine_name = 'chado_taxonomy';
-
-  /**
-   * A brief description for this loader.  This description will be
-   * presented to the site user.
-   */
-  public static $description = 'Imports new organisms from NCBI using taxonomy IDs, ' .
-                                'or loads taxonomic details about existing organisms.';
-
-  /**
-   * An array containing the extensions of allowed file types.
-   */
-  public static $file_types = [];
-
-
-  /**
-   * Provides information to the user about the file upload.  Typically this
-   * may include a description of the file types allowed.
-   */
-  public static $upload_description = '';
-
-  /**
-   * The title that should appear above the upload button.
-   */
-  public static $upload_title = 'File Upload';
-
-  /**
-   * If the loader should require an analysis record.  To maintain provenance
-   * we should always indicate where the data we are uploading comes from.
-   * The method that Tripal attempts to use for this by associating upload files
-   * with an analysis record.  The analysis record provides the details for
-   * how the file was created or obtained. Set this to FALSE if the loader
-   * should not require an analysis when loading. if $use_analysis is set to
-   * true then the form values will have an 'analysis_id' key in the $form_state
-   * array on submitted forms.
-   */
-  public static $use_analysis = FALSE;
-
-  /**
-   * If the $use_analysis value is set above then this value indicates if the
-   * analysis should be required.
-   */
-  public static $require_analysis = FALSE;
-
-  /**
-   * Text that should appear on the button at the bottom of the importer
-   * form.
-   */
-  public static $button_text = 'Import from NCBI Taxonomy';
-
-  /**
-   * Indicates the methods that the file uploader will support.
-   */
-  public static $methods = [
-    // Allow the user to upload a file to the server.
-    'file_upload' => FALSE,
-    // Allow the user to provide the path on the Tripal server for the file.
-    'file_local' => FALSE,
-    // Allow the user to provide a remote URL for the file.
-    'file_remote' => FALSE,
-  ];
-
-  /**
-   * Indicates if the file must be provided.  An example when it may not be
-   * necessary to require that the user provide a file for uploading if the
-   * loader keeps track of previous files and makes those available for
-   * selection.
-   */
-  public static $file_required = FALSE;
-
-
-  /**
-   * The array of arguments used for this loader.  Each argument should
-   * be a separate array containing a machine_name, name, and description
-   * keys.  This information is used to build the help text for the loader.
-   */
-  public static $argument_list = [];
-
-
-  /**
-   * Indicates how many files are allowed to be uploaded.  By default this is
-   * set to allow only one file.  Change to any positive number. A value of
-   * zero indicates an unlimited number of uploaded files are allowed.
-   */
-  public static $cardinality = 0;
 
   /**
    * Holds the list of all organisms currently in Chado. This list


### PR DESCRIPTION

# Tripal 4 Core Dev Task

### Issue #1359 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This is a pet peeve of mine and I needed an easy task ;-) 

When the importers were upgraded, the kept the original variables used in our Tripal 3 classes but then also added these properties to the annotation. This resulted in duplicated information. The upgrade was done well though so only the annotation values are being used which is correct ✅ This PR removes the old variables to reduce confusion and ensure there doesn't end up being confusing mismatches ;-) 

Additionally I set defaults for the annotation values where it made sense to do so which allows these to be left out of the annotation of importers happy to use the defaults.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
All these forms have 100% automated test coverage of the elements controlled by the annotation so this should not even need manual testing.

That said, if you would like to be thorough, simply starting up a fresh docker and loading each of the importers provided by core to ensure the form elements appear as expected:
 - check that the text from the annotation is on the form
 - check that the form elements for file upload, analysis and submit are still present