### PR TITLE
Tripal Layout naming change to human readable format in Admin -> Extensions

### DIFF
--- a/tripal_layout/tripal_layout.info.yml
+++ b/tripal_layout/tripal_layout.info.yml
@@ -1,4 +1,4 @@
-name: 'tripal_layout'
+name: 'Tripal Layout'
 type: module
 description: 'Auto generates layouts for Tripal entity types'
 core_version_requirement: ^9.4 || ^10


### PR DESCRIPTION
The simplest PR ever but just to keep it standard on the UI
This fix will change tripal_layout to 'Tripal Layout' on the admin extensions UI
![image](https://github.com/tripal/tripal/assets/33866403/1063f533-608a-4675-9505-aa24af3bdbf6)
