### PR TITLE
Update remaining t4d8 references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["tripal","drupal", "biological-data", "species", "model-organism"],
   "homepage": "https://tripal.info",
   "support": {
-    "issues": "https://github.com/tripal/t4d8/issues"
+    "issues": "https://github.com/tripal/tripal/issues"
   },
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",

--- a/tripal/tripal.permissions.yml
+++ b/tripal/tripal.permissions.yml
@@ -63,7 +63,7 @@ publish tripal content:
 
 ##
 # These should all be per content type.
-# @todo See Issue #270 (https://github.com/tripal/t4d8/issues/270)
+# @todo See Issue #1355 (https://github.com/tripal/tripal/issues/1355)
 ##
 add tripal content entities:
   title: 'Create new Tripal Content'

--- a/tripal_chado/tests/fixtures/regenerate_scripts/regenerate_fill_test_prepare.sh
+++ b/tripal_chado/tests/fixtures/regenerate_scripts/regenerate_fill_test_prepare.sh
@@ -1,8 +1,8 @@
 ## This script is used to recreate the fill_chado_test_prepare.sql file used
 ## to simulate a chado prepare task being applied to the test schema more efficiently.
 ##
-## Example Usage with TripalDocker named t4d8
-## docker exec -it t4d8 bash modules/contrib/tripal/tripal_chado/tests/fixtures/regenerate_scripts/regenerate_fill_test_prepare.sh
+## Example Usage with TripalDocker named t4
+## docker exec -it t4 bash modules/contrib/tripal/tripal_chado/tests/fixtures/regenerate_scripts/regenerate_fill_test_prepare.sh
 ##
 ## NOTE: This script uses an already prepared chado database to create the file.
 ## As such, make sure to use the UI to create a new Chado 1.3 schema named "preparedchado"

--- a/tripaldocker/legacy/Dockerfile
+++ b/tripaldocker/legacy/Dockerfile
@@ -363,7 +363,7 @@ COPY apache.conf /etc/httpd/conf.d/apache.conf
 # COPY init.sh /usr/bin/init.sh
 # RUN chmod +x /usr/bin/init.sh
 
-RUN git clone https://github.com/tripal/t4d8.git sites/all/modules/contrib/tripal
+RUN git clone https://github.com/tripal/tripal.git sites/all/modules/contrib/tripal
 
 # Enable tripal 4 module
 RUN /etc/init.d/postgresql start \


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #1811

### Tripal Version: 4.alpha3

## Description
This is a simple PR to update the few remaining references to the t4d8 "temporary" repository, left over from prior to moving the Tripal 4 development back to the main Tripal repo.

## Testing?
Code review. These are all non-functional changes, except that "legacy" docker - is that even used?