### PR TITLE
Fixed publication terms error

### DIFF
--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -271,7 +271,11 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     }
     $term = $idSpace->getTerm($field_def['settings']['termAccession']);
     if (!$term) {
-      $this->logger->error('The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements.');
+      $this->logger->error('The term accession. "@id:@accession", is not known in the Term Id Space for field, "@field". Check the "termIdSpace" and "termAccession" elements.',
+          ['@id' => $field_def['settings']['termIdSpace'],
+           '@accession' => $field_def['settings']['termAccession'],
+           '@field' => $field_def['name']
+          ]);
       return FALSE;
     }
 

--- a/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
+++ b/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
@@ -904,6 +904,12 @@ vocabularies:
         terms:
             -   id: 'TPUB:0000002'
                 name: 'Publication'
+            -   id: 'TPUB:0000003'
+                name: 'Citation'
+            -   id: 'TPUB:0000015'
+                name: 'Publication Type'
+            -   id: 'TPUB:0000243'
+                name: 'Volume Title'
 
     -   name: 'foaf'
         label: 'Friend of a Friend. A dictionary of people-related terms that can be used in structured data).'

--- a/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
+++ b/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
@@ -906,6 +906,7 @@ vocabularies:
                 name: 'Publication'
             -   id: 'TPUB:0000003'
                 name: 'Citation'
+                description: 'Biblographic reference for the publication.'
             -   id: 'TPUB:0000015'
                 name: 'Publication Type'
             -   id: 'TPUB:0000243'

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -265,7 +265,7 @@ fields:
         content_type: analysis
         label: Program, Pipeline, Workflow or Method Name
         type: chado_string_type_default
-        description: Tchado_string_type_defaulte.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
+        description: The program name (e.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
         cardinality: 1
         required: true
         storage_settings:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -265,7 +265,7 @@ fields:
         content_type: analysis
         label: Program, Pipeline, Workflow or Method Name
         type: chado_string_type_default
-        description: The program name (e.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
+        description: Tchado_string_type_defaulte.g. blastx, blastp, sim4, genscan. If the analysis was not derived from a software package then provide a very brief description of the pipeline, workflow or method.
         cardinality: 1
         required: true
         storage_settings:
@@ -1000,7 +1000,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: TPUB
-            termAccession: 0000003
+            termAccession: "0000003"
         display:
           view:
             default:
@@ -1027,7 +1027,7 @@ fields:
                 type_column: type_id
         settings:
             termIdSpace: TPUB
-            termAccession: 0000015
+            termAccession: "0000015"
         display:
           view:
             default:
@@ -1053,7 +1053,7 @@ fields:
                 base_column: title
         settings:
             termIdSpace: TPUB
-            termAccession: 0000039
+            termAccession: "0000039"
         display:
           view:
             default:
@@ -1080,7 +1080,7 @@ fields:
                 base_column: volumetitle
         settings:
             termIdSpace: TPUB
-            termAccession: 0000243
+            termAccession: "0000243"
         display:
           view:
             default:


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1717

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  10.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When installing the "General Content Types", you would see the following errors:

```
 [error]  ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements. 
[site http://default] [TRIPAL] ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements.
 [error]  ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements. 
[site http://default] [TRIPAL] ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements.
 [notice] Added field, "publication_title", to content type: "pub".
 [error]  ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements. 
[site http://default] [TRIPAL] ERROR: The term accession is not known in the Term Id Space. Check the "termIdSpace" and "termAccession" elements.
```
This PR fixes that probem by adding in the missing terms, improving the error message to make it more clear which field may be the problem (as the error message above isn't too descriptive).

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Simply install the site with and without this PR's fix and you'll see that the error messagse are gone.  

Also, you can go to the  Admin > Structure > Tripal Content Type  and select "Manage Fields" under publication and you'll see all four fields that are currently part of the Publication content type.
