### PR TITLE
URL and name field filters default to plain text

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -340,6 +340,14 @@ tripal.tripalfield_collection.*:
                            type: integer
                            label: 'Weight'
                            nullable: false
+                         settings:
+                           type: mapping
+                           label: 'Settings'
+                           mapping:
+                             filter_format:
+                             type: string
+                             label: 'Filter format for a filtered text field'
+                             nullable: true
 
 field.formatter.settings.*:
   type: mapping

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -340,6 +340,10 @@ tripal.tripalfield_collection.*:
                            type: integer
                            label: 'Weight'
                            nullable: false
+                         filter_format:
+                           type: string
+                           label: 'Filter format for a filtered text field'
+                           nullable: true
 
 field.formatter.settings.*:
   type: mapping

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -320,7 +320,7 @@ tripal.tripalfield_collection.*:
                            nullable: false
                    form:
                      type: sequence
-                     label: 'View'
+                     label: 'Edit'
                      sequence:
                        type: mapping
                        mapping:

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -340,10 +340,6 @@ tripal.tripalfield_collection.*:
                            type: integer
                            label: 'Weight'
                            nullable: false
-                         filter_format:
-                           type: string
-                           label: 'Filter format for a filtered text field'
-                           nullable: true
 
 field.formatter.settings.*:
   type: mapping

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -345,9 +345,9 @@ tripal.tripalfield_collection.*:
                            label: 'Settings'
                            mapping:
                              filter_format:
-                             type: string
-                             label: 'Filter format for a filtered text field'
-                             nullable: true
+                               type: string
+                               label: 'Filter format for a filtered text field'
+                               nullable: true
 
 field.formatter.settings.*:
   type: mapping

--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -221,32 +221,36 @@ class TripalEntityLookup {
   protected function getRequiredFields($bundle_id, $entity_type) {
     $field_list = [];
     $cache_id = 'tripal_required_fields';
+
     // Get cached value if available
     if ($cache = \Drupal::cache()->get($cache_id)) {
       $field_list = $cache->data;
+      if (array_key_exists($bundle_id, $field_list)) {
+        return $field_list[$bundle_id];
+      }
     }
-    else {
-      // Get and cache values. Look up every bundle so that
-      // we only have to cache once. Takes about 1/10 second.
-      $entityFieldManager = \Drupal::service('entity_field.manager');
-      $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
-      foreach ($bundles as $bundle_name => $bundle_info) {
-        $fields = $entityFieldManager->getFieldDefinitions($entity_type, $bundle_name);
-        foreach ($fields as $field_name => $field_info) {
-          $storage_settings = $field_info->getSetting('storage_plugin_settings');
-          $base_table = $storage_settings['base_table'] ?? '';
-          $base_column = $storage_settings['base_table_dependant']['base_column']
-              ?? $storage_settings['base_column'] ?? '';
-          $is_required = $field_info->isRequired();
-          if ($is_required and $base_table and $base_column) {
-            $field_list[$bundle_name][$field_name] = $base_table;
-          }
+
+    // Get and cache values. Look up every bundle so that
+    // we only have to cache once. Takes about 1/10 second.
+    $entityFieldManager = \Drupal::service('entity_field.manager');
+    $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
+    foreach ($bundles as $bundle_name => $bundle_info) {
+      $fields = $entityFieldManager->getFieldDefinitions($entity_type, $bundle_name);
+      foreach ($fields as $field_name => $field_info) {
+        $storage_settings = $field_info->getSetting('storage_plugin_settings');
+        $base_table = $storage_settings['base_table'] ?? '';
+        $base_column = $storage_settings['base_table_dependant']['base_column']
+            ?? $storage_settings['base_column'] ?? '';
+        $is_required = $field_info->isRequired();
+        if ($is_required and $base_table and $base_column) {
+          $field_list[$bundle_name][$field_name] = $base_table;
         }
       }
-      // Cache the values, specifying expiration in 1 hour.
-      \Drupal::cache()->set($cache_id, $field_list, \Drupal::time()->getRequestTime() + (3600));
     }
-    return $field_list[$bundle_id];
+    // Cache the values, specifying expiration in 1 hour.
+    \Drupal::cache()->set($cache_id, $field_list, \Drupal::time()->getRequestTime() + (3600));
+
+    return $field_list[$bundle_id] ?? NULL;
   }
 
 }

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -30,6 +30,8 @@ fields:
             default:
               region: content
               weight: 10
+              settings:
+                filter_format: plain_text
 
     -   name: biosample_description
         content_type: biosample
@@ -537,6 +539,8 @@ fields:
             default:
               region: content
               weight: 10
+              settings:
+                filter_format: plain_text
 
     -   name: array_design_description
         content_type: array_design

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -194,32 +194,6 @@ fields:
               region: content
               weight: 10
 
-    -   name: assay_batch_id
-        content_type: assay
-        label: Array Batch Identifier
-        type: chado_text_type_default
-        description: A unique identifier for an array batch.
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: assay
-                base_column: arraybatchidentifier
-        settings:
-            termIdSpace: local
-            termAccession: array_batch_identifier
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 15
-          form:
-            default:
-              region: content
-              weight: 15
-
     -   name: assay_name
         content_type: assay
         label: Name

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -168,32 +168,6 @@ fields:
 
 ## Assay ##
 
-    -   name: assay_unique_name
-        content_type: assay
-        label: Unique Name
-        type: chado_text_type_default
-        description: A text token, number or something else which identifies an entity, but which may not be persistent (stable) or unique (the same identifier may identify multiple things).
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: assay
-                base_column: arrayidentifier
-        settings:
-            termIdSpace: data
-            termAccession: "0842"
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 10
-          form:
-            default:
-              region: content
-              weight: 10
-
     -   name: assay_name
         content_type: assay
         label: Name

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -219,6 +219,8 @@ fields:
             default:
               region: content
               weight: 10
+              settings:
+                filter_format: plain_text
 
     -   name: assay_description
         content_type: assay

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -475,6 +475,8 @@ fields:
             default:
               region: content
               weight: 45
+              settings:
+                filter_format: plain_text
 
     -   name: analysis_pub
         content_type: analysis
@@ -1035,6 +1037,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: protocol_description
         content_type: protocol

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -1011,6 +1011,8 @@ fields:
             default:
               region: content
               weight: 10
+              settings:
+                filter_format: plain_text
 
     -   name: protocol_uri
         content_type: protocol

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -1956,6 +1956,8 @@ fields:
             default:
               region: content
               weight: 34
+              settings:
+                filter_format: plain_text
 
     -   name: pub_dbxref
         content_type: pub

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -758,6 +758,8 @@ fields:
             default:
               region: content
               weight: 10
+              settings:
+                filter_format: plain_text
 
     -   name: study_description
         content_type: study

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -1094,32 +1094,6 @@ fields:
               region: content
               weight: 25
 
-    -   name: protocol_hardware
-        content_type: protocol
-        label: Hardware
-        type: chado_text_type_default
-        description: An instrument is a device which provides a mechanical or electronic function.
-        cardinality: 1
-        required: false
-        storage_settings:
-            storage_plugin_id: chado_storage
-            storage_plugin_settings:
-                base_table: protocol
-                base_column: hardwaredescription
-        settings:
-            termIdSpace: EFO
-            termAccession: "0000548"
-        display:
-          view:
-            default:
-              region: content
-              label: above
-              weight: 29
-          form:
-            default:
-              region: content
-              weight: 29
-
     -   name: protocol_software
         content_type: protocol
         label: Software

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -220,6 +220,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: qtl_sequence
         content_type: QTL
@@ -594,6 +596,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: sequence_variant_sequence
         content_type: sequence_variant
@@ -967,6 +971,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: genetic_marker_sequence
         content_type: genetic_marker
@@ -1340,6 +1346,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: phenotypic_marker_sequence
         content_type: phenotypic_marker

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -1565,6 +1565,8 @@ fields:
             default:
               region: content
               weight: 45
+              settings:
+                filter_format: plain_text
 
     -   name: genome_assembly_type
         content_type: genome_assembly
@@ -1863,6 +1865,8 @@ fields:
             default:
               region: content
               weight: 45
+              settings:
+                filter_format: plain_text
 
     -   name: genome_annotation_type
         content_type: genome_annotation

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -57,6 +57,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: gene_sequence
         content_type: gene
@@ -487,6 +489,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: mrna_sequence
         content_type: mrna
@@ -1187,6 +1191,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: dna_library_type
         content_type: dna_library

--- a/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
@@ -57,6 +57,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: germplasm_organism
         content_type: germplasm
@@ -298,6 +300,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: breeding_cross_organism
         content_type: breeding_cross
@@ -539,6 +543,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: germplasm_variety_organism
         content_type: germplasm_variety
@@ -780,6 +786,8 @@ fields:
             default:
               region: content
               weight: 15
+              settings:
+                filter_format: plain_text
 
     -   name: ril_organism
         content_type: ril


### PR DESCRIPTION
# Bug Fix

### Closes #1864

### Tripal Version: 4.x

## Description
This changes the default filter for `text` (i.e. unlimited length) fields from `basic_html` (the default) to `plain_text` for those fields that should not have formatting. Specifically, any URI field should not allow formatting, and fields likely to be used in a content type title, such as a `name` or `uniquename` field, should also default to plain_text.

Other minor changes:
  * There was a duplicated field for the "Protocol" content type ‼️, so I removed the "extra" one. https://github.com/tripal/tripal/pull/1871/commits/951958cc101df34f933f053d3a51103b4ac12eb4
  * The label in the schema for the edit form was "View" so I fixed that. https://github.com/tripal/tripal/pull/1871/commits/9be2006ca5e7f7dc0a0f1d45011903b9e480f6aa
  * @laceysanderson pointed out that there was also a duplicated field for the Array Batch Identifier, fixed with commit https://github.com/tripal/tripal/pull/1871/commits/f149c96433349f7126123703223997ba4782ce04

## Testing?
 * Build a new docker on this branch.
 * Create a protocol.
The uri field should not show a formatting toolbar, and once saved, the title should no longer have HTML paragraph tags.
 * Test array design, assay, biomaterial, and study to make sure titles do not show paragraph tags
 * Test analysis, genome assembly, and genome annotation to make sure URI fields do not have a formatting toolbar.
