### PR TITLE
Fixes validation missing values bug

### DIFF
--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1449,7 +1449,7 @@ class ChadoRecords  {
           if (($record_id == 0) or ($record_id != $match->$pkey)) {
             // Documentation for how to create a violation is here
             // https://github.com/symfony/validator/blob/6.1/ConstraintViolation.php
-            $message = 'The item cannot be saved as another already exists with the following values. ';
+            $message = 'The item cannot be saved as another already exists with the following values: ';
             $params = [];
             foreach ($ukey_cols as $col) {
               $col = trim($col);
@@ -1458,9 +1458,18 @@ class ChadoRecords  {
                 // @todo need to use the column alias when getting the value.
                 $col_val = $record['values'][$col];
               }
-              $message .=  ucfirst($col) . ": '@$col'. ";
               $params["@$col"] = $col_val;
+              $message .=  ucfirst($col) . ": '@$col'" . (count($ukey_cols) == count($params)?'. ':', ');
             }
+            // Explanation of the unique violation.
+            if (count($params) > 1) {
+              $message .= 'The combination of these @param_count values';
+              $params['@param_count'] = count($params);
+            }
+            else {
+              $message .= 'This value';
+            }
+            $message .= ' must be unique for every item.';
             $this->violations[] = new ConstraintViolation(t($message, $params)->render(),
                 $message, $params, '', NULL, '', 1, 0, NULL, '');
           }

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1443,7 +1443,7 @@ class ChadoRecords  {
 
           // Add a constraint violation if we have a match and the
           // record_id is 0. This would be an insert but a record already
-          // exists. Or, if the record_id isn't the same as the  matched
+          // exists. Or, if the record_id isn't the same as the matched
           // record. This is an update that conflicts with an existing
           // record.
           if (($record_id == 0) or ($record_id != $match->$pkey)) {
@@ -1454,12 +1454,9 @@ class ChadoRecords  {
             foreach ($ukey_cols as $col) {
               $col = trim($col);
               $col_val = NULL;
-              if (array_key_exists($col, $record['columns'])) {
+              if (in_array($col, $record['columns'])) {
                 // @todo need to use the column alias when getting the value.
                 $col_val = $record['values'][$col];
-              }
-              if ($table_def['fields'][$col]['not null'] == FALSE and !$col_val) {
-                continue;
               }
               $message .=  ucfirst($col) . ": '@$col'. ";
               $params["@$col"] = $col_val;


### PR DESCRIPTION
# Bug Fix

### Closes #1826

### Tripal Version: 4.x

## Description
This PR does three very simple things (plus a stray double space)
 1. change `array_key_exists` to `in_array` - this is all that was needed to display the missing values
 2. deletes the lines that `continue` if the column in the unique constraint **can be null**, and is null.
 By removing this, we now get feedback on **all** of the columns that make up the unique constraint.
 3. Adds a short explanation of the unique violation (commit https://github.com/tripal/tripal/pull/1855/commits/d16e43f5e07655b8b09b9e205520d1517118c9fb)
The error message for the described testing steps, where there are more than one columns making up the unique constraint, will now be
`The item cannot be saved as another already exists with the following values: Program: 'science', Programversion: '1.0', Sourcename: ''. The combination of these 3 values must be unique for every item.`

For a unique constraint based on a single column, for example contact, the message will appear as
`The item cannot be saved as another already exists with the following values: Name: 'Borg'. This value must be unique for every item.`

## Testing?
Described in issue #1826