### PR TITLE
Fix sequence coordinates widget when creating new feature

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
@@ -27,6 +27,15 @@ class ChadoSequenceCoordinatesWidgetDefault extends ChadoWidgetBase {
 
     $item_vals = $items[$delta]->getValue();
     $elements = [];
+
+    // This widget currently only passes through existing values,
+    // it doesn't currently allow editing. If no existing record
+    // exists, then just return without setting any defaults,
+    // because we don't want to generate a new record.
+    if (!array_key_exists('featureloc_id', $item_vals) or !$item_vals['featureloc_id']) {
+      return $elements;
+    }
+
     $elements['record_id'] = [
       '#type' => 'value',
       '#default_value' => $item_vals['record_id'] ?? 0,


### PR DESCRIPTION
# Bug Fix

### Closes #1873 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4.x

## Description
The ChadoSequenceCoordinatesWidget is causing a WSOD when creating a new gene from scratch.
The reason is that the widget is effectively generating a "blank" record that Chado storage is trying to save. The simple solution is to NOT create this blank record.

## Testing?

 1. Build a docker on this branch, or switch to this branch
 2. Import genomic type collection
 3. Create an organism - only fill out required fields
 4. Create a gene - only fill out required fields
 5. Observe no error 🎉
