### PR TITLE
Fix to improve loading speed of content type listing

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -559,6 +559,21 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   public static function postLoad(EntityStorageInterface $storage, array &$entities) {
     parent::postLoad($storage, $entities);
 
+
+    // IF we are doing a listing of content types there is no way in Drupal 10
+    // to specify which fields to load.  By deafult the SqlContentEntityStorage
+    // storage system we're using will always attach all fields.  But we can
+    // control what fields get attached to entities with this postLoad function.
+    // In the TripalEntityListBuilder::load() function we set the
+    // `tripal_load_listing` session variable to TRUE.  If it is TRUE then
+    // we skip this. @todo: in the future if we want to only attach
+    // specific fields we can get more fancy.
+    $session = \Drupal::request()->getSession();
+    $is_listing = $session->get('tripal_load_listing');
+    if ($is_listing === TRUE) {
+      return;
+    }
+
     $entity_type_id = $storage->getEntityTypeId();
     $field_manager = \Drupal::service('entity_field.manager');
     $field_type_manager = \Drupal::service('plugin.manager.field.field_type');

--- a/tripal/src/ListBuilders/TripalEntityListBuilder.php
+++ b/tripal/src/ListBuilders/TripalEntityListBuilder.php
@@ -54,4 +54,24 @@ class TripalEntityListBuilder extends EntityListBuilder {
     return $row + parent::buildRow($entity);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function load() {
+    $session = \Drupal::request()->getSession();
+    $session->set('tripal_load_listing', TRUE);
+    try {
+      $entity_ids = $this->getEntityIds();
+      $entities = $this->storage->loadMultiple($entity_ids);
+      $session->set('tripal_load_listing', FALSE);
+      return $entities;
+    }
+    catch (\Exception $e) {
+      $session->set('tripal_load_listing', FALSE);
+      throw new \Exception($e);
+    }
+  }
+
+
+
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1647 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the content listing page so that it loads much faster.  Previously if you published tens of thousands of entities the page would take a very long time to load or could time out.  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

1. Use the GFF loader to import a bunch of genes
2. Publish the gene records
3. Go to the Tripal Content Listing page.  The page should load extremely quickly. You can use the page to move between pages also very quickly. 

