### PR TITLE
ChadoStorage should support loading base values

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeDefault.php
@@ -157,19 +157,19 @@ class ChadoAdditionalTypeDefault extends ChadoFieldItemBase {
     // This field needs the term name, idspace and accession for proper
     // display of the type.
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'term_name', $name_term, 128, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $type_table . '.' . $type_column . '>cvterm.cvterm_id',
       'chado_column' => 'name',
       'as' => 'term_name'
     ]);
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'id_space', $idspace_term, 128, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $type_table . '.' . $type_column . '>cvterm.cvterm_id;cvterm.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id',
       'chado_column' => 'name',
       'as' => 'idSpace'
     ]);
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'accession', $accession_term, 128, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $type_table. '.' . $type_column . '>cvterm.cvterm_id;cvterm.dbxref_id>dbxref.dbxref_id',
       'chado_column' => 'accession',
       'as' => 'accession'

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisDefault.php
@@ -125,7 +125,7 @@ class ChadoAnalysisDefault extends ChadoFieldItemBase {
       'chado_column' => $base_fkey_col,
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_name', $analysis_name_term, $analysis_name_length, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.' . $base_fkey_col . '>analysis.analysis_id',
       'chado_column' => 'name',
       'as' => 'analysis_name',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactDefault.php
@@ -128,7 +128,7 @@ class ChadoContactDefault extends ChadoFieldItemBase {
       'chado_column' => $base_fkey_col,
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_name', $contact_name_term, $contact_name_length, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.' . $base_fkey_col . '>contact.contact_id',
       'chado_column' => 'name',
       'as' => 'contact_name',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismDefault.php
@@ -115,22 +115,22 @@ class ChadoOrganismDefault extends ChadoFieldItemBase {
       'template' => "<i>[genus] [species]</i> [infraspecific_type] [infraspecific_name]",
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'genus', $genus_term, $genus_len, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.organism_id>organism.organism_id',
       'chado_column' => 'genus'
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'species', $species_term, $species_len, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.organism_id>organism.organism_id',
       'chado_column' => 'species'
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'infraspecific_name', $ifname_term, $ifname_len, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.organism_id>organism.organism_id',
       'chado_column' => 'infraspecific_name',
     ]);
     $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'infraspecific_type', $iftype_term, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.organism_id>organism.organism_id;organism.type_id>cvterm.cvterm_id',
       'chado_column' => 'name',
       'as' => 'infraspecific_type_name'

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -684,6 +684,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
           // Get the values of properties that just want to read values.
           if (in_array($action, ['read_value', 'join'])) {
+            $chado_table = $prop_storage_settings['chado_table'];
             $chado_column = $prop_storage_settings['chado_column'];
             $as = array_key_exists('as', $prop_storage_settings) ? $prop_storage_settings['as'] : $chado_column;
             $value = $records[$chado_table][$delta]['fields'][$as];
@@ -973,7 +974,17 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           // ................................................................
           if ($action == 'read_value') {
             $chado_column = $prop_storage_settings['chado_column'];
-            $records[$chado_table][$delta]['fields'][$chado_column] = NULL;
+            // We will only set this if it's not already set.
+            // This is to allow another field with a store set for this column
+            // to set this value. We actually only do this to ensure it ends up
+            // in the query fields.
+            if (!array_key_exists('fields', $records[$chado_table][$delta])) {
+              $records[$chado_table][$delta]['fields'] = [];
+              $records[$chado_table][$delta]['fields'][$chado_column] = NULL;
+            }
+            elseif (!array_key_exists($chado_column, $records[$chado_table][$delta]['fields'])) {
+              $records[$chado_table][$delta]['fields'][$chado_column] = NULL;
+            }
           }
           // JOIN: performs a join across multiple tables for the purposes of
           // selecting a single column. This cannot be used for inserting or

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -682,8 +682,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
             }
           }
 
-          // Get the values of properties that have values added by a join.
-          if ($action == 'join') {
+          // Get the values of properties that just want to read values.
+          if (in_array($action, ['read_value', 'join'])) {
             $chado_column = $prop_storage_settings['chado_column'];
             $as = array_key_exists('as', $prop_storage_settings) ? $prop_storage_settings['as'] : $chado_column;
             $value = $records[$chado_table][$delta]['fields'][$as];
@@ -967,6 +967,13 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
             if ($delete_if_empty) {
               $records[$chado_table][$delta]['delete_if_empty'][] = $chado_column;
             }
+          }
+          // READ_VALUE: selecting a single column. This cannot be used for inserting or
+          // updating values. Instead we use store actions for that.
+          // ................................................................
+          if ($action == 'read_value') {
+            $chado_column = $prop_storage_settings['chado_column'];
+            $records[$chado_table][$delta]['fields'][$chado_column] = NULL;
           }
           // JOIN: performs a join across multiple tables for the purposes of
           // selecting a single column. This cannot be used for inserting or

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -684,7 +684,23 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
           // Get the values of properties that just want to read values.
           if (in_array($action, ['read_value', 'join'])) {
-            $chado_table = $prop_storage_settings['chado_table'];
+            if (array_key_exists('chado_table', $prop_storage_settings)) {
+              $chado_table = $prop_storage_settings['chado_table'];
+            }
+            // Otherwise this is a join + we need the base table.
+            // We can use the path to look this up.
+            elseif (array_key_exists('path', $prop_storage_settings)) {
+              // Examples of the path:
+              //   - phylotree.analysis_id>analysis.analysis_id'.
+              //   - feature.type_id>cvterm.cvterm_id;cvterm.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id'
+              $path_arr = explode(';', $prop_storage_settings['path']);
+              // Now grab the left/right sides of the first part of the path.
+              list($left, $right) = explode(">", array_shift($path_arr));
+              // Break the left side into table + column.
+              list($left_table, $left_col) = explode(".", $left);
+              // The base table is the left table of the first part of the path.
+              $chado_table = $left_table;
+            }
             $chado_column = $prop_storage_settings['chado_column'];
             $as = array_key_exists('as', $prop_storage_settings) ? $prop_storage_settings['as'] : $chado_column;
             $value = $records[$chado_table][$delta]['fields'][$as];

--- a/tripal_chado/tests/src/Functional/Plugin/ChadoStorageTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/ChadoStorageTest.php
@@ -473,22 +473,22 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
         'template' => "<i>[genus] [species]</i> [infraspecific_type] [infraspecific_name]",
       ]),
       'genus' => new ChadoVarCharStoragePropertyType($this->content_type, $field_name, 'genus', 'TAXRANK:0000005', 255, [
-        'action' => 'join',
+        'action' => 'read_value',
         'path' => $base_table . '.organism_id>organism.organism_id',
         'chado_column' => 'genus'
       ]),
       'species' => new ChadoVarCharStoragePropertyType($this->content_type, $field_name, 'species', 'TAXRANK:0000006', 255, [
-        'action' => 'join',
+        'action' => 'read_value',
         'path' => $base_table . '.organism_id>organism.organism_id',
         'chado_column' => 'species'
       ]),
       'infraspecific_name' => new ChadoVarCharStoragePropertyType($this->content_type, $field_name, 'infraspecific_name', 'TAXRANK:0000045', 255, [
-        'action' => 'join',
+        'action' => 'read_value',
         'path' => $base_table . '.organism_id>organism.organism_id',
         'chado_column' => 'infraspecific_name',
       ]),
       'infraspecific_type'=> new ChadoIntStoragePropertyType($this->content_type, $field_name, 'infraspecific_type', 'local:infraspecific_type', [
-        'action' => 'join',
+        'action' => 'read_value',
         'path' => $base_table . '.organism_id>organism.organism_id;organism.type_id>cvterm.cvterm_id',
         'chado_column' => 'name',
         'as' => 'infraspecific_type_name'

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoAnalysisDefaultTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoAnalysisDefaultTest.php
@@ -60,7 +60,7 @@ class ChadoAnalysisDefaultTest extends ChadoTestKernelBase {
       'chado_column' => $base_fkey_col,
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_name', $analysis_name_term, $analysis_name_length, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.' . $base_fkey_col . '>analysis.analysis_id',
       'chado_column' => 'name',
       'as' => 'analysis_name',
@@ -90,7 +90,7 @@ class ChadoAnalysisDefaultTest extends ChadoTestKernelBase {
         ],
         'analysis_name' => [
           'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
-          'action' => 'join',
+          'action' => 'read_value',
           'path' => 'phylotree.analysis_id>analysis.analysis_id',
           'chado_column' => 'name',
           'as' => 'analysis_name',
@@ -138,7 +138,7 @@ class ChadoAnalysisDefaultTest extends ChadoTestKernelBase {
         ],
         'analysis_name' => [
           'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
-          'action' => 'join',
+          'action' => 'read_value',
           'path' => 'quantification.analysis_id>analysis.analysis_id',
           'chado_column' => 'name',
           'as' => 'analysis_name',

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoContactDefaultTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoContactDefaultTest.php
@@ -53,7 +53,7 @@ class ChadoContactDefaultTest extends ChadoTestKernelBase {
       'chado_column' => $base_fkey_col,
     ]);
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_name', $contact_name_term, $contact_name_length, [
-      'action' => 'join',
+      'action' => 'read_value',
       'path' => $base_table . '.' . $base_fkey_col . '>contact.contact_id',
       'chado_column' => 'name',
       'as' => 'contact_name',
@@ -89,7 +89,7 @@ class ChadoContactDefaultTest extends ChadoTestKernelBase {
         ],
         'contact_name' => [
           'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
-          'action' => 'join',
+          'action' => 'read_value',
           'path' => 'study.contact_id>contact.contact_id',
           'chado_column' => 'name',
           'as' => 'contact_name',
@@ -121,7 +121,7 @@ class ChadoContactDefaultTest extends ChadoTestKernelBase {
         ],
         'contact_name' => [
           'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
-          'action' => 'join',
+          'action' => 'read_value',
           'path' => 'arraydesign.manufacturer_id>contact.contact_id',
           'chado_column' => 'name',
           'as' => 'contact_name',

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActionsTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActionsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Drupal\Tests\tripal_chado\Kernel\Plugin\ChadoStorage;
+
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Traits\ChadoStorageTestTrait;
+
+use Drupal\tripal\TripalStorage\StoragePropertyValue;
+use Drupal\tripal\TripalStorage\StoragePropertyTypeBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Tests that specific ChadoStorage actions perform as expected.
+ *
+ * @group Tripal
+ * @group Tripal Chado
+ * @group ChadoStorage
+ */
+class ChadoStorageActionsTest extends ChadoTestKernelBase {
+
+  use ChadoStorageTestTrait;
+
+  // We will populate this variable at the start of each test
+  // with fields specific to that test.
+  protected $fields = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() :void {
+    parent::setUp();
+
+    // Ensure we see all logging in tests.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // We need to mock the logger to test the progress reporting.
+    $container = \Drupal::getContainer();
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['warning'])
+      ->getMock();
+    $mock_logger->method('warning')
+      ->willReturnCallback(function($message, $context, $options) {
+        print str_replace(array_keys($context), $context, $message);
+        return NULL;
+      });
+    $container->set('tripal.logger', $mock_logger);
+
+    $this->setUpChadoStorageTestEnviro();
+  }
+
+  /**
+   * Test the read_value action.
+   *
+   * Chado Table: project
+   *     Columns: project_id*, name*, description
+   *
+   * Specifically,
+   *  - Ensure that a property with the read_value action has the value set
+   *  - Ensure that a property with the read_value action can't change the value
+   *  - That two fields accessing the same chado column do not conflict
+   *      A. both read_value action for the same column
+   *      B. one read_value and one store for the same column
+   */
+  public function testReadValueAction() {
+
+    // This is the field we are actually testing.
+    $this->fields['test_read'] = [
+      'field_name' => 'test_read',
+      'base_table' => 'project',
+      'properties' => [
+        'record_id' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType',
+          'action' => 'store_id',
+          'chado_table' => 'project',
+          'chado_column' => 'project_id'
+        ],
+        'name_read' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
+          'action' => 'read_value',
+          'chado_table' => 'project',
+          'chado_column' => 'name'
+        ],
+      ],
+    ];
+    // This is another field (STORE) which we want to ensure there are no conflicts with.
+    $this->fields['other_field_store'] = [
+      'field_name' => 'other_field_store',
+      'base_table' => 'project',
+      'properties' => [
+        'record_id' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType',
+          'action' => 'store_id',
+          'chado_table' => 'project',
+          'chado_column' => 'project_id'
+        ],
+        'name_store' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
+          'action' => 'store',
+          'chado_table' => 'project',
+          'chado_column' => 'name'
+        ],
+      ],
+    ];
+    // This is another field (READ) which we want to ensure there are no conflicts with.
+    $this->fields['other_field_read'] = [
+      'field_name' => 'other_field_read',
+      'base_table' => 'project',
+      'properties' => [
+        'record_id' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType',
+          'action' => 'store_id',
+          'chado_table' => 'project',
+          'chado_column' => 'project_id'
+        ],
+        'name_read_again' => [
+          'propertyType class' => 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType',
+          'action' => 'read',
+          'chado_table' => 'project',
+          'chado_column' => 'name'
+        ],
+      ],
+    ];
+    // Needed to ensure these fields are added to the storage arrays e.g. field config.
+    $this->cleanChadoStorageValues();
+
+    // Test Case: Insert valid values when they do not yet exist in Chado.
+    // ---------------------------------------------------------
+    $insert_values = [
+      'test_read' => [
+        [
+          'record_id' => NULL,
+          // A read value should not set the value for insert
+          // We are doing so here to make sure it cannot modify the
+          // values of the table!
+          'name_read' => 'Project Name Set By Read',
+        ],
+      ],
+      'other_field_store' => [
+        [
+          'record_id' => NULL,
+          'name_store' => 'Correct Project Name',
+        ],
+      ],
+      'other_field_read' => [
+        [
+          'record_id' => NULL,
+          'name_read_again' => NULL,
+        ],
+      ],
+    ];
+    $this->chadoStorageTestInsertValues($insert_values);
+
+    // Check that there is now a single project record.
+    $query = $this->chado_connection->select('1:project', 'p')
+      ->fields('p', ['project_id', 'name'])
+      ->execute();
+    $projects = $query->fetchAll();
+    $this->assertIsArray($projects,
+    "We should have been able to select from the project table.");
+    $this->assertCount(1, $projects,
+      "There should only be a single project inserted by these 3 fields");
+
+    // Check that the single project record has the name set by the `store` action.
+
+  }
+}


### PR DESCRIPTION
# Tripal 4 Core Dev Task 

### Issue #1662 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As found in https://github.com/tripal/tripal/pull/1619, we need the ability to read a value from the base table. Currently you have the choice of a variety of store* actions for the base table and join for linked tables but no read on the base table.

This is needed for fields which do not handle editing of a base table column, as well as, fields which add additional functionality or specialized displays for a specific column in addition to another field which handles editing.

This PR:
 - adds support for a new `read_value` action which allows you to indicate you want to read a value from the base table
 - Fixes a bug for the join action which assumed you would have a base_table store property directly before defining the join property.
 - Adds automated tests for the read_value action.
 - Deprecated the join action in favour of the read_value action. Now you can provide read_value for any value you do not want to edit... if it's on the base table define chado_table and if it's on another table define `path`.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Automated Tests

- Ensure that a property with the read_value action has the value set
- Ensure that a property with the read_value action can't change the value
- That two fields accessing the same chado column do not conflict
    A. both read_value action for the same column
    B. one read_value and one store for the same column

### Manual Testing

1. Download [the following Field](https://github.com/tripal/tripal/files/12821857/ChadoReadFeatureNameTypeItem.txt) and save it in the `tripal_chado/src/Plugin/Field/FieldType` folder. Change the file suffix to `.php`.
2. Go to Admin > Tripal > Page Structure > Gene > Manage Fields and add a field of the type "Chado Read Feature Name Field Type".
3. Create an organism record
4. Create a gene record. Any value entered into the widget for the field you created in step 2 should not be saved but rather display the same as the name field for the gene.
5. Edit the gene record and change the name but not the value of your field. Ensure the value of your field is updated to the new name.
6. Edit the gene record and change the value of your field but not the name field. Ensure the value of your field is reset to the name and the value you entered is not saved.

This PR now also updates the old join action to read_value. To test that, you will want to test the AdditionalType, Analysis, Contact and organism fields to ensure they still act the same way they did before. 

Note: There are already automated tests for these fields.

