### PR TITLE
Fix bug in publish showing up in testing environment

### DIFF
--- a/tripal/src/Services/TripalPublish.php
+++ b/tripal/src/Services/TripalPublish.php
@@ -514,7 +514,7 @@ class TripalPublish {
     $entities = [];
 
     $sql = "
-      SELECT id,type,title FROM tripal_entity\n
+      SELECT id,type,title FROM {tripal_entity}\n
       WHERE type = :type AND title in (:titles[])\n";
 
     $i = 0;
@@ -638,7 +638,7 @@ class TripalPublish {
     $items = [];
 
     $sql = "
-      SELECT entity_id FROM $field_table\n
+      SELECT entity_id FROM {" . $field_table . "}\n
       WHERE bundle = :bundle\n
         AND entity_id IN (:entity_ids[])\n";
 
@@ -725,7 +725,7 @@ class TripalPublish {
 
     // Generate the insert SQL and add to it the field-specific columns.
     $init_sql = "
-      INSERT INTO {$field_table}
+      INSERT INTO {" . $field_table . "}
         (bundle, deleted, entity_id, revision_id, langcode, delta, ";
     foreach (array_keys($this->required_types[$field_name]) as $key) {
       $init_sql .= $field_name . '_'. $key . ', ';

--- a/tripal_chado/tests/src/Kernel/Services/TripalPublishServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalPublishServiceTest.php
@@ -175,5 +175,19 @@ class TripalPublishServiceTest extends ChadoTestKernelBase {
     $this->assertContains(count($entities), [3, 4],
       "We expected there to be the same number of contact entities as we inserted plus the null contact.");
 
+    // Verify that a field table was populated
+    // Because this is a test environment, we know that the entity IDs
+    // that we just published will start with 1, but because of the
+    // "null" contact, we will just check the project table.
+    for ($i=1; $i <= 3; $i++) {
+      $query = \Drupal::entityQuery('tripal_entity')
+        ->condition('type', 'project')
+        ->condition('project_name.record_id', $i, '=')
+        ->accessCheck(TRUE);
+      $ids = $query->execute();
+      $this->assertEquals(1, count($ids), 'We did not retrieve the project name field');
+      $entity_id = reset($ids);
+      $this->assertEquals($i, $entity_id, 'We did not retrieve the expected project entity id from its field');
+    }
   }
 }


### PR DESCRIPTION
# Bug Fix

### Closes #1853

### Tripal Version: 4.x

## Description
Tripal publish is missing braces `{  }` in a couple of sql queries, and having a variable inside `{$field_table}` is not parsed as expected.

1. Adds automated test that detects the bug
2. Adds the bugfix so test can then pass

## Testing?
Because this is showing up in the testing environment, check that tests pass. (sorry I messed up the branch name)