### PR TITLE
Do not display fopen error messages

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -551,6 +551,7 @@ class TaxonomyImporter extends ChadoImporterBase {
         if (!empty($api_key)) {
           $search_url .= "&api_key=" . $api_key;
         }
+$ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure but not affect loading
         $rfh = NULL;
         // Query NCBI. To accomodate occasional glitches, retry up to three times.
         $retries = 3;

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -551,7 +551,6 @@ class TaxonomyImporter extends ChadoImporterBase {
         if (!empty($api_key)) {
           $search_url .= "&api_key=" . $api_key;
         }
-$ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure but not affect loading
         $rfh = NULL;
         // Query NCBI. To accomodate occasional glitches, retry up to three times.
         $retries = 3;
@@ -807,7 +806,6 @@ $ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure 
 
     // Query NCBI. To accomodate occasional glitches, retry up to three times.
     $xml = FALSE;
-$ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure but not affect loading
     $rfh = NULL;
     $retries = 3;
     while (($retries > 0) and (!$rfh)) {

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -807,6 +807,7 @@ $ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure 
 
     // Query NCBI. To accomodate occasional glitches, retry up to three times.
     $xml = FALSE;
+$ffh = fopen('https://will.fail. .surely', "r");  // Try to trigger the failure but not affect loading
     $rfh = NULL;
     $retries = 3;
     while (($retries > 0) and (!$rfh)) {

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -557,7 +557,7 @@ class TaxonomyImporter extends ChadoImporterBase {
         while (($retries > 0) and (!$rfh)) {
           $start = microtime(TRUE);
           // Get the search response from NCBI.
-          $rfh = fopen($search_url, "r");
+          $rfh = @fopen($search_url, "r");
           // If error, delay then retry
           if ((!$rfh) and ($retries)) {
             $this->logger->warning("Error contacting NCBI to look up @sci_name, will retry",
@@ -810,7 +810,7 @@ class TaxonomyImporter extends ChadoImporterBase {
     $retries = 3;
     while (($retries > 0) and (!$rfh)) {
       $start = microtime(TRUE);
-      $rfh = fopen($fetch_url, "r");
+      $rfh = @fopen($fetch_url, "r");
       if ($rfh) {
         $xml_text = '';
         while (!feof($rfh)) {


### PR DESCRIPTION
# Bug Fix
### Issue #1501

### Tripal Version: 4

## Description
All this does is hides error messages from `fopen()` in the taxonomy importer (they are not exceptions). ~I think~ these are preventing the retry loop from working during automated testing.

## Testing?
The errors cannot be reproduced as they are intermittent. This small change should be safe, and maybe we just need time to see if this does it.

**Update**
I found a way to reliably test this. I can add code to create a very similar error.
Add this line to `tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php` after line 810
`$xfh = fopen("https://www.ncbi.nlm.nih.gov/ spaces should give 400 entrez/eutils/efetch.fcgi", "r"); // to give HTTP/1.1 400 Bad Request`
and run the importer tests (my container is named `1381`)
`docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal 1381 phpunit --group 'TaxonomyImporter' --debug`
```
There was 1 error:

1) Drupal\Tests\tripal_chado\Functional\TaxonomyImporterTest::testTaxonomyImporterSimpleTest
fopen(https://www.ncbi.nlm.nih.gov/ spaces should give 400 entrez/eutils/efetch.fcgi): Failed to open stream: HTTP request failed! HTTP/1.1 400 Bad Request
```

Now change this line by adding `@` and run the tests again
`$xfh = @fopen("https://www.ncbi.nlm.nih.gov/ spaces should give 400 entrez/eutils/efetch.fcgi", "r");`
`       ^`
...
`OK (2 tests, 37 assertions)`