### PR TITLE
Tripal 4: Taxonomy importer name comparison now case insensitive

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -595,7 +595,7 @@ class TaxonomyImporter extends ChadoImporterBase {
           if (isset($xml->TranslationStack)) {
             $matched = (string) $xml->TranslationStack->TermSet->Term;
             $matched = preg_replace('/\[All Names\]/', '', $matched);
-            if ($matched == $sci_name) {
+            if (strcasecmp($matched, $sci_name) == 0) {
               $taxid = (string) $xml->IdList->Id;
             }
             else {


### PR DESCRIPTION
# Bug Fix

### Closes #1761

### Tripal Version:  4.alpha2

## Description
Fix for taxonomy importer when importing existing species
![20240123_existing_species](https://github.com/tripal/tripal/assets/8419404/9b1386a4-ac0a-4524-b77e-0eb3b7aadbc3)


## Testing?

 1.  Create a real organism that exists in the NCBI taxonomy, e.g. `Citrus sinensis` - Make sure the first letter of the genus is capitalized to test this fix. You only need to enter genus and species.
 2.  Run the taxonomy importer, just with defaults, don't enter anything.
 3.  Before this PR, when the job is run you will see  `[warning] WARNING: Partial match "citrus sinensis" to query "Citrus sinensis", no taxid available`
   With this PR applied, you should see something like `Import phylotree: Associated <em class="placeholder">Citrus sinensis</em> to organism_id: <em class="placeholder">1</em>`
 4. Verify that info from NCBI has been imported into the `organismprop` table, e.g.
```
select * from chado.organismprop;
 organismprop_id | organism_id | type_id |                                                              value
-----------------+-------------+---------+-----------------------------------------------------------------------------...
               1 |           1 |      88 | Plants and Fungi                                                            
               2 |           1 |      87 | Standard                                                                    
               3 |           1 |      86 | 1                                                                           
               4 |           1 |      85 | Standard                                                                    
               5 |           1 |      83 | cellular organisms; Eukaryota; Viridiplantae; Streptophyta; Streptophytin...
               6 |           1 |      84 | 1                                                                   
```