### PR TITLE
Add IPv6 loopback to support docker v26

### DIFF
--- a/tripaldocker/default_files/postgresql/pg_hba.conf
+++ b/tripaldocker/default_files/postgresql/pg_hba.conf
@@ -95,6 +95,6 @@ local   all             all                                     peer
 # IPv4 local connections:
 host    all    tripaladmin        127.0.0.1/32             md5
 host    all    drupaladmin        127.0.0.1/32             md5
-# IPv6 local connections
+# IPv6 local connections:
 host    all    tripaladmin        ::1/32                   md5
 host    all    drupaladmin        ::1/32                   md5

--- a/tripaldocker/default_files/postgresql/pg_hba.conf
+++ b/tripaldocker/default_files/postgresql/pg_hba.conf
@@ -95,3 +95,6 @@ local   all             all                                     peer
 # IPv4 local connections:
 host    all    tripaladmin        127.0.0.1/32             md5
 host    all    drupaladmin        127.0.0.1/32             md5
+# IPv6 local connections
+host    all    tripaladmin        ::1/32                   md5
+host    all    drupaladmin        ::1/32                   md5


### PR DESCRIPTION
# Bug Fix

### Closes #1832 

### Tripal Version: 4.x

## Description
Under Ubuntu Docker v26 we cannot build an image.
`Docker version 26.0.0, build 2ae903e`
We also cannot run a container built under Docker v25.
(It is of course possible that something else besides Docker is causing this.)
This adds the IPv6 loopback to `tripaldocker/default_files/postgresql/pg_hba.conf`
It is essentially the same as the existing IPv4 loopback.

## Testing?
The easiest test is, if you have Docker v26, try to build an image.
Without this change, you will see this error
```
...
#26 34.80  [notice] Performed install task: install_verify_requirements
#26 34.97 
#26 34.98 In install.core.inc line 987:
#26 34.98                                                                                
#26 34.98   Resolve all issues below to continue the installation. For help configuring  
#26 34.98    your database server, see the <a href="https://www.drupal.org/docs/install  
#26 34.98   ing-drupal">installation handbook</a>, or contact your hosting provider.<di  
#26 34.98   v class="item-list"><ul><li>Failed to connect to your database server. The   
#26 34.98   server reports the following message: <em class="placeholder">SQLSTATE[0800  
#26 34.98   6] [7] connection to server at &quot;localhost&quot; (::1), port 5432 faile  
#26 34.98   d: FATAL:  no pg_hba.conf entry for host &quot;::1&quot;, user &quot;drupal  
#26 34.98   admin&quot;, database &quot;sitedb&quot;, SSL on                             
#26 34.98   connection to server at &quot;localhost&quot; (::1), port 5432 failed: FATA  
#26 34.98   L:  no pg_hba.conf entry for host &quot;::1&quot;, user &quot;drupaladmin&q  
#26 34.98   uot;, database &quot;sitedb&quot;, SSL off</em>.<ul><li>Is the database ser  
#26 34.98   ver running?</li><li>Does the database exist, and have you entered the corr  
#26 34.98   ect database name?</li><li>Have you entered the correct username and passwo  
#26 34.98   rd?</li><li>Have you entered the correct database hostname and port number?  
#26 34.98   </li></ul></li></ul></div>                                                   
#26 34.98                                                                                
#26 34.98 
#26 ERROR: process "/bin/sh -c cd /var/www/drupal   && service apache2 start   && service postgresql start   && sleep 30   && /var/www/drupal/vendor/drush/drush/drush site-install standard   --db-url=pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb   --account-mail=\"drupaladmin@localhost\"   --account-name=drupaladmin   --account-pass=some_admin_password   --site-mail=\"drupaladmin@localhost\"   --site-name=\"Tripal 4.x-dev on Drupal ${drupalversion}\"   && service apache2 stop   && service postgresql stop" did not complete successfully: exit code: 1
...
------

```