### PR TITLE
Fix dbxref field, observed after GFF3 importer

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoDbxrefFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoDbxrefFormatterDefault.php
@@ -59,6 +59,11 @@ class ChadoDbxrefFormatterDefault extends ChadoFormatterBase {
         'db_url' => $item->get('dbxref_db_url')->getString(),
       ];
 
+      // If this database does not have a urlprefix, generate a default one.
+      if (!$values['db_urlprefix']) {
+        $values['db_urlprefix'] = '{db}:{accession}';
+      }
+
       // Substitue db or accession into db_urlprefix
       $values['db_urlprefix'] = preg_replace('/\{db\}/', $values['db_name'], $values['db_urlprefix']);
       $values['db_urlprefix'] = preg_replace('/\{accession\}/', $values['accession'], $values['db_urlprefix']);


### PR DESCRIPTION
# Bug Fix

### Closes #1824

### Tripal Version: 4.x

## Description
Fixes missing dbxref values displaying after importing a gff3 file.
A simple change, generate a default `urlprefix` when a given database does not have one defined. The ones created by the GFF importer do not have these defined.

## Testing?
See issue #1824 for the testing steps.