### PR TITLE
Update or add most remaining linking fields from issue #1381

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -280,6 +280,10 @@ tripal.tripalfield_collection.*:
                      type: string
                      label: "Term Accession"
                      nullable: false
+                   token_string:
+                     type: string
+                     label: "Token string for field display"
+                     nullable: false
                    fixed_value:
                      type: string
                      label: "A fixed value for the field that cannot be changed."

--- a/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
@@ -33,4 +33,18 @@ class TripalIntegerTypeWidget extends TripalWidgetBase {
     ];
     return $element;
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values. We can't pass an empty string when an integer is expected.
+    foreach ($values as $val_key => $value) {
+      if ($value['value'] == '') {
+        unset($values[$val_key]);
+      }
+    }
+    return $values;
+  }
 }

--- a/tripal/src/Services/TripalEntityTypeCollection.php
+++ b/tripal/src/Services/TripalEntityTypeCollection.php
@@ -101,16 +101,18 @@ class TripalEntityTypeCollection implements ContainerInjectionInterface  {
 
         // Iterate through each of the content types in the config.
         $content_types = $config->get('content_types');
-        foreach ($content_types as $content_type) {
+        if ($content_types) {
+          foreach ($content_types as $content_type) {
 
-          // Replace the term ID with a term object
-          list($termIdSpace, $termAccession) = explode(':', $content_type['term']);
-          $idspace = $this->idSpaceManager->loadCollection($termIdSpace);
-          $term =  $idspace->getTerm($termAccession);
-          $content_type['term'] = $term;
+            // Replace the term ID with a term object
+            list($termIdSpace, $termAccession) = explode(':', $content_type['term']);
+            $idspace = $this->idSpaceManager->loadCollection($termIdSpace);
+            $term =  $idspace->getTerm($termAccession);
+            $content_type['term'] = $term;
 
-          // Add the content type
-          $content_type = $this->createContentType($content_type);
+            // Add the content type
+            $content_type = $this->createContentType($content_type);
+          }
         }
       }
       else {

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -266,7 +266,8 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     // Make sure the term exists.
     $idSpace = $this->idSpaceManager->loadCollection($field_def['settings']['termIdSpace']);
     if (!$idSpace) {
-      $this->logger->error('The term Id Space is not known. Check the "termIdSpace" element.');
+      $this->logger->error(t('The term Id Space "@idspace" is not known. Check the "termIdSpace" element.',
+                             ['@idspace' => $field_def['settings']['termIdSpace']]));
       return FALSE;
     }
     $term = $idSpace->getTerm($field_def['settings']['termAccession']);

--- a/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
+++ b/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
@@ -634,6 +634,8 @@ vocabularies:
         terms:
             -   id: 'NCBITaxon:common_name'
                 name: 'common name'
+            -   id: 'NCBITaxon:scientific_name'
+                name: 'scientific name'
 
 
     -   name: 'rdfs'

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -58,8 +58,8 @@ content_types:
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
         id: pub
-        title_format: "[publication_title]"
-        url_format: "pub/[TripalEntity__entity_id]"
+        title_format: "[pub_title]"
+        url_format: "publication/[TripalEntity__entity_id]"
         synonyms:
             - bio_data_6
 

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -58,8 +58,8 @@ content_types:
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
         id: pub
-        title_format: "[pub_title]"
-        url_format: "publication/[TripalEntity__entity_id]"
+        title_format: "[publication_title]"
+        url_format: "pub/[TripalEntity__entity_id]"
         synonyms:
             - bio_data_6
 

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -58,7 +58,7 @@ content_types:
         help_text: Use the publication page for books, journal articles, or other citable work.
         category: General
         id: pub
-        title_format: "[publication_title]"
+        title_format: "[pub_title]"
         url_format: "pub/[TripalEntity__entity_id]"
         synonyms:
             - bio_data_6

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
@@ -1,6 +1,6 @@
 id: 'genomic_chado'
 label: 'Genomic Content Types (Chado)'
-description: 'Content types based on Chado focused on supporting genomic data such as genome assembelies and genes.'
+description: 'Content types based on Chado focused on supporting genomic data such as genome assemblies and genes.'
 content_types:
 
     -   label: Gene

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
@@ -1,6 +1,6 @@
 id: 'germplasm_chado'
 label: 'Germplasm Content Types (Chado)'
-description: 'Content types based on Chado focused on supporting germplasm chatacterization.'
+description: 'Content types based on Chado focused on supporting germplasm characterization.'
 content_types:
 
     -   label: Germplasm Accession

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -5,7 +5,7 @@ fields:
 
 ## Biological Sample ##
 
-    -   name: biomaterial_name
+    -   name: biosample_name
         content_type: biosample
         label: Name
         type: chado_text_type_default
@@ -31,7 +31,7 @@ fields:
               region: content
               weight: 10
 
-    -   name: biomaterial_description
+    -   name: biosample_description
         content_type: biosample
         label: Description
         type: chado_text_type_default
@@ -57,7 +57,7 @@ fields:
               region: content
               weight: 15
 
-    -   name: biomaterial_biosourceprovider
+    -   name: biosample_biosourceprovider
         content_type: biosample
         label: Biosource Provider
         type: chado_contact_type_default
@@ -83,7 +83,7 @@ fields:
               region: content
               weight: 20
 
-    -   name: biomaterial_organism
+    -   name: biosample_organism
         content_type: biosample
         label: Organism
         type: chado_organism_type_default
@@ -109,7 +109,7 @@ fields:
               region: content
               weight: 25
 
-    -   name: biomaterial_dbxref
+    -   name: biosample_dbxref
         content_type: biosample
         label: Primary Database Reference
         type: chado_dbxref_type_default
@@ -135,7 +135,7 @@ fields:
               region: content
               weight: 68
 
-    -   name: biomaterial_dbxref_ann
+    -   name: biosample_dbxref_ann
         content_type: biosample
         label: Database Reference Annotations
         type: chado_dbxref_type_default

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -533,7 +533,7 @@ fields:
           form:
             default:
               region: content
-              weight: 15
+              weight: 10
 
     -   name: array_design_description
         content_type: array_design

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -57,7 +57,59 @@ fields:
               region: content
               weight: 15
 
-    -   name: biosample_dbxref
+    -   name: biosample_biosourceprovider
+        content_type: biosample
+        label: Biosource Provider
+        type: chado_contact_type_default
+        description: An entity (e.g. individual or organization) through whom a person can gain access to information, favors, influential people, and the like.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: biomaterial
+                base_column: biosourceprovider_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C48036
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 20
+          form:
+            default:
+              region: content
+              weight: 20
+
+    -   name: biosample_organism
+        content_type: biosample
+        label: Organism
+        type: chado_organism_type_default
+        description: A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: biomaterial
+                base_column: taxon_id
+        settings:
+            termIdSpace: OBI
+            termAccession: "0100026"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 25
+          form:
+            default:
+              region: content
+              weight: 25
+
+    -   name: biomaterial_dbxref
         content_type: biosample
         label: Primary Database Reference
         type: chado_dbxref_type_default
@@ -126,7 +178,7 @@ fields:
                 base_column: arrayidentifier
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -184,11 +236,11 @@ fields:
             default:
               region: content
               label: above
-              weight: 20
+              weight: 10
           form:
             default:
               region: content
-              weight: 20
+              weight: 10
 
     -   name: assay_description
         content_type: assay
@@ -210,11 +262,224 @@ fields:
             default:
               region: content
               label: above
+              weight: 15
+          form:
+            default:
+              region: content
+              weight: 15
+
+    -   name: assay_array_design
+        content_type: assay
+        label: Array Design
+        type: chado_array_design_type_default
+        description: An instrument design which describes the design of the array.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                base_column: arraydesign_id
+        settings:
+            termIdSpace: EFO
+            termAccession: "0000269"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 20
+          form:
+            default:
+              region: content
+              weight: 20
+
+    -   name: assay_protocol
+        content_type: assay
+        label: Protocol
+        type: chado_protocol_type_default
+        description: The protocol followed to generate this resource.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                base_column: protocol_id
+        settings:
+            termIdSpace: data
+            termAccession: "1047"
+        display:
+          view:
+            default:
+              region: hidden
+              label: above
               weight: 25
           form:
             default:
               region: content
               weight: 25
+
+    -   name: assay_study
+        content_type: assay
+        label: Study
+        type: chado_study_type_default
+        description: A study is a process that realizes the steps of a study design.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                linker_table: study_assay
+                linker_fkey_column: study_id
+        settings:
+            termIdSpace: SIO
+            termAccession: "001066"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
+
+# placeholder for assaydate
+
+    -   name: assay_arrayidentifier
+        content_type: assay
+        label: Array Identifier
+        type: chado_text_type_default
+        description: A text token, number or something else which identifies an entity, but which may not be persistent (stable) or unique (the same identifier may identify multiple things).
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                base_column: arrayidentifier
+        settings:
+            termIdSpace: data
+            termAccession: "0842"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 35
+          form:
+            default:
+              region: content
+              weight: 35
+
+    -   name: assay_arraybatchidentifier
+        content_type: assay
+        label: Array Batch Identifier
+        type: chado_text_type_default
+        description: A unique identifier for an array batch.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                base_column: arraybatchidentifier
+        settings:
+            termIdSpace: local
+            termAccession: array_batch_identifier
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 40
+          form:
+            default:
+              region: content
+              weight: 40
+
+    -   name: assay_operator
+        content_type: assay
+        label: Operator
+        type: chado_contact_type_default
+        description: A person that operates some apparatus or machine
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                base_column: operator_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C48036
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 45
+          form:
+            default:
+              region: content
+              weight: 45
+
+    -   name: assay_biomaterial
+        content_type: assay
+        label: Biosample
+        type: chado_biomaterial_type_default
+        description: A biological sample used in this assay
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                linker_table: assay_biomaterial
+                linker_fkey_column: biomaterial_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C70699
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 55
+          form:
+            default:
+              region: content
+              weight: 55
+
+    -   name: assay_project
+        content_type: assay
+        label: Project
+        type: chado_project_type_default
+        description: The project which this assay is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: assay
+                linker_table: assay_project
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 60
+          form:
+            default:
+              region: content
+              weight: 60
 
     -   name: assay_dbxref
         content_type: assay
@@ -244,33 +509,6 @@ fields:
 
 ## Array Design ##
 
-    -   name: array_design_manufacturer
-        content_type: array_design
-        label: Manufacturer
-        type: chado_contact_type_default
-        description: A manufacturer's contact details
-        cardinality: 1
-        required: true
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: arraydesign
-                linker_table: arraydesign
-                linker_fkey_column: manufacturer_id
-        settings:
-            termIdSpace: NCIT
-            termAccession: C47954
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 10
-          form:
-            default:
-              region: content
-              weight: 10
-
     -   name: array_design_name
         content_type: array_design
         label: Name
@@ -291,37 +529,11 @@ fields:
             default:
               region: content
               label: above
-              weight: 15
+              weight: 10
           form:
             default:
               region: content
               weight: 15
-
-    -   name: array_design_version_num
-        content_type: array_design
-        label: Array Version
-        type: chado_text_type_default
-        description: A version number is an information content entity which is a sequence of characters borne by part of each of a class of manufactured products or its packaging and indicates its order within a set of other products having the same name.
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: arraydesign
-                base_column: version
-        settings:
-            termIdSpace: IAO
-            termAccession: 0000129
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 20
-          form:
-            default:
-              region: content
-              weight: 20
 
     -   name: array_design_description
         content_type: array_design
@@ -343,11 +555,144 @@ fields:
             default:
               region: content
               label: above
+              weight: 15
+          form:
+            default:
+              region: content
+              weight: 15
+
+    -   name: array_design_manufacturer
+        content_type: array_design
+        label: Manufacturer
+        type: chado_contact_type_default
+        description: A manufacturer's contact details
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                linker_table: arraydesign
+                linker_fkey_column: manufacturer_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47954
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 20
+          form:
+            default:
+              region: content
+              weight: 20
+
+    -   name: array_design_platform_type
+        content_type: array_design
+        label: Platform Type
+        type: chado_additional_type_type_default
+        description: The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                type_table: arraydesign
+                type_column: platformtype_id
+        settings:
+            termIdSpace: EFO
+            termAccession: "0000269"
+        display:
+          view:
+            default:
+              region: content
+              label: above
               weight: 25
           form:
             default:
               region: content
               weight: 25
+
+    -   name: array_design_substrate_type
+        content_type: array_design
+        label: Substrate Type
+        type: chado_additional_type_type_default
+        description: Controlled terms for descriptors of types of array substrates.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                type_table: arraydesign
+                type_column: substratetype_id
+        settings:
+            termIdSpace: EFO
+            termAccession: "0000269"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
+
+    -   name: array_design_protocol
+        content_type: array_design
+        label: Protocol
+        type: chado_protocol_type_default
+        description: The protocol followed to generate this resource.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: protocol_id
+        settings:
+            termIdSpace: data
+            termAccession: "1047"
+        display:
+          view:
+            default:
+              region: hidden
+              label: above
+              weight: 35
+          form:
+            default:
+              region: content
+              weight: 35
+
+    -   name: array_design_version_num
+        content_type: array_design
+        label: Array Version
+        type: chado_text_type_default
+        description: A version number is an information content entity which is a sequence of characters borne by part of each of a class of manufactured products or its packaging and indicates its order within a set of other products having the same name.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: version
+        settings:
+            termIdSpace: IAO
+            termAccession: "0000129"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 45
+          form:
+            default:
+              region: content
+              weight: 45
 
     -   name: array_design_dimensions
         content_type: array_design
@@ -369,11 +714,11 @@ fields:
             default:
               region: content
               label: above
-              weight: 30
+              weight: 50
           form:
             default:
               region: content
-              weight: 30
+              weight: 50
 
     -   name: array_design_element_dims
         content_type: array_design
@@ -395,65 +740,193 @@ fields:
             default:
               region: content
               label: above
-              weight: 35
+              weight: 51
           form:
             default:
               region: content
-              weight: 35
+              weight: 51
 
-    -   name: array_design_substrate_type
+    -   name: array_design_num_of_elements
         content_type: array_design
-        label: Substrate Type
-        type: chado_additional_type_type_default
-        description: Controlled terms for descriptors of types of array substrates.
+        label: Num Of Elements
+        type: chado_integer_type_default
+        description: The number of elements.
         cardinality: 1
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: arraydesign
-                type_table: arraydesign
-                type_column: substratetype_id
+                base_column: num_of_elements
         settings:
-            termIdSpace: EFO
-            termAccession: 0000269
+            termIdSpace: local
+            termAccession: num_of_elements
         display:
           view:
             default:
               region: content
               label: above
-              weight: 40
+              weight: 52
           form:
             default:
               region: content
-              weight: 40
+              weight: 52
 
-    -   name: array_design_platform_type
+    -   name: array_design_num_array_columns
         content_type: array_design
-        label: Platform Type
-        type: chado_additional_type_type_default
-        description: The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.
+        label: Num Array Columns
+        type: chado_integer_type_default
+        description: The number of columns in an array.
         cardinality: 1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: arraydesign
-                type_table: arraydesign
-                type_column: platformtype_id
+                base_column: num_array_columns
         settings:
-            termIdSpace: EFO
-            termAccession: 0000269
+            termIdSpace: local
+            termAccession: num_array_columns
         display:
           view:
             default:
               region: content
               label: above
-              weight: 45
+              weight: 53
           form:
             default:
               region: content
-              weight: 45
+              weight: 53
+
+    -   name: array_design_num_array_rows
+        content_type: array_design
+        label: Num Array Rows
+        type: chado_integer_type_default
+        description: The number of rows in an array.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: num_array_rows
+        settings:
+            termIdSpace: local
+            termAccession: num_array_rows
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 54
+          form:
+            default:
+              region: content
+              weight: 54
+
+    -   name: array_design_num_grid_columns
+        content_type: array_design
+        label: Num Grid Columns
+        type: chado_integer_type_default
+        description: The number of columns in a grid.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: num_grid_columns
+        settings:
+            termIdSpace: local
+            termAccession: num_grid_columns
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 55
+          form:
+            default:
+              region: content
+              weight: 55
+
+    -   name: array_design_num_grid_rows
+        content_type: array_design
+        label: Num Grid Rows
+        type: chado_integer_type_default
+        description: The number of rows in a grid.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: num_grid_rows
+        settings:
+            termIdSpace: local
+            termAccession: num_grid_rows
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 56
+          form:
+            default:
+              region: content
+              weight: 56
+
+    -   name: array_design_num_sub_columns
+        content_type: array_design
+        label: Num Sub Columns
+        type: chado_integer_type_default
+        description: The number of sub columns.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: num_sub_columns
+        settings:
+            termIdSpace: local
+            termAccession: num_sub_columns
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 57
+          form:
+            default:
+              region: content
+              weight: 57
+
+    -   name: array_design_num_sub_rows
+        content_type: array_design
+        label: Num Sub Rows
+        type: chado_integer_type_default
+        description: The number of sub rows.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: arraydesign
+                base_column: num_sub_rows
+        settings:
+            termIdSpace: local
+            termAccession: num_sub_rows
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 58
+          form:
+            default:
+              region: content
+              weight: 58
 
     -   name: array_design_dbxref
         content_type: array_design

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -5,7 +5,7 @@ fields:
 
 ## Biological Sample ##
 
-    -   name: biosample_name
+    -   name: biomaterial_name
         content_type: biosample
         label: Name
         type: chado_text_type_default
@@ -31,7 +31,7 @@ fields:
               region: content
               weight: 10
 
-    -   name: biosample_description
+    -   name: biomaterial_description
         content_type: biosample
         label: Description
         type: chado_text_type_default
@@ -57,7 +57,7 @@ fields:
               region: content
               weight: 15
 
-    -   name: biosample_biosourceprovider
+    -   name: biomaterial_biosourceprovider
         content_type: biosample
         label: Biosource Provider
         type: chado_contact_type_default
@@ -83,7 +83,7 @@ fields:
               region: content
               weight: 20
 
-    -   name: biosample_organism
+    -   name: biomaterial_organism
         content_type: biosample
         label: Organism
         type: chado_organism_type_default
@@ -135,7 +135,7 @@ fields:
               region: content
               weight: 68
 
-    -   name: biosample_dbxref_ann
+    -   name: biomaterial_dbxref_ann
         content_type: biosample
         label: Database Reference Annotations
         type: chado_dbxref_type_default

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -68,7 +68,8 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: biomaterial
-                base_column: biosourceprovider_id
+                linker_table: biomaterial
+                linker_fkey_column: biosourceprovider_id
         settings:
             termIdSpace: NCIT
             termAccession: C48036
@@ -94,7 +95,8 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: biomaterial
-                base_column: taxon_id
+                linker_table: biomaterial
+                linker_fkey_column: taxon_id
         settings:
             termIdSpace: OBI
             termAccession: "0100026"
@@ -412,7 +414,8 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: assay
-                base_column: operator_id
+                linker_table: assay
+                linker_fkey_column: operator_id
         settings:
             termIdSpace: NCIT
             termAccession: C48036

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -11,33 +11,6 @@ fields:
 ##          feature, library, stock, biomaterial, cell_line,
 ##          featuremap_organism, phenotype_comparison, phylonode_organism
 
-    -   name: organism_abbreviation
-        content_type: organism
-        label: Abbreviation
-        type: chado_string_type_default
-        description: A shortened name (or abbreviation) for the organism (e.g. O. sativa).
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: organism
-                base_column: abbreviation
-            max_length: 255
-        settings:
-            termIdSpace: local
-            termAccession: abbreviation
-        display:
-            view:
-                default:
-                    region: content
-                    label: above
-                    weight: 25
-            form:
-                default:
-                    region: content
-                    weight: 25
-
     -   name: organism_genus
         content_type: organism
         label: Genus
@@ -59,11 +32,11 @@ fields:
                 default:
                     region: content
                     label: above
-                    weight: 5
+                    weight: 10
             form:
                 default:
                     region: content
-                    weight: 5
+                    weight: 10
 
     -   name: organism_species
         content_type: organism
@@ -86,38 +59,38 @@ fields:
                 default:
                     region: content
                     label: above
-                    weight: 10
+                    weight: 15
             form:
                 default:
                     region: content
-                    weight: 10
+                    weight: 15
 
-    -   name: organism_common_name
+    -   name: organism_infraspecific_type
         content_type: organism
-        label: Common Name
-        type: chado_string_type_default
-        description: "The common name for the organism."
+        label: Infraspecific Type
+        type: chado_additional_type_type_default
+        description: The connector type (e.g. subspecies, varietas, forma, etc.) for the infraspecific name.
         cardinality: 1
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: organism
-                base_column: common_name
-            max_length: 255
+                type_table: organism
+                type_column: type_id
         settings:
-            termIdSpace: NCBITaxon
-            termAccession: common_name
+            termIdSpace: local
+            termAccession: "infraspecific_type"
         display:
             view:
                 default:
                     region: content
                     label: above
-                    weight: 30
+                    weight: 20
             form:
                 default:
                     region: content
-                    weight: 30
+                    weight: 20
 
     -   name: organism_infraspecific_name
         content_type: organism
@@ -140,38 +113,65 @@ fields:
                 default:
                     region: content
                     label: above
-                    weight: 20
+                    weight: 25
             form:
                 default:
                     region: content
-                    weight: 20
+                    weight: 25
 
-    -   name: organism_infraspecific_type
+    -   name: organism_abbreviation
         content_type: organism
-        label: Infraspecific Type
-        type: chado_additional_type_type_default
-        description: The connector type (e.g. subspecies, varietas, forma, etc.) for the infraspecific name.
+        label: Abbreviation
+        type: chado_string_type_default
+        description: A shortened name (or abbreviation) for the organism (e.g. O. sativa).
         cardinality: 1
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: organism
-                type_table: organism
-                type_column: type_id
+                base_column: abbreviation
+            max_length: 255
         settings:
             termIdSpace: local
-            termAccession: "infraspecific_type"
+            termAccession: abbreviation
         display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 15
-          form:
-            default:
-              region: content
-              weight: 15
+            view:
+                default:
+                    region: content
+                    label: above
+                    weight: 30
+            form:
+                default:
+                    region: content
+                    weight: 30
+
+    -   name: organism_common_name
+        content_type: organism
+        label: Common Name
+        type: chado_string_type_default
+        description: "The common name for the organism."
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: organism
+                base_column: common_name
+            max_length: 255
+        settings:
+            termIdSpace: NCBITaxon
+            termAccession: common_name
+        display:
+            view:
+                default:
+                    region: content
+                    label: above
+                    weight: 35
+            form:
+                default:
+                    region: content
+                    weight: 35
 
     -   name: organism_comment
         content_type: organism
@@ -193,11 +193,38 @@ fields:
             default:
               region: content
               label: above
-              weight: 35
+              weight: 40
           form:
             default:
               region: content
-              weight: 35
+              weight: 40
+
+    -   name: organism_pub
+        content_type: organism
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: organism
+                linker_table: organism_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 45
+          form:
+            default:
+              region: content
+              weight: 45
 
     -   name: organism_dbxref
         content_type: organism
@@ -330,7 +357,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -411,7 +438,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -448,6 +475,60 @@ fields:
             default:
               region: content
               weight: 45
+
+    -   name: analysis_pub
+        content_type: analysis
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: analysis_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 50
+          form:
+            default:
+              region: content
+              weight: 50
+
+    -   name: analysis_project
+        content_type: analysis
+        label: Project
+        type: chado_project_type_default
+        description: The project which this analysis is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: project_analysis
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 60
+          form:
+            default:
+              region: content
+              weight: 60
 
     -   name: analysis_dbxref
         content_type: analysis
@@ -590,6 +671,33 @@ fields:
               region: content
               weight: 25
 
+    -   name: project_pub
+        content_type: project
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: project
+                linker_table: project_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
+
     -   name: project_dbxref
         content_type: project
         label: Database Reference Annotations
@@ -702,13 +810,13 @@ fields:
               region: content
               weight: 20
 
-    -   name: study_pub_id
+    -   name: study_pub
         content_type: study
-        label: Publication ID
-        type: chado_integer_type_default
-        description: The primary key of the publication to attach to this study. This field is a placeholder until we develop a more user friendly publication field.
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
         cardinality: 1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
@@ -720,7 +828,7 @@ fields:
         display:
           view:
             default:
-              region: hidden
+              region: content
               label: above
               weight: 15
           form:
@@ -837,11 +945,38 @@ fields:
             default:
               region: content
               label: above
-              weight: 10
+              weight: 20
           form:
             default:
               region: content
-              weight: 10
+              weight: 20
+
+    -   name: contact_project
+        content_type: contact
+        label: Project
+        type: chado_project_type_default
+        description: The project which this contact is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: contact
+                linker_table: project_contact
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 60
+          form:
+            default:
+              region: content
+              weight: 60
 
 ## Protocol ##
 ## Chado Table: protocol
@@ -941,7 +1076,7 @@ fields:
                 base_column: hardwaredescription
         settings:
             termIdSpace: EFO
-            termAccession: 0000548
+            termAccession: "0000548"
         display:
           view:
             default:
@@ -952,6 +1087,32 @@ fields:
             default:
               region: content
               weight: 25
+
+    -   name: protocol_hardware
+        content_type: protocol
+        label: Hardware
+        type: chado_text_type_default
+        description: An instrument is a device which provides a mechanical or electronic function.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: protocol
+                base_column: hardwaredescription
+        settings:
+            termIdSpace: EFO
+            termAccession: "0000548"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 29
+          form:
+            default:
+              region: content
+              weight: 29
 
     -   name: protocol_software
         content_type: protocol
@@ -1006,11 +1167,11 @@ fields:
               region: content
               weight: 10
 
-    -   name: protocol_pub_id
+    -   name: protocol_pub
         content_type: protocol
-        label: Publication ID
-        type: chado_integer_type_default
-        description: The primary key of the publication to attach to this protocol. This field is a placeholder until we develop a more user friendly publication field.
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
         cardinality: 1
         required: true
         storage_settings:
@@ -1065,61 +1226,16 @@ fields:
 ##         series_name (varchar 255), issue (varchar 255), pyear (varchar 255),
 ##         pages (varchar 255), miniref (varchar 255), is_obsolete (bool),
 ##         publisher (varchar 255), pubplace (varchar 255)
+## Related: analysis_pub, cell_line_cvterm, cell_line_feature, cell_line_library, cell_line_pub, cell_line_synonym,
+##          cell_lineprop_pub, expression_pub, feature_cvterm, feature_cvterm_pub, feature_expression, feature_pub,
+##          feature_relationship_pub, feature_relationshipprop_pub, feature_synonym, featureloc_pub, featuremap_pub,
+##          featureprop_pub, library_cvterm, library_expression, library_pub, library_relationship_pub,
+##          library_synonym, libraryprop_pub, nd_experiment_pub, organism_cvterm, organism_pub, organismprop_pub,
+##          phendesc, phenotype_comparison_cvterm, phenotype_comparison, phenstatement, phylonode_pub, phylotree_pub,
+##          project_pub, protocol, pub_dbxref, pub_relationship, pub_relationship, pubauthor, pubprop, stock_cvterm,
+##          stock_pub, stock_relationship_cvterm, stock_relationship_pub, stockprop_pub, study
 
-    -   name: publication_uniquename
-        content_type: pub
-        label: Citation
-        type: chado_text_type_default
-        description: The citation for this publication.
-        cardinality: 1
-        required: true
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: pub
-                base_column: uniquename
-        settings:
-            termIdSpace: TPUB
-            termAccession: "0000003"
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 35
-          form:
-            default:
-              region: content
-              weight: 35
-
-    -   name: publication_type
-        content_type: pub
-        label: Publication Type
-        type: chado_additional_type_type_default
-        description: the type of publication.
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: pub
-                type_table: pub
-                type_column: type_id
-        settings:
-            termIdSpace: TPUB
-            termAccession: "0000015"
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 15
-          form:
-            default:
-              region: content
-              weight: 15
-
-    -   name: publication_title
+    -   name: pub_title
         content_type: pub
         label: Title
         type: chado_text_type_default
@@ -1139,20 +1255,100 @@ fields:
             default:
               region: content
               label: above
-              weight: 35
+              weight: 10
           form:
             default:
               region: content
-              weight: 35
+              weight: 10
 
+    -   name: pub_type
+        content_type: pub
+        label: Publication Type
+        type: chado_additional_type_type_default
+        description: The type of publication, journal article, book, etc.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                type_table: pub
+                type_column: type_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000015"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 12
+          form:
+            default:
+              region: content
+              weight: 12
 
-    -   name: publication_volumetitle
+    -   name: pub_series_name
+        content_type: pub
+        label: Series Name
+        type: chado_string_type_default
+        description: The name media that produces a series of publications (e.g. journal, conference proceedings, etc.).
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: series_name
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000256"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 14
+          form:
+            default:
+              region: content
+              weight: 14
+
+    -   name: pub_volume
+        content_type: pub
+        label: Volume
+        type: chado_string_type_default
+        description: The volume of the series (e.g. journal) where the publication was printed.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: volume
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000042"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 16
+          form:
+            default:
+              region: content
+              weight: 16
+
+    -   name: pub_volumetitle
         content_type: pub
         label: Volume Title
         type: chado_text_type_default
-        description: The volume title for this publication.
+        description: The title of the volume (if applicable).
         cardinality: 1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
@@ -1166,13 +1362,620 @@ fields:
             default:
               region: content
               label: above
+              weight: 18
+          form:
+            default:
+              region: content
+              weight: 18
+
+    -   name: pub_pyear
+        content_type: pub
+        label: Publication Year
+        type: chado_string_type_default
+        description:
+        cardinality: 1
+        # in Tripal 3 this is set as required, although the pub table does not require it.
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: pyear
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000059"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 20
+          form:
+            default:
+              region: content
+              weight: 20
+
+    -   name: pub_issue
+        content_type: pub
+        label: Issue
+        type: chado_string_type_default
+        description: The issue of the series (e.g. journal) where the publication was printed.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: issue
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000043"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 22
+          form:
+            default:
+              region: content
+              weight: 22
+
+    -   name: pub_pages
+        content_type: pub
+        label: Page Numbers
+        type: chado_string_type_default
+        description:
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: pages
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000044"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 24
+          form:
+            default:
+              region: content
+              weight: 24
+
+    -   name: pub_publisher
+        content_type: pub
+        label: Publisher
+        type: chado_string_type_default
+        description:
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: publisher
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000244"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 26
+          form:
+            default:
+              region: content
+              weight: 26
+
+    -   name: pub_pubplace
+        content_type: pub
+        label: Publication Location
+        type: chado_string_type_default
+        description:
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: pubplace
+            max_length: 255
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000245"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 28
+          form:
+            default:
+              region: content
+              weight: 28
+
+# property fields, weight 30-44
+
+    -   name: pub_doi
+        content_type: pub
+        label: DOI
+        type: chado_linker_property_type_default
+        description: 'Digital Object Identifier.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000049"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
+
+    -   name: pub_journal_abbreviation
+        content_type: pub
+        label: Journal Abbreviation
+        type: chado_linker_property_type_default
+        description: 'The journal title ISO Abbreviation.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000038"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 31
+          form:
+            default:
+              region: content
+              weight: 31
+
+    -   name: pub_eissn
+        content_type: pub
+        label: EISSN
+        type: chado_linker_property_type_default
+        description: 'International Standard Serial Number (ISSN) is an eight-character value that uniquely identifies a periodicals in print or other media. There are two sub categories of ISSN: print, p-ISSN and electronic e-ISSN.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000072"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 32
+          form:
+            default:
+              region: content
+              weight: 32
+
+    -   name: pub_publication_date
+        content_type: pub
+        label: Publication Date
+        type: chado_linker_property_type_default
+        description: 'The date the work was published. This should be in the format: YYYY Mon Day, where YYYY is a 4 digit year, Mon is a 3-letter English abbreviation for the month followed by the day. The month and day are optional.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000046"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 33
+          form:
+            default:
+              region: content
+              weight: 33
+
+    -   name: pub_citation
+        content_type: pub
+        label: Citation
+        type: chado_linker_property_type_default
+        description: 'All publications must have a unique citation. Please enter the full citation for this publication. For PubMed style citations list the last name of the author followed by initials. Each author should be separated by a comma. Next comes the title, followed by the series title (e.g. journal name), publication date (4 digit year, 3 character Month, day), volume, issue and page numbers. You may also use HTML to provide a link in the citation. Below is an example:<br>Medeiros PM, Ladio AH, Santos AM, Albuquerque UP. Does the selection of medicinal plants by Brazilian local populations suffer taxonomic influence? J Ethnopharmacol. 2013 Apr 19; 146(3):842-52.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000003"
+        display:
+          view:
+            default:
+              region: content
+              label: above
               weight: 35
           form:
             default:
               region: content
               weight: 35
 
-    -   name: publication_dbxref
+    -   name: pub_issn
+        content_type: pub
+        label: ISSN
+        type: chado_linker_property_type_default
+        description: 'International Standard Serial Number (ISSN) is an eight-character value that uniquely identifies a periodicals in print or other media. There are two sub categories of ISSN: print, p-ISSN and electronic e-ISSN.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000048"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 36
+          form:
+            default:
+              region: content
+              weight: 36
+
+    -   name: pub_language_abbr
+        content_type: pub
+        label: Language Abbr
+        type: chado_linker_property_type_default
+        description: 'An abbreviation for a language (e.g. 3 letters)'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000087"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 37
+          form:
+            default:
+              region: content
+              weight: 37
+
+    -   name: pub_publication_type
+        content_type: pub
+        label: Publication Type
+        type: chado_linker_property_type_default
+        description: 
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000015"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 38
+          form:
+            default:
+              region: content
+              weight: 38
+
+    -   name: pub_publication_model
+        content_type: pub
+        label: Publication Model
+        type: chado_linker_property_type_default
+        description: 'This term is used to identify the medium/media in which the item is published. There are four possible values which are the same as used by: print, print-electronic, electronic, electronic-print. Further explanation: "print", the journal is published in print format only; "print-electronic", the journal is published in both print and electronic format; "electronic", the journal is published in electronic format only; "electronic-print", the journal is published first in electronic format followed by print.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000081"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 39
+          form:
+            default:
+              region: content
+              weight: 39
+
+    -   name: pub_authors
+        content_type: pub
+        label: Authors
+        type: chado_linker_property_type_default
+        description: 'The list of authors of the publication. For PubMed style citations list each author with the last name first, followed by initials. Each author should be separated by a comma.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000047"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 40
+          form:
+            default:
+              region: content
+              weight: 40
+
+    -   name: pub_language
+        content_type: pub
+        label: Language
+        type: chado_linker_property_type_default
+        description: 'The full name of the languge of the publication (e.g. English).'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000064"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 41
+          form:
+            default:
+              region: content
+              weight: 41
+
+    -   name: pub_elocation
+        content_type: pub
+        label: Elocation
+        type: chado_linker_property_type_default
+        description: 'Provides an electronic location for the items. This includes Digital Object Identifiers (DOI) or Publisher Item Identifiers (PII).'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000080"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 42
+          form:
+            default:
+              region: content
+              weight: 42
+
+    -   name: pub_url
+        content_type: pub
+        label: URL
+        type: chado_linker_property_type_default
+        description: 'A univeral resource locator (URL) reference where the publication can be found.  For publications found online, this would be the web address for the publication.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000052"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 42
+          form:
+            default:
+              region: content
+              weight: 42
+
+    -   name: pub_journal_country
+        content_type: pub
+        label: Journal Country
+        type: chado_linker_property_type_default
+        description: 'The country where the journal was published.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000100"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 43
+          form:
+            default:
+              region: content
+              weight: 43
+
+    -   name: pub_abstract
+        content_type: pub
+        label: Abstract
+        type: chado_linker_property_type_default
+        description: 'The fully printed abstract for the publication.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000050"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 44
+          form:
+            default:
+              region: content
+              weight: 44
+
+    -   name: pub_pii
+        content_type: pub
+        label: PII
+        type: chado_linker_property_type_default
+        description: 'Publisher Item Identifier.'
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                prop_table: pubprop
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000082"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 45
+          form:
+            default:
+              region: content
+              weight: 45
+
+    -   name: pub_miniref
+        content_type: pub
+        label: Mini Local identifier
+        type: chado_string_type_default
+        description: Some sites use small identifiers for each publication. if your site uses this please provide the proper miniref for this publication.
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: miniref
+            max_length: 255
+        settings:
+            termIdSpace: local
+            termAccession: miniref
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 50
+          form:
+            default:
+              region: content
+              weight: 50
+
+    -   name: pub_uniquename
+        content_type: pub
+        label: Unique Local Identifier
+        type: chado_text_type_default
+        description: This publication is housed in Chado which requires a unique identifer (or name) be provided for every publication. This identifier need not be shown to end-users but it is required. Each site must decide on a format for this unique name.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: uniquename
+        settings:
+            termIdSpace: data
+            termAccession: "0842"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 34
+          form:
+            default:
+              region: content
+              weight: 34
+
+    -   name: pub_dbxref
         content_type: pub
         label: Database Reference Annotations
         type: chado_dbxref_type_default
@@ -1198,3 +2001,29 @@ fields:
             default:
               region: content
               weight: 68
+
+    -   name: pub_is_obsolete
+        content_type: pub
+        label: Is Obsolete
+        type: chado_boolean_type_default
+        description:
+        cardinality: 1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -112,6 +112,33 @@ fields:
               region: content
               weight: 30
 
+    -   name: genetic_map_pub
+        content_type: genetic_map
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: featuremap
+                linker_table: featuremap_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 35
+          form:
+            default:
+              region: content
+              weight: 35
+
     -   name: genetic_map_dbxref_ann
         content_type: genetic_map
         label: Database Reference Annotations
@@ -182,7 +209,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -354,6 +381,33 @@ fields:
               region: content
               weight: 80
 
+    -   name: qtl_pub
+        content_type: QTL
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
     -   name: qtl_is_analysis
         content_type: QTL
         label: Is Analysis
@@ -369,7 +423,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
         display:
           view:
             default:
@@ -396,7 +449,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -488,7 +540,7 @@ fields:
               region: content
               weight: 68
 
-## Sequence Variant ##
+#### Sequence Variant ##
 
     -   name: sequence_variant_name
         content_type: sequence_variant
@@ -531,7 +583,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -702,6 +754,33 @@ fields:
               region: content
               weight: 80
 
+    -   name: sequence_variant_pub
+        content_type: sequence_variant
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
     -   name: sequence_variant_is_analysis
         content_type: sequence_variant
         label: Is Analysis
@@ -717,7 +796,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
         display:
           view:
             default:
@@ -744,7 +822,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -879,7 +956,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -1050,6 +1127,33 @@ fields:
               region: content
               weight: 80
 
+    -   name: genetic_marker_pub
+        content_type: genetic_marker
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
     -   name: genetic_marker_is_analysis
         content_type: genetic_marker
         label: Is Analysis
@@ -1065,7 +1169,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
         display:
           view:
             default:
@@ -1092,7 +1195,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -1227,7 +1329,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -1398,6 +1500,33 @@ fields:
               region: content
               weight: 80
 
+    -   name: phenotypic_marker_pub
+        content_type: phenotypic_marker
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
     -   name: phenotypic_marker_is_analysis
         content_type: phenotypic_marker
         label: Is Analysis
@@ -1413,7 +1542,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_analysis
-            fixed_value: local:is_analysis
         display:
           view:
             default:
@@ -1440,7 +1568,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -1531,3 +1658,34 @@ fields:
             default:
               region: content
               weight: 68
+
+### Additional genetic fields to add to core content types ###
+
+## Publication ##
+
+    -   name: publication_featuremap
+        content_type: pub
+        label: Map
+        type: chado_featuremap_type_default
+        description: One or more genetic or physical maps mentioned in this publication
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: pub
+                linker_table: featuremap_pub
+                linker_fkey_column: featuremap_id
+        settings:
+            termIdSpace: data
+            termAccession: "1274"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 83
+          form:
+            default:
+              region: content
+              weight: 83

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -46,7 +46,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -216,6 +216,60 @@ fields:
             default:
               region: content
               weight: 80
+
+    -   name: gene_pub
+        content_type: gene
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 82
+          form:
+            default:
+              region: content
+              weight: 82
+
+    -   name: gene_project
+        content_type: gene
+        label: Project
+        type: chado_project_type_default
+        description: The project which this gene is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: project_feature
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 84
+          form:
+            default:
+              region: content
+              weight: 84
 
     -   name: gene_is_analysis
         content_type: gene
@@ -394,7 +448,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -564,6 +618,60 @@ fields:
             default:
               region: content
               weight: 80
+
+    -   name: mrna_pub
+        content_type: mrna
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: feature_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 82
+          form:
+            default:
+              region: content
+              weight: 82
+
+    -   name: mrna_project
+        content_type: mrna
+        label: Project
+        type: chado_project_type_default
+        description: The project which this mRNA is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: feature
+                linker_table: project_feature
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 84
+          form:
+            default:
+              region: content
+              weight: 84
 
     -   name: mrna_is_analysis
         content_type: mrna
@@ -943,6 +1051,33 @@ fields:
               region: content
               weight: 30
 
+    -   name: physical_map_pub
+        content_type: physical_map
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: featuremap
+                linker_table: featuremap_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
     -   name: physical_map_dbxref_ann
         content_type: physical_map
         label: Database Reference Annotations
@@ -1013,7 +1148,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -1160,6 +1295,59 @@ fields:
               region: content
               weight: 68
 
+    -   name: dna_library_pub
+        content_type: dna_library
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: library
+                linker_table: library_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85
+
+    -   name: library_is_obsolete
+        content_type: dna_library
+        label: Is Obsolete
+        type: chado_integer_type_default
+        description: Indicates if this record is obsolete.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: library
+                base_column: is_obsolete
+        settings:
+            termIdSpace: local
+            termAccession: is_obsolete
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 90
+          form:
+            default:
+              region: content
+              weight: 90
+
 ## Genome Assembly ##
 
     -   name: genome_assembly_name
@@ -1257,7 +1445,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -1312,7 +1500,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -1404,6 +1592,60 @@ fields:
             default:
               region: content
               weight: 68
+
+    -   name: genome_assembly_pub
+        content_type: genome_assembly
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: analysis_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 82
+          form:
+            default:
+              region: content
+              weight: 82
+
+    -   name: genome_assembly_project
+        content_type: genome_assembly
+        label: Project
+        type: chado_project_type_default
+        description: The project which this genome assembly is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: project_analysis
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 84
+          form:
+            default:
+              region: content
+              weight: 84
 
 ## Genome Annotation ##
 
@@ -1502,7 +1744,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -1556,7 +1798,7 @@ fields:
             max_length: 255
         settings:
             termIdSpace: IAO
-            termAccession: 0000129
+            termAccession: "0000129"
         display:
           view:
             default:
@@ -1648,6 +1890,60 @@ fields:
             default:
               region: content
               weight: 68
+
+    -   name: genome_annotation_pub
+        content_type: genome_annotation
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: analysis_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 82
+          form:
+            default:
+              region: content
+              weight: 82
+
+    -   name: genome_annotation_project
+        content_type: genome_annotation
+        label: Project
+        type: chado_project_type_default
+        description: The project which this genome annotation is a part of
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: analysis
+                linker_table: project_analysis
+                linker_fkey_column: project_id
+        settings:
+            termIdSpace: NCIT
+            termAccession: C47885
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 84
+          form:
+            default:
+              region: content
+              weight: 84
 
 ## Genome Project ##
 
@@ -1758,3 +2054,30 @@ fields:
             default:
               region: content
               weight: 68
+
+    -   name: genome_project_pub
+        content_type: genome_project
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: project
+                linker_table: project_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 85
+          form:
+            default:
+              region: content
+              weight: 85

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -922,7 +922,7 @@ fields:
         type: chado_dbxref_type_default
         description: The ID where this record may be available in an external online database.
         cardinality: 1
-        required: false
+        required: true
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
@@ -46,7 +46,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -132,11 +132,38 @@ fields:
             default:
               region: content
               label: above
-              weight: 10
+              weight: 25
           form:
             default:
               region: content
-              weight: 10
+              weight: 25
+
+    -   name: germplasm_pub
+        content_type: germplasm
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                linker_table: stock_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
 
     -   name: germplasm_dbxref
         content_type: germplasm
@@ -206,7 +233,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -261,7 +287,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -347,11 +373,38 @@ fields:
             default:
               region: content
               label: above
-              weight: 10
+              weight: 25
           form:
             default:
               region: content
-              weight: 10
+              weight: 25
+
+    -   name: breeding_cross_pub
+        content_type: breeding_cross
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                linker_table: stock_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
 
     -   name: breeding_cross_dbxref
         content_type: breeding_cross
@@ -421,7 +474,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -476,7 +528,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -555,18 +607,45 @@ fields:
                 type_column: type_id
         settings:
             termIdSpace: CO_010
-            termAccession: 0000029
-            fixed_value: CO_010:0000029
+            termAccession: "0000029"
+            fixed_value: "CO_010:0000029"
         display:
           view:
             default:
               region: content
               label: above
-              weight: 10
+              weight: 25
           form:
             default:
               region: content
-              weight: 10
+              weight: 25
+
+    -   name: germplasm_variety_pub
+        content_type: germplasm_variety
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                linker_table: stock_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
 
     -   name: germplasm_variety_dbxref
         content_type: germplasm_variety
@@ -636,7 +715,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:
@@ -691,7 +769,7 @@ fields:
                 base_column: uniquename
         settings:
             termIdSpace: data
-            termAccession: 0842
+            termAccession: "0842"
         display:
           view:
             default:
@@ -777,11 +855,38 @@ fields:
             default:
               region: content
               label: above
-              weight: 10
+              weight: 25
           form:
             default:
               region: content
-              weight: 10
+              weight: 25
+
+    -   name: ril_pub
+        content_type: ril
+        label: Publication
+        type: chado_pub_type_default
+        description: Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record.
+        cardinality: -1
+        required: false
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: stock
+                linker_table: stock_pub
+                linker_fkey_column: pub_id
+        settings:
+            termIdSpace: TPUB
+            termAccession: "0000002"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 30
+          form:
+            default:
+              region: content
+              weight: 30
 
     -   name: ril_dbxref
         content_type: ril
@@ -851,7 +956,6 @@ fields:
         settings:
             termIdSpace: local
             termAccession: is_obsolete
-            fixed_value: local:is_obsolete
         display:
           view:
             default:

--- a/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
+++ b/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
@@ -2618,6 +2618,9 @@ tables:
 
     -   name: 'stock_pub'
         columns:
+            -   name: 'stock_id'
+                term_id: 'NCIT:C70699'
+                term_name: 'Biospecimen'
             -   name: 'pub_id'
                 term_id: 'schema:publication'
                 term_name: 'publication'

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoArrayDesignFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoArrayDesignFormatterDefault.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal array_design formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_array_design_formatter_default",
+ *   label = @Translation("Chado array_design formatter"),
+ *   description = @Translation("A chado array_design formatter"),
+ *   field_types = {
+ *     "chado_array_design_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[version]",
+ *     "[manufacturer]",
+ *     "[platform]",
+ *     "[substrate]",
+ *     "[protocol]",
+ *     "[db]",
+ *     "[accession]",
+ *     "[array_dimensions]",
+ *     "[element_dimensions]",
+ *     "[n_elements]",
+ *     "[n_array_columns]",
+ *     "[n_array_rows]",
+ *     "[n_grid_columns]",
+ *     "[n_grid_rows]",
+ *     "[n_sub_columns]",
+ *     "[n_sub_rows]",
+ *   },
+ * )
+ */
+class ChadoArrayDesignFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('array_design_name')->getString(),
+        'description' => $item->get('array_design_description')->getString(),
+        'version' => $item->get('array_design_version')->getString(),
+        'manufacturer' => $item->get('array_design_manufacturer')->getString(),
+        'platform' => $item->get('array_design_platformtype')->getString(),
+        'substrate' => $item->get('array_design_substratetype')->getString(),
+        'protocol' => $item->get('array_design_protocol')->getString(),
+        'db' => $item->get('array_design_database_name')->getString(),
+        'accession' => $item->get('array_design_database_accession')->getString(),
+        'array_dimensions' => $item->get('array_design_array_dimensions')->getString(),
+        'element_dimensions' => $item->get('array_design_element_dimensions')->getString(),
+        'n_elements' => $item->get('array_design_num_of_elements')->getString(),
+        'n_array_columns' => $item->get('array_design_num_array_columns')->getString(),
+        'n_array_rows' => $item->get('array_design_num_array_rows')->getString(),
+        'n_grid_columns' => $item->get('array_design_num_grid_columns')->getString(),
+        'n_grid_rows' => $item->get('array_design_num_grid_rows')->getString(),
+        'n_sub_columns' => $item->get('array_design_num_sub_columns')->getString(),
+        'n_sub_rows' => $item->get('array_design_num_sub_rows')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAssayFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAssayFormatterDefault.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal assay formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_assay_formatter_default",
+ *   label = @Translation("Chado assay formatter"),
+ *   description = @Translation("A chado assay formatter"),
+ *   field_types = {
+ *     "chado_assay_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[arraydesign]",
+ *     "[arrayidentifier]",
+ *     "[arraybatchidentifier]",
+ *     "[protocol]",
+ *     "[operator]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *   },
+ * )
+ */
+class ChadoAssayFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('assay_name')->getString(),
+        'description' => $item->get('assay_description')->getString(),
+        'arraydesign' => $item->get('assay_arraydesign')->getString(),
+        'arrayidentifier' => $item->get('assay_arrayidentifier')->getString(),
+        'arraybatchidentifier' => $item->get('assay_arraybatchidentifier')->getString(),
+        'protocol' => $item->get('assay_protocol')->getString(),
+        'operator' => $item->get('assay_operator')->getString(),
+        'database_name' => $item->get('assay_database_name')->getString(),
+        'database_accession' => $item->get('assay_database_accession')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBiomaterialFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBiomaterialFormatterDefault.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal biomaterial formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_biomaterial_formatter_default",
+ *   label = @Translation("Chado biomaterial formatter"),
+ *   description = @Translation("A chado biomaterial formatter"),
+ *   field_types = {
+ *     "chado_biomaterial_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[biosourceprovider]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *     "[genus]",
+ *     "[species]",
+ *     "[infratype]",
+ *     "[infratype_abbrev]",
+ *     "[infraname]",
+ *     "[abbreviation]",
+ *     "[common_name]",
+ *   },
+ * )
+ */
+class ChadoBiomaterialFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('biomaterial_name')->getString(),
+        'description' => $item->get('biomaterial_description')->getString(),
+        'biosourceprovider' => $item->get('biomaterial_biosourceprovider')->getString(),
+        'database_name' => $item->get('biomaterial_database_name')->getString(),
+        'database_accession' => $item->get('biomaterial_database_accession')->getString(),
+        'genus' => $item->get('biomaterial_genus')->getString(),
+        'species' => $item->get('biomaterial_species')->getString(),
+        'infratype' => $item->get('biomaterial_infraspecific_type')->getString(),
+        'infraname' => $item->get('biomaterial_infraspecific_name')->getString(),
+        'abbreviation' => $item->get('biomaterial_abbreviation')->getString(),
+        'common_name' => $item->get('biomaterial_common_name')->getString(),
+      ];
+
+      // Special case handling for abbreviation of infraspecific type
+      $values['infratype_abbrev'] = chado_abbreviate_infraspecific_rank($values['infratype']);
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureFormatterDefault.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal feature formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_feature_formatter_default",
+ *   label = @Translation("Chado feature formatter"),
+ *   description = @Translation("A chado feature formatter"),
+ *   field_types = {
+ *     "chado_feature_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[uniquename]",
+ *     "[type]",
+ *     "[seqlen]",
+ *     "[md5checksum]",
+ *     "[is_analysis]",
+ *     "[is_obsolete]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *     "[genus]",
+ *     "[species]",
+ *     "[infratype]",
+ *     "[infratype_abbrev]",
+ *     "[infraname]",
+ *     "[abbreviation]",
+ *     "[common_name]",
+ *   },
+ * )
+ */
+class ChadoFeatureFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('feature_name')->getString(),
+        'uniquename' => $item->get('feature_uniquename')->getString(),
+        'type' => $item->get('feature_type')->getString(),
+        'seqlen' => $item->get('feature_seqlen')->getString(),
+        'md5checksum' => $item->get('feature_md5checksum')->getString(),
+        'is_analysis' => $item->get('feature_is_analysis')->getString(),
+        'is_obsolete' => $item->get('feature_is_obsolete')->getString(),
+        'database_name' => $item->get('feature_database_name')->getString(),
+        'database_accession' => $item->get('feature_database_accession')->getString(),
+        'genus' => $item->get('feature_genus')->getString(),
+        'species' => $item->get('feature_species')->getString(),
+        'infratype' => $item->get('feature_infraspecific_type')->getString(),
+        'infraname' => $item->get('feature_infraspecific_name')->getString(),
+        'abbreviation' => $item->get('feature_abbreviation')->getString(),
+        'common_name' => $item->get('feature_common_name')->getString(),
+        // residues is not implemented in this field since it can be millions of characters long
+        // timeaccessioned, timelastmodified not implemented
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureMapFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureMapFormatterDefault.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal featuremap formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_featuremap_formatter_default",
+ *   label = @Translation("Chado featuremap formatter"),
+ *   description = @Translation("A chado featuremap formatter"),
+ *   field_types = {
+ *     "chado_featuremap_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[units]",
+ *   },
+ * )
+ */
+class ChadoFeatureMapFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('featuremap_name')->getString(),
+        'description' => $item->get('featuremap_description')->getString(),
+        'units' => $item->get('featuremap_unittype')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoLinkerPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoLinkerPropertyFormatterDefault.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**
@@ -32,32 +34,30 @@ class ChadoLinkerPropertyFormatterDefault extends ChadoFormatterBase {
     foreach($items as $delta => $item) {
       $value = $item->get('value')->getString();
       // any URLs are made into clickable links
-      if (preg_match('/^https?:/i', $value) ) {
-        $value = Link::fromTextAndUrl($value, $value);
+      if (UrlHelper::isExternal($value)) {
+        $value = Link::fromTextAndUrl($value, Url::fromUri($value))->toString();
       }
-      $list[$delta] = $value;
+      $list[$delta] = [
+        '#markup' => $value,
+      ];
     }
 
-    // Also need to make sure to not return markup if the field is empty.
-    if (empty($list)) {
-      return $elements;
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
     }
 
-    // If more than one value has been found display all values in an unordered
-    // list.
-    if (count($list) > 1) {
+    // If more than one value has been found, display all values in an
+    // unordered list.
+    elseif (count($list) > 1) {
       $elements[0] = [
         '#theme' => 'item_list',
         '#list_type' => 'ul',
         '#items' => $list,
         '#wrapper_attributes' => ['class' => 'container'],
       ];
-      return $elements;
     }
 
-    $elements[0] = [
-      "#markup" => $list[0]
-    ];
     return $elements;
   }
 }

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoOrganismFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoOrganismFormatterDefault.php
@@ -48,24 +48,20 @@ class ChadoOrganismFormatterDefault extends ChadoFormatterBase {
     $list = [];
     $token_string = $this->getSetting('token_string');
 
-    // Implement the shortcut token "[scientific_name]". Rather than the overhead
-    // of the chado_get_organism_scientific_name() api call, replicate its behavior
-    // with an equivalent token string.
-    $token_string = preg_replace('/\[scientific_name\]/', $token_string,
-        '[genus] [species] [infratype_abbrev] [infraname]');
-
     foreach ($items as $delta => $item) {
       $values = [
         'genus' => $item->get('organism_genus')->getString(),
         'species' => $item->get('organism_species')->getString(),
         'infratype' => $item->get('organism_infraspecific_type')->getString(),
         'infraname' => $item->get('organism_infraspecific_name')->getString(),
+        'scientific_name' => $item->get('organism_scientific_name')->getString(),
         'abbreviation' => $item->get('organism_abbreviation')->getString(),
         'common_name' => $item->get('organism_common_name')->getString(),
         'comment' => $item->get('organism_comment')->getString(),
       ];
 
       // Special case handling of abbreviations for genus and infraspecific type
+      // These are not available to web services!
       $values['genus_abbrev'] = substr($values['genus'], 0, 1) . '.';
       $values['infratype_abbrev'] = chado_abbreviate_infraspecific_rank($values['infratype']);
 

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoOrganismFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoOrganismFormatterDefault.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**
@@ -12,11 +10,23 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
  *
  * @FieldFormatter(
  *   id = "chado_organism_formatter_default",
- *   label = @Translation("Chado Organism Reference Formatter"),
- *   description = @Translation("A chado organism reference formatter"),
+ *   label = @Translation("Chado organism formatter"),
+ *   description = @Translation("A chado organism formatter"),
  *   field_types = {
  *     "chado_organism_type_default"
- *   }
+ *   },
+ *   valid_tokens = {
+ *     "[genus]",
+ *     "[genus_abbrev]",
+ *     "[species]",
+ *     "[infratype]",
+ *     "[infratype_abbrev]",
+ *     "[infraname]",
+ *     "[scientific_name]",
+ *     "[abbreviation]",
+ *     "[common_name]",
+ *     "[comment]",
+ *   },
  * )
  */
 class ChadoOrganismFormatterDefault extends ChadoFormatterBase {
@@ -24,15 +34,69 @@ class ChadoOrganismFormatterDefault extends ChadoFormatterBase {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '<i>[genus] [species]</i> [infratype_abbrev] <i>[infraname]</i>';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
 
-    foreach($items as $delta => $item) {
-      $elements[$delta] = [
-        "#markup" => $item->get('label')->getString()
+    // Implement the shortcut token "[scientific_name]". Rather than the overhead
+    // of the chado_get_organism_scientific_name() api call, replicate its behavior
+    // with an equivalent token string.
+    $token_string = preg_replace('/\[scientific_name\]/', $token_string,
+        '[genus] [species] [infratype_abbrev] [infraname]');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'genus' => $item->get('organism_genus')->getString(),
+        'species' => $item->get('organism_species')->getString(),
+        'infratype' => $item->get('organism_infraspecific_type')->getString(),
+        'infraname' => $item->get('organism_infraspecific_name')->getString(),
+        'abbreviation' => $item->get('organism_abbreviation')->getString(),
+        'common_name' => $item->get('organism_common_name')->getString(),
+        'comment' => $item->get('organism_comment')->getString(),
+      ];
+
+      // Special case handling of abbreviations for genus and infraspecific type
+      $values['genus_abbrev'] = substr($values['genus'], 0, 1) . '.';
+      $values['infratype_abbrev'] = chado_abbreviate_infraspecific_rank($values['infratype']);
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
       ];
     }
 
     return $elements;
   }
+
 }

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoProjectFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoProjectFormatterDefault.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal project formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_project_formatter_default",
+ *   label = @Translation("Chado project formatter"),
+ *   description = @Translation("A chado project formatter"),
+ *   field_types = {
+ *     "chado_project_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *   },
+ * )
+ */
+class ChadoProjectFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('project_name')->getString(),
+        'description' => $item->get('project_description')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoProtocolFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoProtocolFormatterDefault.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal protocol formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_protocol_formatter_default",
+ *   label = @Translation("Chado protocol formatter"),
+ *   description = @Translation("A chado protocol formatter"),
+ *   field_types = {
+ *     "chado_protocol_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[hardware]",
+ *     "[software]",
+ *     "[type]",
+ *     "[pub_title]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *   },
+ * )
+ */
+class ChadoProtocolFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('protocol_name')->getString(),
+        'description' => $item->get('protocol_protocoldescription')->getString(),
+        'hardware' => $item->get('protocol_hardwaredescription')->getString(),
+        'software' => $item->get('protocol_softwaredescription')->getString(),
+        'type' => $item->get('protocol_type')->getString(),
+        'pub_title' => $item->get('protocol_pub_title')->getString(),
+        'database_name' => $item->get('protocol_database_name')->getString(),
+        'database_accession' => $item->get('protocol_database_accession')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal pub formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_pub_formatter_default",
+ *   label = @Translation("Chado pub formatter"),
+ *   description = @Translation("A chado pub formatter"),
+ *   field_types = {
+ *     "chado_pub_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[title]",
+ *     "[volumetitle]",
+ *     "[volume]",
+ *     "[series_name]",
+ *     "[issue]",
+ *     "[pyear]",
+ *     "[pages]",
+ *     "[miniref]",
+ *     "[uniquename]",
+ *     "[type]",
+ *     "[is_obsolete]",
+ *     "[publisher]",
+ *     "[pubplace]",
+ *   },
+ * )
+ */
+class ChadoPubFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    // uniquename is generally the citation and has a not null constraint
+    $settings['token_string'] = '[uniquename]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'title' => $item->get('pub_title')->getString(),
+        'volumetitle' => $item->get('pub_volumetitle')->getString(),
+        'volume' => $item->get('pub_volume')->getString(),
+        'series_name' => $item->get('pub_series_name')->getString(),
+        'issue' => $item->get('pub_issue')->getString(),
+        'pyear' => $item->get('pub_pyear')->getString(),
+        'pages' => $item->get('pub_pages')->getString(),
+        'miniref' => $item->get('pub_miniref')->getString(),
+        'uniquename' => $item->get('pub_uniquename')->getString(),
+        'type' => $item->get('pub_type')->getString(),
+        'is_obsolete' => $item->get('pub_is_obsolete')->getString(),
+        'publisher' => $item->get('pub_publisher')->getString(),
+        'pubplace' => $item->get('pub_pubplace')->getString(),
+      ];
+
+      // Change the non-user-friendly 'null' publication.
+      if ($values['uniquename'] == 'null') {
+        $values['uniquename'] = 'Unknown';
+      }
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStockFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStockFormatterDefault.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal stock formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_stock_formatter_default",
+ *   label = @Translation("Chado stock formatter"),
+ *   description = @Translation("A chado stock formatter"),
+ *   field_types = {
+ *     "chado_stock_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[uniquename]",
+ *     "[description]",
+ *     "[type]",
+ *     "[is_obsolete]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *     "[genus]",
+ *     "[species]",
+ *     "[infratype]",
+ *     "[infratype_abbrev]",
+ *     "[infraname]",
+ *     "[abbreviation]",
+ *     "[common_name]",
+ *   },
+ * )
+ */
+class ChadoStockFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('stock_name')->getString(),
+        'uniquename' => $item->get('stock_uniquename')->getString(),
+        'description' => $item->get('stock_description')->getString(),
+        'is_obsolete' => $item->get('stock_is_obsolete')->getString(),
+        'type' => $item->get('stock_type')->getString(),
+        'database_name' => $item->get('stock_database_name')->getString(),
+        'database_accession' => $item->get('stock_database_accession')->getString(),
+        'genus' => $item->get('stock_genus')->getString(),
+        'species' => $item->get('stock_species')->getString(),
+        'infratype' => $item->get('stock_infraspecific_type')->getString(),
+        'infraname' => $item->get('stock_infraspecific_name')->getString(),
+        'abbreviation' => $item->get('stock_abbreviation')->getString(),
+        'common_name' => $item->get('stock_common_name')->getString(),
+      ];
+
+      // Special case handling for abbreviation of infraspecific type
+      $values['infratype_abbrev'] = chado_abbreviate_infraspecific_rank($values['infratype']);
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStudyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStudyFormatterDefault.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
+
+/**
+ * Plugin implementation of default Tripal study formatter.
+ *
+ * @FieldFormatter(
+ *   id = "chado_study_formatter_default",
+ *   label = @Translation("Chado study formatter"),
+ *   description = @Translation("A chado study formatter"),
+ *   field_types = {
+ *     "chado_study_type_default"
+ *   },
+ *   valid_tokens = {
+ *     "[name]",
+ *     "[description]",
+ *     "[contact_name]",
+ *     "[pub_title]",
+ *     "[database_name]",
+ *     "[database_accession]",
+ *   },
+ * )
+ */
+class ChadoStudyFormatterDefault extends ChadoFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['token_string'] = '[name]';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $list = [];
+    $token_string = $this->getSetting('token_string');
+
+    foreach ($items as $delta => $item) {
+      $values = [
+        'name' => $item->get('study_name')->getString(),
+        'description' => $item->get('study_description')->getString(),
+        'contact_name' => $item->get('study_contact_name')->getString(),
+        'pub_title' => $item->get('study_pub_title')->getString(),
+        'database_name' => $item->get('study_database_name')->getString(),
+        'database_accession' => $item->get('study_database_accession')->getString(),
+      ];
+
+      // Substitute values in token string to generate displayed string.
+      $displayed_string = $token_string;
+      foreach ($values as $key => $value) {
+        $displayed_string = preg_replace("/\[$key\]/", $value, $displayed_string);
+      }
+      $list[$delta] = [
+        '#markup' => $displayed_string,
+      ];
+    }
+
+    // If only one element has been found, don't make into a list.
+    if (count($list) == 1) {
+      $elements = $list;
+    }
+
+    // If more than one value has been found, display all values in an
+    // unordered list.
+// @todo: add a pager
+    elseif (count($list) > 1) {
+      $elements[0] = [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $list,
+        '#wrapper_attributes' => ['class' => 'container'],
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -52,9 +52,10 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
    */
   public static function defaultFieldSettings() {
     $field_settings = parent::defaultFieldSettings();
-    // CV Term is 'Analysis'
-    $field_settings['termIdSpace'] = 'operation';
-    $field_settings['termAccession'] = '2945';
+    // No default CV Term for this field
+    // Analysis is operation:2945
+    // Genome Assembly is operation:0525
+    // Genome Annotation is operation:0362
     return $field_settings;
   }
 
@@ -113,7 +114,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     // For single hop, in the yaml we support using the usual 'base_table'
     // and 'base_column' settings.
     $linker_table = $storage_settings['linker_table'] ?? $base_table;
-    $linker_fkey_col = $storage_settings['linker_fkey_column']
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
       ?? $storage_settings['base_column'] ?? $object_pkey_col;
 
     $extra_linker_columns = [];
@@ -123,13 +124,13 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
       $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
-        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_col)) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
           $term = $mapping->getColumnTermId($linker_table, $column);
           if ($term) {
             $extra_linker_columns[$column] = $term;
@@ -138,7 +139,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_col);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
     }
 
     $properties = [];
@@ -157,9 +158,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
         'action' => 'store',
         'drupal_store' => TRUE,
-        'path' => $base_table . '.' . $linker_fkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $linker_fkey_col,
+        'path' => $base_table . '.' . $linker_fkey_column,
         'delete_if_empty' => TRUE,
         'empty_value' => 0,
       ]);
@@ -172,8 +171,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,
-        //'chado_table' => $linker_table,
-        //'chado_column' => $linker_pkey_col,
       ]);
 
       // Define the link between the base table and the linker table.
@@ -182,10 +179,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_link',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
-        //'left_table' => $base_table,
-        //'left_table_id' => $base_pkey_col,
-        //'right_table' => $linker_table,
-        //'right_table_id' => $linker_left_col,
       ]);
 
       // Define the link between the linker table and the object table.
@@ -193,9 +186,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
         'action' => 'store',
         'drupal_store' => TRUE,
-        'path' => $linker_table . '.' . $linker_fkey_col,
-        //'chado_table' => $linker_table,
-        //'chado_column' => $linker_fkey_col,
+        'path' => $linker_table . '.' . $linker_fkey_column,
         'delete_if_empty' => TRUE,
         'empty_value' => 0,
       ]);
@@ -209,8 +200,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
           'action' => 'store',
           'drupal_store' => FALSE,
           'path' => $linker_table . '.' . $column,
-          //'chado_table' => $linker_table,
-          //'chado_column' => $column,
           'as' => 'linker_' . $column,
         ]);
       }
@@ -221,9 +210,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_name', $name_term, $name_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';name',
-      //'chado_table' => $object_table,
-      //'chado_column' => 'name',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
       'as' => 'analysis_name',
     ]);
 
@@ -231,8 +218,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'analysis_description', $description_term, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';description',
-      //'chado_column' => 'description',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
       'as' => 'analysis_description',
     ]);
 
@@ -240,8 +226,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_program', $program_term, $program_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';program',
-      //'chado_column' => 'program',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';program',
       'as' => 'analysis_program',
     ]);
 
@@ -249,8 +234,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_programversion', $programversion_term, $programversion_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';programversion',
-      //'chado_column' => 'programversion',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';programversion',
       'as' => 'analysis_programversion',
     ]);
 
@@ -258,8 +242,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_algorithm', $algorithm_term, $algorithm_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';algorithm',
-      //'chado_column' => 'algorithm',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';algorithm',
       'as' => 'analysis_algorithm',
     ]);
 
@@ -267,8 +250,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_sourcename', $sourcename_term, $sourcename_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col .';sourcename',
-      //'chado_column' => 'sourcename',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col .';sourcename',
       'as' => 'analysis_sourcename',
     ]);
 
@@ -276,8 +258,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'analysis_sourceversion', $sourceversion_term, $sourceversion_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';sourceversion',
-      //'chado_column' => 'sourceversion',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';sourceversion',
       'as' => 'analysis_sourceversion',
     ]);
 
@@ -285,8 +266,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'analysis_sourceuri', $sourceuri_term, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';sourceuri',
-      //'chado_column' => 'sourceuri',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';sourceuri',
       'as' => 'analysis_sourceuri',
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal Array Design field type.
+ *
+ * @FieldType(
+ *   id = "chado_array_design_type_default",
+ *   object_table = "arraydesign",
+ *   label = @Translation("Chado Array Design"),
+ *   description = @Translation("Add a Chado Array Design to the content type."),
+ *   default_widget = "chado_array_design_widget_default",
+ *   default_formatter = "chado_array_design_formatter_default",
+ * )
+ */
+class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_array_design_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'arraydesign';
+  protected static $object_id = 'arraydesign_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'array_design_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'ArrayDesign'
+    $field_settings['termIdSpace'] = 'NCIT';
+    $field_settings['termAccession'] = 'C47885';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+    $version_term = $mapping->getColumnTermId($object_table, 'version');  // text
+    $array_dimensions_term = $mapping->getColumnTermId($object_table, 'array_dimensions');  // text
+    $element_dimensions_term = $mapping->getColumnTermId($object_table, 'element_dimensions');  // text
+    $num_of_elements_term = $mapping->getColumnTermId($object_table, 'num_of_elements');
+    $num_array_elements_term = $mapping->getColumnTermId($object_table, 'num_array_elements');
+    $num_array_rows_term = $mapping->getColumnTermId($object_table, 'num_array_rows');
+    $num_array_columns_term = $mapping->getColumnTermId($object_table, 'num_array_columns');
+    $num_grid_columns_term = $mapping->getColumnTermId($object_table, 'num_grid_columns');
+    $num_grid_rows_term = $mapping->getColumnTermId($object_table, 'num_grid_rows');
+    $num_sub_columns_term = $mapping->getColumnTermId($object_table, 'num_sub_columns');
+    $num_sub_rows_term = $mapping->getColumnTermId($object_table, 'num_sub_rows');
+
+    // Columns from linked tables
+    // both platformtype and substratetype reference the cvterm table
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_len = $cvterm_schema_def['fields']['name']['size'];
+    $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
+    $manufacturer_term = $mapping->getColumnTermId('contact', 'name');
+    $manufacturer_len = $contact_schema_def['fields']['name']['size'];
+    $protocol_term = $mapping->getColumnTermId('protocol', 'name');  // text
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'array_design_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'array_design_description',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_version', $version_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';version',
+      'as' => 'array_design_version',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_array_dimensions', $array_dimensions_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';array_dimensions',
+      'as' => 'array_design_array_dimensions',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_element_dimensions', $element_dimensions_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';element_dimensions',
+      'as' => 'array_design_element_dimensions',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_of_elements', $num_of_elements_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_of_elements',
+      'as' => 'array_design_num_of_elements',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_array_columns', $num_array_columns_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_array_columns',
+      'as' => 'array_design_num_array_columns',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_array_rows', $num_array_rows_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_array_rows',
+      'as' => 'array_design_num_array_rows',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_grid_columns', $num_grid_columns_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_grid_columns',
+      'as' => 'array_design_num_grid_columns',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_grid_rows', $num_grid_rows_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_grid_rows',
+      'as' => 'array_design_num_grid_rows',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_sub_columns', $num_sub_columns_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_sub_columns',
+      'as' => 'array_design_num_sub_columns',
+    ]);
+
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'array_design_num_sub_rows', $num_sub_rows_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';num_sub_rows',
+      'as' => 'array_design_num_sub_rows',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col 
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'array_design_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'array_design_database_name',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'array_design_platformtype', $type_term, $type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.platformtype_id>cvterm.cvterm_id;name',
+      'as' => 'array_design_platformtype',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'array_design_substratetype', $type_term, $type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.substratetype_id>cvterm.cvterm_id;name',
+      'as' => 'array_design_substratetype',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'array_design_manufacturer', $manufacturer_term, $manufacturer_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.manufacturer_id>contact.contact_id;name',
+      'as' => 'array_design_manufacturer',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'array_design_protocol', $protocol_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.protocol_id>protocol.protocol_id;name',
+      'as' => 'array_design_protocol',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal assay field type.
+ *
+ * @FieldType(
+ *   id = "chado_assay_type_default",
+ *   object_table = "assay",
+ *   label = @Translation("Chado Assay"),
+ *   description = @Translation("Add a Chado assay to the content type."),
+ *   default_widget = "chado_assay_widget_default",
+ *   default_formatter = "chado_assay_formatter_default",
+ * )
+ */
+class ChadoAssayTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_assay_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'assay';
+  protected static $object_id = 'assay_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'assay_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'assay'
+    $field_settings['termIdSpace'] = 'SIO';
+    $field_settings['termAccession'] = '001007';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $description_term = $mapping->getColumnTermId($object_table, 'description');
+    $arrayidentifier_term = $mapping->getColumnTermId($object_table, 'arrayidentifier');
+    $arraybatchidentifier_term = $mapping->getColumnTermId($object_table, 'arraybatchidentifier');
+
+    // Columns from linked tables
+    $arraydesign_term = $mapping->getColumnTermId('arraydesign', 'name');
+    $protocol_term = $mapping->getColumnTermId('protocol', 'name');
+    $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
+    $operator_term = $mapping->getColumnTermId('contact', 'name');
+    $operator_len = $contact_schema_def['fields']['name']['size'];
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'chado_table' => $base_table,
+      'chado_column' => $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col,
+      'chado_table' => $object_table,
+      'chado_column' => 'name',
+      'as' => 'assay_name',
+    ]);
+
+    // Other columns specific to the object table
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . $object_pkey_col . ';description',
+      'as' => 'assay_description',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_arrayidentifier', $arrayidentifier_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';arrayidentifier',
+      'as' => 'assay_arrayidentifier',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_arraybatchidentifier', $arraybatchidentifier_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';arraybatchidentifier',
+      'as' => 'assay_arraybatchidentifier',
+    ]);
+
+    // Values from tables linked to by the object table
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_arraydesign', $arraydesign_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.arraydesign_id>arraydesign.arraydesign_id;name',
+      'as' => 'assay_arraydesign',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_protocol', $protocol_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.protocol_id>protocol.protocol_id; name',
+      'as' => 'assay_protocol',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'assay_operator', $operator_term, $operator_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.operator_id>contact.contact_id;name',
+      'as' => 'assay_operator',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'assay_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'assay_database_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'assay_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'assay_database_name',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal biomaterial field type.
+ *
+ * @FieldType(
+ *   id = "chado_biomaterial_type_default",
+ *   object_table = "biomaterial",
+ *   label = @Translation("Chado Biomaterial"),
+ *   description = @Translation("Add a Chado biomaterial to the content type."),
+ *   default_widget = "chado_biomaterial_widget_default",
+ *   default_formatter = "chado_biomaterial_formatter_default",
+ * )
+ */
+class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_biomaterial_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'biomaterial';
+  protected static $object_id = 'biomaterial_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'biomaterial_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'Biologically Derived Material'
+    $field_settings['termIdSpace'] = 'NCIT';
+    $field_settings['termAccession'] = 'C70699';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $description_term = $mapping->getColumnTermId($object_table, 'description');
+
+    // Columns from linked tables
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+    $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
+    $biosourceprovider_term = $mapping->getColumnTermId('contact', 'name');
+    $biosourceprovider_len = $contact_schema_def['fields']['name']['size'];
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
+    $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
+    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_len = $organism_schema_def['fields']['genus']['size'];
+    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_len = $organism_schema_def['fields']['species']['size'];
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_len = $organism_schema_def['fields']['common_name']['size'];
+
+    // Linker table, when used
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column'] ?? $object_pkey_col;
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'biomaterial_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'biomaterial_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'biomaterial_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'biomaterial_description',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_biosourceprovider', $biosourceprovider_term, $biosourceprovider_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.biosourceprovider_id>contact.contact_id;name',
+      'as' => 'biomaterial_biosourceprovider',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_genus', $genus_term, $genus_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;genus',
+      'as' => 'biomaterial_genus',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_species', $species_term, $species_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;species',
+      'as' => 'biomaterial_species',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_infraspecific_type', $infraspecific_type_term, $infraspecific_type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;organism.type_id>cvterm.cvterm_id;name',
+      'as' => 'biomaterial_infraspecific_type',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_infraspecific_name', $infraspecific_name_term, $infraspecific_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;infraspecific_name',
+      'as' => 'biomaterial_infraspecific_name',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_abbreviation', $abbreviation_term, $abbreviation_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;abbreviation',
+      'as' => 'biomaterial_abbreviation',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'biomaterial_common_name', $common_name_term, $common_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;common_name',
+      'as' => 'biomaterial_common_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'biomaterial_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'biomaterial_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'biomaterial_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'biomaterial_database_name',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -97,9 +97,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $description_term = $mapping->getColumnTermId($object_table, 'description');
     $description_len = $object_schema_def['fields']['description']['size'];
 
-    // Object columns that link to another table
-    $object_type_col = 'type_id';
-
     // Cvterm table, to retrieve the name for the contact type
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $contact_type_term = $mapping->getColumnTermId('cvterm', 'name');
@@ -109,7 +106,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     // For single hop, in the yaml we support using the usual 'base_table'
     // and 'base_column' settings.
     $linker_table = $storage_settings['linker_table'] ?? $base_table;
-    $linker_fkey_col = $storage_settings['linker_fkey_column']
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
       ?? $storage_settings['base_column'] ?? $object_pkey_col;
 
     $extra_linker_columns = [];
@@ -119,13 +116,13 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
       $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
-        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_col)) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
           $term = $mapping->getColumnTermId($linker_table, $column);
           if ($term) {
             $extra_linker_columns[$column] = $term;
@@ -134,7 +131,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_col);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
     }
 
     $properties = [];
@@ -150,12 +147,10 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
 
     // Base table links directly
     if ($base_table == $linker_table) {
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
         'action' => 'store',
         'drupal_store' => TRUE,
-        'path' => $base_table . '.' . $linker_fkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $linker_fkey_col,
+        'path' => $base_table . '.' . $linker_fkey_column,
         'delete_if_empty' => TRUE,
         'empty_value' => 0,
       ]);
@@ -183,12 +178,10 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       ]);
 
       // Define the link between the linker table and the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
         'action' => 'store',
         'drupal_store' => TRUE,
-        'path' => $linker_table . '.' . $linker_fkey_col,
-        //'chado_table' => $linker_table,
-        //'chado_column' => $linker_fkey_col,
+        'path' => $linker_table . '.' . $linker_fkey_column,
         'delete_if_empty' => TRUE,
         'empty_value' => 0,
       ]);
@@ -213,9 +206,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_name', $name_term, $name_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';name',
-      //'chado_table' => $object_table,
-      //'chado_column' => 'name',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
       'as' => 'contact_name',
     ]);
 
@@ -223,8 +214,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_description', $description_term, $description_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col . ';description',
-      //'chado_column' => 'description',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
       'as' => 'contact_description',
     ]);
 
@@ -232,9 +222,8 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_type', $contact_type_term, $contact_type_len, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_col . '>' . $object_table . '.' . $object_pkey_col
-        . ';' . $object_table . '.' . $object_type_col . '>cvterm.cvterm_id;name',
-      //'chado_column' => 'name',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
       'as' => 'contact_type',
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal featuremap field type.
+ *
+ * @FieldType(
+ *   id = "chado_featuremap_type_default",
+ *   object_table = "featuremap",
+ *   label = @Translation("Chado FeatureMap"),
+ *   description = @Translation("Add a Chado featuremap to the content type."),
+ *   default_widget = "chado_featuremap_widget_default",
+ *   default_formatter = "chado_featuremap_formatter_default",
+ * )
+ */
+class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_featuremap_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'featuremap';
+  protected static $object_id = 'featuremap_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'featuremap_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // No default CV Term for this field
+    // Genetic Map is data:1278
+    // Physical Map is data:1280
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_len = $object_schema_def['fields']['name']['size'];
+    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+
+    // Cvterm table, to retrieve the name for the unit type
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $featuremap_unittype_term = $mapping->getColumnTermId('cvterm', 'name');
+    $featuremap_unittype_len = $cvterm_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+         'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The featuremap name
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'featuremap_name', $name_term, $name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'featuremap_name',
+    ]);
+
+    // The featuremap description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'featuremap_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'featuremap_description',
+    ]);
+
+    // The map units
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'featuremap_unittype', $featuremap_unittype_term, $featuremap_unittype_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.unittype_id>cvterm.cvterm_id;name',
+      'as' => 'featuremap_unittype',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal feature field type.
+ *
+ * @FieldType(
+ *   id = "chado_feature_type_default",
+ *   object_table = "feature",
+ *   label = @Translation("Chado Feature"),
+ *   description = @Translation("Add a Chado feature to the content type."),
+ *   default_widget = "chado_feature_widget_default",
+ *   default_formatter = "chado_feature_formatter_default",
+ * )
+ */
+class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_feature_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'feature';
+  protected static $object_id = 'feature_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'feature_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // No default CV Term for this field
+    // Gene is SO:0000704
+    // mRNA is SO:0000234
+    // QTL is SO:0000771
+    // Genetic Marker is SO:0001645
+    // Heritable Phenotypic Marker is SO:0001500
+    // Sequence Variant is SO:0001060
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_len = $object_schema_def['fields']['name']['size'];
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename'); // text
+    // residues is not implemented in this field since it can be millions of characters long
+    $seqlen_term = $mapping->getColumnTermId($object_table, 'seqlen');
+    $md5checksum_term = $mapping->getColumnTermId($object_table, 'md5checksum');
+    $md5checksum_len = $object_schema_def['fields']['md5checksum']['size'];
+    $is_analysis_term = $mapping->getColumnTermId($object_table, 'is_analysis'); // boolean
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete'); // boolean
+    // @todo timeaccessioned, timelastmodified not yet implemented
+
+    // Columns from linked tables
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_len = $cvterm_schema_def['fields']['name']['size'];
+    $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
+    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_len = $organism_schema_def['fields']['genus']['size'];
+    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_len = $organism_schema_def['fields']['species']['size'];
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_len = $organism_schema_def['fields']['common_name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The feature name
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_name', $name_term, $name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'feature_name',
+    ]);
+
+    // The feature uniquename - not null
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'feature_uniquename', $uniquename_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';uniquename',
+      'as' => 'feature_uniquename',
+    ]);
+
+    // The feature sequence length
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'feature_seqlen', $seqlen_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';seqlen',
+      'as' => 'feature_seqlen',
+    ]);
+
+    // The feature md5checksum
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_md5checksum', $md5checksum_term, $md5checksum_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';md5checksum',
+      'as' => 'feature_md5checksum',
+    ]);
+
+    // Feature is analysis - not null, default=false
+    $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'feature_is_analysis', $is_analysis_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';is_analysis',
+      'as' => 'feature_is_analysis',
+    ]);
+
+    // Feature is obsolete - not null, default=false
+    $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'feature_is_obsolete', $is_obsolete_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';is_obsolete',
+      'as' => 'feature_is_obsolete',
+    ]);
+
+    // @todo timeaccessioned, timelastmodified not yet implemented - not null, default CURRENT_TIMESTAMP
+
+    // The type of feature
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_type', $type_term, $type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'feature_type',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_genus', $genus_term, $genus_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;genus',
+      'as' => 'feature_genus',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_species', $species_term, $species_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;species',
+      'as' => 'feature_species',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_infraspecific_type', $type_term, $type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;organism.type_id>cvterm.cvterm_id;name',
+      'as' => 'feature_infraspecific_type',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_infraspecific_name', $infraspecific_name_term, $infraspecific_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;infraspecific_name',
+      'as' => 'feature_infraspecific_name',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_abbreviation', $abbreviation_term, $abbreviation_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;abbreviation',
+      'as' => 'feature_abbreviation',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_common_name', $common_name_term, $common_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.taxon_id>organism.organism_id;common_name',
+      'as' => 'feature_common_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'feature_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'feature_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'feature_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'feature_database_name',
+    ]);
+  
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -31,7 +31,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
    */
   public static function mainPropertyName() {
     // Overrides the default of 'value'
-    return 'species';
+    return 'organism_scientific_name';
   }
 
   /**

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -158,7 +158,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
 
     // Base table links directly
     if ($base_table == $linker_table) {
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
         'action' => 'store',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $linker_fkey_column,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -240,7 +240,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
 
     $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_scientific_name', $scientific_name_term, $scientific_name_len, [
       'action' => 'replace',
-      'template' => '[genus] [species] [infraspecific_type] [infraspecific_name]',
+      'template' => '[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]',
     ]);
 
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_abbreviation', $abbreviation_term, $abbreviation_len, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -111,6 +111,10 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
     $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
 
+    // Scientific name is built from several fields combined with space characters
+    $scientific_name_term = 'NCBItaxon:scientific_name';
+    $scientific_name_len = $genus_len + $species_len + $infraspecific_type_len + $infraspecific_name_len + 3;
+
     // Linker table, when used, requires specifying the linker table and column.
     // For single hop, in the yaml we support using the usual 'base_table'
     // and 'base_column' settings.
@@ -232,6 +236,11 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => FALSE,
       'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';infraspecific_name',
       'as' => 'organism_infraspecific_name',
+    ]);
+
+    $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_scientific_name', $scientific_name_term, $scientific_name_len, [
+      'action' => 'replace',
+      'template' => '[genus] [species] [infraspecific_type] [infraspecific_name]',
     ]);
 
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_abbreviation', $abbreviation_term, $abbreviation_len, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -3,61 +3,69 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
-use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
-use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 
 /**
- * Plugin implementation of Tripal organism field type.
+ * Plugin implementation of default Tripal organism field type.
  *
  * @FieldType(
  *   id = "chado_organism_type_default",
- *   label = @Translation("Chado Organism Reference"),
+ *   object_table = "organism",
+ *   label = @Translation("Chado Organism"),
  *   description = @Translation("A chado organism reference"),
  *   default_widget = "chado_organism_widget_default",
- *   default_formatter = "chado_organism_formatter_default"
+ *   default_formatter = "chado_organism_formatter_default",
  * )
  */
 class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
 
-  public static $id = "chado_organism_type_default";
+  public static $id = 'chado_organism_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'organism';
+  protected static $object_id = 'organism_id';
 
   /**
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    return 'label';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultFieldSettings() {
-    $settings = parent::defaultFieldSettings();
-    $settings['termIdSpace'] = 'OBI';
-    $settings['termAccession'] = '0100026';
-    return $settings;
+    // Overrides the default of 'value'
+    return 'species';
   }
 
   /**
    * {@inheritdoc}
    */
   public static function defaultStorageSettings() {
-    $settings = parent::defaultStorageSettings();
-    return $settings;
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'Organism'
+    $field_settings['termIdSpace'] = 'OBI';
+    $field_settings['termAccession'] = '0100026';
+    return $field_settings;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function tripalTypes($field_definition) {
-    $entity_type_id = $field_definition->getTargetEntityTypeId();
 
-    // Get the base table columns needed for this field.
-    $settings = $field_definition->getSetting('storage_plugin_settings');
-    $base_table = $settings['base_table'];
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
 
     // If we don't have a base table then we're not ready to specify the
     // properties for this field.
@@ -65,69 +73,189 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       return;
     }
 
-    // Get the length of the database fields so we don't go over the size limit.
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
     $chado = \Drupal::service('tripal_chado.database');
     $schema = $chado->schema();
-    $organism_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
-    $cvterm_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $genus_len = $organism_def['fields']['genus']['size'];
-    $species_len = $organism_def['fields']['species']['size'];
-    $iftype_len = $cvterm_def['fields']['name']['size'];
-    $ifname_len = $organism_def['fields']['infraspecific_name']['size'];
-    $label_len = $genus_len + $species_len + $iftype_len + $ifname_len;
-
-    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
-    $base_pkey_col = $base_schema_def['primary key'];
-    $base_fk_col = array_keys($base_schema_def['foreign keys']['organism']['columns'])[0];
-
-    // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
     $record_id_term = 'SIO:000729';
-    $label_term = 'rdfs:label';
-    $org_id_term = $mapping->getColumnTermId($base_table, 'organism_id');
-    $genus_term = $mapping->getColumnTermId('organism', 'genus');
-    $species_term = $mapping->getColumnTermId('organism', 'species');
-    $iftype_term = $mapping->getColumnTermId('organism', 'type_id');
-    $ifname_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
 
-    // Return the properties for this field.
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    $genus_term = $mapping->getColumnTermId($object_table, 'genus');
+    $genus_len = $object_schema_def['fields']['genus']['size'];
+    $species_term = $mapping->getColumnTermId($object_table, 'species');
+    $species_len = $object_schema_def['fields']['species']['size'];
+    $infraspecific_name_term = $mapping->getColumnTermId($object_table, 'infraspecific_name');
+    $infraspecific_name_len = $object_schema_def['fields']['infraspecific_name']['size'];
+    $abbreviation_term = $mapping->getColumnTermId($object_table, 'abbreviation');
+    $abbreviation_len = $object_schema_def['fields']['abbreviation']['size'];
+    $common_name_term = $mapping->getColumnTermId($object_table, 'common_name');
+    $common_name_len = $object_schema_def['fields']['common_name']['size'];
+    $comment_term = $mapping->getColumnTermId($object_table, 'comment');
+
+    // Other columns specific to this object table
+    $comment_term = $mapping->getColumnTermId($object_table, 'comment');
+
+    // Cvterm table, to retrieve the name for the organism type
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
     $properties = [];
+
+    // Define the base table record id.
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_pkey_col
     ]);
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'organism_id', $org_id_term, [
-      'action' => 'store',
-      'path' => $base_table . '.' . $base_fk_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_fk_col,
-    ]);
-    $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'label', $label_term, $label_len, [
-      'action' => 'replace',
-      'template' => "<i>[genus] [species]</i> [infraspecific_type] [infraspecific_name]",
-    ]);
-    $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'genus', $genus_term, $genus_len, [
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_genus', $genus_term, $genus_len, [
       'action' => 'read_value',
-      'path' => $base_table . '.organism_id>organism.organism_id;genus',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';genus',
+      'chado_table' => $object_table,
+      'chado_column' => 'genus',
+      'as' => 'organism_genus',
     ]);
-    $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'species', $species_term, $species_len, [
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_species', $species_term, $species_len, [
       'action' => 'read_value',
-      'path' => $base_table . '.organism_id>organism.organism_id;species',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col. ';species',
+      'chado_table' => $object_table,
+      'chado_column' => 'species',
+      'as' => 'organism_species',
     ]);
-    $properties[] =  new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'infraspecific_name', $ifname_term, $ifname_len, [
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_infraspecific_type', $infraspecific_type_term, $infraspecific_type_len, [
       'action' => 'read_value',
-      'path' => $base_table . '.organism_id>organism.organism_id;infraspecific_name',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'organism_infraspecific_type',
     ]);
-    $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'infraspecific_type', $iftype_term, [
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_infraspecific_name', $infraspecific_name_term, $infraspecific_name_len, [
       'action' => 'read_value',
-      'path' => $base_table . '.organism_id>organism.organism_id;organism.type_id>cvterm.cvterm_id;name',
-      'as' => 'infraspecific_type',
-      //'chado_column' => 'name',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';infraspecific_name',
+      'as' => 'organism_infraspecific_name',
     ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_abbreviation', $abbreviation_term, $abbreviation_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';abbreviation',
+      'as' => 'organism_abbreviation',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'organism_common_name', $common_name_term, $common_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';common_name',
+      'as' => 'organism_common_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'organism_comment', $comment_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';comment',
+      'as' => 'organism_comment',
+    ]);
+
     return $properties;
   }
+
 }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -112,7 +112,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
 
     // Scientific name is built from several fields combined with space characters
-    $scientific_name_term = 'NCBItaxon:scientific_name';
+    $scientific_name_term = 'NCBITaxon:scientific_name';
     $scientific_name_len = $genus_len + $species_len + $infraspecific_type_len + $infraspecific_name_len + 3;
 
     // Linker table, when used, requires specifying the linker table and column.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal project field type.
+ *
+ * @FieldType(
+ *   id = "chado_project_type_default",
+ *   object_table = "project",
+ *   label = @Translation("Chado Project"),
+ *   description = @Translation("Add a Chado project to the content type."),
+ *   default_widget = "chado_project_widget_default",
+ *   default_formatter = "chado_project_formatter_default",
+ * )
+ */
+class ChadoProjectTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_project_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'project';
+  protected static $object_id = 'project_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'project_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'Project'
+    $field_settings['termIdSpace'] = 'NCIT';
+    $field_settings['termAccession'] = 'C47885';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_len = $object_schema_def['fields']['name']['size'];
+    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The project name
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'project_name', $name_term, $name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'project_name',
+    ]);
+
+    // The project description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'project_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'project_description',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal protocol field type.
+ *
+ * @FieldType(
+ *   id = "chado_protocol_type_default",
+ *   object_table = "protocol",
+ *   label = @Translation("Chado Protocol"),
+ *   description = @Translation("Add a Chado protocol to the content type."),
+ *   default_widget = "chado_protocol_widget_default",
+ *   default_formatter = "chado_protocol_formatter_default",
+ * )
+ */
+class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_protocol_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'protocol';
+  protected static $object_id = 'protocol_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'protocol_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'protocol'
+    $field_settings['termIdSpace'] = 'sep';
+    $field_settings['termAccession'] = '00101	';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
+    $uri_term = $mapping->getColumnTermId($object_table, 'uri');  // text
+    $protocoldescription_term = $mapping->getColumnTermId($object_table, 'protocoldescription');  // text
+    $hardwaredescription_term = $mapping->getColumnTermId($object_table, 'hardwaredescription');  // text
+    $softwaredescription_term = $mapping->getColumnTermId($object_table, 'softwaredescription');  // text
+
+    // Columns from linked tables
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $protocol_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $protocol_type_len = $cvterm_schema_def['fields']['name']['size'];
+    $pub_title_term = $mapping->getColumnTermId('pub', 'title');
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used (core tripal does not
+    // have any protocol linker tables, but a site may wish to add one)
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The protocol name
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'protocol_name',
+    ]);
+
+    // The type of protocol
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'protocol_type', $protocol_type_term, $protocol_type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'protocol_type',
+    ]);
+
+    // The linked publication title
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_pub_title', $pub_title_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.pub_id>pub.pub_id;title',
+      'as' => 'protocol_pub_title',
+    ]);
+
+    // The protocol uri
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_uri', $uri_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';uri',
+      'as' => 'protocol_uri',
+    ]);
+
+    // The protocol description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_protocoldescription', $protocoldescription_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';protocoldescription',
+      'as' => 'protocol_protocoldescription',
+    ]);
+
+    // The protocol hardware description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_hardwaredescription', $hardwaredescription_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';hardwaredescription',
+      'as' => 'protocol_hardwaredescription',
+    ]);
+
+    // The protocol software description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_softwaredescription', $softwaredescription_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';softwaredescription',
+      'as' => 'protocol_softwaredescription',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'protocol_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'protocol_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'protocol_database_name',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -132,12 +132,8 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
       $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
       $linker_pkey_col = $linker_schema_def['primary key'];
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-dpm($linker_table, "CP1 linker_table"); //@@@
-dpm($linker_left_col, "CP2 linker_left_col"); //@@@
       $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-dpm($linker_left_term, "CP3 linker_left_term"); //@@@
       $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
-dpm($linker_fkey_term, "CP4 linker_fkey_term"); //@@@
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -131,10 +131,13 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     if ($linker_table != $base_table) {
       $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
       $linker_pkey_col = $linker_schema_def['primary key'];
-      // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+dpm($linker_table, "CP1 linker_table"); //@@@
+dpm($linker_left_col, "CP2 linker_left_col"); //@@@
       $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+dpm($linker_left_term, "CP3 linker_left_term"); //@@@
       $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+dpm($linker_fkey_term, "CP4 linker_fkey_term"); //@@@
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal publication field type.
+ *
+ * @FieldType(
+ *   id = "chado_pub_type_default",
+ *   object_table = "pub",
+ *   label = @Translation("Chado Publication"),
+ *   description = @Translation("Associates a publication (e.g. journal article, conference proceedings, book chapter, etc.) with this record."),
+ *   default_widget = "chado_pub_widget_default",
+ *   default_formatter = "chado_pub_formatter_default",
+ * )
+ */
+class ChadoPubTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_pub_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'pub';
+  protected static $object_id = 'pub_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'pub_title';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'publication'
+    $field_settings['termIdSpace'] = 'schema';
+    $field_settings['termAccession'] = 'publication';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $title_term = $mapping->getColumnTermId($object_table, 'title'); // text
+    $volumetitle_term = $mapping->getColumnTermId($object_table, 'volumetitle'); // text
+    $volume_term = $mapping->getColumnTermId($object_table, 'volume');
+    $volume_len = $object_schema_def['fields']['volume']['size'];
+    $series_name_term = $mapping->getColumnTermId($object_table, 'series_name');
+    $series_name_len = $object_schema_def['fields']['series_name']['size'];
+    $issue_term = $mapping->getColumnTermId($object_table, 'issue');
+    $issue_len = $object_schema_def['fields']['issue']['size'];
+    $pyear_term = $mapping->getColumnTermId($object_table, 'pyear');
+    $pyear_len = $object_schema_def['fields']['pyear']['size'];
+    $pages_term = $mapping->getColumnTermId($object_table, 'pages');
+    $pages_len = $object_schema_def['fields']['pages']['size'];
+    $miniref_term = $mapping->getColumnTermId($object_table, 'miniref');
+    $miniref_len = $object_schema_def['fields']['miniref']['size'];
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename'); // text
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete'); // boolean
+    $publisher_term = $mapping->getColumnTermId($object_table, 'publisher');
+    $publisher_len = $object_schema_def['fields']['publisher']['size'];
+    $pubplace_term = $mapping->getColumnTermId($object_table, 'pubplace');
+    $pubplace_len = $object_schema_def['fields']['pubplace']['size'];
+
+    // Cvterm table, to retrieve the name for the publication type
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_len = $cvterm_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The publication title
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'pub_title', $title_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';title',
+      'as' => 'pub_title',
+    ]);
+
+    // The publication volumetitle
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'pub_volumetitle', $volumetitle_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';volumetitle',
+      'as' => 'pub_volumetitle',
+    ]);
+
+    // The publication volume
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_volume', $volume_term, $volume_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';volume',
+      'as' => 'pub_volume',
+    ]);
+
+    // The publication series (e.g. journal name)
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_series_name', $series_name_term, $series_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';series_name',
+      'as' => 'pub_series_name',
+    ]);
+
+    // The publication issue
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_issue', $issue_term, $issue_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';issue',
+      'as' => 'pub_issue',
+    ]);
+
+    // The publication pyear
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_pyear', $pyear_term, $pyear_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';pyear',
+      'as' => 'pub_pyear',
+    ]);
+
+    // The publication pages
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_pages', $pages_term, $pages_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';pages',
+      'as' => 'pub_pages',
+    ]);
+
+    // The publication miniref
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_miniref', $miniref_term, $miniref_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';miniref',
+      'as' => 'pub_miniref',
+    ]);
+
+    // The publication uniquename - not null
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'pub_uniquename', $uniquename_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';uniquename',
+      'as' => 'pub_uniquename',
+    ]);
+
+    // The type of publication - not null
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_type', $type_term, $type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'pub_type',
+    ]);
+
+    // Publication is obsolete - default=false
+    $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'pub_is_obsolete', $is_obsolete_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';is_obsolete',
+      'as' => 'pub_is_obsolete',
+    ]);
+
+    // The publication publisher
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_publisher', $publisher_term, $publisher_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';publisher',
+      'as' => 'pub_publisher',
+    ]);
+
+    // The publication pubplace
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'pub_pubplace', $pubplace_term, $pubplace_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';pubplace',
+      'as' => 'pub_pubplace',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal stock field type.
+ *
+ * @FieldType(
+ *   id = "chado_stock_type_default",
+ *   object_table = "stock",
+ *   label = @Translation("Chado Stock"),
+ *   description = @Translation("Add a Chado stock to the content type."),
+ *   default_widget = "chado_stock_widget_default",
+ *   default_formatter = "chado_stock_formatter_default",
+ * )
+ */
+class ChadoStockTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_stock_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'stock';
+  protected static $object_id = 'stock_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'stock_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // No default CV Term for this field
+    // Germplasm Accession is CO_010:0000044
+    // Breeding Cross is CO_010:0000255
+    // Germplasm Variety is CO_010:0000029
+    // Recombinant Inbred Line is CO_010:0000162
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_len = $object_schema_def['fields']['name']['size'];
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename');  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete');  // boolean
+
+    // Columns from linked tables
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+    $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
+    $stock_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $stock_type_len = $cvterm_schema_def['fields']['name']['size'];
+    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
+    $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
+    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_len = $organism_schema_def['fields']['genus']['size'];
+    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_len = $organism_schema_def['fields']['species']['size'];
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_len = $organism_schema_def['fields']['common_name']['size'];
+
+    // Linker table, when used
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column'] ?? $object_pkey_col;
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, self::$object_id, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'stock_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'stock_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'stock_uniquename', $uniquename_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';uniquename',
+      'as' => 'stock_uniquename',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'stock_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'stock_description',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_type', $stock_type_term, $stock_type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'stock_type',
+    ]);
+
+    $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'stock_is_obsolete', $is_obsolete_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';is_obsolete',
+      'as' => 'stock_is_obsolete',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_genus', $genus_term, $genus_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;genus',
+      'as' => 'stock_genus',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_species', $species_term, $species_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;species',
+      'as' => 'stock_species',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_infraspecific_type', $infraspecific_type_term, $infraspecific_type_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;organism.type_id>cvterm.cvterm_id;name',
+      'as' => 'stock_infraspecific_type',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_infraspecific_name', $infraspecific_name_term, $infraspecific_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;infraspecific_name',
+      'as' => 'stock_infraspecific_name',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_abbreviation', $abbreviation_term, $abbreviation_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;abbreviation',
+      'as' => 'stock_abbreviation',
+    ]);
+
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'stock_common_name', $common_name_term, $common_name_len, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.organism_id>organism.organism_id;common_name',
+      'as' => 'stock_common_name',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'stock_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'stock_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'stock_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'stock_database_name',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+
+/**
+ * Plugin implementation of default Tripal study field type.
+ *
+ * @FieldType(
+ *   id = "chado_study_type_default",
+ *   object_table = "study",
+ *   label = @Translation("Chado Study"),
+ *   description = @Translation("Add a Chado study to the content type."),
+ *   default_widget = "chado_study_widget_default",
+ *   default_formatter = "chado_study_formatter_default",
+ * )
+ */
+class ChadoStudyTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_study_type_default';
+  // The following needs to match the object_table annotation above
+  protected static $object_table = 'study';
+  protected static $object_id = 'study_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'study_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $field_settings = parent::defaultFieldSettings();
+    // CV Term is 'study'
+    $field_settings['termIdSpace'] = 'SIO';
+    $field_settings['termAccession'] = '001066';
+    return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    // Create a variable for easy access to settings.
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    // If we don't have a base table then we're not ready to specify the
+    // properties for this field.
+    if (!$base_table) {
+      return;
+    }
+
+    // Get the various tables and columns needed for this field.
+    // We will get the property terms by using the Chado table columns they map to.
+    $chado = \Drupal::service('tripal_chado.database');
+    $schema = $chado->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $record_id_term = 'SIO:000729';
+
+    // Base table
+    $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
+    $base_pkey_col = $base_schema_def['primary key'];
+
+    // Object table
+    $object_table = self::$object_table;
+    $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
+    $object_pkey_col = $object_schema_def['primary key'];
+    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+
+    // Columns specific to the object table
+    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $description_term = $mapping->getColumnTermId($object_table, 'description');
+
+    // Columns from linked tables
+    $contact_term = $mapping->getColumnTermId('contact', 'name');
+    $pub_title_term = $mapping->getColumnTermId('pub', 'title');
+    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_len = $db_schema_def['fields']['name']['size'];
+
+    // Linker table, when used, requires specifying the linker table and column.
+    // For single hop, in the yaml we support using the usual 'base_table'
+    // and 'base_column' settings.
+    $linker_table = $storage_settings['linker_table'] ?? $base_table;
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? $object_pkey_col;
+
+    $extra_linker_columns = [];
+    if ($linker_table != $base_table) {
+      $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
+      $linker_pkey_col = $linker_schema_def['primary key'];
+      // the following should be the same as $base_pkey_col @todo make sure it is
+      $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+
+      // Some but not all linker tables contain rank, type_id, and maybe other columns.
+      // These are conditionally added only if they exist in the linker
+      // table, and if a term is defined for them.
+      foreach (array_keys($linker_schema_def['fields']) as $column) {
+        if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
+          $term = $mapping->getColumnTermId($linker_table, $column);
+          if ($term) {
+            $extra_linker_columns[$column] = $term;
+          }
+        }
+      }
+    }
+    else {
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+    }
+
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // Base table links directly
+    if ($base_table == $linker_table) {
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $base_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+    }
+    // An intermediate linker table is used
+    else {
+      // Define the linker table that links the base table to the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+        'action' => 'store_pkey',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_pkey_col,
+      ]);
+
+      // Define the link between the base table and the linker table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $linker_left_term, [
+        'action' => 'store_link',
+        'drupal_store' => FALSE,
+        'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
+      ]);
+
+      // Define the link between the linker table and the object table.
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $linker_fkey_term, [
+        'action' => 'store',
+        'drupal_store' => TRUE,
+        'path' => $linker_table . '.' . $linker_fkey_column,
+        'delete_if_empty' => TRUE,
+        'empty_value' => 0,
+      ]);
+
+      // Other columns in the linker table. Set in the widget, but currently not implemented in the formatter.
+      // Typically these are type_id and rank, but are not present in all linker tables,
+      // so they are added only if present in the linker table.
+      foreach ($extra_linker_columns as $column => $term) {
+        $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_' . $column, $term, [
+          'action' => 'store',
+          'drupal_store' => FALSE,
+          'path' => $linker_table . '.' . $column,
+          'as' => 'linker_' . $column,
+        ]);
+      }
+    }
+
+    // The object table, the destination table of the linker table
+    // The study name
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_name', $name_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'study_name',
+    ]);
+
+    // The study description
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_description', $description_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'study_description',
+    ]);
+
+    // The linked contact
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_contact_name', $contact_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.contact_id>contact.contact_id;name',
+      'as' => 'study_contact_name',
+    ]);
+
+    // The linked publication title
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_pub_title', $pub_title_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.pub_id>pub.pub_id;title',
+      'as' => 'study_pub_title',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_database_accession', $dbxref_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
+      'as' => 'study_database_accession',
+    ]);
+
+    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'study_database_name', $db_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
+      'as' => 'study_database_name',
+    ]);
+
+    return $properties;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado Array Design widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_array_design_widget_default",
+ *   label = @Translation("Chado Array Design Widget"),
+ *   description = @Translation("The default array design widget."),
+ *   field_types = {
+ *     "chado_array_design_type_default"
+ *   }
+ * )
+ */
+class ChadoArrayDesignWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'arraydesign_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of arraydesigns.
+    $arraydesigns = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('arraydesign', 'a');
+    $query->fields('a', ['arraydesign_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($arraydesign = $results->fetchObject()) {
+      $arraydesign_name = $arraydesign->name;
+      $arraydesigns[$arraydesign->arraydesign_id] = $arraydesign_name;
+    }
+    natcasesort($arraydesigns);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $arraydesign_id = $item_vals[$linker_fkey_column] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $arraydesigns,
+      '#default_value' => $arraydesign_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is arraydesign_id.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no arraydesign_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado assay widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_assay_widget_default",
+ *   label = @Translation("Chado Assay Widget"),
+ *   description = @Translation("The default assay widget."),
+ *   field_types = {
+ *     "chado_assay_type_default"
+ *   }
+ * )
+ */
+class ChadoAssayWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'assay_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of assays.
+    $assays = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('assay', 'a');
+    $query->fields('a', ['assay_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($assay = $results->fetchObject()) {
+      $assays[$assay->assay_id] = $assay->name;
+    }
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $assay_id = $item_vals['assay_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $assays,
+      '#default_value' => $assay_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is assay_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no assay_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado biomaterial widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_biomaterial_widget_default",
+ *   label = @Translation("Chado Biomaterial Widget"),
+ *   description = @Translation("The default biomaterial widget."),
+ *   field_types = {
+ *     "chado_biomaterial_type_default"
+ *   }
+ * )
+ */
+class ChadoBiomaterialWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'biomaterial_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of biomaterials.
+    $biomaterials = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('biomaterial', 'b');
+    $query->fields('b', ['biomaterial_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($biomaterial = $results->fetchObject()) {
+      $biomaterials[$biomaterial->biomaterial_id] = $biomaterial->name;
+    }
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $biomaterial_id = $item_vals['biomaterial_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $biomaterials,
+      '#default_value' => $biomaterial_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is biomaterial_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no biomaterial_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -25,6 +25,13 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
 
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'contact_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
     // Get the list of contacts.
     $contacts = [];
     $chado = \Drupal::service('tripal_chado.database');
@@ -51,12 +58,7 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $contact_id = $item_vals['contact_id'] ?? 0;
-    // If a linker table is used, values for additional columns that
-    // may or may not be present in that table.
-    $linker_type_id = $item_vals['linker_type_id'] ?? 1;
-    $linker_rank = $item_vals['linker_rank'] ?? $delta;
-    $linker_pub_id = $item_vals['linker_pub_id'] ?? 1;
+    $contact_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [
@@ -71,29 +73,30 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
       '#type' => 'value',
       '#default_value' => $link,
     ];
-    $elements['contact_id'] = $element + [
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
       '#type' => 'select',
       '#options' => $contacts,
       '#default_value' => $contact_id,
       '#empty_option' => '-- Select --',
     ];
 
-    // For linker table columns that may or may not be present,
-    // it doesn't hurt to always include them, they will be ignored
-    // when not needed.
-    $elements['linker_type_id'] = [
-      '#type' => 'value',
-      '#default_value' => $linker_type_id,
-    ];
-    $elements['linker_rank'] = [
-      '#type' => 'value',
-      '#default_value' => $linker_rank,
-    ];
-    // e.g. cell_line_feature has pub_id with not null constraint
-    $elements['linker_pub_id'] = [
-      '#type' => 'value',
-      '#default_value' => $linker_pub_id,
-    ];
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
 
     return $elements;
   }
@@ -102,16 +105,19 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
    * {@inheritDoc}
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
     // Handle any empty values.
     foreach ($values as $val_key => $value) {
-      if ($value['contact_id'] == '') {
+      // Foreign key is usually contact_id, but not always.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
         if ($value['record_id']) {
           // If there is a record_id, but no contact_id, this means
           // we need to pass in this record to chado storage to
           // have the linker record be deleted there. To do this,
           // we need to have the correct primitive type for this
           // field, so change from empty string to zero.
-          $values[$val_key]['contact_id'] = 0;
+          $values[$val_key][$linker_fkey_column] = 0;
         }
         else {
           unset($values[$val_key]);

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado featuremap widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_featuremap_widget_default",
+ *   label = @Translation("Chado FeatureMap Widget"),
+ *   description = @Translation("The default featuremap widget."),
+ *   field_types = {
+ *     "chado_featuremap_type_default"
+ *   }
+ * )
+ */
+class ChadoFeatureMapWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'featuremap_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of featuremaps.
+    $featuremaps = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('featuremap', 'm');
+    $query->fields('m', ['featuremap_id', 'name', 'description']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($featuremap = $results->fetchObject()) {
+      $featuremap_name = $featuremap->name;
+      $featuremaps[$featuremap->featuremap_id] = $featuremap_name;
+    }
+    natcasesort($featuremaps);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $featuremap_id = $item_vals[$linker_fkey_column] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $featuremaps,
+      '#default_value' => $featuremap_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is usually featuremap_id, but not always.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no featuremap_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado feature widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_feature_widget_default",
+ *   label = @Translation("Chado Feature Widget"),
+ *   description = @Translation("The default feature widget."),
+ *   field_types = {
+ *     "chado_feature_type_default"
+ *   }
+ * )
+ */
+class ChadoFeatureWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'feature_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of features.
+    $features = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('feature', 'f');
+    $query->leftJoin('cvterm', 'cvt', 'f.type_id = cvt.cvterm_id');
+    $query->fields('f', ['feature_id', 'name']);
+    $query->addField('cvt', 'name', 'feature_type');
+    $query->orderBy('name', 'feature_type');
+    $results = $query->execute();
+    while ($feature = $results->fetchObject()) {
+      $feature_name = $feature->name;
+      if ($feature->feature_type) {
+        $feature_name .= ' (' . $feature->feature_type . ')';
+      }
+      $features[$feature->feature_id] = $feature_name;
+    }
+    natcasesort($features);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $feature_id = $item_vals['feature_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $features,
+      '#default_value' => $feature_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is feature_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no feature_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
@@ -2,18 +2,17 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**
- * Plugin implementation of default Tripal organism widget.
+ * Plugin implementation of default Chado organism widget.
  *
  * @FieldWidget(
  *   id = "chado_organism_widget_default",
- *   label = @Translation("Chado Organism Reference Widget"),
- *   description = @Translation("A chado organism reference widget"),
+ *   label = @Translation("Chado Organism Widget"),
+ *   description = @Translation("The default organism widget."),
  *   field_types = {
  *     "chado_organism_type_default"
  *   }
@@ -21,37 +20,25 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
  */
 class ChadoOrganismWidgetDefault extends ChadoWidgetBase {
 
-
   /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
 
-    // Get the list of organisms.
-    $organisms = [];
-    $chado = \Drupal::service('tripal_chado.database');
-    $query = $chado->select('organism', 'o');
-    $query->leftJoin('cvterm', 'cvt', 'o.type_id = cvt.cvterm_id');
-    $query->fields('o', ['organism_id', 'genus', 'species', 'infraspecific_name']);
-    $query->fields('cvt', ['name']);
-    $query->orderBy('genus');
-    $query->orderBy('species');
-    $results = $query->execute();
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'organism_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
 
-    while ($organism = $results->fetchObject()) {
-      $org_name = $organism->genus . ' ' . $organism->species;
-
-      if ($organism->name) {
-        $org_name .= ' ' . $organism->name;
-      }
-      if ($organism->infraspecific_name) {
-        $org_name .= ' ' . $organism->infraspecific_name;
-      }
-      $organisms[$organism->organism_id] = $org_name;
-    }
+    // Get the list of organisms. Second parameter true includes common names.
+    $organisms = chado_get_organism_select_options(FALSE, TRUE);
 
     $item_vals = $items[$delta]->getValue();
     $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
     $organism_id = $item_vals['organism_id'] ?? 0;
 
     $elements = [];
@@ -59,14 +46,73 @@ class ChadoOrganismWidgetDefault extends ChadoWidgetBase {
       '#type' => 'value',
       '#default_value' => $record_id,
     ];
-    $elements['organism_id'] = $element + [
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
       '#type' => 'select',
       '#options' => $organisms,
       '#default_value' => $organism_id,
-      '#placeholder' => $this->getSetting('placeholder'),
       '#empty_option' => '-- Select --',
     ];
 
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
     return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is usually organism_id, but not always.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no organism_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
   }
 }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado project widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_project_widget_default",
+ *   label = @Translation("Chado Project Widget"),
+ *   description = @Translation("The default project widget."),
+ *   field_types = {
+ *     "chado_project_type_default"
+ *   }
+ * )
+ */
+class ChadoProjectWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'project_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of projects.
+    $projects = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('project', 'p');
+    $query->fields('p', ['project_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($project = $results->fetchObject()) {
+      $project_name = $project->name;
+      $projects[$project->project_id] = $project_name;
+    }
+    natcasesort($projects);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $project_id = $item_vals[$linker_fkey_column] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $projects,
+      '#default_value' => $project_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is project_id.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no project_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado protocol widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_protocol_widget_default",
+ *   label = @Translation("Chado Protocol Widget"),
+ *   description = @Translation("The default protocol widget."),
+ *   field_types = {
+ *     "chado_protocol_type_default"
+ *   }
+ * )
+ */
+class ChadoProtocolWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'protocol_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of protocols.
+    $protocols = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('protocol', 'p');
+    $query->fields('p', ['protocol_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($protocol = $results->fetchObject()) {
+      $protocol_name = $protocol->name;
+      $protocols[$protocol->protocol_id] = $protocol_name;
+    }
+    natcasesort($protocols);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $protocol_id = $item_vals[$linker_fkey_column] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $protocols,
+      '#default_value' => $protocol_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id, rank,
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is protocol_id.
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no protocol_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado publication widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_pub_widget_default",
+ *   label = @Translation("Chado Publication Widget"),
+ *   description = @Translation("The default publication widget."),
+ *   field_types = {
+ *     "chado_pub_type_default"
+ *   }
+ * )
+ */
+class ChadoPubWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'pub_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of publications.
+    $pubs = [];
+    $chado = \Drupal::service('tripal_chado.database');
+
+    // In addition to getting a sorted list of pubs, include
+    // the pubprop rdfs:type when it is present, e.g.
+    // genome assembly or genome annotation.
+    $sql = 'SELECT P.pub_id, P.title FROM {1:pub} P
+      ORDER BY LOWER(P.title)';
+    $results = $chado->query($sql, []);
+
+    while ($pub = $results->fetchObject()) {
+      $pubs[$pub->pub_id] = $pub->title;
+      // Change the non-user-friendly 'null' publication.
+      if ($pubs[$pub->pub_id] == '') {
+        $pubs[$pub->pub_id] = '-- Unknown --';  // This will sort to the top.
+      }
+    }
+    natcasesort($pubs);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $pub_id = $item_vals['pub_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $pubs,
+      '#default_value' => $pub_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is pub_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no pub_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado stock widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_stock_widget_default",
+ *   label = @Translation("Chado Stock Widget"),
+ *   description = @Translation("The default stock widget."),
+ *   field_types = {
+ *     "chado_stock_type_default"
+ *   }
+ * )
+ */
+class ChadoStockWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'stock_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of stocks.
+    $stocks = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('stock', 's');
+    $query->fields('s', ['stock_id', 'name']);
+    $query->orderBy('name');
+    $results = $query->execute();
+    while ($stock = $results->fetchObject()) {
+      $stocks[$stock->stock_id] = $stock->name;
+    }
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $stock_id = $item_vals['stock_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $stocks,
+      '#default_value' => $stock_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is stock_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no stock_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Chado study widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_study_widget_default",
+ *   label = @Translation("Chado Study Widget"),
+ *   description = @Translation("The default study widget."),
+ *   field_types = {
+ *     "chado_study_type_default"
+ *   }
+ * )
+ */
+class ChadoStudyWidgetDefault extends ChadoWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $linker_fkey_column = $storage_settings['linker_fkey_column']
+      ?? $storage_settings['base_column'] ?? 'study_id';
+    $property_definitions = $items[$delta]->getFieldDefinition()->getFieldStorageDefinition()->getPropertyDefinitions();
+
+    // Get the list of studies. Include contacts because that has a not null constraint.
+    $studys = [];
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('study', 's');
+    $query->leftJoin('contact', 'c', 's.contact_id = c.contact_id');
+    $query->fields('s', ['study_id', 'name']);
+    $query->addField('c', 'name', 'contact_name');
+    $query->orderBy('name', 'contact_name');
+    $results = $query->execute();
+    while ($study = $results->fetchObject()) {
+      $study_name = $study->name;
+      if ($study->contact_name) {
+        $study_name .= ' (' . $study->contact_name . ')';
+      }
+      $studys[$study->study_id] = $study_name;
+    }
+    natcasesort($studys);
+
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $link = $item_vals['link'] ?? 0;
+    $study_id = $item_vals['study_id'] ?? 0;
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_id,
+    ];
+    $elements['link'] = [
+      '#type' => 'value',
+      '#default_value' => $link,
+    ];
+    // pass the foreign key name through the form for massageFormValues()
+    $elements['linker_fkey_column'] = [
+      '#type' => 'value',
+      '#default_value' => $linker_fkey_column,
+    ];
+    $elements[$linker_fkey_column] = $element + [
+      '#type' => 'select',
+      '#options' => $studys,
+      '#default_value' => $study_id,
+      '#empty_option' => '-- Select --',
+    ];
+
+    // If there are any additional columns present in the linker table,
+    // use a default of 1 which will work for type_id or rank.
+    // or pub_id. Any existing value will pass through as the default.
+    foreach ($property_definitions as $property => $definition) {
+      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
+        $default_value = $item_vals[$property] ?? 1;
+        $elements[$property] = [
+          '#type' => 'value',
+          '#default_value' => $default_value,
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // Handle any empty values.
+    foreach ($values as $val_key => $value) {
+      // Foreign key is usually study_id
+      $linker_fkey_column = $value['linker_fkey_column'];
+      if ($value[$linker_fkey_column] == '') {
+        if ($value['record_id']) {
+          // If there is a record_id, but no study_id, this means
+          // we need to pass in this record to chado storage to
+          // have the linker record be deleted there. To do this,
+          // we need to have the correct primitive type for this
+          // field, so change from empty string to zero.
+          $values[$val_key][$linker_fkey_column] = 0;
+        }
+        else {
+          unset($values[$val_key]);
+        }
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      $values[$val_key]['_weight'] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -42,11 +42,7 @@ class ChadoStudyWidgetDefault extends ChadoWidgetBase {
     $query->orderBy('name', 'contact_name');
     $results = $query->execute();
     while ($study = $results->fetchObject()) {
-      $study_name = $study->name;
-      if ($study->contact_name) {
-        $study_name .= ' (' . $study->contact_name . ')';
-      }
-      $studys[$study->study_id] = $study_name;
+      $studys[$study->study_id] = $study->name;
     }
     natcasesort($studys);
 


### PR DESCRIPTION
# New Feature

### Closes #1381 
### Closes #1387
### Issue #1414 
### Issue #1550 

### Tripal Version: 4.alpha1

## Description
This PR will add all of the linking fields needed by core tripal, and updates a few existing ones to have linking capability.
For issue #1550 it will add the remaining missing fields from columns of the content type's base table to several content types, especially pub.
It will also add these linking fields to most content types through the yaml files in `tripal_chado/config/install/tripal.tripalfield_collection.xxx_chado.yml`

What is not done here is adding fields for the "complicated" content types. These are the cases where there are multiple content types derived from a single chado table. Four example, there are four content types from the `stock` table, they are all listed https://github.com/tripal/tripal_doc/issues/32#issuecomment-1837528225

Also, linking fields between two different entity groups are not yet added, for example stock (germplasm) <->feature (genetic or genomic)
Any table columns needing a timestamp are not here because the ChadoTimeDefault field does not yet exist (https://github.com/tripal/tripal/issues/1550#issuecomment-1623912019)

## Testing?
1. Build a docker on this branch
```
port=8080
git clone https://github.com/tripal/tripal.git testing-1381
cd testing-1381
git checkout tv4g1-issue1381-chado_linker_simple_fields
docker build --tag=tripaldocker:testing-1381 --build-arg drupalversion="10.1.x-dev" --build-arg chadoschema='chado' --file tripaldocker/Dockerfile-php8.2-pgsql13 ./
docker run --publish=${port}:80 --name=1381 -tid --volume=$(pwd):/var/www/drupal/web/modules/contrib/tripal tripalproject/tripaldocker:latest
docker exec testing-1381 service postgresql start
```
2. Go to "Page Structure" -> "+Import type collection"  -> Check all boxes and click "Import"
`drush trp-run-jobs --username=drupaladmin --root=/var/www/drupal/web`
There should of course be no errors.
3. Create some content for testing, this order lets you proceed nicely through the 15 tables use by core Tripal content:
Organism - Enter something for all the fields, and as you go down this list you will be able to link to the earlier content you just made. 
4. Contact
5. Publication - Make sure to put unique content in each of the publication fields to test them all. For ELocation and URL try something with a `https:` prefix to make sure it displays as a link
![20240110_ElocationURL](https://github.com/tripal/tripal/assets/8419404/eb9c85aa-009b-4b87-8ea6-179b2823dbf2)

7. Protocol
8. ArrayDesign - leave at least one of the later integer fields empty. Having a non-required integer field left blank tests the fix for issue #1387.
9. Study - specify both contact and publication when you create it. This tests the current version of chado storage - there should  be no error.
10. Assay
11. Analysis
12. Phylogenetic Tree
13. Project
14. Genetic Map
15. Germplasm accession (stock table)
16. Biological Sample
17. Gene (feature table)
18. DNA Library - Here the "Is Obsolete" field is a integer, and it is required. (Don't ask me why, chado defines it that way) Test using `0` to make sure zero is an integer! (Tests #1707)
![20240110_15tables](https://github.com/tripal/tripal/assets/8419404/42b20eb0-1b26-4327-adf4-0b2762ea1793)

19. Test as many other content types as you can stand, filling out all of the fields to make sure they work.