### PR TITLE
Fix for Quota  Page

### DIFF
--- a/tripal/src/Form/TripalFileQuota.php
+++ b/tripal/src/Form/TripalFileQuota.php
@@ -105,7 +105,7 @@ class TripalFileQuota implements FormInterface{
         'user' => $user->getAccountName(),
         'custom_quota' => tripal_format_bytes($entry->custom_quota),
         'exp_date' => $entry->custom_expiration,
-        'actions' => render($actions_renderable),
+        'actions' => Drupal::service('renderer')->render($actions_renderable),
       ];
     }
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# 
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1734

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
To load a large file using any of our Tripal loaders, you have to set the Tripal managed user quota for the user. This includes the administrator. Doing so, unfortunately results in a white screen with an error message. Setting the quota actually works but display of the quota page no longer works and you can no longer change or add any new quotas.

This is a super easy fix.  Drupal deprecated the `render()` function in favor of a service and the bit of code that used it never got updated.  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

You can confirm the problem by going to Admin > Tripal > Tripal Managed Files > Disk Usage Quotas. If you have no user quotas defined the page loads fine. Add a new quota for the admin user and save it. The page breaks and is no longer usable.

To confirm the PR fixes the problem, pull the branch, and go to the Quota page. It should now be fixed.