### PR TITLE
Fixes to Importers focused on remote-term lookup

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2391,7 +2391,7 @@ class OBOImporter extends ChadoImporterBase {
           // We need to ensure this term has an id.
           // This one is non-negotiable!
           if (!array_key_exists('id', $stanza)) {
-            $this->logger('We are skipping the following term because it does not have and id. Term information: ' . print_r($stanza, TRUE));
+            $this->logger->warning('We are skipping the following term because it does not have and id. Term information: ' . print_r($stanza, TRUE));
           }
           else {
             // We need to ensure this term has a name.

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -4,9 +4,11 @@ namespace Drupal\tripal_chado\Plugin\TripalImporter;
 
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\tripal\TripalVocabTerms\TripalTerm;
+use Drupal\Component\Serialization\Json;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Ajax\ReplaceCommand;
+
 /**
  * OBO Importer implementation of the TripalImporterBase.
  *
@@ -1312,7 +1314,7 @@ class OBOImporter extends ChadoImporterBase {
       $this->setInterval(1);
     }
 
-    $this->logger->notice(t("Performing EBI OLS Lookup for: @id", ['@id' => $id]));
+    $this->logger->notice('Performing EBI OLS Lookup for: @id', ['@id' => $id]);
 
     // Get the short name and accession for the term.
     $pair = explode(":", $id, 2);
@@ -1328,21 +1330,31 @@ class OBOImporter extends ChadoImporterBase {
       list($ontologyID, $base_iri) = $this->baseIRIs[$short_name];
     }
     else {
-      $ontology_results =  $this->oboEbiLookup($id, 'query');
+      $ontology_results =  $this->oboEbiLookup($ontologyID, 'query');
+      if ($ontology_results === FALSE OR !is_array($ontology_results)) {
+        throw new \Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !id',
+          ['!id' => $ontologyID]));
+      }
       // If results were received but the number of results is 0, do a query-non-local lookup.
       if ($ontology_results['response']['numFound'] == 0) {
-        $ontology_results =  $this->oboEbiLookup($id, 'query-non-local');
+        $ontology_results =  $this->oboEbiLookup($ontologyID, 'query-non-local');
       }
-      if (!$ontology_results) {
-        throw new \Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !id',
-          ['!id' => $id]));
-      }
-      if ($ontology_results['error']) {
+      if (array_key_exists('error', $ontology_results) AND !empty($ontology_results['error'])) {
         $message = t('Cannot find the ontology via an EBI OLS lookup: @short_name. ' .
           'EBI Reported: @message. Consider finding the OBO file for this ' .
           ' ontology and manually loading it first.', ['@message' => $ontology_results['message'],
             '@short_name' => $short_name]);
-        $this->logger->warning($message);
+        $this->logger->error($message);
+        throw new \Exception('Unable to lookup ontology via EBI. See previous error for details.');
+      }
+      // If results were received but the number of results is 0 and we already
+      // tried a query-non-local lookup then we just have to admin defeat.
+      if ($ontology_results['response']['numFound'] == 0) {
+        $this->logger->error('Cannot find the ontology via an EBI OLS lookup: @short_name. ' .
+          'While EBI did not provide an error, no results were found. Consider ' .
+          ' finding the OBO file for this ontology and manually loading it first.',
+          ['@short_name' => $short_name]);
+        throw new \Exception('Unable to lookup ontology via EBI. See previous error for details.');
       }
       // The following foreach code works but, I am not sure that
       // I am retrieving each query result from the json associative
@@ -2861,6 +2873,8 @@ class OBOImporter extends ChadoImporterBase {
    * @ingroup tripal_obo_loader
    */
   private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL, $found_ontology = NULL) {
+    $client = \Drupal::httpClient();
+
     // Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
     $ontology = strtolower($parts[0]);
@@ -2879,55 +2893,43 @@ class OBOImporter extends ChadoImporterBase {
       }
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . $type . '/' . $found_iri;
       $options = [];
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
     elseif ($type_of_search == 'ontology') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology;
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
     elseif ($type_of_search == 'term') {
       // The IRI of the terms, this value must be double URL encoded
       $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':', '_', $accession)));
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'terms/' . $iri;
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
     elseif ($type_of_search == 'property') {
       // The IRI of the terms, this value must be double URL encoded
       $iri = urlencode(urlencode("http://purl.obolibrary.org/obo/" . str_replace(':', '_', $accession)));
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/ontologies/' . $ontology . '/' . 'properties/' . $iri;
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
     elseif ($type_of_search == 'query') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id&local=true';
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
     elseif ($type_of_search == 'query-non-local') {
       $options = [];
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
-      $response = drupal_http_request($full_url, $options);
-      if (!empty($response)) {
-        $response = drupal_json_decode($response->data);
-      }
     }
-    return $response;
+
+    try {
+      $response = $client->get($full_url, $options);
+      $response = $response->getBody();
+      $response = Json::decode($response);
+      return $response;
+    }
+    catch (RequestException $e) {
+      $this->logger->error('Unable to get response from @url when trying to retrieve data for @accession. @exception',
+          ['@url' => $full_url, '@accession' => $accession, '@exception' => $e->getMessage()]);
+    }
+
+    return FALSE;
   }
 }

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -1428,7 +1428,7 @@ class OBOImporter extends ChadoImporterBase {
     $stanza = [];
     $stanza['id'][0] = $id;
     $stanza['name'][0] = $results['label'];
-    $stanza['def'][0] = $results['def'];
+    $stanza['def'][0] = (array_key_exists('def', $results)) ? $results['def'] : '';
     $stanza['namespace'][0] = $results['ontology_name'];
     $stanza['is_obsolete'][0] = $results['is_obsolete'] ? 'true' : '';
     $stanza['is_relationshiptype'][0] = '';

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2391,7 +2391,7 @@ class OBOImporter extends ChadoImporterBase {
           // We need to ensure this term has an id.
           // This one is non-negotiable!
           if (!array_key_exists('id', $stanza)) {
-            $this->logger->warning('We are skipping the following term because it does not have and id. Term information: ' . print_r($stanza, TRUE));
+            $this->logger->warning('We are skipping the following term because it does not have an id. Term information: ' . print_r($stanza, TRUE));
           }
           else {
             // We need to ensure this term has a name.

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2050,13 +2050,13 @@ class OBOImporter extends ChadoImporterBase {
     // Create a new stanza using the values of this cvterm.
     $stanza = [];
     $stanza['id'][0] = $short_name . ':' . $accession;
-    $stanza['name'][0] = $cvterm->getValue('name');
-    $stanza['def'][0] = $cvterm->getValue('definition');
-    $stanza['namespace'][0] = $cv->getValue('name');
-    $stanza['is_obsolete'][0] = $cvterm->getValue('is_obsolete') == 1 ? 'true' : '';
+    $stanza['name'][0] = $cvterm->name;
+    $stanza['def'][0] = $cvterm->definition;
+    $stanza['namespace'][0] = $cv->name;
+    $stanza['is_obsolete'][0] = ($cvterm->is_obsolete == 1) ? 'true' : '';
     $stanza['is_relationshiptype'][0] = '';
     $stanza['db_name'][0] = $db->name;
-    $stanza['cv_name'][0] = $cv->getValue('name');
+    $stanza['cv_name'][0] = $cv->name;
     return $stanza;
   }
 


### PR DESCRIPTION
# Bug Fix

### Issue #1675 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The fixes in this PR were bugs I found while debugging my own custom OBO file.
Specifically, they are:

1. Upgrade [drupal_http_request()](https://www.drupal.org/node/1862446) and [drupal_json_decode()](https://www.drupal.org/node/2219113) based on their change records. These functions were completely removed in Drupal 10.
2. Fix a number of logger calls to ensure variables were substituted.
3. Add catches for a number of 'undefined index' errors that were popping up due to assumptions.
4. Provide defaults for the name and definition of a term.
5. Ensure that if the term already exists then the details are correctly retrieved.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

I've provided a short OBO for testing.
[to_subset.obo.txt](https://github.com/tripal/tripal/files/13269703/to_subset.obo.txt)

NOTE: This is a subset of an existing ontology with an added term without id. Do not use for any purpose other than testing and do not import into a production site.

1. Download the previous OBO file and rename it to have the `.obo` suffix.
2. Copy this file into the local environment. If you are using TripalDocker the you can use the following command from the directory containing the downloaded obo file: `docker cp to_subset.obo CONTAINERNAME:/var/www/drupal9/web/`
3. Go to the obo importer (Admin > Tripal > Data Loaders > OBO Vocabulary Importer)
4. Expand the "Add a New Ontology Reference" fieldset and fill in the form as follows:
    - New Vocabulary Name: TO Subset for PR
    - Local File: /var/www/drupal9/web/to_subset.obo
6. Then click "Import OBO File"
7. Finally run the Tripal job on the command-line.

With this PR the job will complete successfully whereas without, you will see the same message in the attached issue.

To check terms were inserted as expected. There are 71 instances of `[Term]` in the file and the following query says there are a total of 72 terms in these ontologies. That's because any OBO with is_a relationships included will create an additional term in the default ontology for the `is_a` term.

```sql
SELECT cv.name, count(cvt.cvterm_id) as num_terms 
FROM chado.cvterm cvt 
LEFT JOIN chado.cv ON cv.cv_id=cvt.cv_id 
WHERE cv.name IN ('chebi', 'bfo', 'plant_trait_ontology') 
GROUP BY cv.name;
```

```
plant_trait_ontology	1
bfo	15
chebi	56
```

You can also use the following query to look at the terms specifically to confirm.

```sql
SELECT cv.name as cv, cvt.name as term, db.name||':'||dbxref.accession as accession
FROM chado.cvterm cvt LEFT JOIN chado.cv ON cv.cv_id=cvt.cv_id 
LEFT JOIN chado.dbxref ON dbxref.dbxref_id=cvt.dbxref_id
LEFT JOIN chado.db ON db.db_id=dbxref.db_id
WHERE cv.name IN ('chebi', 'bfo', 'plant_trait_ontology');
```

8. Next resubmit the job that you ran above to ensure that if the term is already in the database, the importer correctly selects and uses the existing one.

Again, this should complete without errors and you should see no change to the counts with this PR but without this PR you would see the following:

```
2023-11-02 22:42:06: Calling: tripal_run_importer(5)
Running 'OBO Vocabulary Loader' importer
NOTE: Loading of this file is performed using a database transaction. If it fails or is terminated prematurely then all insertions and updates are rolled back and will not be found in the database
 [notice] Running 'OBO Vocabulary Loader' importer
 [notice] NOTE: Loading of this file is performed using a database transaction. If it fails or is terminated prematurely then all insertions and updates are rolled back and will not be found in the database
Importing into schema: chado
 [notice] Importing into schema: chado
Step 1: Preloading File //var/www/drupal9/web/to_subset.obo...
Percent complete: 0%. Memory: 36,336,424 bytes.
 [notice] Step 1: Preloading File //var/www/drupal9/web/to_subset.obo...
 [notice] Percent complete: 0%. Memory: 36,336,424 bytes.
Percent complete: 5.04 %. Memory: 36,347,688 bytes.
 [notice] Percent complete: 5.04 %. Memory: 36,347,688 bytes.
Percent complete: 10.69 %. Memory: 36,348,952 bytes.
 [notice] Percent complete: 10.69 %. Memory: 36,348,952 bytes.
Percent complete: 15.38 %. Memory: 36,349,656 bytes.
 [notice] Percent complete: 15.38 %. Memory: 36,349,656 bytes.
Error: Call to undefined method stdClass::getValue() in Drupal\tripal_chado\Plugin\TripalImporter\OBOImporter->lookupTerm() (line 2053 of /var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php).
 [error]  Error: Call to undefined method stdClass::getValue() in Drupal\tripal_chado\Plugin\TripalImporter\OBOImporter->lookupTerm() (line 2053 of /var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php) #0 /var/www/drupal9/web/modules/contrib/tripal/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php(2103): Drupal\tripal_chado\Plugin\TripalImporter\OBOImporter->lookupTerm('BFO', '0000002')
```