### PR TITLE
ChadoStorage fix for joins that loop back to the root table

### DIFF
--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -432,7 +432,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
             // becuase this is the table that will have the value.
             $my_delta = $delta;
             if($action == 'read_value' and array_key_exists('join', $path_array)) {
-              $root_table = $value_col_info['root_table'];
               $root_alias = $value_col_info['root_alias'];
               $table_alias = $root_alias;
             }
@@ -1134,6 +1133,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       $elements = [
         'base_table' => $context['base_table'],
         'root_table' => $context['root_table'],
+        'root_alias' => $context['root_alias'],
         'chado_table' => $path_array['root_table'],
         'table_alias' => $path_array['root_alias'],
         'delta' => $context['delta'],

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -126,16 +126,6 @@ class ChadoRecords  {
     $table_alias = $elements['table_alias'];
     $delta = $elements['delta'];
 
-    if ($base_table == $chado_table) {
-      if ($base_table != $table_alias) {
-        throw new \Exception(t('ChadoRecords::initTable(). Invalid attempt to '
-            . 'initalize a table as the base table cannot have an alias. '
-            . 'The element tries to set a table alias, which is not supported: '
-            . '@elements',
-            ['@elements' => print_r($elements, TRUE)]));
-      }
-    }
-
     // We do not want to initalize the base table more than once. When a
     // field has a cardinality > 0 then it can pass a delta value > 0. That
     // delta value is for the item not for the base table.  There can only
@@ -456,7 +446,7 @@ class ChadoRecords  {
    * @throws \Exception
    *   If the any required fields are missing an error is thrown.
    */
-  public function addJoin(array $elements) {
+  public function addJoin(array &$elements) {
 
     // Initlaize the table. If the function returns FALSE
     // then the caller is trying to re-intalize the base table so jus quit.
@@ -509,6 +499,10 @@ class ChadoRecords  {
     if (!array_key_exists('columns', $this->records[$base_table]['tables'][$table_alias]['items'][$delta]['joins'][$join_path])) {
       $this->records[$base_table]['tables'][$table_alias]['items'][$delta]['joins'][$join_path]['columns'] = [];
     }
+
+    // Set the elements array
+    $elements['left_alias'] = $left_alias;
+    $elements['right_alias'] = $right_alias;
   }
 
   /**
@@ -1594,7 +1588,7 @@ class ChadoRecords  {
       // zero.
       unset($values[$pkey]);
 
-      // Add the fiels to the insert.
+      // Add the fields to the insert.
       $insert->fields($values);
       $this->field_debugger->reportQuery($insert, "Insert Query for $chado_table ($delta)");
 

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -116,15 +116,28 @@ class ChadoRecords  {
 
     // Make sure all of the required elements are preesent
     $this->checkElement($elements, 'base_table', 'Initializing', 'table');
+    $this->checkElement($elements, 'root_table', 'Initializing', 'table');
+    $this->checkElement($elements, 'root_alias', 'Initializing', 'table');
     $this->checkElement($elements, 'chado_table', 'Initializing', 'table');
     $this->checkElement($elements, 'table_alias', 'Initializing', 'table');
     $this->checkElement($elements, 'delta', 'Initializing', 'table');
 
     // Get the items needed to initalize a table.
     $base_table = $elements['base_table'];
+    $root_table = $elements['root_table'];
+    $root_alias = $elements['root_alias'];
     $chado_table = $elements['chado_table'];
     $table_alias = $elements['table_alias'];
     $delta = $elements['delta'];
+
+    if ($base_table == $root_table) {
+      if ($base_table != $root_alias) {
+        throw new \Exception(t('ChadoRecords::initTable(). The base table cannot have an alias. '
+          . 'Check all fields the contribute properties and make sure none of them use an alias '
+          . 'for the root table in the "path" element. @elements',
+          ['@elements' => print_r($elements, TRUE)]));
+      }
+    }
 
     // We do not want to initalize the base table more than once. When a
     // field has a cardinality > 0 then it can pass a delta value > 0. That

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions-FieldDefinitions.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions-FieldDefinitions.yml
@@ -604,3 +604,40 @@ testStoreLinkAction:
         # chado_table: 'projectprop' # deprecated
         # chado_table_alias: 'pippin' # deprecated
         # chado_column: 'rank' # deprecated
+testReadValueActionJoinLoop:
+  featurelocfield:
+    field_name: featurelocfield
+    base_table: feature
+    properties:
+      record_id:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: store_id
+        path: feature.feature_id
+      featureloc_id:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: store_pkey
+        path: featureloc.featureloc_id
+      fkey:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: store_link
+        path: feature.feature_id>featureloc.feature_id
+      uniquename:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType
+        action: read_value
+        path: feature.feature_id>featureloc.feature_id;featureloc.srcfeature_id>feature.feature_id;uniquename
+      fmin:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: read_value
+        path: feature.feature_id>featureloc.feature_id;fmin
+      fmax:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: read_value
+        path: feature.feature_id>featureloc.feature_id;fmax
+      strand:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: read_value
+        path: feature.feature_id>featureloc.feature_id;strand
+      phase:
+        propertyType class: Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType
+        action: read_value
+        path: feature.feature_id>featureloc.feature_id;phase

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions_StoreIdTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoStorage/ChadoStorageActions_StoreIdTest.php
@@ -224,7 +224,7 @@ class ChadoStorageActions_StoreIdTest extends ChadoTestKernelBase {
         ],
       ],
     ];
-    $this->expectExceptionMessage('tries to set a table alias, which is not supported');
+    $this->expectExceptionMessage('The base table cannot have an alias');
     $this->chadoStorageTestInsertValues($insert_values);
   }
 }


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #1700 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR addresses the problem where a field (such as the sequence coordinate field of PR #1700) wants to loop back on the same table that was previously joined. Fields that want to  use the `featureloc` table of Chado will need to do this if they want to get the landmark sequence.  

The fix for this is not too complicated because the `ChadoRecords::getJoinAliases()` function already created aliases for every table in a join. It ensures that every table has an alias and that if a join is used repeatedly the same alias is used for the same table.   The problem is that those aliases were available for querying but they weren't used when setting up the records array.  This PR fixes that and solves the problem. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
There is no way to manually test this until we have the Coordiante field working.  However, I did add a functional test named `ChadoStorageActions_ReadValueTest::testReadValueActionJoinLoop`.  This test adds an organism, feature, landmark feature and featureloc records to the table. It creates a temporary field that uses the featureloc table.  The field is then used to read values from the `featureloc` table and check that those value are properly returned.  

The test function worked for me. I think if all tests pass (assuming I didn't break anything else) and the code looks good to @laceysanderson then it's good to be merged and can be fully tested with a fix to PR #1700 .