### PR TITLE
Update matrix to build docker images for 10.0 and 10.1 only

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - tv4g9-1572-expandDockerBuild
+      - tv4g0-issue1714-updateDockerBuildWorkflow
 
 jobs:
   push_to_registry:
@@ -13,30 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
         pgsql-version:
           - "13"
         drupal-version:
-          - "9.4.x-dev"
-          - "9.5.x-dev"
           - "10.0.x-dev"
           - "10.1.x-dev"
-        exclude:
-          - php-version: "8.2"
-            drupal-version: "9.4.x-dev"
-          - php-version: "8.2"
-            drupal-version: "9.5.x-dev"
-          - php-version: "8.0"
-            drupal-version: "10.0.x-dev"
-          - php-version: "8.0"
-            drupal-version: "10.1.x-dev"
     name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
       - uses: actions/checkout@v3
         name: Check out code
-      - uses: mr-smithers-excellent/docker-build-push@v5
+      - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Full matrix of Docker images
         with:
           image: tripalproject/tripaldocker
@@ -47,7 +35,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
-      - uses: mr-smithers-excellent/docker-build-push@v5
+      - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Full matrix of Docker images WITH NO CHADO
         with:
           image: tripalproject/tripaldocker
@@ -58,7 +46,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=FALSE"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
-      - uses: mr-smithers-excellent/docker-build-push@v5
+      - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Docker image Drupal focused Docker images.
         if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' }}
         with:
@@ -70,7 +58,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
-      - uses: mr-smithers-excellent/docker-build-push@v5
+      - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build latest using 10.0.x-dev, PHP 8.1, PgSQL 13
         if: ${{ matrix.drupal-version == '10.0.x-dev' && matrix.php-version == '8.1' && matrix.pgsql-version == '13' }}
         with:


### PR DESCRIPTION

# Tripal 4 Core Dev Task 

### Issue #1714 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The docker build action was showing failing since it was still trying to build Drupal 9.4 and 9.5 images which we no longer support. This was a minor annoyance only since it was still building all the other images as it was supposed to. However, I finally got annoyed at seeing the ❌ in our testing on branch 4.x so I've fixed it 😉 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I updated the workflow to run on this branch as well so we can test it before merge. This is needed since typically the changed workflow only runs on 4.x.

Testing just involves looking at the tests run on this PR and confirming there are not build docker runs for 9.4 and 9.5 images, and that all tests pass.