### PR TITLE
Fixes to Tripal Importer Forms

### DIFF
--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -11,10 +11,31 @@ use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
 /**
  * Defines an interface for tripal impoerter plugins.
  */
 abstract class TripalImporterBase extends PluginBase implements TripalImporterInterface {
+
+  /**
+   * Needed to allow AJAX on TripalImporter forms once Dependency injection is used.
+   *
+   * The error message implies that the log exception this trait is needed to
+   * solve is caused by the form serializing an object that has an indirect
+   * reference to the database connection (TripalImporter) and that we should
+   * adjust your code so that is not necessary.
+   *
+   * That said, the TripalImporterForm does not appear to save the TripalImporter
+   * object in the form or form state at any point. Instead it only uses
+   * the importer object to get strings and arrays that are incorporated
+   * into the form.
+   *
+   * Anyway, using this trait solves the problem and although the error
+   * mentions this should be a temporary solution, there are no mentioned plans
+   * in the Drupal forumns or code that this trait will be removed at any point.
+   */
+  use DependencySerializationTrait;
 
   /**
    * The number of items that this importer needs to process. A progress

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -17,12 +17,13 @@ use Drupal\Core\Ajax\ReplaceCommand;
  *    file_types = {"obo"},
  *    upload_description = @Translation("Please provide the details for importing a new OBO file. The file must have a .obo extension."),
  *    upload_title = @Translation("New OBO File"),
- *    use_analysis = False,
- *    require_analysis = True,
+ *    use_analysis = FALSE,
+ *    require_analysis = FALSE,
  *    button_text = @Translation("Import OBO File"),
- *    file_upload = False,
- *    file_remote = False,
- *    file_required = False,
+ *    file_upload = FALSE,
+ *    file_local = FALSE,
+ *    file_remote = FALSE,
+ *    file_required = FALSE,
  *  )
  */
 class OBOImporter extends ChadoImporterBase {

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -396,12 +396,18 @@ class OBOImporter extends ChadoImporterBase {
     $public = \Drupal::database();
 
     $obo_id = $form_state->getValue('obo_id');
-    $obo_name = trim($form_state->getValue('obo_name'));
-    $obo_url = trim($form_state->getValue('obo_url'));
-    $obo_file = trim($form_state->getValue('obo_file'));
-    $uobo_name = trim($form_state->getValue('uobo_name'));
-    $uobo_url = trim($form_state->getValue('uobo_url'));
-    $uobo_file = trim($form_state->getValue('uobo_file'));
+    $obo_name = $form_state->getValue('obo_name');
+    $obo_url = $form_state->getValue('obo_url');
+    $obo_file = $form_state->getValue('obo_file');
+    $uobo_name = $form_state->getValue('uobo_name');
+    $uobo_url = $form_state->getValue('uobo_url');
+    $uobo_file = $form_state->getValue('uobo_file');
+    // Now trim variables. We do it this way to avoid trimming an empty value.
+    foreach(['obo_name', 'obo_url', 'obo_file', 'uobo_name', 'uobo_url', 'uobo_file'] as $varname) {
+      if (!empty($$varname)) {
+        $$varname = trim($$varname);
+      }
+    }
 
     // If the user requested to alter the details then do that.
 

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -220,7 +220,7 @@ class OBOImporter extends ChadoImporterBase {
       '#options' => $obos,
       '#default_value' => $obo_id,
       '#ajax' => [
-        'callback' =>  [$this, 'formAjaxCallback'],
+        'callback' =>  [$this::class, 'formAjaxCallback'],
         'wrapper' => 'obo-existing-fieldset',
       ],
       '#description' => t('Select a vocabulary to import.'),
@@ -374,7 +374,7 @@ class OBOImporter extends ChadoImporterBase {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state object.
    */
-  public function formAjaxCallback($form, &$form_state) {
+  public static function formAjaxCallback($form, &$form_state) {
 
     $uobo_name = $form['obo_existing']['uobo_name']['#default_value'];
     $uobo_url = $form['obo_existing']['uobo_url']['#default_value'];

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -92,7 +92,7 @@ class TaxonomyImporter extends ChadoImporterBase {
       ))->toString() . '.',
       '#default_value' => \Drupal::state()->get('tripal_ncbi_api_key', NULL),
       '#ajax' => array(
-        'callback' => [$this, 'tripal_taxon_importer_set_ncbi_api_key'],
+        'callback' => [$this::class, 'tripal_taxon_importer_set_ncbi_api_key'],
         'wrapper' => 'ncbi_api_key',
         'disable-refocus' => true,
       ),
@@ -1169,7 +1169,7 @@ class TaxonomyImporter extends ChadoImporterBase {
    * @return array
    *   The new api key field.
    */
-  function tripal_taxon_importer_set_ncbi_api_key($form, &$form_state) {
+  public static function tripal_taxon_importer_set_ncbi_api_key($form, &$form_state) {
     $key_value = $form_state->getValue(['ncbi_api_key']);
     \Drupal::state()->set('tripal_ncbi_api_key', \Drupal\Component\Utility\HTML::escape($key_value));
     \Drupal::messenger()->addMessage(t('NCBI API key has been saved successfully!'));


### PR DESCRIPTION

# Bug Fix

### Issue #1672 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Specifically this PR fixes the following issues:

> There is a new fieldset for "New OBO File" which should not be there.

This was because the changes to annotation added defaults for missing values. The OBO importer did not set the `file_local` and this defaulted to TRUE; whereas apparently in the past an excluded annotation value always defaulted to FALSE. This was fixed by simply setting the annotation properly.

> Creating a new OBO reference submits a job with a 0 obo_id.

This was caused by a bug in the form submit for the TripalImporterForm. Specifically, any changes made during the importer formSubmit were not being carried through to the job arguments. Since the OBO importer sets the obo_id in it's own form submit after creating the new obo reference, this was not available in the job arguments.

> Trying to run an existing OBO reference incorrectly shows validation errors for not filling in anything in the new obo reference section.

This was actually due to broken AJAX although that was not immediately evident at first. The logic in the submit thought that the update button was being triggered even though it wasn't actually present visually due to failed AJAX.

> Ajax appears to be broken

It turns out the dependency injection PR for ChadoImporter caused this. Specifically, the AJAX callback was being specified using `$this` which serialized the entire importer object for an AJAX call just to be able to access the callback! This wasn't a problem before because the TripalImporter class didn't use dependency injection and thus was serializable... 

This was fixed by simply making the AJAX callbacks static (an easy change since they didn't use any initialized info in the class anyway) and then changing the callback specification to pass in the class name instead of the object. This is also more efficient.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### There is a new fieldset for "New OBO File" which should not be there.

Just go to the OBO importer form (Admin > Tripal > Data Loaders > OBO Vocab Importer) and ensure the importer looks like this:
![image](https://github.com/tripal/tripal/assets/1566301/c88def1c-5343-45cf-b91b-a447125e001f)

### Creating a new OBO reference submits a job with a 0 obo_id

1. Go to the OBO importer form (Admin > Tripal > Data Loaders > OBO Vocab Importer)
2. Expand the "Add a New Ontology Reference" fieldset and fill in the form as follows:
     - New Vocabulary Name: required but you can put in anything here
     - Local File: /var/www/drupal9/web/modules/contrib/tripal/tripal_chado/files/tcontact.obo
3. Then click Import OBO File

You should see a success message at the top saying the vocab was completed, it should show up in the existing list and it should have submitted a job.

**Make sure to run the job! This should work now whereas before you got the following message:
```
2023-11-01 21:54:50
Tripal Job Launcher
Running as user 'drupaladmin'
-------------------
2023-11-01 21:54:50: Job ID 5.
2023-11-01 21:54:50: Calling: tripal_run_importer(9)
Running 'OBO Vocabulary Loader' importer
NOTE: Loading of this file is performed using a database transaction. If it fails or is terminated prematurely then all insertions and updates are rolled back and will not be found in the database
ERROR: Invalid OBO ID provided: '0'.
[site http://default] [TRIPAL] ERROR: Invalid OBO ID provided: '0'.
```
### Trying to run an existing OBO reference incorrectly shows validation errors for not filling in anything in the new obo reference section.

***This also confirms that AJAX is not broken any more.***

1. Go to the OBO importer form (Admin > Tripal > Data Loaders > OBO Vocab Importer)
2. Select an existing obo record from the drop down.
3. Confirm that there are no errors on the page and that the "Use a Saved Ontology Reference" fieldset expands with additional info specific to the selected ontology, plus the update and delete buttons show up as shown in the screenshot shared below.
4. Click Import OBO File and confirm that you get the message that the job was successfully submitted.

![Screenshot 2023-11-01 at 4 20 13 PM](https://github.com/tripal/tripal/assets/1566301/5331f4ba-b90c-413c-ad0d-36acf50a0212)
