### PR TITLE
Support detailed upload file format descriptions

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -60,7 +60,7 @@ class TripalImporterForm implements FormInterface {
 
       $form['file']['upload_description'] = [
         '#type' => 'markup',
-        '#markup' => $importer_def['upload_description'] . ' The following file extensions are supported: ' . implode(', ', $importer_def['file_types']) . '.',
+        '#markup' => $importer->describeUploadFileFormat(),
       ];
     }
 

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -103,7 +103,6 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
    */
   protected $plugin_definition;
 
-
   /**
    * {@inheritdoc}
    */
@@ -130,6 +129,21 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
     // Initialize messenger
     $this->messenger = \Drupal::messenger();
 
+  }
+
+  /**
+   * Provide more informative description than is ideal in the annotation alone.
+   *
+   * NOTE: Supports full HTML.
+   *
+   * @return
+   *   A fully formatted string describing the format of the file to be uploaded
+   *   and providing any additional upload file information.
+   */
+  public function describeUploadFileFormat() {
+    $default_description = $this->plugin_definition['upload_description'];
+    $file_types = $this->plugin_definition['file_types'];
+    return $default_description . ' The following file extensions are supported: ' . implode(', ', $file_types) . '.';
   }
 
    /**

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -127,7 +127,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
     // Mock Tripal Importer Plugin.
     $configuration = [];
     $plugin_id = 'fakeImporterName';
-    $plugin_definition = $annotations['fakeImporterName'];
+    $plugin_definition = $annotation['fakeImporterName'];
     $this->mock_plugin = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
       [$configuration, $plugin_id, $plugin_definition]

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterFormBuildTest.php
@@ -127,7 +127,7 @@ class TripalImporterFormBuildTest extends KernelTestBase {
     // Mock Tripal Importer Plugin.
     $configuration = [];
     $plugin_id = 'fakeImporterName';
-    $plugin_definition = [];
+    $plugin_definition = $annotations['fakeImporterName'];
     $this->mock_plugin = $this->getMockForAbstractClass(
       '\Drupal\tripal\TripalImporter\TripalImporterBase',
       [$configuration, $plugin_id, $plugin_definition]

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -18,7 +18,7 @@ use Drupal\Core\Url;
  *    label = @Translation("Newick Tree Loader"),
  *    description = @Translation("Import Newick Tree into Chado"),
  *    file_types = {"tree","txt","newick"},
- *    upload_description = @Translation("Please provide the Newick formatted tree file (one tree per file only).  The file must have a .txt or .tree extension"),
+ *    upload_description = @Translation("Please provide the Newick formatted tree file (one tree per file only)."),
  *    upload_title = @Translation("Newick Tree File"),
  *    use_analysis = True,
  *    require_analysis = True,


### PR DESCRIPTION
# New Feature

### Issue #1656 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds a method to allow TripalImporter developers to provide formatted and detailed upload file descriptions. It is backwards compatible :-)

Whereas before, an importer wanting to provide a HTML list describing the columns would need to do something like this:
![](https://user-images.githubusercontent.com/7927760/270805875-1bee3dd3-a183-4585-b961-2d4ea0b01760.png)

Now they can implement the `describeUploadFileFormat` in their importer class like this:

```php
/**
 * @{inheritdoc}
 */
public function describeUploadFileFormat() {
  $output = "Germplasm file should be a tab separated file with the following columns:";

  $columns = [
    'Germplasm Name' => 'Name of this germplasm accession.',
    'External Database' => 'The institution who assigned the accession.',
    'Accession Number' => 'A unique identifier for the accession.',
    'Germplasm Species' => 'The species of the accession.',
    'Germplasm Subtaxa' => 'Subtaxon can be specified here or any additional taxonomic identifier.',
    'Institute Code' => 'The code for the Institute that bred the material.',
    'Institute Name' => 'The name of the Institute that bred the material.',
    'Country of Origin Code' => '3-letter ISO 3166-1 code of the country in which the sample was originally sourced.',
    'Biological Status of Accession' => 'The 3 digit code representing the biological status of the accession.',
    'Breeding Method' => 'The unique identifier for the breeding method used to create this germplasm.',
    'Pedigree' => 'The cross name and optional selection history.',
    'Synonyms' => 'Any synonyms of the accession.',
  ];

  $output .= '<ol>';
  foreach ($columns as $title => $definition) {
    $output .= '<li><b>' . $title . '</b>: ' . $definition . '</li>';
  }
  $output .= '</ol>';

  return $output;
}
```

Additionally, they can also use a twig template :-)

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

Test that this is a backwards compatible change by loading each of the core loaders and confirming that they are the same as before.

Test in an existing importer by implementing the `describeUploadFileFormat` method and returning a string. Then confirm that the string shows up as expected above the upload file form element.