### PR TITLE
Fix for the fixed_value discrepancy that Doug pointed out on PR #1729

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -129,8 +129,8 @@ field.field.tripal_entity.*.*:
           label: 'Flag to Enable field debugging'
           nullable: true
         fixed_value:
-          type: string
-          label: "A fixed value for the field that cannot be changed."
+          type: boolean
+          label: "Indicates if this field has a fixed value for one or more of it's property types."
           nullable: true
 
 ## For TripalEntityTypeCollection functionality
@@ -281,8 +281,8 @@ tripal.tripalfield_collection.*:
                      label: "Term Accession"
                      nullable: false
                    fixed_value:
-                     type: string
-                     label: "A fixed value for the field that cannot be changed."
+                     type: boolean
+                     label: "Indicates if this field has a fixed value for one or more of it's property types."
                      nullable: true
                display:
                  type: mapping

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -288,7 +288,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0000771"
-            fixed_value: SO:0000771
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -342,7 +342,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -369,7 +369,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -583,7 +583,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0001060"
-            fixed_value: SO:0001060
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -637,7 +637,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -664,7 +664,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -878,7 +878,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0001645"
-            fixed_value: SO:0001645
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -932,7 +932,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -959,7 +959,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1173,7 +1173,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0001500"
-            fixed_value: SO:0001500
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1227,7 +1227,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1254,7 +1254,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -178,7 +178,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0000704"
-            fixed_value: SO:0000704
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -232,7 +232,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -259,7 +259,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -473,7 +473,7 @@ fields:
         settings:
             termIdSpace: SO
             termAccession: "0000234"
-            fixed_value: SO:0000234
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -527,7 +527,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -554,7 +554,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -664,7 +664,7 @@ fields:
         settings:
             termIdSpace: data
             termAccession: '0872'
-            fixed_value: data:0872
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -908,7 +908,7 @@ fields:
         settings:
             termIdSpace: NCIT
             termAccession: C16223
-            fixed_value: NCIT:C16223
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1206,7 +1206,7 @@ fields:
         settings:
             termIdSpace: operation
             termAccession: "0525"
-            fixed_value: operation:0525
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1423,7 +1423,7 @@ fields:
         settings:
             termIdSpace: operation
             termAccession: "0362"
-            fixed_value: operation:0362
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -1506,7 +1506,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: Genome Project
-            fixed_value: local:Genome Project
+            fixed_value: TRUE Project
         display:
           view:
             default:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
@@ -126,7 +126,7 @@ fields:
         settings:
             termIdSpace: CO_010
             termAccession: "0000044"
-            fixed_value: CO_010:0000044
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -153,7 +153,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -288,7 +288,7 @@ fields:
         settings:
             termIdSpace: CO_010
             termAccession: "0000255"
-            fixed_value: CO_010:0000255
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -315,7 +315,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -450,7 +450,7 @@ fields:
         settings:
             termIdSpace: CO_010
             termAccession: 0000029
-            fixed_value: CO_010:0000029
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -477,7 +477,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -612,7 +612,7 @@ fields:
         settings:
             termIdSpace: CO_010
             termAccession: "0000162"
-            fixed_value: CO_010:0000162
+            fixed_value: TRUE
         display:
           view:
             default:
@@ -639,7 +639,7 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
+            fixed_value: TRUE
         display:
           view:
             default:

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -49,7 +49,8 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // It indicates to the publishing step to include this field.
     // If not set, then the publishing step may not be able to find matches
     // for this field based on the fixed value.
-    $settings['fixed_value'] = TRUE;
+    // NOTE: This field is not always a fixed value (e.g. organism.type_id)!!
+    $settings['fixed_value'] = FALSE;
     return $settings;
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -62,8 +62,17 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     }
 
     // If this is a fixed value then get it.
-    else if ($fixed_value) {
-      list($idSpace, $accession) = explode(':', $fixed_value);
+    else if ($fixed_value === TRUE) {
+
+      // If this field is indicated to be a fixed value
+      // Then we want to grab the term information from
+      // the field settings and use that rather then a
+      // user submitted value.
+      $idSpace = $field_settings['termIdSpace'];
+      $accession = $field_settings['termAccession'];
+      $fixed_value_value = $idSpace . ':' . $accession;
+
+      // Now we need the cvterm name.
       $query = $chado->select('1:cvterm', 'cvt');
       if ($accession) {
         $query->fields('cvt', ['cvterm_id', 'name']);
@@ -101,7 +110,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     ];
     $elements['value'] = [
       '#type' => 'value',
-      '#default_value' => $fixed_value,
+      '#default_value' => $fixed_value_value,
     ];
     $elements['term_name'] = [
       '#type' => 'value',

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -50,7 +50,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     // Find the term if one is present.
     $default_autoc = '';
     $term_string = '';
-    if ($type_id) {
+    if ($type_id !== NULL) {
       $query = $chado->select('1:cvterm', 'cvt');
       $query->leftJoin('1:dbxref', 'dbx', 'dbx.dbxref_id = cvt.dbxref_id');
       $query->leftJoin('1:db', 'db', 'dbx.db_id = db.db_id');
@@ -64,7 +64,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     }
 
     // If this is a fixed value then get it.
-    else if ($fixed_value === TRUE) {
+    else if ($fixed_value) {
 
       // If this field is indicated to be a fixed value
       // Then we want to grab the term information from

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -49,6 +49,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
 
     // Find the term if one is present.
     $default_autoc = '';
+    $term_string = '';
     if ($type_id) {
       $query = $chado->select('1:cvterm', 'cvt');
       $query->leftJoin('1:dbxref', 'dbx', 'dbx.dbxref_id = cvt.dbxref_id');
@@ -59,6 +60,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
       $query->condition('cvt.cvterm_id', $type_id);
       $result = $query->execute()->fetchObject();
       $default_autoc = $result->name  . ' (' . $result->db_name . ':' . $result->accession . ')';
+      $term_string = $result->db_name . ':' . $result->accession;
     }
 
     // If this is a fixed value then get it.
@@ -70,7 +72,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
       // user submitted value.
       $idSpace = $field_settings['termIdSpace'];
       $accession = $field_settings['termAccession'];
-      $fixed_value_value = $idSpace . ':' . $accession;
+      $term_string = $idSpace . ':' . $accession;
 
       // Now we need the cvterm name.
       $query = $chado->select('1:cvterm', 'cvt');
@@ -110,7 +112,7 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
     ];
     $elements['value'] = [
       '#type' => 'value',
-      '#default_value' => $fixed_value_value,
+      '#default_value' => $term_string,
     ];
     $elements['term_name'] = [
       '#type' => 'value',


### PR DESCRIPTION
There were discrepancies between how the fixed_value field setting was being used. Based on the new documentation and implementation provided by @spficklin it should be a boolean but in the past it actually held the fixed_value.

This PR makes it consistently a boolean and updates the ChadoAdditionalTypeWidgetDefault to generate the value based on the term if fixed_value is true.

Note: I also say that the boolean fields are set to fixed_value as well and something in my memory thinks I had a convo about this with @dsenalik?

## Testing

1. Create a new docker/install
2. Create an organism and confirm the intraspecific type field works as expected without errors.
3. Create a gene and confirm that the type field works here as well. Note: you should not be able to edit the type here and it should be disabled.