### PR TITLE
Fix for issue #1661

### DIFF
--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -20,8 +20,10 @@ class ChadoSchema extends TripalDbxSchema {
     $source = $parameters['source'] ?? 'file';
     $format = strtolower($parameters['format'] ?? '');
 
-    $version = $parameters['version'];
-    if (!array_key_exists('version', $parameters) OR empty($parameters['version'])) {
+    if (array_key_exists('version', $parameters) and !empty($parameters['version'])) {
+      $version = $parameters['version'];
+    }
+    else {
       $version = $this->connection->getVersion();
     }
 


### PR DESCRIPTION

# Bug Fix

### Issue #1661

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
While testing a new field, the following message shows in the message area of the browser:

```
_Warning_: Undefined array key "version" in Drupal\tripal_chado\Database\ChadoSchema->getSchemaDef() (line 23 of modules/contrib/tripal/tripal_chado/src/Database/ChadoSchema.php).
Drupal\tripal_chado\Database\ChadoSchema->getSchemaDef(Array) (Line: 808)
Drupal\tripal\TripalDBX\TripalDbxSchema->getTables(Array) (Line: 34)
Drupal\tripal_chado\TripalField\ChadoFieldItemBase->storageSettingsForm(Array, Object, ) (Line: 90)
Drupal\field_ui\Form\FieldStorageConfigEditForm->form(Array, Object) (Line: 106)
Drupal\Core\Entity\EntityForm->buildForm(Array, Object) (Line: 60)
Drupal\field_ui\Form\FieldStorageConfigEditForm->buildForm(Array, Object, 'tripal_entity.genetic_map.field_genetic_map_measurement_un')
:::
:::
```
(Only first few lines of the message are shown here)

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

1. Got to Admin > Tripal > Page Structure > [any content type] > Manage Fields
2. Click create a new field
3. Choose any type (e.g. ChadoIntegerFieldType) and fill in a label
4. Click "Save and continue and this error was shown on 4.x but not on this branch.