### PR TITLE
Chado fix for box_range

### DIFF
--- a/tripal_chado/chado_schema/chunk_sql_file.php
+++ b/tripal_chado/chado_schema/chunk_sql_file.php
@@ -8,6 +8,14 @@
  *   - Support multi-line SQL statements to ensure none are split
  *   - expected to be run on the command-line
  *   - does NOT require drush/drupal.
+ *
+ * Example usage:
+ *   cd parts-v1.3
+ *   php ../chunk_sql_file.php ../default_schema-1.3.sql default_schema-1.3.part
+ *
+ * The script will generate multiple lines of output showing you where
+ * it split. Check this output to make sure that it didn't split within
+ * the middle of a valid SQL statement.
  */
 
 // -- PARAMETERS --------------------------------------------------------------

--- a/tripal_chado/chado_schema/default_schema-1.3.sql
+++ b/tripal_chado/chado_schema/default_schema-1.3.sql
@@ -42870,3 +42870,51 @@ CREATE INDEX nd_experiment_analysis_idx2 ON nd_experiment_analysis (analysis_id)
 CREATE INDEX nd_experiment_analysis_idx3 ON nd_experiment_analysis (type_id);
 
 COMMENT ON TABLE nd_experiment_analysis IS 'An analysis that is used in an experiment';
+
+
+---
+--- The following additions are part of the pull request on Chado:
+--- https://github.com/GMOD/Chado/pull/105 
+--- Once a new version of Chado is made these changes will be integrated
+--- but we need them now to prevent create_point errors when deleting features
+--- or cloning Chado.
+---
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(INTEGER) RETURNS INTEGER
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    cvid alias for $1;
+    root cvterm%ROWTYPE;
+BEGIN
+    DELETE FROM cvtermpath WHERE cv_id = cvid;
+    FOR root IN SELECT DISTINCT t.* from cvterm t LEFT JOIN cvterm_relationship r ON (t.cvterm_id = r.subject_id) INNER JOIN cvterm_relationship r2 ON (t.cvterm_id = r2.object_id) WHERE t.cv_id = cvid AND r.subject_id is null LOOP
+        PERFORM _fill_cvtermpath4root(root.cvterm_id, root.cv_id);
+    END LOOP;
+    RETURN 1;
+END;
+$_$;
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(cv.name%TYPE) RETURNS INTEGER
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    cvname alias for $1;
+    cv_id   int;
+    rtn     int;
+BEGIN
+    SELECT INTO cv_id cv.cv_id from cv WHERE cv.name = cvname;
+    SELECT INTO rtn fill_cvtermpath(cv_id);
+    RETURN rtn;
+END;
+$_$;
+
+-- create a range box
+-- (make this immutable so we can index it)
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point(CAST(0 AS bigint), $1), create_point($2,500000000))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;
+
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point($1, $2), create_point($1,$3))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part1.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part1.sql
@@ -72,8 +72,8 @@ CREATE VIEW db_dbxref_count AS
   SELECT db.name,count(*) AS num_dbxrefs FROM db INNER JOIN dbxref USING (db_id) GROUP BY db.name;
 COMMENT ON VIEW db_dbxref_count IS 'per-db dbxref counts';
 
-CREATE OR REPLACE FUNCTION store_db (VARCHAR)
-  RETURNS BIGINT AS
+CREATE OR REPLACE FUNCTION store_db (VARCHAR) 
+  RETURNS BIGINT AS 
 'DECLARE
    v_name             ALIAS FOR $1;
 
@@ -92,9 +92,9 @@ CREATE OR REPLACE FUNCTION store_db (VARCHAR)
     RETURN v_db_id;
  END;
 ' LANGUAGE 'plpgsql';
-
-CREATE OR REPLACE FUNCTION store_dbxref (VARCHAR,VARCHAR)
-  RETURNS BIGINT AS
+  
+CREATE OR REPLACE FUNCTION store_dbxref (VARCHAR,VARCHAR) 
+  RETURNS BIGINT AS 
 'DECLARE
    v_dbname                ALIAS FOR $1;
    v_accession             ALIAS FOR $2;
@@ -118,7 +118,7 @@ CREATE OR REPLACE FUNCTION store_dbxref (VARCHAR,VARCHAR)
     RETURN v_dbxref_id;
  END;
 ' LANGUAGE 'plpgsql';
-
+  
 -- $Id: cv.sql,v 1.37 2007-02-28 15:08:48 briano Exp $
 -- ==========================================
 -- Chado cv module
@@ -359,17 +359,17 @@ it is a dbxref for provenance information for the definition.';
 -- ================================================
 -- TABLE: cvtermprop
 -- ================================================
-create table cvtermprop (
-    cvtermprop_id bigserial not null,
-    primary key (cvtermprop_id),
-    cvterm_id bigint not null,
-    foreign key (cvterm_id) references cvterm (cvterm_id) on delete cascade,
-    type_id bigint not null,
-    foreign key (type_id) references cvterm (cvterm_id) on delete cascade,
-    value text not null default '',
+create table cvtermprop ( 
+    cvtermprop_id bigserial not null, 
+    primary key (cvtermprop_id), 
+    cvterm_id bigint not null, 
+    foreign key (cvterm_id) references cvterm (cvterm_id) on delete cascade, 
+    type_id bigint not null, 
+    foreign key (type_id) references cvterm (cvterm_id) on delete cascade, 
+    value text not null default '', 
     rank int not null default 0,
 
-    unique(cvterm_id, type_id, value, rank)
+    unique(cvterm_id, type_id, value, rank) 
 );
 create index cvtermprop_idx1 on cvtermprop (cvterm_id);
 create index cvtermprop_idx2 on cvtermprop (type_id);
@@ -483,11 +483,11 @@ completely extensible. There is a unique constraint, dbprop_c1, for
 the combination of db_id, rank, and type_id. Multivalued property-value pairs must be differentiated by rank.';
 
 CREATE OR REPLACE VIEW cv_root AS
- SELECT
+ SELECT 
   cv_id,
   cvterm_id AS root_cvterm_id
  FROM cvterm
- WHERE
+ WHERE 
   cvterm_id NOT IN ( SELECT subject_id FROM cvterm_relationship)    AND
   is_obsolete=0;
 
@@ -497,11 +497,11 @@ relation). Most cvs will have a single root, some may have >1. All
 will have at least 1';
 
 CREATE OR REPLACE VIEW cv_leaf AS
- SELECT
+ SELECT 
   cv_id,
   cvterm_id
  FROM cvterm
- WHERE
+ WHERE 
   cvterm_id NOT IN ( SELECT object_id FROM cvterm_relationship);
 
 COMMENT ON VIEW cv_leaf IS 'the leaves of a cv are the set of terms
@@ -520,7 +520,7 @@ CREATE OR REPLACE VIEW common_ancestor_cvterm AS
  FROM
   cvtermpath AS p1,
   cvtermpath AS p2
- WHERE
+ WHERE 
   p1.object_id = p2.object_id;
 
 COMMENT ON VIEW common_ancestor_cvterm IS 'The common ancestor of any
@@ -540,7 +540,7 @@ CREATE OR REPLACE VIEW common_descendant_cvterm AS
  FROM
   cvtermpath AS p1,
   cvtermpath AS p2
- WHERE
+ WHERE 
   p1.subject_id = p2.subject_id;
 
 COMMENT ON VIEW common_descendant_cvterm IS 'The common descendant of
@@ -549,8 +549,8 @@ can have multiple common descendants. Use total_pathdistance to get
 the least common ancestor';
 
 CREATE OR REPLACE VIEW stats_paths_to_root AS
- SELECT
-  subject_id                            AS cvterm_id,
+ SELECT 
+  subject_id                            AS cvterm_id, 
   count(DISTINCT cvtermpath_id)         AS total_paths,
   avg(pathdistance)                     AS avg_distance,
   min(pathdistance)                     AS min_distance,
@@ -576,11 +576,11 @@ CREATE VIEW cv_link_count AS
         relation.name AS relation_name,
         relation_cv.name AS relation_cv_name,
         count(*) AS num_links
- FROM cv
-  INNER JOIN cvterm ON (cvterm.cv_id=cv.cv_id)
+ FROM cv 
+  INNER JOIN cvterm ON (cvterm.cv_id=cv.cv_id) 
   INNER JOIN cvterm_relationship ON (cvterm.cvterm_id=subject_id)
   INNER JOIN cvterm AS relation ON (type_id=relation.cvterm_id)
-  INNER JOIN cv AS relation_cv ON (relation.cv_id=relation_cv.cv_id)
+  INNER JOIN cv AS relation_cv ON (relation.cv_id=relation_cv.cv_id) 
  GROUP BY cv.name,relation.name,relation_cv.name;
 
 COMMENT ON VIEW cv_link_count IS 'per-cv summary of number of
@@ -593,11 +593,11 @@ CREATE VIEW cv_path_count AS
         relation.name AS relation_name,
         relation_cv.name AS relation_cv_name,
         count(*) AS num_paths
- FROM cv
-  INNER JOIN cvterm ON (cvterm.cv_id=cv.cv_id)
+ FROM cv 
+  INNER JOIN cvterm ON (cvterm.cv_id=cv.cv_id) 
   INNER JOIN cvtermpath ON (cvterm.cvterm_id=subject_id)
   INNER JOIN cvterm AS relation ON (type_id=relation.cvterm_id)
-  INNER JOIN cv AS relation_cv ON (relation.cv_id=relation_cv.cv_id)
+  INNER JOIN cv AS relation_cv ON (relation.cv_id=relation_cv.cv_id) 
  GROUP BY cv.name,relation.name,relation_cv.name;
 
 COMMENT ON VIEW cv_path_count IS 'per-cv summary of number of
@@ -620,7 +620,7 @@ BEGIN
         END LOOP;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -645,7 +645,7 @@ BEGIN
         END LOOP;
     END IF;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -665,7 +665,7 @@ BEGIN
         END LOOP;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -686,7 +686,7 @@ BEGIN
         END LOOP;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -705,7 +705,7 @@ BEGIN
         END LOOP;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -731,7 +731,7 @@ BEGIN
         END LOOP;
     END IF;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -751,7 +751,7 @@ BEGIN
         END LOOP;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 --- example: select * from fill_cvtermpath(7); where 7 is cv_id for an ontology
@@ -821,7 +821,7 @@ BEGIN
         PERFORM _fill_cvtermpath4root(root.cvterm_id, root.cv_id);
     END LOOP;
     RETURN 1;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -836,7 +836,7 @@ BEGIN
     SELECT INTO cv_id cv.cv_id from cv WHERE cv.name = cvname;
     SELECT INTO rtn fill_cvtermpath(cv_id);
     RETURN rtn;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -947,7 +947,7 @@ BEGIN
     END IF;
     DROP TABLE tmpcvtermpath;
     RETURN 0;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -967,7 +967,7 @@ BEGIN
         END IF;
     END LOOP;
     RETURN;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -991,7 +991,7 @@ BEGIN
     END LOOP;
     DROP TABLE tmpcvtermpath;
     RETURN 0;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -1007,7 +1007,7 @@ BEGIN
     SELECT INTO rtn  get_cycle_cvterm_id(cv_id);
 
     RETURN rtn;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 -- $Id: contact.sql,v 1.5 2007-02-25 17:00:17 briano Exp $

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part10.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part10.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** U2 is a small nuclear RNA (snRNA) compon ***
 --- *** ent of the spliceosome (involved in pre- ***
 --- *** mRNA splicing). Complementary binding be ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part11.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part11.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: chromosomal_transposition ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part12.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part12.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** eptor gene in germline configuration inc ***
 --- *** luding at least one J-gene and one C-gen ***
 --- *** e.                                       ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part13.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part13.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: inversion_derived_aneuploid_chromosome ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part14.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part14.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: silencer ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part15.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part15.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: golden_path ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part16.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part16.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: cyanelle_sequence ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part17.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part17.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- ***                                          ***
 --- *** A gene that rescues.                     ***
 --- ************************************************

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part18.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part18.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- ************************************************
 ---
 

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part19.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part19.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: rna_chromosome ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part2.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part2.sql
@@ -33,7 +33,7 @@ CREATE TABLE contactprop (
     type_id bigint NOT NULL,
     value text,
     rank integer DEFAULT 0 NOT NULL,
-    CONSTRAINT contactprop_c1 UNIQUE (contact_id, type_id, rank),
+    CONSTRAINT contactprop_c1 UNIQUE (contact_id, type_id, rank),    
     FOREIGN KEY (contact_id) REFERENCES contact(contact_id) ON DELETE CASCADE,
     FOREIGN KEY (type_id) REFERENCES cvterm(cvterm_id) ON DELETE CASCADE
 );
@@ -41,8 +41,8 @@ CREATE TABLE contactprop (
 CREATE INDEX contactprop_idx1 ON contactprop USING btree (contact_id);
 CREATE INDEX contactprop_idx2 ON contactprop USING btree (type_id);
 
-COMMENT ON TABLE contactprop IS 'A contact can have any number of slot-value property
-tags attached to it. This is an alternative to hardcoding a list of columns in the
+COMMENT ON TABLE contactprop IS 'A contact can have any number of slot-value property 
+tags attached to it. This is an alternative to hardcoding a list of columns in the 
 relational schema, and is completely extensible.';
 
 
@@ -268,11 +268,11 @@ this is appended onto the species name. Follows standard NCBI taxonomy
 pattern.';
 
 COMMENT ON COLUMN organism.type_id IS 'A controlled vocabulary term that
-specifies the organism rank below species. It is used when an infraspecific
-name is provided.  Ideally, the rank should be a valid ICN name such as
+specifies the organism rank below species. It is used when an infraspecific 
+name is provided.  Ideally, the rank should be a valid ICN name such as 
 subspecies, varietas, subvarietas, forma and subforma';
 
-COMMENT ON COLUMN organism.infraspecific_name IS 'The scientific name for any taxon
+COMMENT ON COLUMN organism.infraspecific_name IS 'The scientific name for any taxon 
 below the rank of species.  The rank should be specified using the type_id field
 and the name is provided here.';
 
@@ -372,7 +372,7 @@ DEFERRED,
        rank int not null default 0,
        pub_id bigint not null,
        foreign key (pub_id) references pub (pub_id) on delete cascade INITIALLY DEFERRED,
-       constraint organism_cvterm_c1 unique(organism_id,cvterm_id,pub_id)
+       constraint organism_cvterm_c1 unique(organism_id,cvterm_id,pub_id) 
 );
 create index organism_cvterm_idx1 on organism_cvterm (organism_id);
 create index organism_cvterm_idx2 on organism_cvterm (cvterm_id);
@@ -435,15 +435,15 @@ CREATE TABLE organism_relationship (
     CONSTRAINT organism_relationship_c1 UNIQUE (subject_id, object_id, type_id, rank),
     FOREIGN KEY (object_id) REFERENCES organism(organism_id) ON DELETE CASCADE,
     FOREIGN KEY (subject_id) REFERENCES organism(organism_id) ON DELETE CASCADE,
-    FOREIGN KEY (type_id) REFERENCES cvterm(cvterm_id) ON DELETE CASCADE
+    FOREIGN KEY (type_id) REFERENCES cvterm(cvterm_id) ON DELETE CASCADE    
 );
 
 CREATE INDEX organism_relationship_idx1 ON organism_relationship USING btree (subject_id);
 CREATE INDEX organism_relationship_idx2 ON organism_relationship USING btree (object_id);
 CREATE INDEX organism_relationship_idx3 ON organism_relationship USING btree (type_id);
 
-COMMENT ON TABLE organism_relationship IS 'Specifies relationships between organisms
-that are not taxonomic. For example, in breeding, relationships such as
+COMMENT ON TABLE organism_relationship IS 'Specifies relationships between organisms 
+that are not taxonomic. For example, in breeding, relationships such as 
 "sterile_with", "incompatible_with", or "fertile_with" would be appropriate. Taxonomic
 relatinoships should be housed in the phylogeny tables.';
 
@@ -451,14 +451,14 @@ relatinoships should be housed in the phylogeny tables.';
 
 CREATE OR REPLACE FUNCTION get_organism_id(VARCHAR,VARCHAR) RETURNS BIGINT
  AS '
-  SELECT organism_id
+  SELECT organism_id 
   FROM organism
   WHERE genus=$1
     AND species=$2
  ' LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION get_organism_id(VARCHAR) RETURNS BIGINT
- AS '
+ AS ' 
 SELECT organism_id
   FROM organism
   WHERE genus=substring($1,1,position('' '' IN $1)-1)
@@ -473,8 +473,8 @@ SELECT organism_id
     AND species=substring($1,position('' '' IN $1)+1)
  ' LANGUAGE 'sql';
 
-CREATE OR REPLACE FUNCTION store_organism (VARCHAR,VARCHAR,VARCHAR)
-  RETURNS BIGINT AS
+CREATE OR REPLACE FUNCTION store_organism (VARCHAR,VARCHAR,VARCHAR) 
+  RETURNS BIGINT AS 
 'DECLARE
    v_genus            ALIAS FOR $1;
    v_species          ALIAS FOR $2;
@@ -500,7 +500,7 @@ CREATE OR REPLACE FUNCTION store_organism (VARCHAR,VARCHAR,VARCHAR)
     RETURN v_organism_id;
  END;
 ' LANGUAGE 'plpgsql';
-
+  
 -- $Id: sequence.sql,v 1.69 2009-05-14 02:44:23 scottcain Exp $
 -- ==========================================
 -- Chado sequence module
@@ -929,7 +929,7 @@ COMMENT ON COLUMN feature_relationship.value IS 'Additional notes or comments.';
 -- ================================================
 -- TABLE: feature_relationship_pub
 -- ================================================
-
+ 
 create table feature_relationship_pub (
 	feature_relationship_pub_id bigserial not null,
 	primary key (feature_relationship_pub_id),
@@ -944,7 +944,7 @@ create index feature_relationship_pub_idx2 on feature_relationship_pub (pub_id);
 
 COMMENT ON TABLE feature_relationship_pub IS 'Provenance. Attach optional evidence to a feature_relationship in the form of a publication.';
 
-
+ 
 -- ================================================
 -- TABLE: feature_relationshipprop
 -- ================================================

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part20.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part20.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation type: VIEW                      ***
 --- ***                                          ***
 --- *** A genome is the sum of genetic material  ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part21.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part21.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- ***                                          ***
 --- *** A binding site that, in the polypeptide  ***
 --- *** molecule, interacts selectively and non- ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part22.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part22.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: gamma_turn_inverse ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part23.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part23.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: tna ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part24.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part24.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation type: VIEW                      ***
 --- ***                                          ***
 --- *** A region of the genome of known length t ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part25.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part25.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: n6_hydroxynorvalylcarbamoyladenosine ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part26.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part26.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: five_carbamoylmethyluridine ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part27.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part27.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 ---
 
 CREATE VIEW ligation_based_read AS

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part28.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part28.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** g platforms, and is assembled into conti ***
 --- *** gs. Genome sequence of this quality may  ***
 --- *** harbour regions of poor quality and can  ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part29.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part29.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation type: VIEW                      ***
 --- ***                                          ***
 --- *** A transcript processing variant whereby  ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part30.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part30.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- ***                                          ***
 --- ************************************************
 ---

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part31.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part31.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: promoter_element ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part32.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part32.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: histone_ubiqitination_site ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part33.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part33.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: benign_variant ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part34.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part34.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: catmat_right_handed_four ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part35.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part35.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** oid product of recombination between a p ***
 --- *** ericentric inversion and a cytologically ***
 --- ***  wild-type chromosome.                   ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part36.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part36.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: four_bp_start_codon ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***
@@ -2216,7 +2216,7 @@ CREATE VIEW intron_combined_view AS
   r1.object_id          AS transcript_id
  FROM
  cvterm
-  INNER JOIN
+  INNER JOIN 
    feature                AS x1    ON (x1.type_id=cvterm.cvterm_id)
     INNER JOIN
      feature_relationship AS r1    ON (x1.feature_id=r1.subject_id)
@@ -2250,10 +2250,10 @@ CREATE VIEW intronloc_view AS
   strand,
   srcfeature_id
  FROM intron_combined_view;
-CREATE OR REPLACE FUNCTION store_feature
+CREATE OR REPLACE FUNCTION store_feature 
 (INT,INT,INT,INT,
  INT,INT,VARCHAR,VARCHAR,INT,BOOLEAN)
- RETURNS INT AS
+ RETURNS INT AS 
 'DECLARE
   v_srcfeature_id       ALIAS FOR $1;
   v_fmin                ALIAS FOR $2;
@@ -2320,7 +2320,7 @@ CREATE OR REPLACE FUNCTION store_feature
 
 CREATE OR REPLACE FUNCTION store_featureloc
 (INT,INT,INT,INT,INT,INT,INT)
- RETURNS INT AS
+ RETURNS INT AS 
 'DECLARE
   v_feature_id          ALIAS FOR $1;
   v_srcfeature_id       ALIAS FOR $2;
@@ -2374,7 +2374,7 @@ CREATE OR REPLACE FUNCTION store_featureloc
 
 CREATE OR REPLACE FUNCTION store_feature_synonym
 (INT,VARCHAR,INT,BOOLEAN,BOOLEAN,INT)
- RETURNS INT AS
+ RETURNS INT AS 
 'DECLARE
   v_feature_id          ALIAS FOR $1;
   v_syn                 ALIAS FOR $2;
@@ -2436,8 +2436,8 @@ CREATE OR REPLACE FUNCTION store_feature_synonym
 
 CREATE OR REPLACE FUNCTION subsequence(bigint,bigint,bigint,INT)
  RETURNS TEXT AS
- 'SELECT
-  CASE WHEN $4<0
+ 'SELECT 
+  CASE WHEN $4<0 
    THEN reverse_complement(substring(srcf.residues,CAST(($2+1) as int),CAST(($3-$2) as int)))
    ELSE substring(residues,CAST(($2+1) as int),CAST(($3-$2) as int))
   END AS residues
@@ -2448,8 +2448,8 @@ LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION subsequence_by_featureloc(bigint)
  RETURNS TEXT AS
- 'SELECT
-  CASE WHEN strand<0
+ 'SELECT 
+  CASE WHEN strand<0 
    THEN reverse_complement(substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int)))
    ELSE substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int))
   END AS residues
@@ -2461,8 +2461,8 @@ LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION subsequence_by_feature(bigint,INT,INT)
  RETURNS TEXT AS
- 'SELECT
-  CASE WHEN strand<0
+ 'SELECT 
+  CASE WHEN strand<0 
    THEN reverse_complement(substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int)))
    ELSE substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int))
   END AS residues
@@ -2492,11 +2492,11 @@ DECLARE v_rank       ALIAS FOR $3;
 DECLARE v_locgroup   ALIAS FOR $4;
 DECLARE subseq       TEXT;
 DECLARE seqrow       RECORD;
-BEGIN
+BEGIN 
   subseq = '''';
  FOR seqrow IN
    SELECT
-    CASE WHEN strand<0
+    CASE WHEN strand<0 
      THEN reverse_complement(substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int)))
      ELSE substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int))
     END AS residues
@@ -2540,11 +2540,11 @@ DECLARE v_rank       ALIAS FOR $3;
 DECLARE v_locgroup   ALIAS FOR $4;
 DECLARE subseq       TEXT;
 DECLARE seqrow       RECORD;
-BEGIN
+BEGIN 
   subseq = '''';
  FOR seqrow IN
    SELECT
-    CASE WHEN strand<0
+    CASE WHEN strand<0 
      THEN reverse_complement(substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int)))
      ELSE substring(srcf.residues,CAST(fmin+1 as int),CAST((fmax-fmin) as int))
     END AS residues
@@ -2571,7 +2571,7 @@ CREATE OR REPLACE FUNCTION subsequence_by_typed_subfeatures(bigint,bigint)
  'SELECT subsequence_by_typed_subfeatures($1,$2,0,0)'
 LANGUAGE 'sql';
 
-
+ 
 
 
 CREATE OR REPLACE FUNCTION feature_subalignments(bigint) RETURNS SETOF featureloc AS '
@@ -2914,7 +2914,7 @@ BEGIN
     END LOOP;
 
     RETURN 1;
-END;
+END;   
 ' LANGUAGE 'plpgsql';
 
 SET search_path = chado,pg_catalog;
@@ -2974,7 +2974,7 @@ DECLARE
     cterm soi_type%ROWTYPE;
 
 BEGIN
-
+    
     SELECT INTO ttype cvterm_id FROM cvterm WHERE name = ''isa'';
     --RAISE NOTICE ''got ttype %'',ttype;
     PERFORM _fill_cvtermpath4soinode(rootid, rootid, cvid, ttype, 0);
@@ -2982,7 +2982,7 @@ BEGIN
         PERFORM _fill_cvtermpath4soi(cterm.subject_id, cvid);
     END LOOP;
     RETURN 1;
-END;
+END;   
 '
 LANGUAGE 'plpgsql';
 
@@ -3061,7 +3061,7 @@ BEGIN
             AND tmp.cvterm_id = p.type_id AND t.cvterm_id = c.type_id AND tmp.status = 1;
         UPDATE tmproot SET status = 2 WHERE status = 1;
         EXECUTE cquery;
-        GET DIAGNOSTICS pcount = ROW_COUNT;
+        GET DIAGNOSTICS pcount = ROW_COUNT; 
     END LOOP;
     DELETE FROM tmproot;
 
@@ -3243,7 +3243,7 @@ BEGIN
         ON (f.feature_id = fl.feature_id) INNER join feature src ON (src.feature_id = fl.srcfeature_id)
         WHERE t.name = '' || quote_literal(gtype) || '' AND src.uniquename = '' || quote_literal(src)
         || '' AND f.is_analysis = '' || quote_literal(is_an) || '';'';
-
+ 
     IF (STRPOS(gtype, ''%'') > 0) THEN
         query := ''SELECT DISTINCT f.feature_id FROM feature f INNER join cvterm t ON (f.type_id = t.cvterm_id)
              INNER join featureloc fl
@@ -3271,11 +3271,11 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT f.feature_id
+    query := ''SELECT DISTINCT f.feature_id 
         FROM feature f, cvterm t WHERE t.cvterm_id = f.type_id AND t.name = '' || quote_literal(gtype) ||
         '' AND f.is_analysis = '' || quote_literal(is_an) || '';'';
     IF (STRPOS(gtype, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT f.feature_id
+        query := ''SELECT DISTINCT f.feature_id 
             FROM feature f, cvterm t WHERE t.cvterm_id = f.type_id AND t.name like ''
             || quote_literal(gtype) || '' AND f.is_analysis = '' || quote_literal(is_an) || '';'';
     END IF;
@@ -3300,14 +3300,14 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT f.feature_id
+    query := ''SELECT DISTINCT f.feature_id 
         FROM feature f INNER join cvterm t ON (f.type_id = t.cvterm_id) INNER join featureloc fl
         ON (f.feature_id = fl.feature_id) INNER join feature src ON (src.feature_id = fl.srcfeature_id)
         WHERE t.name = '' || quote_literal(gtype) || '' AND src.uniquename = '' || quote_literal(src)
         || '' AND f.is_analysis = '' || quote_literal(is_an) || '';'';
-
+ 
     IF (STRPOS(gtype, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT f.feature_id
+        query := ''SELECT DISTINCT f.feature_id 
             FROM feature f INNER join cvterm t ON (f.type_id = t.cvterm_id) INNER join featureloc fl
             ON (f.feature_id = fl.feature_id) INNER join feature src ON (src.feature_id = fl.srcfeature_id)
             WHERE t.name like '' || quote_literal(gtype) || '' AND src.uniquename = '' || quote_literal(src)
@@ -3334,13 +3334,13 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT f.feature_id
+    query := ''SELECT DISTINCT f.feature_id 
         FROM feature f INNER join cvterm t ON (f.type_id = t.cvterm_id)
         WHERE t.name = '' || quote_literal(gtype) || '' AND (f.uniquename = '' || quote_literal(name)
         || '' OR f.name = '' || quote_literal(name) || '') AND f.is_analysis = '' || quote_literal(is_an) || '';'';
-
+ 
     IF (STRPOS(name, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT f.feature_id
+        query := ''SELECT DISTINCT f.feature_id 
             FROM feature f INNER join cvterm t ON (f.type_id = t.cvterm_id)
             WHERE t.name = '' || quote_literal(gtype) || '' AND (f.uniquename like '' || quote_literal(name)
             || '' OR f.name like '' || quote_literal(name) || '') AND f.is_analysis = '' || quote_literal(is_an) || '';'';
@@ -3366,12 +3366,12 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT fcvt.feature_id
+    query := ''SELECT DISTINCT fcvt.feature_id 
         FROM feature_cvterm fcvt, cv, cvterm t WHERE cv.cv_id = t.cv_id AND
         t.cvterm_id = fcvt.cvterm_id AND cv.name = '' || quote_literal(aspect) ||
         '' AND t.name = '' || quote_literal(term) || '';'';
     IF (STRPOS(term, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT fcvt.feature_id
+        query := ''SELECT DISTINCT fcvt.feature_id 
             FROM feature_cvterm fcvt, cv, cvterm t WHERE cv.cv_id = t.cv_id AND
             t.cvterm_id = fcvt.cvterm_id AND cv.name = '' || quote_literal(aspect) ||
             '' AND t.name like '' || quote_literal(term) || '';'';
@@ -3397,13 +3397,13 @@ DECLARE
 
 BEGIN
 
-    subquery := ''SELECT t.cvterm_id FROM cv, cvterm t WHERE cv.cv_id = t.cv_id
+    subquery := ''SELECT t.cvterm_id FROM cv, cvterm t WHERE cv.cv_id = t.cv_id 
         AND cv.name = '' || quote_literal(aspect) || '' AND t.name = '' || quote_literal(term) || '';'';
     IF (STRPOS(term, ''%'') > 0) THEN
-        subquery := ''SELECT t.cvterm_id FROM cv, cvterm t WHERE cv.cv_id = t.cv_id
+        subquery := ''SELECT t.cvterm_id FROM cv, cvterm t WHERE cv.cv_id = t.cv_id 
             AND cv.name = '' || quote_literal(aspect) || '' AND t.name like '' || quote_literal(term) || '';'';
     END IF;
-    query := ''SELECT DISTINCT fcvt.feature_id
+    query := ''SELECT DISTINCT fcvt.feature_id 
         FROM feature_cvterm fcvt INNER JOIN (SELECT cvterm_id FROM get_it_sub_cvterm_ids('' || quote_literal(subquery) || '')) AS ont ON (fcvt.cvterm_id = ont.cvterm_id);'';
 
     FOR myrc IN SELECT * FROM get_feature_ids(query) LOOP
@@ -3426,11 +3426,11 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT fprop.feature_id
+    query := ''SELECT DISTINCT fprop.feature_id 
         FROM featureprop fprop, cvterm t WHERE t.cvterm_id = fprop.type_id AND t.name = '' ||
         quote_literal(p_type) || '' AND fprop.value = '' || quote_literal(p_val) || '';'';
     IF (STRPOS(p_val, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT fprop.feature_id
+        query := ''SELECT DISTINCT fprop.feature_id 
             FROM featureprop fprop, cvterm t WHERE t.cvterm_id = fprop.type_id AND t.name = '' ||
             quote_literal(p_type) || '' AND fprop.value like '' || quote_literal(p_val) || '';'';
     END IF;
@@ -3454,10 +3454,10 @@ DECLARE
 
 BEGIN
 
-    query := ''SELECT DISTINCT fprop.feature_id
+    query := ''SELECT DISTINCT fprop.feature_id 
         FROM featureprop fprop WHERE fprop.value = '' || quote_literal(p_val) || '';'';
     IF (STRPOS(p_val, ''%'') > 0) THEN
-        query := ''SELECT DISTINCT fprop.feature_id
+        query := ''SELECT DISTINCT fprop.feature_id 
             FROM featureprop fprop WHERE fprop.value like '' || quote_literal(p_val) || '';'';
     END IF;
 
@@ -3470,7 +3470,7 @@ END;
 LANGUAGE 'plpgsql';
 
 
----4 args: ptype, ctype, count, operator (valid SQL number comparison operator), and is_analysis
+---4 args: ptype, ctype, count, operator (valid SQL number comparison operator), and is_analysis 
 ---get feature ids for any node with type = ptype whose child node type = ctype
 ---and child node feature count comparing (using operator) to ccount
 CREATE OR REPLACE FUNCTION get_feature_ids_by_child_count(cvterm.name%TYPE, cvterm.name%TYPE, INTEGER, varchar, char(1)) RETURNS SETOF feature_by_fx_type AS
@@ -3495,7 +3495,7 @@ BEGIN
         WHERE pt.name = '' || quote_literal(ptype) || '' AND ct.name = '' || quote_literal(ctype)
         || '' AND p.is_analysis = '' || quote_literal(is_an) || '' group by p.feature_id) as cq
         ON (cq.feature_id = f.feature_id) WHERE cq.c '' || operator || ccount || '';'';
-    ---RAISE NOTICE ''%'', query;
+    ---RAISE NOTICE ''%'', query; 
 
     FOR myrc IN SELECT * FROM get_feature_ids(query) LOOP
         RETURN NEXT myrc;

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part37.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part37.sql
@@ -128,8 +128,8 @@ create index analysis_dbxref_idx2 on analysis_dbxref (dbxref_id);
 
 COMMENT ON TABLE analysis_dbxref IS 'Links an analysis to dbxrefs.';
 
-COMMENT ON COLUMN analysis_dbxref.is_current IS 'True if this dbxref
-is the most up to date accession in the corresponding db. Retired
+COMMENT ON COLUMN analysis_dbxref.is_current IS 'True if this dbxref 
+is the most up to date accession in the corresponding db. Retired 
 accessions should set this field to false';
 
 
@@ -153,8 +153,8 @@ create index analysis_cvterm_idx2 on analysis_cvterm (cvterm_id);
 
 COMMENT ON TABLE analysis_cvterm IS 'Associate a term from a cv with an analysis.';
 
-COMMENT ON COLUMN analysis_cvterm.is_not IS 'If this is set to true, then this
-annotation is interpreted as a NEGATIVE annotation - i.e. the analysis does
+COMMENT ON COLUMN analysis_cvterm.is_not IS 'If this is set to true, then this 
+annotation is interpreted as a NEGATIVE annotation - i.e. the analysis does 
 NOT have the specified term.';
 
 -- ================================================
@@ -181,18 +181,18 @@ create index analysis_relationship_idx3 on analysis_relationship (type_id);
 COMMENT ON COLUMN analysis_relationship.subject_id IS 'analysis_relationship.subject_id i
 s the subject of the subj-predicate-obj sentence.';
 
-COMMENT ON COLUMN analysis_relationship.object_id IS 'analysis_relationship.object_id
+COMMENT ON COLUMN analysis_relationship.object_id IS 'analysis_relationship.object_id 
 is the object of the subj-predicate-obj sentence.';
 
-COMMENT ON COLUMN analysis_relationship.type_id IS 'analysis_relationship.type_id
-is relationship type between subject and object. This is a cvterm, typically
+COMMENT ON COLUMN analysis_relationship.type_id IS 'analysis_relationship.type_id 
+is relationship type between subject and object. This is a cvterm, typically 
 from the OBO relationship ontology, although other relationship types are allowed.';
 
-COMMENT ON COLUMN analysis_relationship.rank IS 'analysis_relationship.rank is
-the ordering of subject analysiss with respect to the object analysis may be
+COMMENT ON COLUMN analysis_relationship.rank IS 'analysis_relationship.rank is 
+the ordering of subject analysiss with respect to the object analysis may be 
 important where rank is used to order these; starts from zero.';
 
-COMMENT ON COLUMN analysis_relationship.value IS 'analysis_relationship.value
+COMMENT ON COLUMN analysis_relationship.value IS 'analysis_relationship.value 
 is for additional notes or comments.';
 
 -- ================================================
@@ -213,8 +213,8 @@ create index analysis_pub_idx2 on analysis_pub (pub_id);
 
 COMMENT ON TABLE analysis_pub IS 'Provenance. Linking table between analyses and the publications that mention them.';
 
-CREATE OR REPLACE FUNCTION store_analysis (VARCHAR,VARCHAR,VARCHAR)
-  RETURNS BIGINT AS
+CREATE OR REPLACE FUNCTION store_analysis (VARCHAR,VARCHAR,VARCHAR) 
+  RETURNS BIGINT AS 
 'DECLARE
    v_program            ALIAS FOR $1;
    v_programversion     ALIAS FOR $2;
@@ -227,7 +227,7 @@ CREATE OR REPLACE FUNCTION store_analysis (VARCHAR,VARCHAR,VARCHAR)
             programversion=v_programversion AND
             sourcename=v_sourcename;
     IF NOT FOUND THEN
-      INSERT INTO analysis
+      INSERT INTO analysis 
        (program,programversion,sourcename)
          VALUES
        (v_program,v_programversion,v_sourcename);
@@ -242,7 +242,7 @@ CREATE OR REPLACE FUNCTION store_analysis (VARCHAR,VARCHAR,VARCHAR)
 --RETURNS INT AS
 --'DECLARE
 --  v_srcfeature_id       ALIAS FOR $1;
-
+  
 -- $Id: phenotype.sql,v 1.6 2007-04-27 16:09:46 emmert Exp $
 -- ==========================================
 -- Chado phenotype module
@@ -322,7 +322,7 @@ CREATE TABLE feature_phenotype (
     FOREIGN KEY (feature_id) REFERENCES feature (feature_id) ON DELETE CASCADE,
     phenotype_id bigint NOT NULL,
     FOREIGN KEY (phenotype_id) REFERENCES phenotype (phenotype_id) ON DELETE CASCADE,
-    CONSTRAINT feature_phenotype_c1 UNIQUE (feature_id,phenotype_id)
+    CONSTRAINT feature_phenotype_c1 UNIQUE (feature_id,phenotype_id)       
 );
 CREATE INDEX feature_phenotype_idx1 ON feature_phenotype (feature_id);
 CREATE INDEX feature_phenotype_idx2 ON feature_phenotype (phenotype_id);
@@ -362,13 +362,13 @@ COMMENT ON TABLE phenotypeprop IS 'A phenotype can have any number of slot-value
 -- redesigned 2003-10-28
 --
 -- changes 2003-11-10:
---   incorporating suggestions to make everything a gcontext; use
---   gcontext_relationship to make some gcontexts derivable from others. we
---   would incorporate environment this way - just add the environment
+--   incorporating suggestions to make everything a gcontext; use 
+--   gcontext_relationship to make some gcontexts derivable from others. we 
+--   would incorporate environment this way - just add the environment 
 --   descriptors as properties of the child gcontext
 --
 -- changes 2004-06 (Documented by DE: 10-MAR-2005):
---   Many, including rename of gcontext to genotype,  split
+--   Many, including rename of gcontext to genotype,  split 
 --   phenstatement into phenstatement & phenotype, created environment
 --
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -400,10 +400,10 @@ create index genotype_idx2 on genotype(name);
 
 COMMENT ON TABLE genotype IS 'Genetic context. A genotype is defined by a collection of features, mutations, balancers, deficiencies, haplotype blocks, or engineered constructs.';
 
-COMMENT ON COLUMN genotype.uniquename IS 'The unique name for a genotype;
+COMMENT ON COLUMN genotype.uniquename IS 'The unique name for a genotype; 
 typically derived from the features making up the genotype.';
 
-COMMENT ON COLUMN genotype.name IS 'Optional alternative name for a genotype,
+COMMENT ON COLUMN genotype.name IS 'Optional alternative name for a genotype, 
 for display purposes.';
 
 -- ===============================================
@@ -713,8 +713,8 @@ CREATE TABLE featuremapprop (
 create index featuremapprop_idx1 on featuremapprop(featuremap_id);
 create index featuremapprop_idx2 on featuremapprop(type_id);
 
-COMMENT ON TABLE featuremapprop IS 'A featuremap can have any number of slot-value property
-tags attached to it. This is an alternative to hardcoding a list of columns in the
+COMMENT ON TABLE featuremapprop IS 'A featuremap can have any number of slot-value property 
+tags attached to it. This is an alternative to hardcoding a list of columns in the 
 relational schema, and is completely extensible.';
 
 -- ================================================
@@ -732,8 +732,8 @@ CREATE TABLE featuremap_contact (
 CREATE INDEX featuremap_contact_idx1 ON featuremap_contact USING btree (featuremap_id);
 CREATE INDEX featuremap_contact_idx2 ON featuremap_contact USING btree (contact_id);
 
-COMMENT ON TABLE featuremap_contact IS 'Links contact(s) with a featuremap.  Used to
-indicate a particular person or organization responsible for constrution of or
+COMMENT ON TABLE featuremap_contact IS 'Links contact(s) with a featuremap.  Used to 
+indicate a particular person or organization responsible for constrution of or 
 that can provide more information on a particular featuremap.';
 
 
@@ -755,8 +755,8 @@ CREATE INDEX featuremap_dbxref_idx2 ON featuremap_dbxref USING btree (dbxref_id)
 
 COMMENT ON TABLE feature_dbxref IS 'Links a feature to dbxrefs.';
 
-COMMENT ON COLUMN feature_dbxref.is_current IS 'True if this secondary dbxref is
-the most up to date accession in the corresponding db. Retired accessions
+COMMENT ON COLUMN feature_dbxref.is_current IS 'True if this secondary dbxref is 
+the most up to date accession in the corresponding db. Retired accessions 
 should set this field to false';
 
 
@@ -856,19 +856,19 @@ create table phylotreeprop (
 create index phylotreeprop_idx1 on phylotreeprop (phylotree_id);
 create index phylotreeprop_idx2 on phylotreeprop (type_id);
 
-COMMENT ON TABLE phylotreeprop IS 'A phylotree can have any number of slot-value property
-tags attached to it. This is an alternative to hardcoding a list of columns in the
+COMMENT ON TABLE phylotreeprop IS 'A phylotree can have any number of slot-value property 
+tags attached to it. This is an alternative to hardcoding a list of columns in the 
 relational schema, and is completely extensible.';
 
-COMMENT ON COLUMN phylotreeprop.type_id IS 'The name of the property/slot is a cvterm.
+COMMENT ON COLUMN phylotreeprop.type_id IS 'The name of the property/slot is a cvterm. 
 The meaning of the property is defined in that cvterm.';
 
-COMMENT ON COLUMN phylotreeprop.value IS 'The value of the property, represented as text.
-Numeric values are converted to their text representation. This is less efficient than
+COMMENT ON COLUMN phylotreeprop.value IS 'The value of the property, represented as text. 
+Numeric values are converted to their text representation. This is less efficient than 
 using native database types, but is easier to query.';
 
 COMMENT ON COLUMN phylotreeprop.rank IS 'Property-Value ordering. Any
-phylotree can have multiple values for any particular property type
+phylotree can have multiple values for any particular property type 
 these are ordered in a list using rank, counting from zero. For
 properties that are single-valued rather than multi-valued, the
 default 0 value should be used';
@@ -1018,7 +1018,7 @@ create index phylonode_relationship_idx1 on phylonode_relationship (subject_id);
 create index phylonode_relationship_idx2 on phylonode_relationship (object_id);
 create index phylonode_relationship_idx3 on phylonode_relationship (type_id);
 
-COMMENT ON TABLE phylonode_relationship IS 'This is for
+COMMENT ON TABLE phylonode_relationship IS 'This is for 
 relationships that are not strictly hierarchical; for example,
 horizontal gene transfer. Most phylogenetic trees are strictly
 hierarchical, nevertheless it is here for completeness.';
@@ -1030,7 +1030,7 @@ CREATE OR REPLACE FUNCTION phylonode_depth(bigint)
   DECLARE  curr_node phylonode%ROWTYPE;
   BEGIN
    SELECT INTO curr_node *
-    FROM phylonode
+    FROM phylonode 
     WHERE phylonode_id=id;
    depth = depth + curr_node.distance;
    IF curr_node.parent_phylonode_id IS NULL

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part38.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part38.sql
@@ -20,7 +20,7 @@ create table expression (
        uniquename text not null,
        md5checksum character(32),
        description text,
-       constraint expression_c1 unique (uniquename)
+       constraint expression_c1 unique (uniquename)       
 );
 
 COMMENT ON TABLE expression IS 'The expression table is essentially a bridge table.';
@@ -113,7 +113,7 @@ create table expression_pub (
        foreign key (expression_id) references expression (expression_id) on delete cascade INITIALLY DEFERRED,
        pub_id bigint not null,
        foreign key (pub_id) references pub (pub_id) on delete cascade INITIALLY DEFERRED,
-       constraint expression_pub_c1 unique (expression_id,pub_id)
+       constraint expression_pub_c1 unique (expression_id,pub_id)       
 );
 create index expression_pub_idx1 on expression_pub (expression_id);
 create index expression_pub_idx2 on expression_pub (pub_id);
@@ -132,7 +132,7 @@ create table feature_expression (
        foreign key (feature_id) references feature (feature_id) on delete cascade INITIALLY DEFERRED,
        pub_id bigint not null,
        foreign key (pub_id) references pub (pub_id) on delete cascade INITIALLY DEFERRED,
-       constraint feature_expression_c1 unique (expression_id,feature_id,pub_id)
+       constraint feature_expression_c1 unique (expression_id,feature_id,pub_id)       
 );
 create index feature_expression_idx1 on feature_expression (expression_id);
 create index feature_expression_idx2 on feature_expression (feature_id);
@@ -614,7 +614,7 @@ create table stockprop_pub (
      constraint stockprop_pub_c1 unique (stockprop_id,pub_id)
 );
 create index stockprop_pub_idx1 on stockprop_pub (stockprop_id);
-create index stockprop_pub_idx2 on stockprop_pub (pub_id);
+create index stockprop_pub_idx2 on stockprop_pub (pub_id); 
 
 COMMENT ON TABLE stockprop_pub IS 'Provenance. Any stockprop assignment can optionally be supported by a publication.';
 
@@ -794,7 +794,7 @@ a genotype. Features with genotypes can be linked to stocks thru feature_genotyp
 -- ================================================
 
 create table stockcollection (
-	stockcollection_id bigserial not null,
+	stockcollection_id bigserial not null, 
         primary key (stockcollection_id),
 	type_id bigint not null,
         foreign key (type_id) references cvterm (cvterm_id) on delete cascade,
@@ -901,10 +901,10 @@ CREATE TABLE stockcollection_db (
 CREATE INDEX stockcollection_db_idx1 ON stockcollection_db USING btree (stockcollection_id);
 CREATE INDEX stockcollection_db_idx2 ON stockcollection_db USING btree (db_id);
 
-COMMENT ON TABLE stockcollection_db IS 'Stock collections may be respresented
-by an external online database. This table associates a stock collection with
-a database where its member stocks can be found. Individual stock that are part
-of this collction should have entries in the stock_dbxref table with the same
+COMMENT ON TABLE stockcollection_db IS 'Stock collections may be respresented 
+by an external online database. This table associates a stock collection with 
+a database where its member stocks can be found. Individual stock that are part 
+of this collction should have entries in the stock_dbxref table with the same 
 db_id record';
 
 
@@ -922,7 +922,7 @@ CREATE TABLE stock_feature (
   FOREIGN KEY (feature_id) REFERENCES feature (feature_id) ON DELETE CASCADE INITIALLY DEFERRED,
   FOREIGN KEY (stock_id) REFERENCES stock (stock_id) ON DELETE CASCADE INITIALLY DEFERRED,
   FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE CASCADE INITIALLY DEFERRED,
-  CONSTRAINT stock_feature_c1 UNIQUE (feature_id, stock_id, type_id, rank)
+  CONSTRAINT stock_feature_c1 UNIQUE (feature_id, stock_id, type_id, rank)  
 );
 create index stock_feature_idx1 on stock_feature (stock_feature_id);
 create index stock_feature_idx2 on stock_feature (feature_id);
@@ -945,7 +945,7 @@ CREATE TABLE stock_featuremap (
   FOREIGN KEY (featuremap_id) REFERENCES featuremap (featuremap_id) ON DELETE CASCADE INITIALLY DEFERRED,
   FOREIGN KEY (stock_id) REFERENCES stock (stock_id)  ON DELETE CASCADE INITIALLY DEFERRED,
   FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE CASCADE INITIALLY DEFERRED,
-  CONSTRAINT stock_featuremap_c1 UNIQUE (featuremap_id, stock_id, type_id)
+  CONSTRAINT stock_featuremap_c1 UNIQUE (featuremap_id, stock_id, type_id)  
 );
 
 create index stock_featuremap_idx1 on stock_featuremap (featuremap_id);

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part39.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part39.sql
@@ -112,7 +112,7 @@ create table project_analysis (
 create index project_analysis_idx1 on project_analysis (project_id);
 create index project_analysis_idx2 on project_analysis (analysis_id);
 
-COMMENT ON TABLE project_analysis IS 'Links an analysis to a project that may contain multiple analyses.
+COMMENT ON TABLE project_analysis IS 'Links an analysis to a project that may contain multiple analyses. 
 The rank column can be used to specify a simple ordering in which analyses were executed.';
 
 
@@ -915,10 +915,10 @@ COMMENT ON TABLE studyfactorvalue IS NULL;
 
 --
 -- studyprop and studyprop_feature added for Kara Dolinski's group
---
+-- 
 -- Here is her description of it:
---Both of the tables are used for our YFGdb project
---(http://yfgdb.princeton.edu/), which uses chado.
+--Both of the tables are used for our YFGdb project 
+--(http://yfgdb.princeton.edu/), which uses chado. 
 --
 --Here is how we use those tables, using the following example:
 --
@@ -927,17 +927,17 @@ COMMENT ON TABLE studyfactorvalue IS NULL;
 --The above data set is represented as a row in the STUDY table.  We have
 --lots of attributes that we want to store about each STUDY (status, etc)
 --and in the official schema, the only prop table we could use was the
---STUDYDESIGN_PROP table.  This forced us to go through the STUDYDESIGN
---table when we often have no real data to store in that table (small
---percent of our collection use MAGE-ML unfortunately, and even fewer
---provide all the data in the MAGE model, of which STUDYDESIGN is a vestige).
---So, we created a STUDYPROP table.  I'd think this table would be
---generally useful to people storing various types of data sets via the
+--STUDYDESIGN_PROP table.  This forced us to go through the STUDYDESIGN 
+--table when we often have no real data to store in that table (small 
+--percent of our collection use MAGE-ML unfortunately, and even fewer 
+--provide all the data in the MAGE model, of which STUDYDESIGN is a vestige). 
+--So, we created a STUDYPROP table.  I'd think this table would be 
+--generally useful to people storing various types of data sets via the 
 --STUDY table.
 --
 --The other new table is STUDYPROP_FEATURE.  This basically allows us to
 --group features together per study.  For example, we can store microarray
---clustering results by saying that the STUDYPROP type is 'cluster'  (via
+--clustering results by saying that the STUDYPROP type is 'cluster'  (via 
 --type_id -> CVTERM of course), the value is 'cluster id 123', and then
 --that cluster would be associated with all the features that are in that
 --cluster via STUDYPROP_FEATURE.  Adding type_id to STUDYPROP_FEATURE is
@@ -950,7 +950,7 @@ create table studyprop (
     study_id bigint not null,
         foreign key (study_id) references study (study_id) on delete cascade,
     type_id bigint not null,
-        foreign key (type_id) references cvterm (cvterm_id) on delete cascade,
+        foreign key (type_id) references cvterm (cvterm_id) on delete cascade,  
     value text null,
     rank int not null default 0,
     unique (study_id,type_id,rank)
@@ -972,7 +972,7 @@ CREATE TABLE studyprop_feature (
     foreign key (type_id) references cvterm (cvterm_id) on delete cascade,
     unique (studyprop_id, feature_id)
     );
-
+ 
 
 create index studyprop_feature_idx1 on studyprop_feature (studyprop_id);
 create index studyprop_feature_idx2 on studyprop_feature (feature_id);

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part4.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part4.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: linkage_group ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part41.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part41.sql
@@ -21,7 +21,7 @@ CREATE TABLE nd_experiment_phenotype (
     nd_experiment_id bigint NOT NULL REFERENCES nd_experiment (nd_experiment_id) on delete cascade INITIALLY DEFERRED,
     phenotype_id bigint NOT NULL references phenotype (phenotype_id) on delete cascade INITIALLY DEFERRED,
    constraint nd_experiment_phenotype_c1 unique (nd_experiment_id,phenotype_id)
-);
+); 
 CREATE INDEX nd_experiment_phenotype_idx1 ON nd_experiment_phenotype (nd_experiment_id);
 CREATE INDEX nd_experiment_phenotype_idx2 ON nd_experiment_phenotype (phenotype_id);
 
@@ -164,3 +164,51 @@ CREATE INDEX nd_experiment_analysis_idx2 ON nd_experiment_analysis (analysis_id)
 CREATE INDEX nd_experiment_analysis_idx3 ON nd_experiment_analysis (type_id);
 
 COMMENT ON TABLE nd_experiment_analysis IS 'An analysis that is used in an experiment';
+
+
+---
+--- The following additions are part of the pull request on Chado:
+--- https://github.com/GMOD/Chado/pull/105 
+--- Once a new version of Chado is made these changes will be integrated
+--- but we need them now to prevent create_point errors when deleting features
+--- or cloning Chado.
+---
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(INTEGER) RETURNS INTEGER
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    cvid alias for $1;
+    root cvterm%ROWTYPE;
+BEGIN
+    DELETE FROM cvtermpath WHERE cv_id = cvid;
+    FOR root IN SELECT DISTINCT t.* from cvterm t LEFT JOIN cvterm_relationship r ON (t.cvterm_id = r.subject_id) INNER JOIN cvterm_relationship r2 ON (t.cvterm_id = r2.object_id) WHERE t.cv_id = cvid AND r.subject_id is null LOOP
+        PERFORM _fill_cvtermpath4root(root.cvterm_id, root.cv_id);
+    END LOOP;
+    RETURN 1;
+END;
+$_$;
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(cv.name%TYPE) RETURNS INTEGER
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    cvname alias for $1;
+    cv_id   int;
+    rtn     int;
+BEGIN
+    SELECT INTO cv_id cv.cv_id from cv WHERE cv.name = cvname;
+    SELECT INTO rtn fill_cvtermpath(cv_id);
+    RETURN rtn;
+END;
+$_$;
+
+-- create a range box
+-- (make this immutable so we can index it)
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point(CAST(0 AS bigint), $1), create_point($2,500000000))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;
+
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point($1, $2), create_point($1,$3))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part5.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part5.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: cyanelle_gene ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part6.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part6.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** relation: cosmid ***
 --- *** relation type: VIEW                      ***
 --- ***                                          ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part7.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part7.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- ************************************************
 ---
 

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part8.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part8.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 --- *** endogenous transcript of a miRNA gene. M ***
 --- *** icro RNAs are produced from precursor mo ***
 --- *** lecules (SO:0000647) that can form local ***

--- a/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part9.sql
+++ b/tripal_chado/chado_schema/parts-v1.3/default_schema-1.3.part9.sql
@@ -1,4 +1,4 @@
-SET search_path = so,chado,pg_catalog;
+SET search_path=so,chado,pg_catalog;
 ---
 
 CREATE VIEW chromosome AS


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1746 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There is a bug in the `box_range` function of Chado that doesn't cast a 0 value passed to `create_point` to a bigint.  This causes the an error when cloning a Chado schema or deleting a feature.   

![image](https://github.com/tripal/tripal/assets/1719352/fdce5134-c0b3-498d-92a5-bea492e53f43)

This PR applies a change to the Chado SQL file in Tripal that includes a fix in the Chado repo here: https://github.com/GMOD/Chado/pull/105/files


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Install a fresh version of Tripal using this branch. 
2. Install Chado and then try to clone it. Cloning should work just fine.  
3. Create an Organism content type, then a Gene content type using the Tripal interface.  Next use your favorite SQL tool to manually delete the gene from the feature table.  It should delete without a problem.  
