### PR TITLE
Add dependency injection to the ChadoImporterBase

### DIFF
--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -232,7 +232,7 @@ class TripalImporterForm implements FormInterface {
         return;
       }
 
-      $importer->create($run_args, $file_details);
+      $importer->createImportJob($run_args, $file_details);
       $importer->submitJob();
 
     }

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -177,7 +177,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
    * @return int
    *   Returns the import_id.
    */
-  public function create($run_args, $file_details = []) {
+  public function createImportJob($run_args, $file_details = []) {
 
     // global $user;
     $user = User::load(\Drupal::currentUser()->id());
@@ -308,7 +308,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
     $uid = $user->id();
 
     if (!$this->import_id) {
-      throw new \Exception('Cannot submit an importer job without an import record. Please run create() first.');
+      throw new \Exception('Cannot submit an importer job without an import record. Please run createImportJob() first.');
     }
 
     // Add a job to run the importer.

--- a/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
+++ b/tripal/tests/src/Kernel/TripalImporter/TripalImporterBaseTest.php
@@ -105,7 +105,7 @@ class TripalImporterBaseTest extends KernelTestBase {
 
   /**
    * Tests focusing on the Tripal importer base class.
-   * Specifically, create(), load(), and getArguments() methods.
+   * Specifically, createImportJob(), load(), and getArguments() methods.
    *
    * @group tripal_importer
    */
@@ -122,10 +122,10 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file not required so expected to succeed.
+    // Execute createImportJob, file not required so expected to succeed.
     $run_args = [];
     $file_details = [];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now check that a record was added to the tripal_import table.
     $public = \Drupal::database();
@@ -166,12 +166,12 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file required so expected to FAIL.
+    // Execute createImportJob, file required so expected to FAIL.
     $exception_msg = NULL;
     try {
       $run_args = [];
       $file_details = [];
-      $import_id = $importer->create($run_args, $file_details);
+      $import_id = $importer->createImportJob($run_args, $file_details);
     }
     catch(\Exception $e) {
       $exception_msg = $e->getMessage();
@@ -196,10 +196,10 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file not required so expected to succeed.
+    // Execute createImportJob, file not required so expected to succeed.
     $run_args = ['test' => 'single run arg'];
     $file_details = ['file_local' => $test_file_path];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now check that a record was added to the tripal_import table.
     $public = \Drupal::database();
@@ -244,10 +244,10 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file not required so expected to succeed.
+    // Execute createImportJob, file not required so expected to succeed.
     $run_args = ['test' => 'single run arg'];
     $file_details = ['file_remote' => $test_file_path];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now check that a record was added to the tripal_import table.
     $public = \Drupal::database();
@@ -295,10 +295,10 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file not required so expected to succeed.
+    // Execute createImportJob, file not required so expected to succeed.
     $run_args = ['test' => 'single run arg'];
     $file_details = ['fid' => $test_fid];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now check that a record was added to the tripal_import table.
     $public = \Drupal::database();
@@ -349,10 +349,10 @@ class TripalImporterBaseTest extends KernelTestBase {
       [$configuration, $plugin_id, $plugin_defn]
     );
 
-    // Execute create, file not required so expected to succeed.
+    // Execute createImportJob, file not required so expected to succeed.
     $run_args = ['test' => 'single run arg'];
     $file_details = ['fid' => "$test_fid|$test_fid|$test_fid"];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now check that a record was added to the tripal_import table.
     $public = \Drupal::database();
@@ -460,7 +460,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     );
     $run_args = [];
     $file_details = [];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
     $job_id = $importer->submitJob();
     $this->assertIsNumeric($job_id,
       "We expected to have a tripal job_id returned from submitJob().");
@@ -470,7 +470,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     $importer->setJob($job);
 
     // CASE --- Exception Expected
-    // submit job when import not yet created.
+    // submit job when import job not yet created.
     $configuration = [];
     $plugin_id = 'fakeImporterName';
     $importer = $this->getMockForAbstractClass(
@@ -516,7 +516,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     );
     $run_args = [];
     $file_details = ['file_remote' => $test_file_path];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now try to prepare the file.
     $importer->prepareFiles();
@@ -543,7 +543,7 @@ class TripalImporterBaseTest extends KernelTestBase {
     );
     $run_args = [];
     $file_details = ['file_remote' => $test_file_path];
-    $import_id = $importer->create($run_args, $file_details);
+    $import_id = $importer->createImportJob($run_args, $file_details);
 
     // Now try to prepare the file.
     $importer->prepareFiles();

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -876,7 +876,7 @@ class ChadoPreparer extends ChadoTaskBase {
   }
 
   /**
-   * Gets a controlled voabulary object.
+   * Gets a controlled vocabulary object.
    *
    * @param string $name
    *   The name of the vocabulary
@@ -960,7 +960,7 @@ class ChadoPreparer extends ChadoTaskBase {
         $this->logger->notice("Importing " . $ontology['idSpace']->getDescription());
         $importer_manager = \Drupal::service('tripal.importer');
         $obo_importer = $importer_manager->createInstance('chado_obo_loader');
-        $obo_importer->create(['obo_id' => $obo_id, 'schema_name' => $schema_name]);
+        $obo_importer->createImportJob(['obo_id' => $obo_id, 'schema_name' => $schema_name]);
         $obo_importer->run();
         $obo_importer->postRun();
       }

--- a/tripal_chado/src/TripalImporter/ChadoImporterBase.php
+++ b/tripal_chado/src/TripalImporter/ChadoImporterBase.php
@@ -28,13 +28,6 @@ abstract class ChadoImporterBase extends TripalImporterBase implements Container
   protected $messenger = NULL;
 
   /**
-   * The logger for reporting progress, warnings and errors to admin.
-   *
-   * @var Drupal\tripal\Services\TripalLogger
-   */
-  protected $logger;
-
-  /**
    * The database connection for querying Chado.
    *
    * @var Drupal\tripal_chado\Database\ChadoConnection
@@ -55,12 +48,11 @@ abstract class ChadoImporterBase extends TripalImporterBase implements Container
    *
    * @return static
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('tripal.logger'),
       $container->get('tripal_chado.database')
     );
   }
@@ -78,10 +70,9 @@ abstract class ChadoImporterBase extends TripalImporterBase implements Container
    * @param mixed $plugin_definition
    * @param Drupal\tripal_chado\Database\ChadoConnection $connection
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, TripalLogger $logger, ChadoConnection $connection) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $connection) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    $this->logger = $logger;
     $this->connection = $connection;
   }
 

--- a/tripal_chado/src/TripalImporter/ChadoImporterBase.php
+++ b/tripal_chado/src/TripalImporter/ChadoImporterBase.php
@@ -3,11 +3,14 @@
 namespace Drupal\tripal_chado\TripalImporter;
 
 use Drupal\tripal\TripalImporter\TripalImporterBase;
+use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines an interface for tripal importer plugins.
  */
-abstract class ChadoImporterBase extends TripalImporterBase {
+abstract class ChadoImporterBase extends TripalImporterBase implements ContainerFactoryPluginInterface {
 
   /**
    * The main chado schema for this importer.
@@ -25,10 +28,61 @@ abstract class ChadoImporterBase extends TripalImporterBase {
   protected $messenger = NULL;
 
   /**
-   * {@inheritdoc}
+   * The logger for reporting progress, warnings and errors to admin.
+   *
+   * @var Drupal\tripal\Services\TripalLogger
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+  protected $logger;
+
+  /**
+   * The database connection for querying Chado.
+   *
+   * @var Drupal\tripal_chado\Database\ChadoConnection
+   */
+  protected $connection;
+
+  /**
+   * Implements ContainerFactoryPluginInterface->create().
+   *
+   * Since we have implemented the ContainerFactoryPluginInterface this static function
+   * will be called behind the scenes when a Plugin Manager uses createInstance(). Specifically
+   * this method is used to determine the parameters to pass to the contructor.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('tripal.logger'),
+      $container->get('tripal_chado.database')
+    );
+  }
+
+  /**
+   * Implements __contruct().
+   *
+   * Since we have implemented the ContainerFactoryPluginInterface, the constructor
+   * will be passed additional parameters added by the create() function. This allows
+   * our plugin to use dependency injection without our plugin manager service needing
+   * to worry about it.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param Drupal\tripal_chado\Database\ChadoConnection $connection
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, TripalLogger $logger, ChadoConnection $connection) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->logger = $logger;
+    $this->connection = $connection;
   }
 
   /**
@@ -37,7 +91,7 @@ abstract class ChadoImporterBase extends TripalImporterBase {
    * Requires you to call the parent::form in your form.
    */
   public function getChadoConnection() {
-    $chado = \Drupal::service('tripal_chado.database');
+    $chado = $this->connection;
 
     // Get the chado schema name if available.
     $schema_name = '';
@@ -75,7 +129,7 @@ abstract class ChadoImporterBase extends TripalImporterBase {
     ];
 
     $chado_schemas = [];
-    $chado = \Drupal::service('tripal_chado.database');
+    $chado = $this->connection;
     foreach ($chado->getAvailableInstances() as $schema_name => $details) {
       $chado_schemas[$schema_name] = $schema_name;
     }
@@ -98,7 +152,7 @@ abstract class ChadoImporterBase extends TripalImporterBase {
    */
   public function addAnalysis($form, &$form_state) {
 
-    $chado = \Drupal::service('tripal_chado.database');
+    $chado = $this->connection;
 
     // Get the list of analyses.
     $query = $chado->select('1:analysis', 'A');

--- a/tripal_chado/tests/src/Functional/Plugin/FASTAImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/FASTAImporterTest.php
@@ -96,7 +96,7 @@ class FASTAImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/fasta_loader/Citrus_sinensis-orange1.1g015632m.g.fasta',
     ];
 
-    $fasta_importer->create($run_args, $file_details);
+    $fasta_importer->createImportJob($run_args, $file_details);
     $fasta_importer->prepareFiles();
     $fasta_importer->run();
     $fasta_importer->postRun();
@@ -168,7 +168,7 @@ class FASTAImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/fasta_loader/Citrus_sinensis-scaffold00001-trimmed.fasta',
     ];
 
-    $fasta_importer->create($run_args, $file_details);
+    $fasta_importer->createImportJob($run_args, $file_details);
     $fasta_importer->prepareFiles();
     $fasta_importer->run();
     $fasta_importer->postRun();

--- a/tripal_chado/tests/src/Functional/Plugin/GFF3ImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/GFF3ImporterTest.php
@@ -117,7 +117,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/small_gene.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -234,7 +234,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -287,7 +287,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -337,7 +337,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -391,7 +391,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -443,7 +443,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -492,7 +492,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_phase.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -553,7 +553,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -604,7 +604,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -664,7 +664,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_score.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -741,7 +741,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -793,7 +793,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     $has_exception = false;
     try {
-      $gff3_importer->create($run_args, $file_details);
+      $gff3_importer->createImportJob($run_args, $file_details);
       $gff3_importer->prepareFiles();
       $gff3_importer->run();
       $gff3_importer->postRun();
@@ -844,7 +844,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_strand.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -937,7 +937,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_tag_parent_verification.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -989,7 +989,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_tagvalue_encoded_character.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -1040,7 +1040,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/gff_tagvalue_comma_character.gff',
     ];
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -1101,7 +1101,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     ];
 
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -1155,7 +1155,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     ];
 
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();
@@ -1269,7 +1269,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     ];
 
 
-    $gff3_importer->create($run_args, $file_details);
+    $gff3_importer->createImportJob($run_args, $file_details);
     $gff3_importer->prepareFiles();
     $gff3_importer->run();
     $gff3_importer->postRun();

--- a/tripal_chado/tests/src/Functional/Plugin/NewickImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/NewickImporterTest.php
@@ -152,7 +152,7 @@ class NewickImporterTest extends ChadoTestBrowserBase
       'file_local' => __DIR__ . '/../../../fixtures/newick_loader/newick_T92076.tree',
     ];
 
-    $newick_importer->create($run_args, $file_details);
+    $newick_importer->createImportJob($run_args, $file_details);
     $newick_importer->prepareFiles();
     $newick_importer->run();
     $newick_importer->postRun();

--- a/tripal_chado/tests/src/Functional/Plugin/OBOImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/OBOImporterTest.php
@@ -48,7 +48,7 @@ class OBOImporterTest extends ChadoTestBrowserBase {
      */
     $importer_manager = \Drupal::service('tripal.importer');
     $obo_importer = $importer_manager->createInstance('chado_obo_loader');
-    $obo_importer->create([
+    $obo_importer->createImportJob([
       'obo_id' => $obo_id,
       'schema_name' => $test_chado->getSchemaName()
     ]);

--- a/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
@@ -64,7 +64,7 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase
       // 'file_local' => __DIR__ . '/../../../fixtures/gff3_loader/small_gene.gff',
     ];
 
-    $taxonomy_importer->create($run_args, $file_details);
+    $taxonomy_importer->createImportJob($run_args, $file_details);
     $taxonomy_importer->prepareFiles();
     $taxonomy_importer->run();
     $taxonomy_importer->postRun();


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Tripal 4 Core Dev Task

### Issue #1522 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
While developing a Tripal Importer, access to the database was needed via dependency injection. Thus, changes were made to the ChadoImporterBase class according to method 2 in Issue #1522. Some important notes:
<!--- Why is this change required? What problem does it solve? -->

- TripalImporterBase has not been changed except to rename the create() function since that name is needed by the ContainerFactoryPluginInterface. The old create() function has been renamed to createImportJob() and all references to it have been updated (hopefully!). Thus, TripalImporterBase is now _compatible_ to use dependency injection but **does not yet use it**.
- ChadoImporterBase function getChadoConnection() is still needed to set the database connection, the only change is that it no longer uses the static method (Drupal::service) to grab the connection.
- These changes are backwards compatible. 


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I tested these changes by running the functional tests for the various Tripal importers. You can run them individually or run tests for all the importers at once using (assuming your docker container is named tripal-1522):
`docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal/ tripal-1522 phpunit --group TripalImporter`

If you have a custom Tripal importer, try it to see if the changes are indeed backwards compatible. I tested it on the importer I'm currently developing on, you can do so as well by:
- Cloning this repo: https://github.com/TripalCultivate/TripalCultivate-Germplasm.git 
- Switch to the branch `g2.2-germAccessionImporter`
- Run phpunit on `trpcultivate_germplasm/tests/src/Kernel/TripalImporter/GermplasmAccessionImporterTest.php` 

Laslty, you can try testing by setting up 2 different chado instances. When submitting an importer job, choose the 2nd instance and afterwards check that it imported into the right one.