### PR TITLE
Ensure that Tripal Layout is installed in our dockers

### DIFF
--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -1,7 +1,7 @@
 FROM php:8.1-apache-bullseye
 
 ARG drupalversion='~10.1.0'
-ARG modules='devel devel_php'
+ARG modules='devel devel_php field_group field_group_table'
 ARG chadoschema='chado'
 ARG installchado=TRUE
 ARG phpuploadsize=8M
@@ -192,7 +192,7 @@ RUN service apache2 start \
   && sleep 30 \
   && mkdir -p /var/www/drupal/web/modules/contrib \
   && cp -R /app /var/www/drupal/web/modules/contrib/tripal \
-  && vendor/bin/drush en tripal tripal_biodb tripal_chado ${modules} -y \
+  && vendor/bin/drush en tripal tripal_biodb tripal_chado tripal_layout ${modules} -y \
   && if [ "$installchado" = "TRUE" ]; then \
     vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
     && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -151,7 +151,7 @@ RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
 ## Use composer to install Drupal.
 WORKDIR /var/www
 ARG requiredcomposerpackages="drupal/core:${drupalversion} drupal/core-dev:${drupalversion} drush/drush phpspec/prophecy-phpunit"
-ARG composerpackages="drupal/devel drupal/devel_php"
+ARG composerpackages="drupal/devel drupal/devel_php drupal/field_group drupal/field_group_table"
 RUN composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal \
   && cd drupal \
   && composer config --no-plugins allow-plugins.composer/installers true \

--- a/tripaldocker/Dockerfile-php8.2-pgsql13
+++ b/tripaldocker/Dockerfile-php8.2-pgsql13
@@ -1,7 +1,7 @@
 FROM php:8.2-apache-bullseye
 
 ARG drupalversion='~10.1.0'
-ARG modules='devel devel_php'
+ARG modules='devel devel_php field_group field_group_table'
 ARG chadoschema='chado'
 ARG installchado=TRUE
 ARG phpuploadsize=8M
@@ -192,7 +192,7 @@ RUN service apache2 start \
   && sleep 30 \
   && mkdir -p /var/www/drupal/web/modules/contrib \
   && cp -R /app /var/www/drupal/web/modules/contrib/tripal \
-  && vendor/bin/drush en tripal tripal_biodb tripal_chado ${modules} -y \
+  && vendor/bin/drush en tripal tripal_biodb tripal_chado tripal_layout ${modules} -y \
   && if [ "$installchado" = "TRUE" ]; then \
     vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
     && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \

--- a/tripaldocker/Dockerfile-php8.2-pgsql13
+++ b/tripaldocker/Dockerfile-php8.2-pgsql13
@@ -151,7 +151,7 @@ RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
 ## Use composer to install Drupal.
 WORKDIR /var/www
 ARG requiredcomposerpackages="drupal/core:${drupalversion} drupal/core-dev:${drupalversion} drush/drush phpspec/prophecy-phpunit"
-ARG composerpackages="drupal/devel drupal/devel_php"
+ARG composerpackages="drupal/devel drupal/devel_php drupal/field_group drupal/field_group_table"
 RUN composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal \
   && cd drupal \
   && composer config --no-plugins allow-plugins.composer/installers true \

--- a/tripaldocker/Dockerfile-php8.3-pgsql13
+++ b/tripaldocker/Dockerfile-php8.3-pgsql13
@@ -1,7 +1,7 @@
 FROM php:8.3-apache-bullseye
 
 ARG drupalversion='~10.2.0'
-ARG modules='devel devel_php'
+ARG modules='devel devel_php field_group field_group_table'
 ARG chadoschema='chado'
 ARG installchado=TRUE
 ARG phpuploadsize=8M
@@ -192,7 +192,7 @@ RUN service apache2 start \
   && sleep 30 \
   && mkdir -p /var/www/drupal/web/modules/contrib \
   && cp -R /app /var/www/drupal/web/modules/contrib/tripal \
-  && vendor/bin/drush en tripal tripal_biodb tripal_chado ${modules} -y \
+  && vendor/bin/drush en tripal tripal_biodb tripal_chado tripal_layout ${modules} -y \
   && if [ "$installchado" = "TRUE" ]; then \
     vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
     && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \

--- a/tripaldocker/Dockerfile-php8.3-pgsql13
+++ b/tripaldocker/Dockerfile-php8.3-pgsql13
@@ -151,7 +151,7 @@ RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
 ## Use composer to install Drupal.
 WORKDIR /var/www
 ARG requiredcomposerpackages="drupal/core:${drupalversion} drupal/core-dev:${drupalversion} drush/drush phpspec/prophecy-phpunit"
-ARG composerpackages="drupal/devel drupal/devel_php"
+ARG composerpackages="drupal/devel drupal/devel_php drupal/field_group drupal/field_group_table"
 RUN composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal \
   && cd drupal \
   && composer config --no-plugins allow-plugins.composer/installers true \


### PR DESCRIPTION
# Tripal 4 Core Dev Task 

### Issue #1812

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Downloads field_group and field_group table in the dockerfiles via composer and then enables them and tripal_layout.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Automated testing build these docker images from scratch for the full matrix of php/drupal versions we support. As such, we don't need to test on all versions :-) 

### Manual Testing

This PR only changes the dockerfiles. As such, it only makes sense to test on docker rather then a manual install.
1. Build and run on this branch.
2. Go to the site UI and confirm that Tripal Layout is enabled.
3. Go to Tripal > Page Structure > Organism > Manage Display and click "Apply Tripal Layout"
4. Create an organism through the UI and confirm that it has the new layout styles applied (i.e. fieldset for the details).
**See https://github.com/tripal/tripal/pull/1792 for more info on testing Tripal Layout**