### PR TITLE
GFF importer, fix loading gene sequence from FASTA section

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -1432,7 +1432,7 @@ class GFF3Importer extends ChadoImporterBase {
       if (array_key_exists($uniquename, $this->features)) {
         $findex = $this->features[$uniquename]['findex'];
         $feature = $this->getCachedFeature($findex);
-        $feature_id = $feature['feature_id'];
+        $feature_id = $feature['feature_id'] ?? $this->features[$uniquename]['feature_id'];
       }
       else {
         $feature_id = $this->landmarks[$uniquename];


### PR DESCRIPTION
# Bug Fix

### Issue #1823 

### Tripal Version: 4.x

## Description
A gff3 file can provide sequence information in a `##FASTA` section.
Currently this is only working for landmark sequence, it is not working for a feature sequence like gene.

## Testing?
This simple gff3 file can be used for testing. Import with the gff3 importer, publish gene content type, and a sequence should be present for gene-YAL068C
[PAU8-withgeneseq.txt](https://github.com/tripal/tripal/files/14792698/PAU8-withgeneseq.txt)

![2024-03-28_gene-with-sequence](https://github.com/tripal/tripal/assets/8419404/b975f296-2053-4691-87f1-52681f2ab548)
