### PR TITLE
Remove all '#type' => 'markup' because it doesn't do anything

### DIFF
--- a/tripal/src/Controller/TripalController.php
+++ b/tripal/src/Controller/TripalController.php
@@ -114,7 +114,6 @@ class TripalController extends ControllerBase{
 
     $content = [
       [
-        '#type' => 'markup',
         '#markup' => 'Usage reports coming in the future...',
       ],
     ];

--- a/tripal/src/Form/TripalAdminAddCustomForm.php
+++ b/tripal/src/Form/TripalAdminAddCustomForm.php
@@ -74,7 +74,6 @@ class TripalAdminAddCustomForm extends ConfigFormBase {
       '#value' => $this->t('Submit'),
     ];
     $form['cancel'] = [
-      '#type' => 'markup',
       '#markup' => l('Cancel', 'admin/tripal/files/quota'),
     ];
 

--- a/tripal/src/Form/TripalAdminManageQuotaForm.php
+++ b/tripal/src/Form/TripalAdminManageQuotaForm.php
@@ -72,7 +72,6 @@ class TripalAdminManageQuotaForm implements FormInterface{
     ];
 
     $form['cancel'] = [
-      '#type' => 'markup',
       '#markup' => Link::fromTextAndUrl('Cancel',
         Url::fromRoute('tripal.files_quota'))->toString(),
     ];

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -169,7 +169,6 @@ class TripalEntityTypeForm extends EntityForm {
     ];
 
     $form['title_settings']['tokens']['msg'] = [
-      '#type' => 'markup',
       '#markup' => 'Copy the token and paste it into the "Page Title Format" text field above.'
     ];
 
@@ -204,7 +203,6 @@ class TripalEntityTypeForm extends EntityForm {
     ];
 
     $form['url_settings']['tokens']['msg'] = [
-      '#type' => 'markup',
       '#markup' => 'Copy the token and paste it into the "URL Alias Pattern" text field above.'
     ];
 

--- a/tripal/src/Form/TripalFileQuota.php
+++ b/tripal/src/Form/TripalFileQuota.php
@@ -118,7 +118,6 @@ class TripalFileQuota implements FormInterface{
     ];
 
     $form['custom']['links'] = [
-      '#type' => 'markup',
       '#markup' => '<br>' . Link::fromTextAndUrl('Add Custom User Quota',
           Drupal\Core\Url::fromUri('internal:/admin/tripal/files/quota/add'))
           ->toString(),

--- a/tripal/src/Form/TripalFileQuotaCustomEdit.php
+++ b/tripal/src/Form/TripalFileQuotaCustomEdit.php
@@ -75,7 +75,6 @@ class TripalFileQuotaCustomEdit implements FormInterface{
     $link = Link::fromTextAndUrl('Cancel',
       Drupal\Core\Url::fromRoute('tripal.files_quota'));
     $form['cancel'] = [
-      '#type' => 'markup',
       '#markup' => $link->toString(),
     ];
     return $form;

--- a/tripal/src/Form/TripalImporterForm.php
+++ b/tripal/src/Form/TripalImporterForm.php
@@ -59,7 +59,6 @@ class TripalImporterForm implements FormInterface {
       ];
 
       $form['file']['upload_description'] = [
-        '#type' => 'markup',
         '#markup' => $importer->describeUploadFileFormat(),
       ];
     }

--- a/tripal_chado/src/Form/ChadoCustomTableForm.php
+++ b/tripal_chado/src/Form/ChadoCustomTableForm.php
@@ -207,7 +207,6 @@ class ChadoCustomTableForm extends FormBase {
     ];
 
     $form['cancel'] = [
-      '#type' => 'markup',
       '#markup' => Link::fromTextAndUrl('Cancel', Url::fromUserInput('/admin/tripal/storage/chado/custom_tables'))->toString(),
     ];
 

--- a/tripal_chado/src/Form/ChadoCustomTablesDeleteForm.php
+++ b/tripal_chado/src/Form/ChadoCustomTablesDeleteForm.php
@@ -35,7 +35,6 @@ class ChadoCustomTablesDeleteForm extends FormBase {
     ];
 
     $form['sure'] = [
-      '#type' => 'markup',
       '#markup' => '<p>Are you sure you want to delete the "' . $custom_table->getTableName() .
         '" custom table in the "' . $custom_table->getChadoSchema() . '" schema?</p>',
     ];

--- a/tripal_chado/src/Form/ChadoMviewDeleteForm.php
+++ b/tripal_chado/src/Form/ChadoMviewDeleteForm.php
@@ -35,7 +35,6 @@ class ChadoMviewDeleteForm extends FormBase {
     ];
 
     $form['sure'] = [
-      '#type' => 'markup',
       '#markup' => '<p>Are you sure you want to delete the "' . $mview->getTableName() .
       '" materialized view in the "' . $mview->getChadoSchema() . '" schema?</p>',
     ];

--- a/tripal_chado/src/Form/ChadoMviewForm.php
+++ b/tripal_chado/src/Form/ChadoMviewForm.php
@@ -260,7 +260,6 @@ SELECT
     ];
 
     $form['cancel'] = [
-      '#type' => 'markup',
       '#markup' => Link::fromTextAndUrl('Cancel', Url::fromUserInput('/admin/tripal/storage/chado/mviews'))->toString(),
     ];
 

--- a/tripal_chado/src/Form/ChadoMviewPopulateForm.php
+++ b/tripal_chado/src/Form/ChadoMviewPopulateForm.php
@@ -35,7 +35,6 @@ class ChadoMviewPopulateForm extends FormBase {
     ];
 
     $form['sure'] = [
-      '#type' => 'markup',
       '#markup' => '<p>Please confirm you want to populate the "' . $mview->getTableName() .
       '" materialized view in the "' . $mview->getChadoSchema() . '" schema?</p>',
     ];

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoLinkerPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoLinkerPropertyFormatterDefault.php
@@ -56,7 +56,6 @@ class ChadoLinkerPropertyFormatterDefault extends ChadoFormatterBase {
     }
 
     $elements[0] = [
-      '#type' => 'markup',
       "#markup" => $list[0]
     ];
     return $elements;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
@@ -55,7 +55,6 @@ class ChadoSourceDataFormatterDefault extends ChadoFormatterBase {
 
     // The cardinality of this field is always 1, so only create element for $delta of zero.
     $elements[0] = [
-      '#type' => 'markup',
       '#markup' => $content,
     ];
 

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
@@ -51,7 +51,6 @@ class ChadoSynonymFormatterDefault extends ChadoFormatterBase {
     }
 
     $elements[0] = [
-      '#type' => 'markup',
       "#markup" => $list[0]
     ];
     return $elements;


### PR DESCRIPTION
# Bug Fix

### Issue #1686

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
Removes `'#type' => 'markup'` from everywhere.
This is because since Drupal 8 it is no longer a valid type, and was not needed in Drupal 7.
For a reference see https://www.drupal.org/node/2036237

## Testing?
An easy place to test this is on the FASTA importer, the file format description element is one of the places changed.
### Before
![fasta-before](https://github.com/tripal/tripal/assets/8419404/26a5cf7d-4129-49c5-914d-10c15465c9fc)

### After
![fasta-after](https://github.com/tripal/tripal/assets/8419404/fd5097ee-22f4-44f9-9235-2fd663f9792c)

They look the same to me 😀
