### PR TITLE
Enable Wysiwyg toolbar for Tripal/Chado Text fields

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -376,3 +376,10 @@ field.formatter.settings.*:
       type: integer
       label: 'Word wrap setting'
       nullable: true
+
+field.widget.settings.*:
+  type: mapping
+  mapping:
+    filter_format:
+      type: string
+      label: 'Filter format for a filtered text field'

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -28,7 +28,10 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
 
     foreach($items as $delta => $item) {
       $elements[$delta] = [
-        "#markup" => $item->get("value")->getString(),
+        '#type' => 'processed_text',
+        '#text' => $item->get('value'),
+        '#format' => 'full_html',
+        '#langcode' => $item->getLangcode(),
       ];
     }
 

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -26,6 +26,9 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    // Default filter format.
+    $filter_format = 'basic_html';
+
     // We need to get the format set in the widget settings
     // because they need to match.
     $entity_type = $this->fieldDefinition->get('entity_type');
@@ -33,7 +36,9 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
     $field_name = $this->fieldDefinition->get('field_name');
     $form_display = \Drupal::service('entity_display.repository')->getFormDisplay($entity_type, $bundle);
     $widget = $form_display->getComponent($field_name);
-    $filter_format = $widget['settings']['filter_format'];
+    if (array_key_exists('filter_format', $widget['settings'])) {
+      $filter_format = $widget['settings']['filter_format'];
+    }
 
     foreach($items as $delta => $item) {
       $value_string = $item->get('value')->getValue();

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -29,7 +29,7 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
     // Default filter format.
     $filter_format = 'basic_html';
 
-    // We need to get the format set in the widget settings
+    // We need to get the format which was set in the widget settings
     // because they need to match.
     $entity_type = $this->fieldDefinition->get('entity_type');
     $bundle = $this->fieldDefinition->get('bundle');

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -26,11 +26,21 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    // We need to get the format set in the widget settings
+    // because they need to match.
+    $entity_type = $this->fieldDefinition->get('entity_type');
+    $bundle = $this->fieldDefinition->get('bundle');
+    $field_name = $this->fieldDefinition->get('field_name');
+    $form_display = \Drupal::service('entity_display.repository')->getFormDisplay($entity_type, $bundle);
+    $widget = $form_display->getComponent($field_name);
+    $filter_format = $widget['settings']['filter_format'];
+
     foreach($items as $delta => $item) {
+      $value_string = $item->get('value')->getValue();
       $elements[$delta] = [
         '#type' => 'processed_text',
-        '#text' => $item->get('value'),
-        '#format' => 'full_html',
+        '#text' => $value_string,
+        '#format' => $filter_format,
         '#langcode' => $item->getLangcode(),
       ];
     }

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -56,6 +56,19 @@ class TripalTextTypeWidget extends TripalWidgetBase {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // The text_format element returns an item consisting of both a value and a
+    // format. We only want to keep the format.
+    foreach ($values as $key => $item) {
+      $values[$key]['value'] = $item['value']['value'];
+    }
+    return $values;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function defaultSettings() {

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -82,12 +82,11 @@ class TripalTextTypeWidget extends TripalWidgetBase {
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
 
-    $options = [
-      'plain_text' => 'Plain Text',
-      'basic_html' => 'Basic HTML',
-      'filtered_html' => 'Filtered HTML',
-      'full_html' => 'Full HTML',
-    ];
+    // Get all the filter formats available for the current site.
+    $options = [];
+    foreach (filter_formats() as $name => $object) {
+      $options[$name] = $object->get('name');
+    }
 
     $element['filter_format'] = [
       '#type' => 'select',
@@ -113,14 +112,10 @@ class TripalTextTypeWidget extends TripalWidgetBase {
     $summary = [];
 
     $format = $this->getSetting('filter_format');
-    $options = [
-      'plain_text' => 'Plain Text',
-      'basic_html' => 'Basic HTML',
-      'filtered_html' => 'Filtered HTML',
-      'full_html' => 'Full HTML',
-    ];
+    $all_formats = filter_formats();
+    $format_label = $all_formats[$format]->get('name');
 
-    $summary[] = $this->t("Text Format: @format", ['@format' => $options[$format]]);
+    $summary[] = $this->t("Text Format: @format", ['@format' => $format_label]);
 
     return $summary;
   }

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -26,7 +26,9 @@ class TripalTextTypeWidget extends TripalWidgetBase {
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element['value'] = $element + [
-      '#type' => 'textarea',
+      '#base_type' => 'textarea',
+      '#type' => 'text_format',
+      '#format' => 'full_html',
       '#default_value' => $items[$delta]->value ?? '',
       '#placeholder' => $this->getSetting('placeholder'),
       '#attributes' => ['class' => ['js-text-full', 'text-full']],

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -25,14 +25,90 @@ class TripalTextTypeWidget extends TripalWidgetBase {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
     $element['value'] = $element + [
       '#base_type' => 'textarea',
       '#type' => 'text_format',
-      '#format' => 'full_html',
+      '#format' => $this->getSetting('filter_format'),
       '#default_value' => $items[$delta]->value ?? '',
       '#placeholder' => $this->getSetting('placeholder'),
       '#attributes' => ['class' => ['js-text-full', 'text-full']],
     ];
+
     return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function afterBuild(array $element, FormStateInterface $form_state) {
+    parent::afterBuild($element, $form_state);
+
+    // Alter the format drop down so that it is hidden.
+    // We do this because any changes here are not actually saved and thus
+    // having it enabled is misleading.
+    // Note: We couldn't disable it for the text format element would stop working ;-)
+    foreach(\Drupal\Core\Render\Element::children($element) as $key) {
+      $element[$key]['value']['format']['#attributes']['class'][] = 'hidden';
+    }
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'filter_format' => 'basic_html',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+
+    $options = [
+      'plain_text' => 'Plain Text',
+      'basic_html' => 'Basic HTML',
+      'filtered_html' => 'Filtered HTML',
+      'full_html' => 'Full HTML',
+    ];
+
+    $element['filter_format'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Text Filter Format'),
+      '#options' => $options,
+      '#description' => $this->t("Select the text filter format you want applied
+        to this field. Everyone will use the same format. If a user does not have
+        permission to the format chosen for this field then they won't be able to
+        edit it. Please keep in mind there are security concerns with choosing
+        'full_html' and thus this should only be your choice if you have
+        restricted all people able to edit this field to those you trust."),
+      '#default_value' => $this->getSetting('filter_format'),
+      '#required' => TRUE,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $format = $this->getSetting('filter_format');
+    $options = [
+      'plain_text' => 'Plain Text',
+      'basic_html' => 'Basic HTML',
+      'filtered_html' => 'Filtered HTML',
+      'full_html' => 'Full HTML',
+    ];
+
+    $summary[] = $this->t("Text Format: @format", ['@format' => $options[$format]]);
+
+    return $summary;
   }
 }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #1852

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are a number of Chado fields that provide a textarea in the widget. However, none of these have text filtering enabled and thus curators do not see the editing toolbar on these fields... This is a usability concern -especially for long description fields- as it makes it very difficult for formatted text to be entered.

This PR alters the Tripal Text Field Widget + Formatter to support a configurable filter format. Choosing a filter format that the Wysiwyg toolbar is configured for, enables the toolbar on that field :-)


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Checkout this branch on an existing Tripal site or in a docker container.
2. Ensure that you can still create an organism or any other content type with text fields without first going to the page structure form display settings. You should already see the Wysiwyg toolbar as it will use the default "Basic HTML" format.
3. Go to Page Structure > Organism > Manage Form Display and configure the Description field widget to use a filter format of "Full HTML". This will allow HTML to entered and rendered in the field without filtering.
4. Now go back to your organism and edit it. Confirm you now see the Wysiwyg toolbar and that you can use it to include formatted text :-) Confirm you can save the content without error. Confirm that it is rendered as expected on the page.

<img width="916" alt="Screenshot 2024-04-27 at 3 14 23 PM" src="https://github.com/tripal/tripal/assets/1566301/6648e98a-927d-4e7b-92c8-67ed73705324">
