### PR TITLE
Change CV terms for Contact bundle

### DIFF
--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -45,7 +45,7 @@ content_types:
 
     -   label: Contact
         term: NCIT:C47954
-        help_text: A channel for communication between groups.
+        help_text: Use the contact page for a person or institution that can be linked as a responsible party for data or results.
         category: General
         id: contact
         title_format: "[contact_name]"

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -43,9 +43,9 @@ content_types:
         synonyms:
             - bio_data_4
 
-    -   label: Contact
-        term: local:contact
-        help_text: Use the contage page a person or institution that can be linked as a responsible party for data or results.
+    -   label: Communication Contact
+        term: NCIT:C47954
+        help_text: A channel for communication between groups.
         category: General
         id: contact
         title_format: "[contact_name]"

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml
@@ -43,7 +43,7 @@ content_types:
         synonyms:
             - bio_data_4
 
-    -   label: Communication Contact
+    -   label: Contact
         term: NCIT:C47954
         help_text: A channel for communication between groups.
         category: General

--- a/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
+++ b/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
@@ -350,8 +350,8 @@ tables:
                 term_id: 'sep:00195'
                 term_name: 'biological sample'
             -   name: 'biosourceprovider_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'dbxref_id'
                 term_id: 'data:2091'
                 term_name: 'Accession'
@@ -581,8 +581,8 @@ tables:
     -   name: 'contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'description'
                 term_id: 'schema:description'
                 term_name: 'description'
@@ -596,8 +596,8 @@ tables:
     -   name: 'contactprop'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'rank'
                 term_id: 'OBCS:0000117'
                 term_name: 'rank order'
@@ -1033,8 +1033,8 @@ tables:
     -   name: 'feature_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'feature_id'
                 term_id: 'SO:0000110'
                 term_name: 'sequence_feature'
@@ -1180,8 +1180,8 @@ tables:
     -   name: 'featuremap_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'featuremap_id'
                 term_id: 'data:1274'
                 term_name: 'Map'
@@ -1441,8 +1441,8 @@ tables:
     -   name: 'library_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'library_id'
                 term_id: 'local:library'
                 term_name: 'Library'
@@ -1620,8 +1620,8 @@ tables:
     -   name: 'nd_experiment_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
 
     -   name: 'nd_experiment_dbxref'
         columns:
@@ -2178,8 +2178,8 @@ tables:
     -   name: 'project_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'project_id'
                 term_id: 'NCIT:C47885'
                 term_name: 'Project'
@@ -2349,8 +2349,8 @@ tables:
     -   name: 'pubauthor_contact'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
 
     -   name: 'pub_dbxref'
         columns:
@@ -2466,8 +2466,8 @@ tables:
     -   name: 'stockcollection'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'name'
                 term_id: 'schema:name'
                 term_name: 'name'
@@ -2661,8 +2661,8 @@ tables:
     -   name: 'study'
         columns:
             -   name: 'contact_id'
-                term_id: 'local:contact'
-                term_name: 'contact'
+                term_id: 'NCIT:C47954'
+                term_name: 'communication contact'
             -   name: 'dbxref_id'
                 term_id: 'data:2091'
                 term_name: 'Accession'

--- a/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
+++ b/tripal_chado/config/install/tripal_chado.chado_term_mapping.core_mapping.yml
@@ -351,7 +351,7 @@ tables:
                 term_name: 'biological sample'
             -   name: 'biosourceprovider_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'dbxref_id'
                 term_id: 'data:2091'
                 term_name: 'Accession'
@@ -582,7 +582,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'description'
                 term_id: 'schema:description'
                 term_name: 'description'
@@ -597,7 +597,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'rank'
                 term_id: 'OBCS:0000117'
                 term_name: 'rank order'
@@ -1034,7 +1034,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'feature_id'
                 term_id: 'SO:0000110'
                 term_name: 'sequence_feature'
@@ -1181,7 +1181,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'featuremap_id'
                 term_id: 'data:1274'
                 term_name: 'Map'
@@ -1442,7 +1442,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'library_id'
                 term_id: 'local:library'
                 term_name: 'Library'
@@ -1621,7 +1621,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
 
     -   name: 'nd_experiment_dbxref'
         columns:
@@ -2179,7 +2179,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'project_id'
                 term_id: 'NCIT:C47885'
                 term_name: 'Project'
@@ -2350,7 +2350,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
 
     -   name: 'pub_dbxref'
         columns:
@@ -2467,7 +2467,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'name'
                 term_id: 'schema:name'
                 term_name: 'name'
@@ -2662,7 +2662,7 @@ tables:
         columns:
             -   name: 'contact_id'
                 term_id: 'NCIT:C47954'
-                term_name: 'communication contact'
+                term_name: 'Communication Contact'
             -   name: 'dbxref_id'
                 term_id: 'data:2091'
                 term_name: 'Accession'


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Tripal 4 Core Dev Task

### Issue #1783 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Changed all CV terms for the Contact bundle from `local:contact` to `NCIT:C47954` and `contact` to `Communication Contact`. Also fixed a typo for `help_text` in `tripal_chado/config/install/tripal.tripalentitytype_collection.general_chado.yml`.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Functional review required.