### PR TITLE
Fixes Usage of TripalJob

### DIFF
--- a/tripal/src/Form/ImportTripalEntityTypeCollection.php
+++ b/tripal/src/Form/ImportTripalEntityTypeCollection.php
@@ -77,7 +77,7 @@ final class ImportTripalEntityTypeCollection extends FormBase {
 
     // Now create the job.
     $job_submitted = \Drupal::service('tripal.job')->create([
-      'job_name' => "Import Tripal Entity Type Collection",
+      'job_name' => t('Import Tripal Entity Type Collection'),
       'modulename' => 'tripal',
       'uid' => $current_user->id(),
       'callback' => 'import_tripalentitytype_collection',

--- a/tripal/src/Form/TripalEntityPublishForm.php
+++ b/tripal/src/Form/TripalEntityPublishForm.php
@@ -168,6 +168,12 @@ class TripalEntityPublishForm extends FormBase {
     $current_user = \Drupal::currentUser();
     $job_args = [$bundle, $datastore, $values];
     $job_name = 'Publish pages of type: ' . $bundle;
-    tripal_add_job($job_name, 'tripal', 'tripal_publish', $job_args, $current_user->id());
+    \Drupal::service('tripal.job')->create([
+      'job_name' => $job_name,
+      'modulename' => 'tripal',
+      'callback' => 'tripal_publish',
+      'arguments' => $job_args,
+      'uid' => $current_user->id(),
+    ]);
   }
 }

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -335,9 +335,13 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
     // Add a job to run the importer.
     try {
       $args = [$this->import_id];
-      $includes = [];
-      $job_id = tripal_add_job($this->plugin_definition['button_text'], 'tripal',
-        'tripal_run_importer', $args, $uid, 10, $includes);
+      $job_id = \Drupal::service('tripal.job')->create([
+        'job_name' => $this->plugin_definition['button_text'],
+        'modulename' => 'tripal',
+        'callback' => 'tripal_run_importer',
+        'arguments' => $args,
+        'uid' => $uid
+      ]);
 
       return $job_id;
     }

--- a/tripal_chado/src/Form/ChadoInstallForm.php
+++ b/tripal_chado/src/Form/ChadoInstallForm.php
@@ -32,15 +32,15 @@ class ChadoInstallForm extends FormBase {
     $form['msg-top'] = [
       '#type' => 'item',
       '#markup' => t('@chado is a relational database schema for storing molecular
-        biological and ancillary data. It is used in many tools. Tripal 
+        biological and ancillary data. It is used in many tools. Tripal
         uses Chado as a datastore for biological content.  If Chado is not installed
         then click the button below to install it.  You may also use the advanced
-        options to use a specific PostgreSQL schema name for Chado or 
+        options to use a specific PostgreSQL schema name for Chado or
         install multiple Chado instances if desired.', [
-          '@chado' => Link::fromTextAndUrl('Chado', Url::fromUri('https://chado.readthedocs.io/en/rtd/'))->toString(), 
+          '@chado' => Link::fromTextAndUrl('Chado', Url::fromUri('https://chado.readthedocs.io/en/rtd/'))->toString(),
         ]),
     ];
-    
+
     // Now that we support multiple chado instances, we need to list all the
     // currently installed ones here since they may be different versions.
     $rows = [];
@@ -87,23 +87,23 @@ class ChadoInstallForm extends FormBase {
       }
       return $order;
     });
-    
+
     // Get the default Chado instance.
     $default_chado = NULL;
     if ($chado->schema()->schemaExists()) {
       $default_chado =$chado->getSchemaName();
     }
-    
+
     // Determine if the default Chado is integrated with Tripal.
     $default_integrated = False;
     $none_integrated = True;
     if ($default_chado && $instances[$default_chado]['integration']) {
       $default_integrated = True;
     }
-    
+
     // Build the table of Chado installations.
-    foreach ($instances as $schema_name => $details) {  
-      
+    foreach ($instances as $schema_name => $details) {
+
       // Integrated schemas and non-integrated have different informations.
       if ($details['integration']) {
         $none_integrated = False;
@@ -128,17 +128,17 @@ class ChadoInstallForm extends FormBase {
         ];
       }
     }
-    
+
     $form['existing_instances'] = [
       '#type' => 'table',
       '#header' => ['Schema Name', 'Chado Version', 'Has data', 'In Tripal', 'Created', 'Updated'],
       '#rows' => $rows,
       '#empty' => 'There are no instances of Chado available.  Please submit this form to install Chado.'
     ];
-    
+
     if (count($rows) > 0 and empty($default_chado)) {
-      \Drupal::messenger()->addWarning(t('Chado is installed but no default 
-        schema was set. Please @select or install a new default Chado instance.', 
+      \Drupal::messenger()->addWarning(t('Chado is installed but no default
+        schema was set. Please @select or install a new default Chado instance.',
           ['@select' => Link::fromTextAndUrl('select a default Chado schema',
               Url::fromUri('internal:/admin/tripal/storage/chado/manager'))->toString()],
       ));
@@ -146,14 +146,14 @@ class ChadoInstallForm extends FormBase {
     if (count($rows) > 0 and $none_integrated) {
       \Drupal::messenger()->addWarning(t('There is no Chado installation that
         has been integratred with Tripal. Please @integrate it into Tripal.',
-          ['@integrate' => Link::fromTextAndUrl('add', 
+          ['@integrate' => Link::fromTextAndUrl('add',
               Url::fromUri('internal:/admin/tripal/storage/chado/manager'))->toString()],
           ));
     }
     if (count($rows) > 0 and $default_chado and !$default_integrated) {
-      \Drupal::messenger()->addWarning(t('The default Chado schema is not 
+      \Drupal::messenger()->addWarning(t('The default Chado schema is not
         integrated with Tripal. Please @integrate it into Tripal.',
-          ['@integrate' => Link::fromTextAndUrl('add', 
+          ['@integrate' => Link::fromTextAndUrl('add',
               Url::fromUri('internal:/admin/tripal/storage/chado/manager'))->toString()],
       ));
     }
@@ -161,7 +161,7 @@ class ChadoInstallForm extends FormBase {
     if (count($rows) == 0) {
       \Drupal::messenger()->addWarning('Chado is not installed.');
     }
-    
+
     $form['advanced'] = [
       '#type' => 'details',
       '#title' => 'Advanced Options',
@@ -176,10 +176,10 @@ class ChadoInstallForm extends FormBase {
       '#description' => t('By default, the PostgreSQL schema name for Chado
         is "chado".  Change this if you perfer a different name.
         Additionally, you may install multiple instances of Chado by submitting
-        this form once for each Chado instance and providing a unique schema 
-        name each time. Examples cases when you may want multiple chado 
-        instances are for a separate testing version, if different chado 
-        instances are needed for different user groups (e.g., breeders of 
+        this form once for each Chado instance and providing a unique schema
+        name each time. Examples cases when you may want multiple chado
+        instances are for a separate testing version, if different chado
+        instances are needed for different user groups (e.g., breeders of
         different crops) or both a public and private chado).'),
     ];
 
@@ -234,13 +234,13 @@ class ChadoInstallForm extends FormBase {
     $schema_name = trim($values['schema_name']);
     $current_user = \Drupal::currentUser();
     $args = [$schema_name, ChadoInstaller::DEFAULT_CHADO_VERSION];
-    tripal_add_job(
-      t('Install Chado ' . ChadoInstaller::DEFAULT_CHADO_VERSION),
-      'tripal_chado',
-      'tripal_chado_install_chado',
-      $args,
-      $current_user->id(),
-      10
-    );
+
+    \Drupal::service('tripal.job')->create([
+      'job_name' => t('Install Chado @version', ['@version' => ChadoInstaller::DEFAULT_CHADO_VERSION]),
+      'modulename' => 'tripal_chado',
+      'callback' => 'tripal_chado_install_chado',
+      'arguments' => $args,
+      'uid' => $current_user->id(),
+    ]);
   }
 }

--- a/tripal_chado/src/Form/ChadoManagerForm.php
+++ b/tripal_chado/src/Form/ChadoManagerForm.php
@@ -719,14 +719,14 @@ class ChadoManagerForm extends FormBase {
 
     $current_user = \Drupal::currentUser();
     $args = [$source_schema_name, $new_schema_name];
-    tripal_add_job(
-      t('Clone Chado schema'),
-      'tripal_chado',
-      'tripal_chado_clone_schema',
-      $args,
-      $current_user->id(),
-      10
-    );
+
+    \Drupal::service('tripal.job')->create([
+      'job_name' => t('Clone Chado schema'),
+      'modulename' => 'tripal_chado',
+      'callback' => 'tripal_chado_clone_schema',
+      'arguments' => $args,
+      'uid' => $current_user->id()
+    ]);
 
     // Go back.
     $this->goBackForm($form, $form_state);
@@ -810,14 +810,14 @@ class ChadoManagerForm extends FormBase {
 
     $current_user = \Drupal::currentUser();
     $args = [$schema_name, '1.3', $sql_file, $cleanup];
-    tripal_add_job(
-      t('Upgrade Chado schema'),
-      'tripal_chado',
-      'tripal_chado_upgrade_schema',
-      $args,
-      $current_user->id(),
-      10
-    );
+
+    \Drupal::service('tripal.job')->create([
+      'job_name' => t('Upgrade Chado schema'),
+      'modulename' => 'tripal_chado',
+      'callback' => 'tripal_chado_upgrade_schema',
+      'arguments' => $args,
+      'uid' => $current_user->id(),
+    ]);
 
     // Go back.
     $this->goBackForm($form, $form_state);

--- a/tripal_chado/src/Form/ChadoMviewPopulateForm.php
+++ b/tripal_chado/src/Form/ChadoMviewPopulateForm.php
@@ -66,8 +66,13 @@ class ChadoMviewPopulateForm extends FormBase {
       $mview = $mviews->loadById($mview_id);
       $current_user = \Drupal::currentUser();
       $args = [$mview_id];
-      tripal_add_job("Populate materialized view '$mview->getTableName()'", 'tripal_chado',
-          'chado_populate_mview', $args, $current_user->id());
+      \Drupal::service('tripal.job')->create([
+        'job_name' => t("Populate materialized view: '@table'", ['@table' => $mview->getTableName()]),
+        'modulename' => 'tripal_chado',
+        'callback' => 'chado_populate_mview',
+        'arguments' => $args,
+        'uid' => $current_user->id()
+      ]);
     }
     else {
       \Drupal::messenger()->addMessage(t("No action performed."));

--- a/tripal_chado/src/Form/ChadoPrepareForm.php
+++ b/tripal_chado/src/Form/ChadoPrepareForm.php
@@ -33,20 +33,20 @@ class ChadoPrepareForm extends FormBase {
         It will also add some management tables to Drupal and add some default
         content types for biological and ancillary data."),
     ];
-        
+
     $form['advanced'] = [
       '#type' => 'details',
       '#title' => 'Advanced Options',
-    ];   
-    
-    
+    ];
+
+
     $chado_schemas = [];
     $chado = \Drupal::service('tripal_chado.database');
     foreach ($chado->getAvailableInstances() as $schema_name => $details) {
       $chado_schemas[$schema_name] = $schema_name;
     }
     $default_chado = $chado->getSchemaName();
-    
+
     $form['advanced']['schema_name'] = [
       '#type' => 'select',
       '#title' => 'Chado Schema Name',
@@ -73,8 +73,13 @@ class ChadoPrepareForm extends FormBase {
       $current_user = \Drupal::currentUser();
       $args = [$schema_name];
 
-      tripal_add_job('Prepare Chado', 'tripal_chado',
-        'tripal_chado_prepare_chado', $args, $current_user->id(), 10);
+      \Drupal::service('tripal.job')->create([
+        'job_name' => t('Prepare Chado'),
+        'modulename' => 'tripal_chado',
+        'callback' => 'tripal_chado_prepare_chado',
+        'arguments' => $args,
+        'uid' => $current_user->id()
+      ]);
     }
   }
 }

--- a/tripal_chado/src/api/tripal_chado.mviews.api.php
+++ b/tripal_chado/src/api/tripal_chado.mviews.api.php
@@ -203,9 +203,14 @@ function chado_refresh_mview($mview_id) {
 
   $mviews = \Drupal::service('tripal_chado.materialized_views');
   $mview = $mviews->loadById($mview_id);
-  $args = ["$mview_id"];
-  tripal_add_job("Populate materialized view '" . $mview->getTableName() . "'", 'tripal_chado',
-    'chado_populate_mview', $args, $current_user->id());
+
+  \Drupal::service('tripal.job')->create([
+    'job_name' => t("Populate materialized view: '@table'", ['@table' => $mview->getTableName()]),
+    'modulename' => 'tripal_chado',
+    'callback' => 'chado_populate_mview',
+    'arguments' => [$mview_id],
+    'uid' => $current_user->id()
+  ]);
 }
 
 /**


### PR DESCRIPTION
# Bug Fix

### Issue #1705
### Issue #1744

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The interface for importing multiple collection types works but would never report to the user the command-line needed to run the job. It turns out that code was use the Drupal service for jobs, but everywhere else that we are using jobs, we uesd the old legacy API function.

This PR makes 3 fixes.

1. It fixes the TripalJob::create() function so it prints out the command-line instructions for running the job.
2. It updates the tripal_add_job() legacy API function to fully use the TripalJob service. 
3. It updates everywhere that we used the old `tripal_add_job` to use the TripalJob service.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

On a fresh install you'll need to test everywhere that a `tripal_add_job` function got replaced.  This includes
1. Installation of Chado
2. Preparing Chado.
3. Clone Chado -- the running of the job shoudl work but cloning at the moment is broken.
4. Running any importer
5. Publising a Tripal Content
6. Populating a materialized view

All jobs should launch!
