### PR TITLE
Publish is not publishing more than one linking record

### DIFF
--- a/tripal/src/Services/TripalPublish.php
+++ b/tripal/src/Services/TripalPublish.php
@@ -884,7 +884,7 @@ class TripalPublish {
     $this->logger->notice("Step  1 of 6: Find matching records... ");
     $matches = $this->storage->findValues($search_values);
 
-    /* @debug matches array
+    /* @debug matches array *
     print "\nDebuggin Matches after findValues():\n";
     foreach ($matches as $entity_id => $lvl1) {
       foreach ($lvl1 as $field_name => $lvl2) {
@@ -899,7 +899,7 @@ class TripalPublish {
         }
       }
     }
-    */
+    * */
 
 
     $this->logger->notice("Step  2 of 6: Generate page titles...");

--- a/tripal/src/Services/TripalPublish.php
+++ b/tripal/src/Services/TripalPublish.php
@@ -632,7 +632,7 @@ class TripalPublish {
     $items = [];
 
     $sql = "
-      SELECT entity_id FROM $field_table\n
+      SELECT entity_id, delta FROM $field_table\n
       WHERE bundle = :bundle\n
         AND entity_id IN (:entity_ids[])\n";
 
@@ -654,7 +654,7 @@ class TripalPublish {
         ];
         $results = $database->query($sql, $args);
         while ($result = $results->fetchAssoc()) {
-          $items[$result['entity_id']] = $result['entity_id'];
+          $items[$result['entity_id']][$result['delta']] = 1;
         }
         $this->setItemsHandled($batch_num);
         $batch_num++;
@@ -703,7 +703,7 @@ class TripalPublish {
    * @param array $entities
    *   An associative array that maps entity titles to their keys.
    * @param array $existing
-   *   An associative array of entities that already have an existing item for this field.
+   *   An associative array of [entity_id][delta] that already have an existing item for this field.
    */
   protected function insertFieldItems($field_name, $matches, $titles, $entities, $existing) {
 
@@ -744,7 +744,7 @@ class TripalPublish {
         $total++;
 
         // No need to add items to those that are already published.
-        if (array_key_exists($entity_id, $existing)) {
+        if (array_key_exists($entity_id, $existing) and array_key_exists($delta, $existing[$entity_id])) {
           continue;
         }
 

--- a/tripal/src/Services/TripalPublish.php
+++ b/tripal/src/Services/TripalPublish.php
@@ -790,11 +790,11 @@ class TripalPublish {
           // Do we need to worry about the delta not matching? Let's check this
           // is really the same record just in case.
           if (empty(array_diff_assoc($existing[$entity_id][$delta], $required_property_values))) {
-            print "SKIPPING: Not publishing $entity_id|$delta because the required property values are already published:" . print_r($required_property_values, TRUE);
+            // @debug print "SKIPPING: Not publishing $entity_id|$delta because the required property values are already published:" . print_r($required_property_values, TRUE);
             continue;
           }
           else {
-            print "WARNING: The delta didn't match the value we expected!\n";
+            // @debug print "WARNING: The delta didn't match the value we expected!\n";
           }
         }
 
@@ -802,7 +802,7 @@ class TripalPublish {
         // Note: when publishing a contact, we see the description is published
         // every time if no description was entered.
 
-        print "-- PUBLISHING: $entity_id|$delta " . print_r($required_property_values, TRUE);
+        // @debug print "-- PUBLISHING: $entity_id|$delta " . print_r($required_property_values, TRUE);
         // Add items to those that are not already published.
         $sql .= "(:bundle_$j, :deleted_$j, :entity_id_$j, :revision_id_$j, :langcode_$j, :delta_$j, ";
         $args[":bundle_$j"] = $this->bundle;
@@ -895,6 +895,18 @@ class TripalPublish {
 
     $this->logger->notice("Step  1 of 6: Find matching records... ");
     $matches = $this->storage->findValues($search_values);
+
+    /* @debug matches srray
+    foreach ($matches as $entity_id => $lvl1) {
+      foreach ($lvl1 as $field_name => $lvl2) {
+        foreach ($lvl2 as $delta => $lvl3) {
+          $record_id = $lvl3['record_id']['value']->getValue();
+          $link = (array_key_exists('link', $lvl3)) ? $lvl3['link']['value']->getValue() : 'Not a Linker';
+          print "Match $entity_id|$field_name|$delta: record '$record_id'; link '$link'.\n";
+        }
+      }
+    }
+    */
 
     $this->logger->notice("Step  2 of 6: Generate page titles...");
     $titles = $this->getEntityTitles($matches);

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -319,6 +319,11 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
         // Now for each matching base record we need to select
         // the ancillary tables.
         foreach ($matches as $match) {
+          /* @debug
+          $records_array_debug = $match->getRecordsArray();
+          foreach ($records_array_debug as $table_name => $lvl1) {
+            print "Chado storage $table_name: " . print_r($lvl1, true);
+          }*/
 
           // Clone the value array for this match.
           $new_values = $this->cloneValues($values);
@@ -574,6 +579,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           $prop_type = $this->getPropertyType($field_name, $key);
           $prop_storage_settings = $prop_type->getStorageSettings();
 
+          // @debug if ($field_name == 'contact_project') { print "$field_name|$delta|$key: " . print_r($prop_storage_settings, TRUE); }
+
           // Make sure we have an action for this property.
           if (!array_key_exists('action', $prop_storage_settings)) {
             $this->logger->error($this->t('Cannot store the property, @field.@prop ("@label"), in Chado. The property is missing an action in the property settings: @settings',
@@ -604,7 +611,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           $context['property_settings'] = $prop_storage_settings;
           $context['delta'] = $delta;
           $context['action'] = $action;
-
 
           // Get the path array for this field and add any joins if any are needed.
           if (array_key_exists('path', $prop_storage_settings)) {
@@ -830,6 +836,19 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $this->records->addColumn($elements, TRUE);
 
     $this->records->addCondition($elements);
+
+    // If this is a find then we want to add the join as well.
+    if ($context['is_find']) {
+      $elements['join_path'] = $context['path_string'];
+      $elements['join_type'] = $context['path_array']['join']['type'];
+      $elements['left_table'] = $context['path_array']['join']['root_table'];
+      $elements['left_column'] = $context['path_array']['join']['left_column'];
+      $elements['right_table'] = $context['path_array']['join']['chado_table'];
+      $elements['right_column'] = $context['path_array']['join']['right_column'];
+      $elements['left_alias'] = $context['path_array']['join']['root_alias'];
+      $elements['right_alias'] = $context['path_array']['join']['table_alias'];
+      $this->records->addJoin($elements);
+    }
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -298,6 +298,13 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     // Build the ChadoRecords object.
     $this->records = new ChadoRecords($this->field_debugger, $this->logger, $this->connection);
     $this->buildChadoRecords($values, TRUE);
+    /** @debug
+    print "Checking records after buildChadoRecords():\n";
+    $records_array_debug = $this->records->getRecordsArray();
+    foreach ($records_array_debug as $table_name => $lvl1) {
+      print "Chado storage $table_name: " . print_r($lvl1, true);
+    }
+    */
 
     // Start an array to keep track of the results we find.
     // Each element in this array will be a clone of the full $values array
@@ -839,15 +846,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     // If this is a find then we want to add the join as well.
     if ($context['is_find']) {
-      $elements['join_path'] = $context['path_string'];
-      $elements['join_type'] = $context['path_array']['join']['type'];
-      $elements['left_table'] = $context['path_array']['join']['root_table'];
-      $elements['left_column'] = $context['path_array']['join']['left_column'];
-      $elements['right_table'] = $context['path_array']['join']['chado_table'];
-      $elements['right_column'] = $context['path_array']['join']['right_column'];
-      $elements['left_alias'] = $context['path_array']['join']['root_alias'];
-      $elements['right_alias'] = $context['path_array']['join']['table_alias'];
-      $this->records->addJoin($elements);
+      $this->handleJoins($context['path_array'], $context);
     }
   }
 

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1655,7 +1655,7 @@ class ChadoRecords  {
     // Get informatino about this Chado table.
     $chado_table = $this->getTableFromAlias($base_table, $table_alias);
 
-    // Iterate through each item of the table and perform an insert.
+    // Iterate through each item of the table...
     $items = $this->getTableItems($base_table, $table_alias);
     foreach ($items as $delta => $record) {
 


### PR DESCRIPTION

# Bug Fix

### Issue #1843 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## NOT COMPLETE!

Putting up as draft so that the tests run automatically to ensure I don't break anything ;-p

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are a number of fields with unlimited cardinality (e.g. properties and linking fields). Currently if you have multiple records added to chado that these fields would normally show, publish will only show the first one. Furthermore, I'm not sure it's even doing that correctly. For example, if you have multiple contacts linked to a project, when you publish the projects only the first contact link will be published.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

1-4. Create two contacts, and two projects. Do not put a contact on the project or vice versa.
5. Generate links with this SQL: `insert into chado.project_contact (project_id, contact_id) values (1,2), (1,3), (2,2), (2,3);`
`INSERT 0 4`
6. Publish contact and project and run the job
8. Rebuild cache `drush cache:rebuild`

Currently you will observe that only one contact is present on each project, and only one project present on each contact. There should actually be two contacts on each project and two projects on each contact.
