### PR TITLE
additional type widget regex fix

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -139,7 +139,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     foreach ($values as $delta => $item) {
        $matches = [];
-       if (preg_match('/(.+?)\((.+?):(.+?)\)/', $item['term_autoc'], $matches)) {
+       if (preg_match('/(.+?)\(([^\(]+?):(.+?)\)/', $item['term_autoc'], $matches)) {
          $termIdSpace = $matches[2];
          $termAccession = $matches[3];
 


### PR DESCRIPTION
# Bug Fix

### Closes #1683

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
A small change to the regex for the ChadoAdditionalTypeWidgetDefault to make sure we match the last pair of parentheses

## Testing?
Described in issue #1683