### PR TITLE
New Widgets for Property Fields

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -122,7 +122,7 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
    */
   public static function defaultSettings() {
     return [
-      'options' => [],
+      'options' => '',
     ] + parent::defaultSettings();
   }
 
@@ -148,9 +148,13 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     $summary = [];
 
     $raw_options = $this->getSetting('options');
-    $count = sizeof(explode("\n", $raw_options));
-
-    $summary[] = $this->t("There are $count options configured.");
+    if (!empty($raw_options)) {
+      $count = sizeof(explode("\n", $raw_options));
+      $summary[] = $this->t("There are $count options configured.");
+    }
+    else {
+      $summary[] = $this->t("There are no options yet options configured.");
+    }
 
     return $summary;
   }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Tripal linker property widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_property_select_widget_default",
+ *   label = @Translation("Chado Property Select"),
+ *   description = @Translation("Provides a configurable drop-down widget for Chado Properties."),
+ *   field_types = {
+ *     "chado_property_type_default"
+ *   }
+ * )
+ */
+class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $field_settings = $field_definition->getSettings();
+
+    // Get the default values.
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $prop_id = $item_vals['prop_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $default_value = $item_vals['value'] ?? NULL;
+    $term_id = NULL;
+    if ($field_settings['termIdSpace'] and $field_settings['termAccession']) {
+      $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+      $idSpace = $idSpace_manager->loadCollection($field_settings['termIdSpace']);
+
+      $term = $idSpace->getTerm($field_settings['termAccession']);
+      $term_id = $term->getInternalId();
+    }
+
+    // Process the options from the configuration.
+    $raw_options = $this->getSetting('options');
+    $options = [];
+    foreach( explode("\n", $raw_options) as $item) {
+      $item = trim($item);
+      $options[$item] = $item;
+    }
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['prop_id'] = [
+      '#type' => 'value',
+      '#default_value' => $prop_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#value' => $linker_id,
+    ];
+    $elements['type_id'] = [
+      '#type' => 'value',
+      '#value' => $term_id,
+    ];
+    $elements['value'] = $element + [
+      '#type' => 'select',
+      '#default_value' => $default_value,
+      '#empty_option' => '- None -',
+      '#options' => $options,
+      '#required' => FALSE,
+    ];
+    $elements['rank'] = [
+      '#type' => 'value',
+      '#value' => $delta,
+    ];
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+
+    $storage_settings = $this->getFieldSetting('storage_plugin_settings');
+    $prop_table = $storage_settings['prop_table'];
+    $rank_term = $this->sanitizeKey($mapping->getColumnTermId($prop_table, 'rank'));
+
+    // Remove any empty values that aren't mapped to a record id.
+    foreach ($values as $val_key => $value) {
+      if ($value['value'] == '' and $value['record_id'] == 0) {
+        unset($values[$val_key]);
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      if ($value['value'] == '') {
+        continue;
+      }
+      $values[$val_key]['_weight'] = $i;
+      $values[$val_key][$rank_term] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      // Create the custom setting 'size', and
+      // assign a default value of 60
+      'options' => [],
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['options'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Widget Options'),
+      '#description' => "Enter the options you want to be available in the widget drop down with each option on it's own line.",
+      '#default_value' => $this->getSetting('options'),
+      '#required' => TRUE,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $summary[] = $this->t('Its too hard to summarize these options.');
+
+    return $summary;
+  }
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -57,7 +57,8 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     // Check that the default value is one of the available options.
     if (!array_key_exists($default_value, $options)){
       $field_label = $field_definition->label();
-      $this->messenger()->addWarning("The value saved for the '$field_label' does not match any of the available options. As such it has been set to none and the original value ('$default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.");
+      $this->messenger()->addWarning($this->t("The value saved for the '@field_label' does not match any of the available options. As such it has been set to 'None' and the original value ('@default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.",
+          ['@field_label' => $field_label, '@default_value' => $default_value]));
     }
 
     $elements = [];

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -54,6 +54,12 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
       $options[$item] = $item;
     }
 
+    // Check that the default value is one of the available options.
+    if (!array_key_exists($default_value, $options)){
+      $field_label = $field_definition->label();
+      $this->messenger()->addWarning("The value saved for the '$field_label' does not match any of the available options. As such it has been set to none and the original value ('$default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.");
+    }
+
     $elements = [];
     $elements['record_id'] = [
       '#type' => 'value',

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -122,8 +122,6 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
    */
   public static function defaultSettings() {
     return [
-      // Create the custom setting 'size', and
-      // assign a default value of 60
       'options' => [],
     ] + parent::defaultSettings();
   }
@@ -149,7 +147,10 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
   public function settingsSummary() {
     $summary = [];
 
-    $summary[] = $this->t('Its too hard to summarize these options.');
+    $raw_options = $this->getSetting('options');
+    $count = sizeof(explode("\n", $raw_options));
+
+    $summary[] = $this->t("There are $count options configured.");
 
     return $summary;
   }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -157,7 +157,7 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     $raw_options = $this->getSetting('options');
     if (!empty($raw_options)) {
       $count = sizeof(explode("\n", $raw_options));
-      $summary[] = $this->t("There are $count options configured.");
+      $summary[] = $this->t("There are @count options configured.", ['@count' => $count]);
     }
     else {
       $summary[] = $this->t("There are no options configured yet.");

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
  *
  * @FieldWidget(
  *   id = "chado_property_select_widget_default",
- *   label = @Translation("Chado Property Select"),
+ *   label = @Translation("Chado Property: Select Drop-down"),
  *   description = @Translation("Provides a configurable drop-down widget for Chado Properties."),
  *   field_types = {
  *     "chado_property_type_default"

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -55,7 +55,7 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     }
 
     // Check that the default value is one of the available options.
-    if (!array_key_exists($default_value, $options)){
+    if (isset($default_value) and !array_key_exists($default_value, $options)){
       $field_label = $field_definition->label();
       $this->messenger()->addWarning($this->t("The value saved for the '@field_label' does not match any of the available options. As such it has been set to 'None' and the original value ('@default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.",
           ['@field_label' => $field_label, '@default_value' => $default_value]));

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -56,9 +56,8 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
 
     // Check that the default value is one of the available options.
     if (isset($default_value) and !array_key_exists($default_value, $options)) {
-      $request_method = \Drupal::requestStack()->getCurrentRequest()->getMethod();
       // Do not display the warning when saving
-      if ($request_method == 'GET') {
+      if (!$form_state->getUserInput()) {
         $field_label = $field_definition->label();
         $this->messenger()->addWarning($this->t("The value saved for the '@field_label' does not match any of the available options. As such it has been set to 'None' and the original value ('@default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.",
             ['@field_label' => $field_label, '@default_value' => $default_value]));

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -55,10 +55,14 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     }
 
     // Check that the default value is one of the available options.
-    if (isset($default_value) and !array_key_exists($default_value, $options)){
-      $field_label = $field_definition->label();
-      $this->messenger()->addWarning($this->t("The value saved for the '@field_label' does not match any of the available options. As such it has been set to 'None' and the original value ('@default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.",
-          ['@field_label' => $field_label, '@default_value' => $default_value]));
+    if (isset($default_value) and !array_key_exists($default_value, $options)) {
+      $request_method = \Drupal::requestStack()->getCurrentRequest()->getMethod();
+      // Do not display the warning when saving
+      if ($request_method == 'GET') {
+        $field_label = $field_definition->label();
+        $this->messenger()->addWarning($this->t("The value saved for the '@field_label' does not match any of the available options. As such it has been set to 'None' and the original value ('@default_value') will be overwritten when you save this page. Please contact your administrator to get this added as an option before making any changes to this page.",
+            ['@field_label' => $field_label, '@default_value' => $default_value]));
+      }
     }
 
     $elements = [];

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -139,7 +139,7 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
     $element['options'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Widget Options'),
-      '#description' => "Enter the options you want to be available in the widget drop down with each option on it's own line.",
+      '#description' => $this->t("Enter the options you want to be available in the widget drop down with each option on its own line."),
       '#default_value' => $this->getSetting('options'),
       '#required' => TRUE,
     ];

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -159,7 +159,7 @@ class ChadoPropertySelectWidgetDefault extends ChadoWidgetBase {
       $summary[] = $this->t("There are $count options configured.");
     }
     else {
-      $summary[] = $this->t("There are no options yet options configured.");
+      $summary[] = $this->t("There are no options configured yet.");
     }
 
     return $summary;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
+
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
+
+/**
+ * Plugin implementation of default Tripal linker property widget.
+ *
+ * @FieldWidget(
+ *   id = "chado_property_string_widget_default",
+ *   label = @Translation("Chado Property String"),
+ *   description = @Translation("Provides a simple string widget for Chado Properties."),
+ *   field_types = {
+ *     "chado_property_type_default"
+ *   }
+ * )
+ */
+class ChadoPropertyStringWidgetDefault extends ChadoWidgetBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get the field settings.
+    $field_definition = $items[$delta]->getFieldDefinition();
+    $field_settings = $field_definition->getSettings();
+
+    // Get the default values.
+    $item_vals = $items[$delta]->getValue();
+    $record_id = $item_vals['record_id'] ?? 0;
+    $prop_id = $item_vals['prop_id'] ?? 0;
+    $linker_id = $item_vals['linker_id'] ?? 0;
+    $default_value = $item_vals['value'] ?? '';
+    $term_id = NULL;
+    if ($field_settings['termIdSpace'] and $field_settings['termAccession']) {
+      $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+      $idSpace = $idSpace_manager->loadCollection($field_settings['termIdSpace']);
+
+      $term = $idSpace->getTerm($field_settings['termAccession']);
+      $term_id = $term->getInternalId();
+    }
+
+    $elements = [];
+    $elements['record_id'] = [
+      '#type' => 'value',
+      '#default_value' => $record_id,
+    ];
+    $elements['prop_id'] = [
+      '#type' => 'value',
+      '#default_value' => $prop_id,
+    ];
+    $elements['linker_id'] = [
+      '#type' => 'value',
+      '#value' => $linker_id,
+    ];
+    $elements['type_id'] = [
+      '#type' => 'value',
+      '#value' => $term_id,
+    ];
+    $elements['value'] = $element + [
+      '#type' => 'textfield',
+      '#default_value' => $default_value,
+      '#title' => '',
+      '#description' => '',
+      '#rows' => '',
+      '#required' => FALSE,
+    ];
+    $elements['rank'] = [
+      '#type' => 'value',
+      '#value' => $delta,
+    ];
+    return $elements;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
+    $mapping = $storage->load('core_mapping');
+
+    $storage_settings = $this->getFieldSetting('storage_plugin_settings');
+    $prop_table = $storage_settings['prop_table'];
+    $rank_term = $this->sanitizeKey($mapping->getColumnTermId($prop_table, 'rank'));
+
+    // Remove any empty values that aren't mapped to a record id.
+    foreach ($values as $val_key => $value) {
+      if ($value['value'] == '' and $value['record_id'] == 0) {
+        unset($values[$val_key]);
+      }
+    }
+
+    // Reset the weights
+    $i = 0;
+    foreach ($values as $val_key => $value) {
+      if ($value['value'] == '') {
+        continue;
+      }
+      $values[$val_key]['_weight'] = $i;
+      $values[$val_key][$rank_term] = $i;
+      $i++;
+    }
+
+    return $values;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -12,8 +12,8 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
  *
  * @FieldWidget(
  *   id = "chado_property_string_widget_default",
- *   label = @Translation("Chado Property String"),
- *   description = @Translation("Provides a simple string widget for Chado Properties."),
+ *   label = @Translation("Chado Property: Short Text"),
+ *   description = @Translation("Provides a simple string widget for Chado Properties using a textfield."),
  *   field_types = {
  *     "chado_property_type_default"
  *   }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -12,8 +12,8 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
  *
  * @FieldWidget(
  *   id = "chado_property_widget_default",
- *   label = @Translation("Chado Property"),
- *   description = @Translation("Add a property or attribute to the content type."),
+ *   label = @Translation("Chado Property: Long Text"),
+ *   description = @Translation("Provides a long text widget for Chado Properties using a formatted textarea."),
  *   field_types = {
  *     "chado_property_type_default"
  *   }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### No Linked Issue; Playing over weekend

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds two new widgets to the core property fields:
 - chado_property_string_widget_default: provides a simple textbox for a cleaner and more compact widget
 - chado_property_select_widget_default: provides a configurable select box

These were added to improve the experience of data entry for curators and to allow admin to control the entries accepted for various metadata.

Note: The select widget configuration UI specifically does not support a key => value mapping as we want to ensure the value entered for metadata matches what is displayed.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Start a fresh site on this branch or drush cr on an existing site.
2. Create 1+ property fields on a content type of your choice. In this example we will create 2 fields on the organism content type: Category (Term: Group (NCIT:C43359)) only supports a single value; Breeding Techniques (Term: Methods (local:Methods)) which supports unlimited values.
3. Go to Manage form display and confirm these property type fields have 3 options for widget (Long Text, Short Text, Select Drop-down) and the default is "Long Text". **Do not change them yet** <img width="1007" alt="Screenshot 2024-04-15 at 3 13 00 PM" src="https://github.com/tripal/tripal/assets/1566301/578acaf2-2b54-4ac3-b5a2-5e0d57a50efd">
4. Go to the add content page to create an organism and confirm that the two property widgets match the old long text style. <img width="1440" alt="Screenshot 2024-04-15 at 3 07 04 PM" src="https://github.com/tripal/tripal/assets/1566301/38277d93-fd62-48ee-b46f-8bb81f149e8b">
5. Now go back to manage form display for organism and change one or both properties to use the short text widget. When you edit or create an organism these fields now use a textfield. They do not limit the length of text entered though! <img width="1430" alt="Screenshot 2024-04-15 at 3 09 41 PM" src="https://github.com/tripal/tripal/assets/1566301/7e6e9349-619f-488f-a564-1d83e91d16ff">
6. Go back to manage form display for organism and change one or both properties to use the select drop-down widget. Right after selecting it you should see a configuration cog appear and the summary "There are no options yet configured."<img width="1420" alt="Screenshot 2024-04-15 at 3 28 54 PM" src="https://github.com/tripal/tripal/assets/1566301/d0539e7e-cccc-4f0f-8b86-7bff1a2eb3b1">
7. Click on the cog and configure the options. Then click update and ensure the summary statement has been updated to indicate the number of options you configured. Click save at the bottom of the page. <img width="1417" alt="Screenshot 2024-04-15 at 3 31 22 PM" src="https://github.com/tripal/tripal/assets/1566301/a0d5c7da-24ef-40a9-a404-a7e9e02d9400">
8. Now check existing content:
  - If you edit an existing organism who had an entry typed in that matched an entry in the select list then it should be automatically chosen.  <img width="585" alt="Screenshot 2024-04-15 at 3 33 35 PM" src="https://github.com/tripal/tripal/assets/1566301/90cc9fe8-9d07-4d5c-971a-d7a1b6b6157f">
  - If you edit an existing organism who had an entry NOT in the select list then `- None -` will be chosen and a warning will be shown to the curator. <img width="1420" alt="Screenshot 2024-04-15 at 4 01 14 PM" src="https://github.com/tripal/tripal/assets/1566301/03ea104e-23ba-4c9c-8169-14b20f7206af">
9. Confirm that you can edit and save till your heart's content.



