### PR TITLE
Fix unquoted leading zeros in yaml

### DIFF
--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -127,7 +127,7 @@ fields:
                 linker_fkey_column: dbxref_id
         settings:
             termIdSpace: SBO
-            termAccession: 0000552
+            termAccession: "0000552"
         display:
           view:
             default:
@@ -476,7 +476,7 @@ fields:
                 linker_fkey_column: dbxref_id
         settings:
             termIdSpace: SBO
-            termAccession: 0000552
+            termAccession: "0000552"
         display:
           view:
             default:
@@ -824,7 +824,7 @@ fields:
                 linker_fkey_column: dbxref_id
         settings:
             termIdSpace: SBO
-            termAccession: 0000552
+            termAccession: "0000552"
         display:
           view:
             default:
@@ -1172,7 +1172,7 @@ fields:
                 linker_fkey_column: dbxref_id
         settings:
             termIdSpace: SBO
-            termAccession: 0000552
+            termAccession: "0000552"
         display:
           view:
             default:
@@ -1520,7 +1520,7 @@ fields:
                 linker_fkey_column: dbxref_id
         settings:
             termIdSpace: SBO
-            termAccession: 0000552
+            termAccession: "0000552"
         display:
           view:
             default:


### PR DESCRIPTION
# Bug Fix

### Closes #1734

### Tripal Version: 4.x

## Description
I'm embarassed I let these unquoted values through. I thought I had checked them all but obviously not.

You can't have unquoted things that look like numbers in yaml.

## Testing?
Just install a new site and import the genetic content collection. Or maybe code review is sufficient for this one.
