### PR TITLE
BUG FIX: ChadoAdditionalType field cannot handle multiple instances at once

### DIFF
--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions-FieldDefinitions.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions-FieldDefinitions.yml
@@ -115,6 +115,48 @@ testReadValueActionJoin:
         chado_table: 'cvterm'
         chado_column: 'name'
         path: 'stock.stock_id>stock_cvterm.stock_id;stock_cvterm.cvterm_id>cvterm.cvterm_id'
+# Ensure joins accessing the same column stay separate.
+testReadValueActionJoinDouble:
+  test_join1:
+    field_name: 'test_join1'
+    base_table: 'arraydesign'
+    properties:
+      record_id:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType'
+        action: 'store_id'
+        chado_table: 'arraydesign'
+        chado_column: 'arraydesign_id'
+      type_id:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType'
+        action: 'arraydesign_id'
+        chado_table: 'arraydesign'
+        chado_column: 'platformtype_id'
+      accession_read:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
+        action: 'read_value'
+        chado_table: 'dbxref'
+        chado_column: 'accession'
+        path: 'arraydesign.platformtype_id>cvterm.cvterm_id;cvterm.dbxref_id>dbxref.dbxref_id'
+  test_join2:
+    field_name: 'test_join2'
+    base_table: 'arraydesign'
+    properties:
+      record_id:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType'
+        action: 'store_id'
+        chado_table: 'arraydesign'
+        chado_column: 'arraydesign_id'
+      type_id:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType'
+        action: 'arraydesign_id'
+        chado_table: 'arraydesign'
+        chado_column: 'substratetype_id'
+      accession_read:
+        propertyType class: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
+        action: 'read_value'
+        chado_table: 'dbxref'
+        chado_column: 'accession'
+        path: 'arraydesign.substratetype_id>cvterm.cvterm_id;cvterm.dbxref_id>dbxref.dbxref_id'
 # Ensure read_value works when there isn't a store action for the same column.
 testReadValueActionNoStore:
   test_read:


### PR DESCRIPTION

# Bug Fix


### Issue #1669 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
@dsenalik discovered (and demonstrated in the attached issue) that the ChadoAdditionalType struggled when there were two instances of it on the same TripalContent page. Specifically, on the Array Design content type, there is a Substrate and Platform Type which are both ChadoAdditionalType fields. This resulted in the term information for only one being shown in the formatter (see below screenshot) although at the database level the platformtype_id and substratetype_id were assigned correctly based on the user submission.

It turns out this was due to a bug in the read_value action for joins. Although the SQL generated was specific enough to keep the different joins separated, the code which retrieved the value after the query was run was not aware of the alias' added and could not accurate look up the value. As such it always defaulted to the first value added to the query as that name wasn't aliased.

This PR fixes the bug by ensuring all columns selected based on a join are aliased with the right table alias and developer specified column alias (e.g. jcvterm0_term_name) and that this alias is kept track of by field and property key to ensure accurate look-up and replacement.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

Automated testing for this exact case has been added to the ChadoStorageActions_ReadValueTest test class in the `testReadValueActionJoinDouble` method. This tests the exact arraydesign case discussed above with a focus on the loadValues. We do not need to test the insertValues and UpdateValues because this bug is specific to the way the records array is built and values set based on the results which are the same between all three *Values methods.

### Manual Testing

1. Setup a testing environment on this branch.
2. Go to Tripal > Content > Add Tripal Content > Array Design (under Expression)
3. Fill out the form including specifying different terms for the Platform and Substrate Types. Take note of the terms and which you entered for each type.
4. Click save and ensure on the view page that both types have the appropriate term shown.

![PR1669-ArrayDesign-Create](https://github.com/tripal/tripal/assets/1566301/f8511434-6846-4a34-9fd9-2a7f53d89657)
![PR1669-ArrayDesign-View](https://github.com/tripal/tripal/assets/1566301/df01b390-5054-4a16-bb7d-19abdc11a00a)
