### PR TITLE
Implement the fallback entity lookup

### DIFF
--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -7,6 +7,15 @@ use Drupal\Core\Render\Markup;
 use Drupal\field\Entity\FieldStorageConfig;
 use \Drupal\tripal\Services\TripalEntityTitle;
 
+/**
+ * This class provides functions to assist with finding a Drupal
+ * entity that corresponds to a Chado record.
+ *
+ * The two public functions defined here are:
+ *   getEntityId() which looks up a Drupal entity id from a Chado record id
+ *   getRenderableItem() is a helper function for field formatters, it will
+ *     handle converting an entity_id into a render array element.
+ */
 class TripalEntityLookup {
 
   /**

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -307,14 +307,15 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: assay
-                base_column: protocol_id
+                linker_table: assay
+                linker_fkey_column: protocol_id
         settings:
             termIdSpace: data
             termAccession: "1047"
         display:
           view:
             default:
-              region: hidden
+              region: content
               label: above
               weight: 25
           form:
@@ -656,14 +657,15 @@ fields:
             storage_plugin_id: chado_storage
             storage_plugin_settings:
                 base_table: arraydesign
-                base_column: protocol_id
+                linker_table: arraydesign
+                linker_fkey_column: protocol_id
         settings:
             termIdSpace: data
             termAccession: "1047"
         display:
           view:
             default:
-              region: hidden
+              region: content
               label: above
               weight: 35
           form:

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -156,7 +156,8 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -167,7 +167,8 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -155,7 +155,8 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -170,7 +170,8 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -148,7 +148,8 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -146,7 +146,8 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -175,7 +175,8 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -159,7 +159,8 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -145,7 +145,8 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -155,7 +155,8 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -163,7 +163,8 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -168,7 +168,8 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -150,7 +150,8 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
-      'fkey' => self::$object_id,
+      'ftable' => self::$object_table,
+      'fkey' => $linker_fkey_column,
     ]);
 
     // Base table links directly

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1261,10 +1261,12 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     }
 
     // Given the Chado record ID and bundle term, we can lookup the Drupal entity ID.
+    $ftable = $prop_storage_settings['ftable'] ?? NULL;
     $entity_id = $lookup_manager->getEntityId(
       $record_id,
       $context['field_settings']['termIdSpace'],
-      $context['field_settings']['termAccession']
+      $context['field_settings']['termAccession'],
+      $ftable
     );
 
     // In the TripalEntity class, the preSave function will flag all falsey

--- a/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
@@ -218,20 +218,12 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
     $this->assertCount(1, $arraydesign_entities,
       "We expected there to be the same number of $bundle entities as we inserted.");
 
-    // Set the third party setting for the base table for the contact
-    // bundle, which is needed for the following fallback entity lookup test.
-    $base_table = 'contact';
-    $entity_type = \Drupal::entityTypeManager()->getStorage('tripal_entity_type')->load('contact');
-    $entity_type->setThirdPartySetting('tripal', 'chado_base_table', $base_table);
-    $entity_type->save();
-    $table = $entity_type->getThirdPartySetting('tripal', 'chado_base_table');
-    $this->assertEquals($base_table, $table, "We did not retrieve the correct third party base table setting");
-
     // The entity lookup from arraydesign manufacturer_id should
     // retrieve the entity for the contact_id we published, internally
     // this uses the fallback entity lookup function getDefaultBundle(),
     // because the term for manufacturer_id is NOT a content type.
     // For the fallback lookup we need to also pass the base table.
+    $base_table = 'contact';
     $chado_contact_id = 2;  // 1 is the null contact
     $expected_contact_entity_id = 8; // 1-3: project, 4-6: analysis, 7: null contact, 8: test contact, 9: array_design
     $entity_id = $lookup_manager->getEntityId(

--- a/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
@@ -22,6 +22,12 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
   protected $project_Accession = 'C47885';
   protected $analysis_termIdSpace = 'operation';
   protected $analysis_Accession = '2945';
+  protected $contact_termIdSpace = 'NCIT';
+  protected $contact_Accession = 'C47954';
+  protected $array_design_termIdSpace = 'EFO';
+  protected $array_design_Accession = '0000269';
+  protected $manufacturer_termIdSpace = 'EFO';
+  protected $manufacturer_Accession = '0001728';
 
   /**
    * {@inheritdoc}
@@ -62,19 +68,36 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
         ])->execute();
     }
 
+    // Create one contact in chado.
+    $this->connection->insert('1:contact')
+      ->fields([
+        'name' => 'Contact No. 1',
+      ])->execute();
+
+    // Create one arraydesign in chado, to test the mismatched
+    // foreign key names manufacturer_id -> contact_id
+    $this->connection->insert('1:arraydesign')
+      ->fields([
+        'name' => 'ArrayDesign No. 1',
+        'platformtype_id' => 1,  // not used, whatever the very first cvterm is
+        'manufacturer_id' => 2,  // 1 is the null contact, defined by chado
+      ])->execute();
+
     // Create the terms for the field property storage types.
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
-    foreach(['local', 'SIO', 'schema', 'data', 'NCIT', 'operation', 'OBCS', 'SWO', 'IAO', 'TPUB', 'SBO', 'ERO'] as $termIdSpace) {
+    foreach(['local', 'SIO', 'schema', 'data', 'NCIT', 'operation', 'OBCS', 'SWO', 'IAO', 'TPUB', 'SBO', 'sep', 'ERO', 'EFO'] as $termIdSpace) {
       $idsmanager->createCollection($termIdSpace, "chado_id_space");
     }
     $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
-    foreach(['local', 'SIO', 'schema', 'EDAM', 'ncit', 'OBCS', 'swo', 'IAO', 'tripal_pub', 'sbo', 'ero'] as $termVocab) {
+    foreach(['local', 'SIO', 'schema', 'EDAM', 'ncit', 'OBCS', 'swo', 'IAO', 'tripal_pub', 'sbo', 'sep', 'ero', 'efo'] as $termVocab) {
       $vmanager->createCollection($termVocab, "chado_vocabulary");
     }
 
     // Create the content types + fields that we need.
     $this->createContentTypeFromConfig('general_chado', 'project', TRUE);
     $this->createContentTypeFromConfig('general_chado', 'analysis', TRUE);
+    $this->createContentTypeFromConfig('general_chado', 'contact', TRUE);
+    $this->createContentTypeFromConfig('expression_chado', 'array_design', TRUE);
   }
 
   /**
@@ -86,21 +109,21 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
     $drupal = \Drupal::service('database');
     $lookup_manager = \Drupal::service('tripal.tripal_entity.lookup');
     $current_user = \Drupal::currentUser();
-    $values = ["schema_name" => $this->testSchemaName];
+    $publish_options = ["schema_name" => $this->testSchemaName];
     $datastore = 'chado_storage';
 
     // Publish the test content entities and confirm that they have been created.
     // Submit the Tripal jobs by calling the callback directly.
     $bundle = 'project';
-    tripal_publish($bundle, $datastore, $values);
-    $project_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => 'project']);
+    tripal_publish($bundle, $datastore, $publish_options);
+    $project_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => $bundle]);
 
     $this->assertCount(3, $project_entities,
       "We expected there to be the same number of project entities as we inserted.");
 
     $bundle = 'analysis';
-    tripal_publish($bundle, $datastore, $values);
-    $analysis_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => 'analysis']);
+    tripal_publish($bundle, $datastore, $publish_options);
+    $analysis_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => $bundle]);
     $this->assertCount(3, $analysis_entities,
       "We expected there to be the same number of analysis entities as we inserted.");
 
@@ -113,6 +136,7 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
         $project_id,
         $this->project_termIdSpace,
         $this->project_Accession,
+        NULL
       );
       $this->assertEquals($expected_entity_id, $entity_id, "We did not retrieve the expected entity_id for project $project_id");
     }
@@ -122,6 +146,7 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
         $analysis_id,
         $this->analysis_termIdSpace,
         $this->analysis_Accession,
+        NULL
       );
       $this->assertEquals($expected_entity_id, $entity_id, "We did not retrieve the expected entity_id for analysis $analysis_id");
     }
@@ -132,6 +157,7 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
       $analysis_id,
       $this->analysis_termIdSpace,
       $this->analysis_Accession,
+      NULL
     );
     $this->assertNull($entity_id, 'We retrieved an entity_id for a nonexistent record');
 
@@ -141,6 +167,7 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
       $analysis_id,
       $this->analysis_termIdSpace,
       'not-a-real-accession',
+      NULL
     );
     $this->assertNull($entity_id, 'We retrieved an entity_id for an invalid CV accession');
 
@@ -172,5 +199,50 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
       $ids = $query->execute();
       $this->assertEquals(1, count($ids), "Expected exactly one match from $entity_table_name query");
     }
+
+    // Sometimes foreign key names are different than the object table
+    // primary key, e.g. arraydesign table column manufacturer_id is
+    // a foreign key to the contact table column contact_id.
+
+    // Publish the (null and) test contact and arraydesign entities and confirm that they have been created.
+    $bundle = 'contact';
+    tripal_publish($bundle, $datastore, $publish_options);
+    $contact_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => $bundle]);
+    // Expect 2 here instead of 1 because the null contact will also be published - Issue #1809
+    $this->assertCount(2, $contact_entities,
+      "We expected there to be the same number of $bundle entities as we inserted plus one.");
+
+    $bundle = 'array_design';  // not the same as the table name
+    tripal_publish($bundle, $datastore, $publish_options);
+    $arraydesign_entities = \Drupal::entityTypeManager()->getStorage('tripal_entity')->loadByProperties(['type' => $bundle]);
+    $this->assertCount(1, $arraydesign_entities,
+      "We expected there to be the same number of $bundle entities as we inserted.");
+
+    // The entity lookup from arraydesign manufacturer_id should
+    // retrieve the entity for the contact_id we published, internally
+    // this uses the fallback entity lookup function getDefaultBundle(),
+    // because the term for manufacturer_id is NOT a content type.
+    // For the fallback lookup we need to also pass the base table.
+    $chado_contact_id = 2;  // 1 is the null contact
+    $base_table = 'contact';
+    $expected_contact_entity_id = 8; // 1-3: project, 4-6: analysis, 7: null contact, 8: test contact, 9: array_design
+
+    $entity_id = $lookup_manager->getEntityId(
+      $chado_contact_id,
+      $this->manufacturer_termIdSpace,
+      $this->manufacturer_Accession,
+      $base_table
+    );
+    $this->assertEquals($expected_contact_entity_id, $entity_id, "We did not retrieve the expected entity_id for manufacturer_id $chado_contact_id");
+
+    // Also check that the contact_id (as manufacturer_id) is in the Drupal table
+    $entity_table_name = 'tripal_entity__array_design_manufacturer';
+    $entity_column_name = 'array_design_manufacturer_record_id';
+    $query = \Drupal::entityQuery('tripal_entity')
+      ->condition('type', 'array_design')
+      ->condition('array_design_manufacturer.manufacturer_id', $chado_contact_id, '=')
+      ->accessCheck(TRUE);
+    $ids = $query->execute();
+    $this->assertEquals(1, count($ids), "Expected exactly one match from array_design manufacturer query");
   }
 }

--- a/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
@@ -218,15 +218,22 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
     $this->assertCount(1, $arraydesign_entities,
       "We expected there to be the same number of $bundle entities as we inserted.");
 
+    // Set the third party setting for the base table for the contact
+    // bundle, which is needed for the following fallback entity lookup test.
+    $base_table = 'contact';
+    $entity_type = \Drupal::entityTypeManager()->getStorage('tripal_entity_type')->load('contact');
+    $entity_type->setThirdPartySetting('tripal', 'chado_base_table', $base_table);
+    $entity_type->save();
+    $table = $entity_type->getThirdPartySetting('tripal', 'chado_base_table');
+    $this->assertEquals($base_table, $table, "We did not retrieve the correct third party base table setting");
+
     // The entity lookup from arraydesign manufacturer_id should
     // retrieve the entity for the contact_id we published, internally
     // this uses the fallback entity lookup function getDefaultBundle(),
     // because the term for manufacturer_id is NOT a content type.
     // For the fallback lookup we need to also pass the base table.
     $chado_contact_id = 2;  // 1 is the null contact
-    $base_table = 'contact';
     $expected_contact_entity_id = 8; // 1-3: project, 4-6: analysis, 7: null contact, 8: test contact, 9: array_design
-
     $entity_id = $lookup_manager->getEntityId(
       $chado_contact_id,
       $this->manufacturer_termIdSpace,

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -403,72 +403,6 @@ function tripal_chado_update_10402() {
 }
 
 /**
- * Updates entity_id properties added to linking fields in PR 1782
- */
-function tripal_chado_update_10403() {
-  try {
-    $messenger = \Drupal::messenger();
-
-    $new_property = 'entity_id';
-    // This is the list of Chado fields needing an entity_id
-    $upgradable_types = [
-      'chado_analysis_type_default',
-      'chado_array_design_type_default',
-      'chado_assay_type_default',
-      'chado_biomaterial_type_default',
-      'chado_contact_type_default',
-      'chado_feature_type_default',
-      'chado_featuremap_type_default',
-      'chado_organism_type_default',
-      'chado_project_type_default',
-      'chado_protocol_type_default',
-      'chado_pub_type_default',
-      'chado_stock_type_default',
-      'chado_study_type_default',
-    ];
-    $entity_type = 'tripal_entity';
-
-    $manager = \Drupal::entityDefinitionUpdateManager();
-    $schema = \Drupal::database()->schema();
-    $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
-    $field_map = \Drupal::service('entity_field.manager')->getFieldMap();
-    $fields = $field_map[$entity_type];
-    $n_added = 0;
-
-    foreach ($fields as $field_name => $field_def) {
-      $id = $field_def['type'];
-      if (in_array($id, $upgradable_types, TRUE)) {
-        $field_storage_definition = $manager->getFieldStorageDefinition($field_name, 'tripal_entity');
-        if ($field_storage_definition) {
-          $field_schema = $field_storage_definition->getSchema();
-          $table_mapping = $storage->getTableMapping([$field_name => $field_storage_definition]);
-          $table_names = $table_mapping->getDedicatedTableNames();
-          $columns = $table_mapping->getColumnNames($field_name);
-
-          foreach ($table_names as $table_name) {
-            $table_exists = $schema->tableExists($table_name);
-            if ($table_exists) {
-              $field_exists = $schema->fieldExists($table_name, $columns[$new_property]);
-              if (!$field_exists) {
-                $messenger->addMessage(t("Adding entity id to Drupal table \"@table_name\", field \"@field_name\"",
-                    ['@table_name' => $table_name, '@field_name' => $field_name]));
-                $schema->addField($table_name, $columns[$new_property], $field_schema['columns'][$new_property]);
-                $manager->updateFieldStorageDefinition($field_storage_definition);
-                $n_added++;
-              }
-            }
-          }
-        }
-      }
-    }
-    $messenger->addMessage(t("Added @n_added entity id properties", ['@n_added' => $n_added]));
-  }
-  catch (\Exception $e) {
-    throw new UpdateException('Could not add entity id to fields: ' . $e->getMessage());
-  }
-}
-
-/**
  * Adds or updates several properties added to the
  * chado_sequence_coordinates_default field in PR 1861
  */
@@ -528,5 +462,80 @@ function tripal_chado_update_10404() {
   }
   catch (\Exception $e) {
     throw new UpdateException('Could not update property: ' . $e->getMessage());
+  }
+}
+
+/**
+ * Updates entity_id properties added to linking fields in PR 1782
+ * This replaces tripal_chado_update_10403
+ */
+function tripal_chado_update_10405() {
+  try {
+    $messenger = \Drupal::messenger();
+
+    $new_property = 'entity_id';
+    // This is the list of Chado fields needing an entity_id
+    $upgradable_types = [
+      'chado_analysis_type_default',
+      'chado_array_design_type_default',
+      'chado_assay_type_default',
+      'chado_biomaterial_type_default',
+      'chado_contact_type_default',
+      'chado_feature_type_default',
+      'chado_featuremap_type_default',
+      'chado_organism_type_default',
+      'chado_project_type_default',
+      'chado_protocol_type_default',
+      'chado_pub_type_default',
+      'chado_stock_type_default',
+      'chado_study_type_default',
+    ];
+    $entity_type = 'tripal_entity';
+
+    $manager = \Drupal::entityDefinitionUpdateManager();
+    $schema = \Drupal::database()->schema();
+    $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+    $field_map = \Drupal::service('entity_field.manager')->getFieldMap();
+    $fields = $field_map[$entity_type];
+    $n_added = 0;
+    $n_updated = 0;
+
+    foreach ($fields as $field_name => $field_def) {
+      $id = $field_def['type'];
+      if (in_array($id, $upgradable_types, TRUE)) {
+        $field_storage_definition = $manager->getFieldStorageDefinition($field_name, 'tripal_entity');
+        if ($field_storage_definition) {
+          $field_schema = $field_storage_definition->getSchema();
+          $table_mapping = $storage->getTableMapping([$field_name => $field_storage_definition]);
+          $table_names = $table_mapping->getDedicatedTableNames();
+          $columns = $table_mapping->getColumnNames($field_name);
+
+          foreach ($table_names as $table_name) {
+            $table_exists = $schema->tableExists($table_name);
+            if ($table_exists) {
+              $field_exists = $schema->fieldExists($table_name, $columns[$new_property]);
+              if ($field_exists) {
+                $messenger->addMessage(t("Updating entity id in Drupal table \"@table_name\", field \"@field_name\"",
+                    ['@table_name' => $table_name, '@field_name' => $field_name]));
+                $schema->changeField($table_name, $columns[$new_property], $columns[$new_property], $field_schema['columns'][$new_property]);
+                $n_added++;
+              }
+              else {
+                $messenger->addMessage(t("Adding entity id to Drupal table \"@table_name\", field \"@field_name\"",
+                    ['@table_name' => $table_name, '@field_name' => $field_name]));
+                $schema->addField($table_name, $columns[$new_property], $field_schema['columns'][$new_property]);
+                $n_added++;
+              }
+              $manager->updateFieldStorageDefinition($field_storage_definition);
+            }
+          }
+        }
+      }
+    }
+    $messenger->addMessage(t("Added @n_added entity id properties, updated @n_updated entity id properties",
+        ['@n_added' => $n_added, '@n_updated' => $n_updated]));
+  }
+  catch (\Exception $e) {
+    throw new UpdateException('Could not add entity id to fields: ' . $e->getMessage());
   }
 }

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -403,6 +403,12 @@ function tripal_chado_update_10402() {
 }
 
 /**
+ * Updates entity_id properties added to linking fields in PR 1782
+ * Note: tripal_chado_update_10403 has been renumbered to
+ * tripal_chado_update_10405 by PR 1865
+ */
+
+/**
  * Adds or updates several properties added to the
  * chado_sequence_coordinates_default field in PR 1861
  */
@@ -466,8 +472,8 @@ function tripal_chado_update_10404() {
 }
 
 /**
- * Updates entity_id properties added to linking fields in PR 1782
- * This replaces tripal_chado_update_10403
+ * Updates entity_id properties added to linking fields in PR 1782 and PR 1865
+ * This is the same as former tripal_chado_update_10403 but we need to run it again
  */
 function tripal_chado_update_10405() {
   try {

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -518,7 +518,7 @@ function tripal_chado_update_10405() {
                 $messenger->addMessage(t("Updating entity id in Drupal table \"@table_name\", field \"@field_name\"",
                     ['@table_name' => $table_name, '@field_name' => $field_name]));
                 $schema->changeField($table_name, $columns[$new_property], $columns[$new_property], $field_schema['columns'][$new_property]);
-                $n_added++;
+                $n_updated++;
               }
               else {
                 $messenger->addMessage(t("Adding entity id to Drupal table \"@table_name\", field \"@field_name\"",
@@ -526,10 +526,10 @@ function tripal_chado_update_10405() {
                 $schema->addField($table_name, $columns[$new_property], $field_schema['columns'][$new_property]);
                 $n_added++;
               }
-              $manager->updateFieldStorageDefinition($field_storage_definition);
             }
           }
         }
+        $manager->updateFieldStorageDefinition($field_storage_definition);
       }
     }
     $messenger->addMessage(t("Added @n_added entity id properties, updated @n_updated entity id properties",

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -53,6 +53,11 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'label' => 'Entity Third Party Setting for Base Chado Table',
     'nullable' => true
   ];
+  $definitions['tripal.content_type.*']['mapping']['third_party_settings']['sequence']['mapping']['chado_base_table'] = [
+    'type' => 'string',
+    'label' => 'Entity Third Party Setting for Base Chado Table',
+    'nullable' => true
+  ];
 
   // ADDITIONS TO TRIPAL FIELDS.
   $definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping']['storage_plugin_settings']['mapping']['base_table'] = [


### PR DESCRIPTION
# New Feature

### Closes #1850 

### Tripal Version: 4.x

## Description
There are four cases in core Tripal where links use a different name, currently entity links do not work for these.
The goofy fields that we need to test are listed at the end of this comment https://github.com/tripal/tripal_doc/issues/32#issuecomment-1837532399
```
arraydesign FOREIGN KEY (manufacturer_id) REFERENCES contact(contact_id)
assay FOREIGN KEY (operator_id) REFERENCES contact(contact_id)
biomaterial FOREIGN KEY (biosourceprovider_id) REFERENCES contact(contact_id)
biomaterial FOREIGN KEY (taxon_id) REFERENCES organism(organism_id)
```

We had originally intended to consult the third party settings, but for reasons of efficiency I decided to have the TripalTypes property pass through the table name. It already knows this, and thus avoids a chunk of code to get at the third party settings to look it up.

Because I changed the entity_id property, we need an update function. Again for efficiency, I recycled the existing update function, so as not to duplicate it, it will just be run again with a higher number.

## Testing?
 1. Create your docker on the 4.x branch so we can test the update function
 2. Change to this branch `git checkout tv4g1-issue1850-entity-lookup-third-party-settings`
 3. Run the update `docker updatedb` - verify no errors are reported
 4. Import the gene expression type collection
 5. Create an organism
 6. Create a contact
 7. Create an array design. You will need a contact that you created in step 6
 8. Verify that the "Manufacturer" is a link 
 9. Create an assay. Use the contact as the "Operator"
 10. Again verify that the "Operator" is a link
 11. Create a biomaterial.
 12. Verify that both biosource provider and Organism (taxon id) are links
 13. I have added a kernel test for the fallback method (manufacturer on arraydesign) so make sure tests pass 🙌