### PR TITLE
Fields Code cleanup : Tv4g0 issue1866 code cleanup and tv4g10-issue1699-remove-unneeded-use-statements

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
@@ -3,9 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalBooleanTypeFormatter;
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of default Chado boolean type formatter.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
@@ -3,9 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalIntegerTypeFormatter;
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of default Chado integer type formatter.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
@@ -3,11 +3,9 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\UrlHelper;
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -3,9 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of default Chado string type formatter.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
@@ -3,9 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalTextTypeFormatter;
-use Drupal\tripal\TripalField\TripalFormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of default Chado text type formatter.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -7,11 +7,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
 
@@ -107,8 +103,6 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_pkey_col
     ]);
 
     // If the type table and the base table are not the same then we are
@@ -127,22 +121,16 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $type_table  . '.' . $type_pkey_col,
-        //'chado_table' => $type_table,
-        //'chado_column' => $type_pkey_col,
       ]);
       // (e.g., analysisprop.feature_id)
       $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link_id', $link_term, [
         'action' => 'store_link',
         'path' => $type_table . '.' . $type_fkey_col,
-        //'chado_table' => $type_table,
-        //'chado_column' => $type_fkey_col,
       ]);
       // (e.g., analysisprop.value)
       $properties[] =  new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, [
         'action' => 'store',
         'path' => $type_table . '.' . 'value',
-        //'chado_table' => $type_table,
-        //'chado_column' => 'value',
       ]);
     }
 
@@ -151,8 +139,6 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'type_id', $type_id_term, [
       'action' => 'store',
       'path' => $type_table . '.' . $type_column,
-      //'chado_table' => $type_table,
-      //'chado_column' => $type_column,
       'empty_value' => 0
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -91,7 +91,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -91,7 +91,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -107,7 +107,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $sourcename_len = $object_schema_def['fields']['sourcename']['size'];
     $sourceversion_term = $mapping->getColumnTermId($object_table, 'sourceversion');
     $sourceversion_len = $object_schema_def['fields']['sourceversion']['size'];
-    $sourceuri_term = $mapping->getColumnTermId($object_table, 'sourceuri'); // text
+    $sourceuri_term = $mapping->getColumnTermId($object_table, 'sourceuri'); // text    
     // @todo timeexecuted not yet implemented
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -145,8 +145,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_pkey_col,
     ]);
 
     // This property will store the Drupal entity ID of the linked chado

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -114,12 +114,9 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $manufacturer_term = $mapping->getColumnTermId('contact', 'name');
     $manufacturer_len = $contact_schema_def['fields']['name']['size'];
     $protocol_term = $mapping->getColumnTermId('protocol', 'name');  // text
-    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
@@ -116,12 +116,12 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $manufacturer_term = $mapping->getColumnTermId('contact', 'name');
     $manufacturer_len = $contact_schema_def['fields']['name']['size'];
     $protocol_term = $mapping->getColumnTermId('protocol', 'name');  // text
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');  // text

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -99,7 +99,6 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $array_dimensions_term = $mapping->getColumnTermId($object_table, 'array_dimensions');  // text
     $element_dimensions_term = $mapping->getColumnTermId($object_table, 'element_dimensions');  // text
     $num_of_elements_term = $mapping->getColumnTermId($object_table, 'num_of_elements');
-    $num_array_elements_term = $mapping->getColumnTermId($object_table, 'num_array_elements');
     $num_array_rows_term = $mapping->getColumnTermId($object_table, 'num_array_rows');
     $num_array_columns_term = $mapping->getColumnTermId($object_table, 'num_array_columns');
     $num_grid_columns_term = $mapping->getColumnTermId($object_table, 'num_grid_columns');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -89,7 +89,6 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -103,12 +102,8 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
     $operator_term = $mapping->getColumnTermId('contact', 'name');
     $operator_len = $contact_schema_def['fields']['name']['size'];
-    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -89,7 +89,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -103,12 +103,12 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
     $operator_term = $mapping->getColumnTermId('contact', 'name');
     $operator_len = $contact_schema_def['fields']['name']['size'];
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -90,17 +90,12 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $name_term = $mapping->getColumnTermId($object_table, 'name');
     $description_term = $mapping->getColumnTermId($object_table, 'description');
 
     // Columns from linked tables
-    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    // $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
     $biosourceprovider_term = $mapping->getColumnTermId('contact', 'name');
     $biosourceprovider_len = $contact_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -90,17 +90,17 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $name_term = $mapping->getColumnTermId($object_table, 'name');
     $description_term = $mapping->getColumnTermId($object_table, 'description');
 
     // Columns from linked tables
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
     $biosourceprovider_term = $mapping->getColumnTermId('contact', 'name');
     $biosourceprovider_len = $contact_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -3,16 +3,9 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
-use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
-use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 
 
 /**
@@ -77,14 +70,10 @@ class ChadoBooleanTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_pkey_col
       ]),
       new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_column,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_column,
       ]),
     ];
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -89,7 +89,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -89,7 +89,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -137,8 +137,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_pkey_col,
     ]);
 
     // This property will store the Drupal entity ID of the linked chado
@@ -168,8 +166,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,
-        //'chado_table' => $linker_table,
-        //'chado_column' => $linker_pkey_col,
       ]);
 
       // Define the link between the base table and the linker table.
@@ -177,10 +173,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_link',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col,
-        //'left_table' => $base_table,
-        //'left_table_id' => $base_pkey_col,
-        //'right_table' => $linker_table,
-        //'right_table_id' => $linker_left_col,
       ]);
 
       // Define the link between the linker table and the object table.
@@ -200,8 +192,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
           'action' => 'store',
           'drupal_store' => FALSE,
           'path' => $linker_table . '.' . $column,
-          //'chado_table' => $linker_table,
-          //'chado_column' => $column,
           'as' => 'linker_' . $column,
         ]);
       }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $db_term = $mapping->getColumnTermId($object_table, 'db_id');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $db_term = $mapping->getColumnTermId($object_table, 'db_id');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -95,7 +95,7 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -110,12 +110,12 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     // @todo timeaccessioned, timelastmodified not yet implemented
 
     // Columns from linked tables
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
+    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $type_term = $mapping->getColumnTermId('cvterm', 'name');
     $type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -95,7 +95,6 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -110,12 +109,8 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     // @todo timeaccessioned, timelastmodified not yet implemented
 
     // Columns from linked tables
-    // $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $type_term = $mapping->getColumnTermId('cvterm', 'name');
     $type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -3,16 +3,8 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
-use Drupal\tripal\TripalStorage\IntStoragePropertyType;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
-use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
-
 
 /**
  * Plugin implementation of the 'integer' field type for Chado.
@@ -85,14 +77,10 @@ class ChadoIntegerTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_pkey_col
       ]),
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_column,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_column,
       ]),
     ];
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $genus_term = $mapping->getColumnTermId($object_table, 'genus');
     $genus_len = $object_schema_def['fields']['genus']['size'];
     $species_term = $mapping->getColumnTermId($object_table, 'species');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $genus_term = $mapping->getColumnTermId($object_table, 'genus');
     $genus_len = $object_schema_def['fields']['genus']['size'];
     $species_term = $mapping->getColumnTermId($object_table, 'species');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -4,14 +4,9 @@ namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
-use Drupal\core\Field\FieldStorageDefinitionInterface;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
-
 
 /**
  * Plugin implementation of Tripal linker property field type.
@@ -102,35 +97,22 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_pkey_col
       ]),
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', $record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_pkey_col,
         'table_alias_mapping' => [$table_alias => $prop_table],
-        //'chado_table' => $prop_table,
-        //'chado_column' => $prop_pkey_col,
-        //'chado_table_alias' => $table_alias,
       ]),
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id',  $link_term, [
         'action' => 'store_link',
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_fk_col,
         'table_alias_mapping' => [$table_alias => $prop_table],
-        //'left_table' => $base_table,
-        //'left_table_id' => $base_pkey_col,
-        //'right_table' => $prop_table,
-        //'right_table_alias' => $table_alias,
-        //'right_table_id' => $prop_fk_col,
       ]),
       new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_fk_col . ';value',
         'table_alias_mapping' => [$table_alias => $prop_table],
-        //'chado_table' => $prop_table,
-        //'chado_table_alias' => $table_alias,
-        //'chado_column' => 'value',
         'delete_if_empty' => TRUE,
         'empty_value' => ''
       ]),
@@ -138,17 +120,11 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
         'action' => 'store',
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_fk_col . ';rank',
         'table_alias_mapping' => [$table_alias => $prop_table],
-        //'chado_table' => $prop_table,
-        //'chado_table_alias' => $table_alias,
-        //'chado_column' => 'rank'
       ]),
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'type_id', $type_id_term, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_fk_col . ';type_id',
         'table_alias_mapping' => [$table_alias => $prop_table],
-        //'chado_table' => $prop_table,
-        //'chado_table_alias' => $table_alias,
-        //'chado_column' => 'type_id'
       ]),
     ];
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
@@ -104,12 +103,8 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $protocol_type_term = $mapping->getColumnTermId('cvterm', 'name');
     $protocol_type_len = $cvterm_schema_def['fields']['name']['size'];
     $pub_title_term = $mapping->getColumnTermId('pub', 'title');
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -90,7 +90,7 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
@@ -106,10 +106,10 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $pub_title_term = $mapping->getColumnTermId('pub', 'title');
     $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -91,7 +91,7 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $title_term = $mapping->getColumnTermId($object_table, 'title'); // text

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -91,7 +91,6 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $title_term = $mapping->getColumnTermId($object_table, 'title'); // text

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -56,9 +56,6 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
   public static function tripalTypes($field_definition) {
     $entity_type_id = $field_definition->getTargetEntityTypeId();
 
-    // Get the base table columns needed for this field.
-    // $settings = $field_definition->getSetting('storage_plugin_settings');
-
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -57,7 +57,7 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
     $entity_type_id = $field_definition->getTargetEntityTypeId();
 
     // Get the base table columns needed for this field.
-    $settings = $field_definition->getSetting('storage_plugin_settings');
+    // $settings = $field_definition->getSetting('storage_plugin_settings');
 
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
@@ -78,20 +78,14 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',
-        //'chado_table' => 'feature',
-        //'chado_column' => 'feature_id'
     ]);
     $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'seqlen', $seqlen_term, [
       'action' => 'read_value',
       'path' => 'feature.seqlen',
-      //'chado_column' => 'seqlen',
-      //'chado_table' => 'feature'
     ]);
     $properties[] =  new ChadoBpCharStoragePropertyType($entity_type_id, self::$id, 'md5checksum', $md5checksum_term, $md5_checksum_len, [
       'action' => 'read_value',
       'path' => 'feature.md5checksum',
-      //'chado_column' => 'md5checksum',
-      //'chado_table' => 'feature'
     ]);
     return $properties;
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -72,14 +72,10 @@ class ChadoSequenceLengthTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',
-        //'chado_table' => 'feature',
-        //'chado_column' => 'feature_id'
     ]);
     $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'seqlen', $seqlen_term, [
       'action' => 'read_value',
       'path' => 'feature.seqlen',
-      //'chado_column' => 'seqlen',
-      //'chado_table' => 'feature'
     ]);
     return $properties;
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -57,9 +57,6 @@ class ChadoSequenceLengthTypeDefault extends ChadoFieldItemBase {
   public static function tripalTypes($field_definition) {
     $entity_type_id = $field_definition->getTargetEntityTypeId();
 
-    // Get the base table columns needed for this field.
-    $settings = $field_definition->getSetting('storage_plugin_settings');
-
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -58,9 +58,6 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
   public static function tripalTypes($field_definition) {
     $entity_type_id = $field_definition->getTargetEntityTypeId();
 
-    // Get the base table columns needed for this field.
-    $settings = $field_definition->getSetting('storage_plugin_settings');
-
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
@@ -75,21 +72,15 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',
-        //'chado_table' => 'feature',
-        //'chado_column' => 'feature_id'
     ]);
     $properties[] =  new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'residues', $residues_term, [
       'action' => 'store',
       'path' => 'feature.residues',
-      //'chado_column' => 'residues',
-      //'chado_table' => 'feature'
     ]);
 
     $properties[] =  new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'seqlen', $seqlen_term, [
       'action' => 'store',
       'path' => 'feature.seqlen',
-      //'chado_column' => 'seqlen',
-      //'chado_table' => 'feature'
     ]);
 
     // Hard-coded as the length of MD3Checksum supported by the chado feature.md5checksum column.
@@ -97,8 +88,6 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
     $properties[] =  new ChadoBpCharStoragePropertyType($entity_type_id, self::$id, 'md5checksum', $md5checksum_term, $md5checksum_len, [
       'action' => 'store',
       'path' => 'feature.md5checksum',
-      //'chado_column' => 'md5checksum',
-      //'chado_table' => 'feature'
     ]);
 
     return $properties;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -77,28 +76,20 @@ class ChadoSourceDataTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => 'analysis.analysis_id',
-      //'chado_table' => 'analysis',
-      //'chado_column' => 'analysis_id',
     ]);
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'sourceuri', $src_uri_term, 100, [
       'action' => 'store',
       'path' => 'analysis.sourceuri',
-      //'chado_table' => 'analysis',
-      //'chado_column' => 'sourceuri',
     ]);
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'sourcename', $src_name_term, 200, [
       'action' => 'store',
       'path' => 'analysis.sourcename',
-      //'chado_table' => 'analysis',
-      //'chado_column' => 'sourcename',
       'delete_if_empty' => TRUE,
       'empty_value' => '',
     ]);
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'sourceversion', $src_vers_term, 100, [
       'action' => 'store',
       'path' => 'analysis.sourceversion',
-      //'chado_table' => 'analysis',
-      //'chado_column' => 'sourceversion',
     ]);
 
     return ($properties);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -93,9 +93,7 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $name_term = $mapping->getColumnTermId($object_table, 'name');
-    // $name_len = $object_schema_def['fields']['name']['size'];
     $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename');  // text
     $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
     $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete');  // boolean

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -93,9 +93,9 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
     $name_term = $mapping->getColumnTermId($object_table, 'name');
-    $name_len = $object_schema_def['fields']['name']['size'];
+    // $name_len = $object_schema_def['fields']['name']['size'];
     $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename');  // text
     $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
     $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete');  // boolean
@@ -103,10 +103,10 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     // Columns from linked tables
     $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $stock_type_term = $mapping->getColumnTermId('cvterm', 'name');
     $stock_type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -101,12 +101,8 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete');  // boolean
 
     // Columns from linked tables
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $stock_type_term = $mapping->getColumnTermId('cvterm', 'name');
     $stock_type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -3,15 +3,11 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 
 
 /**
@@ -122,14 +118,10 @@ class ChadoStringTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_pkey_col
       ]),
       new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, $max_length, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_column,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_column,
       ]),
     ];
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -57,8 +57,6 @@ class ChadoStringTypeDefault extends ChadoFieldItemBase {
    */
   public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
     $values = [];
-    //$random = new Random();
-    //$values['value'] = $random->word(mt_rand(1, $field_definition->getSetting('max_length')));
     return $values;
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -5,7 +5,6 @@ namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
-use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal\Entity\TripalEntityType;
 
 /**
@@ -90,7 +89,7 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
+    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -101,10 +100,10 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $pub_title_term = $mapping->getColumnTermId('pub', 'title');
     $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
+    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    $db_len = $db_schema_def['fields']['name']['size'];
+    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -89,7 +89,6 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    // $object_pkey_term = $mapping->getColumnTermId($object_table, $object_pkey_col);
 
     // Columns specific to the object table
     $name_term = $mapping->getColumnTermId($object_table, 'name');
@@ -98,12 +97,8 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     // Columns from linked tables
     $contact_term = $mapping->getColumnTermId('contact', 'name');
     $pub_title_term = $mapping->getColumnTermId('pub', 'title');
-    $dbxref_schema_def = $schema->getTableDef('dbxref', ['format' => 'Drupal']);
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    // $dbxref_len = $dbxref_schema_def['fields']['accession']['size'];
-    $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
     $db_term = $mapping->getColumnTermId('db', 'name');
-    // $db_len = $db_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -77,8 +77,7 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
       return;
     }
 
-    // Check if a corresponding synonym table exists for the
-    // base table.
+    // Check if a corresponding synonym table exists for the base table.
     $base_table = $form_state->getValue(['settings', 'storage_plugin_settings', 'base_table']);
     $linker_table = $base_table . '_synonym';
     $chado = \Drupal::service('tripal_chado.database');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -7,11 +7,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 
 /**
  * Plugin implementation of Tripal string field type.
@@ -159,8 +155,6 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
-      //'chado_table' => $base_table,
-      //'chado_column' => $base_pkey_col,
     ]);
 
     //
@@ -171,43 +165,31 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_pkey',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_table_pkey,
-      //'chado_table' => $linker_table,
-      //'chado_column' => $linker_table_pkey,
     ]);
     // E.g. feature.feature_id => feature_synonym.feature_id
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_base_fkey_id' , $linker_fkey_id_term, [
       'action' => 'store_link',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_fkey_column,
-      //'left_table' => $base_table,
-      //'left_table_id' => $base_pkey_col,
-      //'right_table' => $linker_table,
-      //'right_table_id' => $linker_fkey_column,
     ]);
     // E.g. feature_synonym.synonym_id
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_synonym_fkey_id' , $linker_fkey_id_term, [
       'action' => 'store',
       'drupal_store' => TRUE,
       'path' => $linker_table . '.synonym_id',
-      //'chado_table' => $linker_table,
-      //'chado_column' => 'synonym_id',
     ]);
     // E.g. feature_synonym.is_current
     $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'is_current', $linker_is_current_term, [
       'action' => 'store',
       'path' => $linker_table . '.is_current',
-      //'chado_table' => $linker_table,
       'drupal_store' => FALSE,
-      //'chado_column' => 'is_current',
       'empty_value' => TRUE
     ]);
     // E.g. feature_synonym.is_internal
     $properties[] = new ChadoBoolStoragePropertyType($entity_type_id, self::$id, 'is_internal', $linker_is_internal_term, [
       'action' => 'store',
       'path' => $linker_table . '.is_internal',
-      //'chado_table' => $linker_table,
       'drupal_store' => FALSE,
-      //'chado_column' => 'is_internal',
       'empty_value' => FALSE
     ]);
     // E.g. feature_synonym.pub_id
@@ -215,8 +197,6 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
       'action' => 'store',
       'path' => $linker_table . '.pub_id',
       'drupal_store' => FALSE,
-      //'chado_table' => $linker_table,
-      //'chado_column' => 'pub_id',
     ]);
 
     //
@@ -226,7 +206,6 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'name', $syn_name_term, $syn_name_len, [
       'action' => 'read_value',
       'path' => $linker_table . '.synonym_id>synonym.synonym_id;name',
-      //'chado_column' => 'name',
       'as' => 'synonym_name',
       'drupal_store' => FALSE,
     ]);
@@ -234,7 +213,6 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'synonym_type', $syn_type_id_term, $syn_type_name_len, [
       'action' => 'read_value',
       'path' => $linker_table . '.synonym_id>synonym.synonym_id;synonym.type_id>cvterm.cvterm_id;name',
-      //'chado_column' => 'name',
       'as' => 'synonym_type',
       'drupal_store' => FALSE,
     ]);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -3,16 +3,9 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
 use Drupal\tripal\Entity\TripalEntityType;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;
-use Drupal\tripal\TripalStorage\StoragePropertyValue;
-use Drupal\core\Form\FormStateInterface;
-use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
-use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 
 
 /**
@@ -78,14 +71,10 @@ class ChadoTextTypeDefault extends ChadoFieldItemBase {
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_pkey_col
       ]),
       new TextStoragePropertyType($entity_type_id, self::$id, 'value', $value_term, [
         'action' => 'store',
         'path' => $base_table . '.' . $base_column,
-        //'chado_table' => $base_table,
-        //'chado_column' => $base_column,
       ]),
     ];
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -80,21 +80,16 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => 'featuremap.featuremap_id',
-      //'chado_table' => 'featuremap',
-      //'chado_column' => 'featuremap_id',
     ]);
 
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'unittype_id', $unittype_id_term, [
       'action' => 'store',
       'path' => 'featuremap.unittype_id',
-      //'chado_table' => 'featuremap',
-      //'chado_column' => 'unittype_id',
     ]);
 
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'cv_name', $cv_name_term, $cv_name_len, [
       'action' => 'read_value',
       'path' => 'featuremap.unittype_id>cvterm.cvterm_id;name',
-      //'chado_column' => 'name',
       'as' => 'cv_name'
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Form\FormValidator;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
@@ -3,7 +3,6 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalBooleanTypeWidget;
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -28,7 +27,6 @@ class ChadoBooleanWidgetDefault extends TripalBooleanTypeWidget {
 
     $item_vals = $items[$delta]->getValue();
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
-    $default_value = !empty($item_vals['record_id']);
     $element['record_id'] = [
       '#default_value' => !empty($item_vals['record_id']),
     ];

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
@@ -3,7 +3,6 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalIntegerTypeWidget;
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
@@ -3,7 +3,6 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalStringTypeWidget;
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -26,14 +26,6 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $chado = \Drupal::service('tripal_chado.database');
 
-    // Get the field settings.
-    $field_definition = $items[$delta]->getFieldDefinition();
-    // $field_settings = $field_definition->getSettings();
-    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
-    // $base_table = $storage_settings['base_table'];
-    // $linker_table = $storage_settings['linker_table'];
-    // $linker_fkey_column = $storage_settings['linker_fkey_column'];
-
     $schema = $chado->schema();
     $synonym_table_def = $schema->getTableDef('synonym', ['format' => 'Drupal']);
     $syn_name_len = $synonym_table_def['fields']['name']['size'];
@@ -48,8 +40,6 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
     $is_current = $item_vals['is_current'] ?? TRUE;
     $is_internal = $item_vals['is_internal'] ?? FALSE;
     $name = $item_vals['name'] ?? '';
-    // $synonym_type = $item_vals['synonym_type'] ?? 'exact';
-    // $synonym_sgml = $item_vals['synonym_sgml'] ?? '';
 
     // Get the `exact` synonym type.  There are other types
     // that are installed by Tripal such as BROAD, NARROW, and RELATED

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\Plugin\Field\FieldWidget\TripalTextTypeWidget;
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
@@ -30,11 +28,11 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
 
     // Get the field settings.
     $field_definition = $items[$delta]->getFieldDefinition();
-    $field_settings = $field_definition->getSettings();
+    // $field_settings = $field_definition->getSettings();
     $storage_settings = $field_definition->getSetting('storage_plugin_settings');
-    $base_table = $storage_settings['base_table'];
-    $linker_table = $storage_settings['linker_table'];
-    $linker_fkey_column = $storage_settings['linker_fkey_column'];
+    // $base_table = $storage_settings['base_table'];
+    // $linker_table = $storage_settings['linker_table'];
+    // $linker_fkey_column = $storage_settings['linker_fkey_column'];
 
     $schema = $chado->schema();
     $synonym_table_def = $schema->getTableDef('synonym', ['format' => 'Drupal']);
@@ -50,8 +48,8 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
     $is_current = $item_vals['is_current'] ?? TRUE;
     $is_internal = $item_vals['is_internal'] ?? FALSE;
     $name = $item_vals['name'] ?? '';
-    $synonym_type = $item_vals['synonym_type'] ?? 'exact';
-    $synonym_sgml = $item_vals['synonym_sgml'] ?? '';
+    // $synonym_type = $item_vals['synonym_type'] ?? 'exact';
+    // $synonym_sgml = $item_vals['synonym_sgml'] ?? '';
 
     // Get the `exact` synonym type.  There are other types
     // that are installed by Tripal such as BROAD, NARROW, and RELATED

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -40,6 +40,8 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
     $is_current = $item_vals['is_current'] ?? TRUE;
     $is_internal = $item_vals['is_internal'] ?? FALSE;
     $name = $item_vals['name'] ?? '';
+    $synonym_type = $item_vals['synonym_type'] ?? 'exact';
+    $synonym_sgml = $item_vals['synonym_sgml'] ?? '';
 
     // Get the `exact` synonym type.  There are other types
     // that are installed by Tripal such as BROAD, NARROW, and RELATED
@@ -101,7 +103,11 @@ class ChadoSynonymWidgetDefault extends ChadoWidgetBase {
     ];
     $elements['synonym_type'] = [
       '#type' => 'value',
-      '#default_value' => 'exact',
+      '#default_value' => $synonym_type,
+    ];
+    $elements['synonym_sgml'] = [
+      '#type' => 'value',
+      '#default_value' => $synonym_sgml,
     ];
     $elements['is_current'] = [
       '#type' => 'checkbox',

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
@@ -3,7 +3,6 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalTextTypeWidget;
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

#
### Issues #  #1699  and #1866 
<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version:  4
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are several **use** statements in the Fields code that are unnecessary as they can increase run time and memory usage of the code being executed. In addition there are several comments that were created temporarily and are not needed anymore. The code in the Field sub-directories have been cleaned up to address 2 issues  #1699 and  #1866  which were created by @dsenalik . 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
