### PR TITLE
Update Tripal Importer database rollback to apply to Chado, not the Drupal database

### DIFF
--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -182,6 +182,44 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
   }
 
   /**
+   * Creates a database transaction in the specific schema(s) this importer will
+   * be importing data into.
+   *
+   * @return array
+   *   An array of Drupal DatabaseTransaction objects. These are usually
+   *   obtained by calling the startTransaction() method on the database
+   *   connection object.
+   */
+  public function startTransactions() {
+    $transactions = [];
+
+    // By default the Tripal importer returns a single transaction
+    // focused on the Drupal schema. This is not usually what we want
+    // as when a transaction is rolled back on the Drupal schema during import
+    // we lose the Tripal job status updates and logs.
+    $public = \Drupal::database();
+    $transactions[] = $public->startTransaction();
+
+    return $transactions;
+  }
+
+  /**
+   * Clean-up anything related to this import in case of error.
+   *
+   * Called when an exception is caught during run() or postRun().
+   * NOTE: This is called after the transaction on the current database
+   * is rolled back. If you want to rollback all changes in multiple Drupal-managed
+   * connections then add each one via startTransaction(). This should only be
+   * needed to perform partial clean-up or when importing into non Drupal-managed
+   * connections.
+   *
+   * @param string $stage
+   *   A string indicating where this method was called from.
+   *   Expected to be one of 'run' or 'postRun'.
+   */
+  public function rollbackTransaction(string $stage) { }
+
+  /**
    * Creates a new importer record.
    *
    * @param array $run_args

--- a/tripal/src/api/tripal.importer.api.php
+++ b/tripal/src/api/tripal.importer.api.php
@@ -175,16 +175,20 @@ function tripal_run_importer($import_id, TripalJob $job = NULL) {
  */
 function tripal_run_importer_run($loader, $logger) {
 
-  // begin the transaction
-  $public = \Drupal::database();
-  $transaction = $public->startTransaction();
+  // Instead of rolling back the drupal database (which contains logs that we want access to),
+  // we want to roll back any changes that were made to chado specifically.
+  //$public = \Drupal::database();
+  //$transaction = $public->startTransaction();
+  $chado = \Drupal::service('tripal_chado.database');
+  //$chado->setSchemaName('chado');
+  $transaction_chado = $chado->startTransaction();
   try {
     $loader->run();
     $logger->notice("Done.");
   }
   catch (\Exception $e) {
     // Rollback and re-throw the error.
-    $transaction->rollback();
+    $transaction_chado->rollback();
     throw $e;
   }
 }
@@ -200,15 +204,19 @@ function tripal_run_importer_run($loader, $logger) {
  * @ingroup tripal_importer_api
  */
 function tripal_run_importer_post_run($loader, $logger) {
-  // the transaction
-  $public = \Drupal::database();
-  $transaction = $public->startTransaction();
+  // Instead of rolling back the drupal database (which contains logs that we want access to),
+  // we want to roll back any changes that were made to chado specifically.
+  //$public = \Drupal::database();
+  //$transaction = $public->startTransaction();
+  $chado = \Drupal::service('tripal_chado.database');
+  //$chado->setSchemaName('chado');
+  $transaction_chado = $chado->startTransaction();
   try {
     $loader->postRun();
   }
   catch (\Exception $e) {
     // Rollback and re-throw the error.
-    $transaction->rollback();
+    $transaction_chado->rollback();
     throw $e;
   }
 }

--- a/tripal_chado/src/TripalImporter/ChadoImporterBase.php
+++ b/tripal_chado/src/TripalImporter/ChadoImporterBase.php
@@ -109,6 +109,29 @@ abstract class ChadoImporterBase extends TripalImporterBase implements Container
   }
 
   /**
+   * Creates a database transaction in the specific schema(s) this importer will
+   * be importing data into.
+   *
+   * @return array
+   *   An array of Drupal DatabaseTransaction objects. These are usually
+   *   obtained by calling the startTransaction() method on the database
+   *   connection object.
+   */
+  public function startTransactions() {
+    $transactions = [];
+
+    // By default the Chado importer returns a single transaction
+    // focused on the chado schema set in the current importer job.
+    // If you are importing into multiple chado schema you will want to
+    // override this and add one transaction object for each schema
+    // you are importing into.
+    $chado = $this->getChadoConnection();
+    $transactions[] = $chado->startTransaction();
+
+    return $transactions;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function form($form, &$form_state) {

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
@@ -45,7 +45,7 @@ class ChadoImporterTransactionTest extends ChadoTestKernelBase {
 
   protected $importer;
 
-	/**
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\Tests\tripal_chado\Kernel\Plugin\TripalImporter;
+
+use Drupal\Core\Url;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+
+/**
+ * Tests the Chado Importer base class transaction functionality.
+ *
+ * @group TripalImporter
+ * @group ChadoImporter
+ */
+class ChadoImporterTransactionTest extends ChadoTestKernelBase {
+
+	protected $defaultTheme = 'stark';
+
+	protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado'];
+
+  protected $connection;
+
+  /**
+   * Annotations associated with the mock_plugin.
+   * @var Array
+   */
+  protected $plugin_definition = [
+    'id' => 'fakeImporterName',
+    'label' => 'Gemstone Loader',
+    'description' => 'Imports details on the incredible diversity of gemstones created by our earth into Chado.',
+    'file_types' => ["gem", "txt"],
+    'upload_description' => "Please provide a plain text, tab-delimited file of gemstone descriptions making sure to include the details which make them most unique and beautiful.",
+    'upload_title' => 'Gemstone Descriptions',
+    'use_analysis' => FALSE,
+    'require_analysis' => FALSE,
+    'button_text' => 'Import file',
+    'file_upload' => FALSE,
+    'file_load' => FALSE,
+    'file_remote' => FALSE,
+    'file_required' => FALSE,
+    'cardinality' => 1,
+  ];
+
+  protected $importer;
+
+	/**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Ensure we see all logging in tests.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+		// Open connection to Chado
+		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+
+    // Ensure we can access file_managed related functionality from Drupal.
+    // ... users need access to system.action config?
+    $this->installConfig('system');
+    // ... managed files are associated with a user.
+    $this->installEntitySchema('user');
+    // ... Finally the file module + tables itself.
+    $this->installEntitySchema('file');
+    $this->installSchema('file', ['file_usage']);
+
+    $expected_args = ['run_args' => [], 'files' => []];
+    $plugin_defn = $this->plugin_definition;
+    $configuration = [];
+    $plugin_id = 'fakeImporterName';
+    $this->importer = $this->getMockForAbstractClass(
+      '\Drupal\tripal_chado\TripalImporter\ChadoImporterBase',
+      [$configuration, $plugin_id, $plugin_defn, $this->connection]
+    );
+  }
+
+  public function testTransactionRollback() {
+    // Override the run() method of our mock importer to:
+    // 1. Insert a record into the chado.organism table
+    // 2. Throw an exception
+    // This mimics the situation where an importer run encounters an
+    // exception partway through a transaction
+    $this->importer        
+      ->method('run')
+      ->willReturnCallback(function (): bool {
+        $connection = \Drupal::service('tripal_chado.database');
+        $connection->insert('1:organism')
+          ->fields([
+            'genus' => 'Tripalus',
+            'species' => 'databasica'
+          ])
+          ->execute();
+          throw new \Exception(
+            t('Mock importer throws new exception.')
+          );
+      });
+    $logger = \Drupal::service("tripal.logger");
+
+    // Try running our importer to ensure an exception is thrown
+    $exception_caught = FALSE;
+    try {
+      tripal_run_importer_run($this->importer, $logger);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+    }
+    $this->assertTrue($exception_caught, 'Did not catch exception that should have been thrown by overriding the run() method.');
+
+    // Now query organism table to ensure the database transaction was
+    // successfully rolled back
+    $organism_count_query = $this->connection->select('1:organism', 'o')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals($organism_count_query, 0, 'The chado.organism table is not empty despite triggering a database rollback.');
+  }
+
+  public function testTransactionCommit() {
+    // Override the run() method of our mock importer to:
+    // 1. Insert a record into the chado.organism table
+    // This mimics the situation where a database transaction
+    // should occur to completion
+    $this->importer        
+      ->method('run')
+      ->willReturnCallback(function (): bool {
+        $connection = \Drupal::service('tripal_chado.database');
+        $connection->insert('1:organism')
+          ->fields([
+            'genus' => 'Tripalus',
+            'species' => 'databasica'
+          ])
+          ->execute();
+          return true;
+      });
+    $logger = \Drupal::service("tripal.logger");
+
+    // Try running our importer to ensure NO exception is thrown
+    $exception_caught = FALSE;
+    try {
+      tripal_run_importer_run($this->importer, $logger);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+    }
+    $this->assertFalse($exception_caught, 'Caught an exception that should not have been thrown from overriding the run() method.');
+
+    // Now query organism table to ensure the database transaction was
+    // successfully committed
+    $organism_count_query = $this->connection->select('1:organism', 'o')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals($organism_count_query, 1, 'The chado.organism table does not contain one record as expected from overriding the run() method.');
+  }
+
+}

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ChadoImporterTransactionTest.php
@@ -54,8 +54,8 @@ class ChadoImporterTransactionTest extends ChadoTestKernelBase {
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
-		// Open connection to Chado
-		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    // Open connection to Chado
+    $this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1764 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Tripal importers are designed to roll back a database transaction if an error occurs during the import, but as found in issue #1764, there was a bug preventing the rollback. It turns out the rollback was occurring if anything was inserted into the Drupal database, but completely ignored Chado (possibly a relic of how this was done in Drupal 7). After discussions with @laceysanderson, we determined that the rollback should not occur for the Drupal database at all, since log messages are stored there which the user will likely want accessible to troubleshoot their failing import job. Rollback in a different database  (such as Drupal) should instead be handled by individual importers. This PR updates the rollback to occur by default in Chado instead.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
### Manual testing
You can follow the steps to reproduce the bug in issue #1764, and then switch to this branch and repeat the process again, this time confirming that Chado has no new records. 

<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
### Automated tests
I created a new kernel test class to override the base importer run method and simulate the following situations:

- [x] **testTransactionRollback()**: Inserts into the organism table in Chado, then throws an exception.
   - Asserts an exception is in fact thrown
   - Asserts chado.organism does not have anything added
- [x] **testTransactionCommit()**: Inserts into the organism table in Chado, no error is thrown
   - Asserts that an exception does not get thrown
   - Asserts that chado.organism has a new organism added since no errors occurred