### PR TITLE
Modified 3 tripaldocker/Dockerfiles for PHP 8.1, 8.2 and 8.3 to accom…

### DIFF
--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -123,9 +123,8 @@ RUN { \
     echo 'opcache.memory_limit=1028M';\
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
+RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini \
+  && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize"'/' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -4,6 +4,7 @@ ARG drupalversion='~10.1.0'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
 ARG installchado=TRUE
+ARG phpuploadsize=8M
 
 # Label docker image
 LABEL drupal.version=${drupalversion}
@@ -123,6 +124,8 @@ RUN { \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 

--- a/tripaldocker/Dockerfile-php8.2-pgsql13
+++ b/tripaldocker/Dockerfile-php8.2-pgsql13
@@ -123,9 +123,8 @@ RUN { \
     echo 'opcache.memory_limit=1028M';\
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
+RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini \
+  && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize"'/' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 

--- a/tripaldocker/Dockerfile-php8.2-pgsql13
+++ b/tripaldocker/Dockerfile-php8.2-pgsql13
@@ -4,6 +4,7 @@ ARG drupalversion='~10.1.0'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
 ARG installchado=TRUE
+ARG phpuploadsize=8M
 
 # Label docker image
 LABEL drupal.version=${drupalversion}
@@ -123,6 +124,8 @@ RUN { \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 

--- a/tripaldocker/Dockerfile-php8.3-pgsql13
+++ b/tripaldocker/Dockerfile-php8.3-pgsql13
@@ -123,9 +123,8 @@ RUN { \
     echo 'opcache.memory_limit=1028M';\
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
+RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini \
+  && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize"'/' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 

--- a/tripaldocker/Dockerfile-php8.3-pgsql13
+++ b/tripaldocker/Dockerfile-php8.3-pgsql13
@@ -4,6 +4,7 @@ ARG drupalversion='~10.2.0'
 ARG modules='devel devel_php'
 ARG chadoschema='chado'
 ARG installchado=TRUE
+ARG phpuploadsize=8M
 
 # Label docker image
 LABEL drupal.version=${drupalversion}
@@ -123,6 +124,8 @@ RUN { \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = '"$phpuploadsize/"'' /usr/local/etc/php/php.ini
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->

<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->
 Accommodate upload of files-size upto 8MB
#

### Issue #
<a href=https://github.com/tripal/tripal/issues/1749>#1749</a> 
<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 
4
## Description
<!--- Describe your changes in detail -->
Docker files were modified to accommodate upload of larger FASTA genome and scaffold files of size upto 8MB. Earlier limit was 2MB.
<!--- Why is this change required? What problem does it solve? -->
Example genomics site has a FASTA file of size 6 MB. Attempt to upload this file via the Chado FASTA File Loader page throws error:
 
`Unfortunately, you can not upload this file as the size exceeds the the maximum file size allowed by this site: 2.1MB. You can manage the maximum file upload size by changing the upload_max_filesize in your php.ini file.
`
## Testing?
<!--- Please describe in detail how to test these changes. -->
Use the new dockerfiles, for example to use php8.2-pgsql13 with Drupal 10.1x-dev,

```
cntr_name="Tripal_4_Drupal_10.1.x_PHP8.2_PG13"

docker build --tag=tripaldocker:$cntr_name \
 --build-arg drupalversion=10.1.x-dev \
 --file tripaldocker/Dockerfile-php8.2-pgsql13 ./

docker run --publish=5207:80 -tid \
    --name=$cntr_name \
    --volume=$(pwd):/var/www/drupal/web/modules/contrib/tripal \
    tripaldocker:$cntr_name 

docker exec $cntr_name service postgresql restart

docker exec -it $cntr_name /bin/bash

grep -i upload_max_filesize /usr/local/etc/php/php.ini

```
would result in:

`upload_max_filesize = 8M
`

With the previous versions of the docker files, it was:

`upload_max_filesize = 2M
`

Checking the feature on the web url:
`http://localhost:5207
`

**Tripal -> Data Loaders -> Chado FASTA File Loader -> Browse FASTA file**
and upload the file <a href=http://tripal.info/sites/default/files/Citrus_sinensis-scaffold00001.fasta>Citrus_sinensis-scaffold00001.fasta</a> of size 6MB.

Ref: https://tripal.readthedocs.io/en/latest/user_guide/example_genomics/genomes_genes.html

PHP memory option can be changed to a new value say 10MB by building the docker image for say PHP 8.2 using the command :

```
docker build --tag=tripaldocker:$cntr_name \
 --build-arg drupalversion=10.1.x-dev \
 --build-arg phpuploadsize=10M \
 --file tripaldocker/Dockerfile-php8.2-pgsql13 ./

```
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
