### PR TITLE
Add function to get default schema and associated tests

### DIFF
--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -212,4 +212,23 @@ class ChadoSchema extends TripalDbxSchema {
     return chado_get_cvterm_mapping($params);
   }*/
 
+   /***
+   * Retrieve the default chado schema.
+   *
+   * This method ensures that we support multiple chado instances
+   * and do not make any assumptions about the name of the chado schema.
+   * 
+   * Note: The admin can change the default chado instance via the UI
+   * by going to Admin > Tripal > Data Storage > Chado > Chado Schemas 
+   * (admin/tripal/storage/chado/manager) and clicking "Set default".
+   * We DO NOT recommend setting this programmaticly as it is confusing
+   * to the admin.
+   * 
+   * @return string
+   *   The name of the schema with Chado installed that is to be considered
+   *   the default.
+   */
+  public function getDefault() {
+    return \Drupal::config('tripal_chado.settings')->get('default_schema');
+  }
 }

--- a/tripal_chado/tests/src/Functional/Database/ChadoSchemaTest.php
+++ b/tripal_chado/tests/src/Functional/Database/ChadoSchemaTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\Tests\tripal_chado\Functional;
+
+/**
+ * Tests for Chado Schema implementation of Tripal DBX Connection.
+ * 
+ * @group Tripal
+ * @group Tripal TripalDBX
+ * @group Tripal TripalDBX Chado
+ * @group TripalDBX Chado
+ */
+class ChadoSchemaTest extends ChadoTestBrowserBase {
+  /**
+   * Test the ChadoSchema::getDefault() method.
+   * 
+   * We will test that the default chado in this test returns the 'testchado' string, which should be the default chado.
+   * There is no way to programatically set the default chado, so we will not test changing the default and seeing if the default is still reported correctly afterwards.
+   */
+  public function testGetDefault() {
+    $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
+    $chado = \Drupal::service('tripal_chado.database');
+    $default_chado_schema = $chado->schema()->getDefault();
+
+    // Test if the reported Chado version matches the test chado format,
+    // e.g. _test_chado_h87g97hkln64vy76
+    $this->assertRegExp('/(\_test\_chado\_[\w]{16})\b/', $default_chado_schema, "The default Chado could not be reliably determined.");
+  }
+}

--- a/tripal_chado/tests/src/Functional/Database/ChadoSchemaTest.php
+++ b/tripal_chado/tests/src/Functional/Database/ChadoSchemaTest.php
@@ -24,6 +24,11 @@ class ChadoSchemaTest extends ChadoTestBrowserBase {
 
     // Test if the reported Chado version matches the test chado format,
     // e.g. _test_chado_h87g97hkln64vy76
-    $this->assertRegExp('/(\_test\_chado\_[\w]{16})\b/', $default_chado_schema, "The default Chado could not be reliably determined.");
+    $this->assertRegExp('/(\_test\_chado\_[\w]{16})\b/', $default_chado_schema, "The default Chado schema returned did not match the format we expected within the testing environment.");
+    
+    // Test if the default chado schema returned matches the
+    // one we created.
+    $this->assertEquals($this->testSchemaName, $default_chado_schema,
+      "The default chado schema name we retrieved did not match the test chado schema we just created.");
   }
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# New Feature

### Issue #1759

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adds a function within the ChadoSchema class to get the current default Chado schema

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

If writing code within a class:

```php
$default_chado_schema = $this->chado_connection->schema()->getDefault();
```
and if you are not within a class, this function can be called through the associated service:
```php
$chado = \Drupal::service('tripal_chado.database');
$default_chado_schema = $chado->schema()->getDefault();
```

This change also adds a PHPUnit test to get the current default Chado schema, it should match the test Chado schema string, `_test_chado_0123456789abcdef`, for example.

---

Thanks @laceysanderson for the suggestion and the sample code.
