### PR TITLE
ChadoTermsInit should take an arguement so it can be re-used

### DIFF
--- a/tripal_chado/src/Services/ChadoTermsInit.php
+++ b/tripal_chado/src/Services/ChadoTermsInit.php
@@ -66,7 +66,7 @@ class ChadoTermsInit{
     $config_factory = \Drupal::service('config.factory');
 
     $config_key = 'tripal.tripal_content_terms.' . $id;
-    $config = $config_factory->get($id);
+    $config = $config_factory->get($config_key);
     if (!$config) {
       throw new \Exception("Unable to find configuration with the key $id.");
     }

--- a/tripal_chado/src/Services/ChadoTermsInit.php
+++ b/tripal_chado/src/Services/ChadoTermsInit.php
@@ -29,6 +29,9 @@ class ChadoTermsInit{
     $vocabulary = $vmanager->loadCollection($name, 'chado_vocabulary');
     if (!$vocabulary) {
       $vocabulary = $vmanager->createCollection($name, 'chado_vocabulary');
+      if (!$vocabulary) {
+        throw new \Exception("Unable to create vocabulary with the name $name.");
+      }
     }
     return $vocabulary;
   }
@@ -46,6 +49,9 @@ class ChadoTermsInit{
     $idSpace = $idsmanager->loadCollection($name, 'chado_id_space');
     if (!$idSpace) {
       $idSpace = $idsmanager->createCollection($name, 'chado_id_space');
+      if (!$idSpace) {
+        throw new \Exception("Unable to create ID Space with the name $name.");
+      }
     }
     return $idSpace;
   }
@@ -53,10 +59,17 @@ class ChadoTermsInit{
   /**
    * Installs the module's default terms into Chado.
    *
+   * @param string $id
+   *   The id of the terms configuration you want to install.
    */
-  public function installTerms() {
+  public function installTerms(string $id = 'chado_content_terms') {
     $config_factory = \Drupal::service('config.factory');
-    $config = $config_factory->get('tripal.tripal_content_terms.chado_content_terms');
+
+    $config_key = 'tripal.tripal_content_terms.' . $id;
+    $config = $config_factory->get($id);
+    if (!$config) {
+      throw new \Exception("Unable to find configuration with the key $id.");
+    }
     $vocabs = $config->get('vocabularies');
     foreach ($vocabs as $vocab_info) {
 


### PR DESCRIPTION
# Tripal 4 Core Dev Task

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Currently the ChadoTermsInit hardcodes the name of the configuration to install terms from. This PR makes installTerms() take the id of the config to install as an arguement so that it can be used by extension modules to install terms. This change is backwards compatible since a default is set of the id parameter.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This service is used as part of the prepare step so simply creating a new docker and ensuring the prepare runs without error, effectively tests this.