### PR TITLE
Create a Github Workflow to Sync Drupal.org on every push to 4.x

### DIFF
--- a/.github/workflows/MAIN-syncDrupalOrg
+++ b/.github/workflows/MAIN-syncDrupalOrg
@@ -1,9 +1,9 @@
 name: Push Recent Commits to Drupal.org
 on:
+  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - tv4g0-issue1720-workflowSyncDrupalOrg
 
 jobs:
   push_to_drupal:

--- a/.github/workflows/MAIN-syncDrupalOrg
+++ b/.github/workflows/MAIN-syncDrupalOrg
@@ -1,0 +1,19 @@
+name: Push Recent Commits to Drupal.org
+on:
+  push:
+    branches:
+      - 4.x
+      - tv4g0-issue1720-workflowSyncDrupalOrg
+
+jobs:
+  push_to_drupal:
+    runs-on: ubuntu-latest
+    name: "Push to Drupal.org"
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out code
+      - name: "Configure git to push to drupal.org"
+        run: |
+          git config user.name "Lacey Sanderson"
+          git config user.email "laceyannesanderson@gmail.com"
+          git remote add drupal git@git.drupal.org:project/tripal.git

--- a/.github/workflows/MAIN-syncDrupalOrg
+++ b/.github/workflows/MAIN-syncDrupalOrg
@@ -16,4 +16,10 @@ jobs:
         run: |
           git config user.name "Lacey Sanderson"
           git config user.email "laceyannesanderson@gmail.com"
-          git remote add drupal git@git.drupal.org:project/tripal.git
+          git config credential.helper 'store --file ~/.drupal-org-credentials'
+          git remote add drupal https://git.drupal.org/project/tripal.git
+     - name: "Authenticate and Push"
+       run: |
+          echo "https://laceysanderson:${{ secrets.DRUPALORG_TOKEN }}@git.drupalcode.org" > ~/.drupal-org-credentials
+          git push drupal 4.x
+         


### PR DESCRIPTION

# Tripal 4 Core Dev Task 

### Issue #1720 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When making a release, we need Drupal.org to be in sync with github. If they diverge too far it causes issues as drupal.org takes a long time to see the updates and sometimes needs intervention from the drupal.org staff.

This PR creates a github workflow that automatically pushes to drupal.org whenever there are updates to the 4.x branch. It can also be triggered manually for specific branches.

It uses my drupal login and a Github secret with my access token. By using a github secret it ensures that no one has access to my token. Furthermore, I use the git credentials helper for an extra level of security as it ensures my password is not encoded in the remote URL.

## Testing?
I have tested these exact commands locally and it successfully updated [Drupal.org GitLab](https://git.drupalcode.org/project/tripal/-/tree/4.x?ref_type=heads). 

Unfortunately we cannot test this github workflow directly until it is in the default branch... So a quick code review will be sufficient.
