### PR TITLE
Add a default label for the Authored by field

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -286,13 +286,13 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
     $fields['uid'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))
-      ->setDescription(t('The user ID of author of the Tripal Content entity.'))
+      ->setDescription(t('The user ID of the author of the Tripal Content entity.'))
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', array(
-        'label' => 'hidden',
+        'label' => 'above',
         'type' => 'author',
         'weight' => 0,
       ))


### PR DESCRIPTION
# Bug Fix

### Closes #1689

### Tripal Version: 4.x

## Description
The "Authored by" field is displaying on all pages without a title which is inconsistent with everything else.
This PR just changes the default. Admins can still change the display settings as with every field.

## Testing?
Build a docker on this branch, and create any content type. Here I created a project.
The "Authored by" field should display a title as shown
### Before
![no_heading](https://github.com/tripal/tripal/assets/8419404/0799b785-e346-4b69-a9c2-c31423ac2d29)

### After
![issue1689](https://github.com/tripal/tripal/assets/8419404/71eaa598-baa0-4e3a-9a45-47d3988f581b)
