### PR TITLE
Changes destroy() to delete() on the ChadoCustomTable class

### DIFF
--- a/tripal_chado/src/ChadoCustomTables/ChadoCustomTable.php
+++ b/tripal_chado/src/ChadoCustomTables/ChadoCustomTable.php
@@ -372,7 +372,7 @@ class ChadoCustomTable {
    * @return bool
    *   True if successful. False otherwise.
    */
-  public function destroy() {
+  public function delete() {
     $logger = \Drupal::service('tripal.logger');
     if (!$this->table_id) {
       $logger->error('Cannot destroy the custom table. Please, first run the init() function.');

--- a/tripal_chado/src/Form/ChadoCustomTablesDeleteForm.php
+++ b/tripal_chado/src/Form/ChadoCustomTablesDeleteForm.php
@@ -64,7 +64,7 @@ class ChadoCustomTablesDeleteForm extends FormBase {
     if (strcmp($action, 'Delete') == 0) {
       $custom_tables = \Drupal::service('tripal_chado.custom_tables');
       $custom_table = $custom_tables->loadById($table_id);
-      $success = $custom_table->destroy();
+      $success = $custom_table->delete();
       if($success == TRUE) {
         \Drupal::messenger()->addMessage(t("Custom table successfully deleted"));
       }

--- a/tripal_chado/src/Form/ChadoMviewDeleteForm.php
+++ b/tripal_chado/src/Form/ChadoMviewDeleteForm.php
@@ -64,7 +64,7 @@ class ChadoMviewDeleteForm extends FormBase {
     if (strcmp($action, 'Delete') == 0) {
       $mviews = \Drupal::service('tripal_chado.materialized_views');
       $mview = $mviews->loadById($mview_id);
-      $success = $mview->destroy();
+      $success = $mview->delete();
       if($success == TRUE) {
         \Drupal::messenger()->addMessage(t("The materialized view was successfully deleted"));
       }

--- a/tripal_chado/src/Task/ChadoRemover.php
+++ b/tripal_chado/src/Task/ChadoRemover.php
@@ -131,7 +131,7 @@ class ChadoRemover extends ChadoTaskBase {
       foreach ($all_mviews as $table_name) {
         $mviews = \Drupal::service('tripal_chado.materialized_views');
         $mview = $mviews->create($table_name, $old_schema->getSchemaName());
-        $mview->destroy();
+        $mview->delete();
       }
 
       // Remove any custom tables in this schema.
@@ -139,7 +139,7 @@ class ChadoRemover extends ChadoTaskBase {
       $all_custom_tables = $custom_tables->getTables($old_schema->getSchemaName());
       foreach ($all_custom_tables as $table_id => $table_name) {
         $custom_table = $custom_tables->loadById($table_id);
-        $custom_table->destroy();
+        $custom_table->delete();
       }
 
       // Drop the schema.

--- a/tripal_chado/src/api/tripal_chado.custom_tables.api.php
+++ b/tripal_chado/src/api/tripal_chado.custom_tables.api.php
@@ -272,5 +272,5 @@ function chado_delete_custom_table(int $table_id) : bool {
     return False;
   }
 
-  return $custom_table->destroy();
+  return $custom_table->delete();
 }

--- a/tripal_chado/src/api/tripal_chado.mviews.api.php
+++ b/tripal_chado/src/api/tripal_chado.mviews.api.php
@@ -274,7 +274,7 @@ function chado_delete_mview($mview_id) {
     $logger->error('Cannot find a materialized view in this instance of Chado that matches the provided ID.');
     return False;
   }
-  return $mview->destroy();
+  return $mview->delete();
 }
 
 /**


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Tripal 4 Core Dev Task

### Issue #1750

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In the codefest it was decided to rename the `ChadoCustomTable::destroy()` function to `delete()`.  This PR simply makes that change.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Install and Prepare Chado -- This will install serveral materialized views (Which inherits the custom table class).  This test makes sure nothing else is broken.
2. Create a new custom table. Admin > Tripal > Data Storage > Chado > Custom Tables. You can use the example array provided in the instructions.
3. Delete the table.  
