### PR TITLE
Fix automated testing on 4.x

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we fully build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build Docker Image

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we fully  build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build the Docker
@@ -35,7 +35,7 @@ jobs:
           docker exec tripaldocker service postgresql restart
       # Ensure we have the variables we need.
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4
       # Prepare for code coverage.
       - name: Prepare for Code Coverage
         run: |

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -17,6 +17,7 @@ jobs:
           - "8.2"
           - "8.3"
         pgsql-version:
+          - "13"
           - "16"
         drupal-version:
           - "10.0.x-dev"
@@ -29,10 +30,17 @@ jobs:
           - php-version: "8.3"
             pgsql-version: "13"
             drupal-version: "10.1.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "16"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "16"
+            drupal-version: "10.1.x-dev"
     name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
       - uses: actions/checkout@v4
         name: Check out code
+      ## Build images tagged drupal{VER}-php{VER}-pgsqlVER
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Full matrix of Docker images
         with:
@@ -44,6 +52,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      ## Build images tagged drupal{VER}-php{VER}-pgsqlVER-noChado without chado installed!
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Full matrix of Docker images WITH NO CHADO
         with:
@@ -55,9 +64,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},installchado=FALSE,postgresqlversion=${{ matrix.pgsql-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      ## Build Images tagged drupal{VER} focused on php 8.2 + postgresql 16
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Docker image Drupal focused Docker images.
-        if: ${{ matrix.php-version == '8.1' && matrix.pgsql-version == '13' }}
+        if: ${{ matrix.php-version == '8.2' && matrix.pgsql-version == '16' }}
         with:
           image: tripalproject/tripaldocker
           tags: drupal${{ matrix.drupal-version }}
@@ -67,9 +77,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }}"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: mr-smithers-excellent/docker-build-push@v6
-        name: Build latest using 10.2.x-dev, PHP 8.3, PgSQL 13
-        if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '13' }}
+        name: Build latest using 10.2.x-dev, PHP 8.3, PgSQL 16
+        if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '16' }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - tv4g0-issue1820-psql-docker-version-settable
+      - tv4g9-1829-bumpActionVersion
 
 jobs:
   push_to_registry:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -31,7 +31,7 @@ jobs:
             drupal-version: "10.1.x-dev"
     name: Docker Build (drupal${{ matrix.drupal-version }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Full matrix of Docker images

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_0x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.0: PHP 8.1"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_1x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_1x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.1: PHP 8.1"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_2x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_2x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.2: PHP 8.1"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_0x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_0x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_0x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_0x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.0: PHP 8.2"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_1x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_1x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.1: PHP 8.2"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_2x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_2x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.2: PHP 8.2"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_2x.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_2x.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - tv4g9-1829-bumpActionVersion
 jobs:
   running-tests:
     name: "Drupal 10.2: PHP 8.3"
@@ -11,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.4
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #1829 

### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR does the following:
- Bumps the tripal-test-action from 1.4 to 1.5. NOTE: the new version of the test action supports the change in the dockerfile name.
- Bumps the checkout and github slug actions from 3 to 4 to keep up with nodejs versions as these actions use node.
- Updates the build docker workflow to ensure we build for both postgresql 13 + 16 and cleans up the logic for the drupal-focused tags.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I've added this branch to the workflows to ensure they all run on this branch including those that usually only run on 4.x This is needed to test the workflows fully.

For testing, we just need to make sure they all pass and that the correct docker images are created.
