### PR TITLE
Fix for error on job view and argument listing

### DIFF
--- a/tripal/src/Controller/TripalJobController.php
+++ b/tripal/src/Controller/TripalJobController.php
@@ -100,13 +100,6 @@ class TripalJobController extends ControllerBase{
   private function buildArrayTable($array, $name = '') {
     $markup = '';
 
-    // If the table only has one key then simplify this down for display
-    $keys = array_keys($array);
-    if (count($keys) == 1) {
-      $key = $keys[0];
-      return $this->buildArrayTable($array[$key], $key);
-    }
-
     $table = [
       '#type' => 'table',
       '#header' => [

--- a/tripal/src/Controller/TripalJobController.php
+++ b/tripal/src/Controller/TripalJobController.php
@@ -88,6 +88,88 @@ class TripalJobController extends ControllerBase{
   }
 
   /**
+   * Helper function to build an HTML table from an array
+   *
+   * @param array $array
+   *   The array elements to format.
+   * @param string $name
+   *   The name of the element to which the table belongs.
+   * @return string
+   *   The rendered HTML markup for the table.
+   */
+  private function buildArrayTable($array, $name = '') {
+    $markup = '';
+
+    // If the table only has one key then simplify this down for display
+    $keys = array_keys($array);
+    if (count($keys) == 1) {
+      $key = $keys[0];
+      return $this->buildArrayTable($array[$key], $key);
+    }
+
+    $table = [
+      '#type' => 'table',
+      '#header' => [
+        ['data' => 'Key'],
+        ['data' => 'Value'],
+      ],
+      '#rows' => [],
+    ];
+    if ($name) {
+      $table['#caption'] = $this->t('Values for the "@name" element:', ['@name' => $name]);
+    }
+
+    // If the argument is an associative array then create a sub table.
+    if(array_keys($array) !== range(0, count($array) - 1)) {
+      foreach ($array as $key => $value) {
+        if (is_array($value)) {
+          $value = $this->buildArrayTable($value, $key);
+        }
+        $table['#rows'][] = [
+          'data' => [
+            ['data' => $key],
+            ['data' => $value],
+          ],
+        ];
+      }
+      $markup = \Drupal::service('renderer')->render($table);
+    }
+    // Otherwise it's just a normal array.
+    else{
+      foreach ($array as $key => $value) {
+        if (is_array($value)) {
+          $value = $this->buildArrayTable($value, $key);
+        }
+        $table['#rows'][] = [
+          'data' => [
+            ['data' => $key],
+            ['data' => $value],
+          ],
+        ];
+      }
+      $markup = \Drupal::service('renderer')->render($table);
+    }
+
+    return $markup;
+  }
+
+  /**
+   * Generates a renderagble array containing the job arguments.
+   *
+   * @param array $arguments
+   */
+  private function buildArgList($arguments) {
+
+    $arglist[] = [
+      '#type' => 'item',
+      '#markup' => $this->buildArrayTable($arguments),
+      '#prefix' => '<div class="tripal-job-arg-array-val">',
+      '#suffix' => '</div>'
+    ];
+    return $arglist;
+  }
+
+  /**
    * Provides a view of all details for a single job
    *
    * @param $id
@@ -121,30 +203,7 @@ class TripalJobController extends ControllerBase{
     }
 
     // Generate the list of arguments for display.
-    $arglist = [];
-    foreach ($arguments as $key => $value) {
-      if (is_array($value)) {
-        $temp = [];
-        foreach ($value as $vk => $vv) {
-          $temp[] = [
-            '#type' => 'item',
-            '#title' => $vk,
-            '#markup' => is_array($vv) ? print_r($vv) : $vv,
-            '#prefix' => '<div class="tripal-job-arg-array-val">',
-            '#suffix' => '</div>'
-          ];
-        }
-        $value = render($temp);
-      }
-      if (is_numeric($key)) {
-        $key = 'Arg #' . $key;
-      }
-      $arglist[] =  [
-        '#type' => 'item',
-        '#title' => $key,
-        '#markup' =>  $value
-      ];
-    }
+    $arglist = $this->buildArgList($arguments);
 
     // Set the title of the page.
     $request = \Drupal::request();


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1786

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
While trying to fix the issue with ChadoStorage found on PR #1700  I noticed that Tripal no longer prints output to the terminal window for some types of jobs (e.g. preparing Chado and importing of content types).  So, I went to the job for importing content types to view it I got an error.  This PR fixes that error and allows the job to be viewed.    I also noticed that the job arguments were not properly displayed.  Just a `print_r` of the array which is hard to read, so  I took a moment to fix it so that job arguments show up nicely.  

This PR does not fix the problem that the log is missing.  I'm not sure why it doesn't show up on the command-line anymore and now doesn't show up in the job log either :0/  

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Before using this branch go to the Tripal Job log where you imported content types and try to view it. You'll get an error.  Then pull the branch and try again, you should be able to see the job and the arguments should be nicely formatted into a table.