### PR TITLE
GFF3 loader validation 

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -317,7 +317,8 @@ class GFF3Importer extends ChadoImporterBase {
     $form['landmark_type'] = [
       '#title' => t('Default Landmark Type'),
       '#type' => 'textfield',
-      '#description' => t("Optional. Use this field to specify a Sequence Ontology type
+      '#required' => TRUE,
+      '#description' => t("Use this field to specify a Sequence Ontology type
        for the default landmark sequences in the GFF fie (e.g. 'chromosome'). This is only needed if
        the landmark features (first column of the GFF3 file) are not already in the database."),
       '#autocomplete_route_name' => 'tripal_chado.cvterm_autocomplete',


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1741 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

When loading a GFF3 file with the Tripal GFF3 loader, if you do not specify the landmark CV term then you get a validation error that says the following:

```
Error message
The Sequence Ontology (SO) term selected for the landmark type is not available in the database. Please check the spelling or select another
Because not all GFF3 files specify properly the sequence type for the landmarks to prevent mistakes in loading we should fix this problem by just requiring it. @laceysanderson agrees.
```
This simply fixes the problem by making the landmark form field required.  


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Pull the PR and try to load a GFF3 file without specifying the landmark... it won't let you. bwahahaha
