### PR TITLE
Chado Contact by Role field

### DIFF
--- a/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
+++ b/tripal_chado/config/install/tripal.tripal_content_terms.chado_content_terms.yml
@@ -153,6 +153,9 @@ vocabularies:
             -   id: 'EFO:0000269'
                 name: 'array design'
                 description: 'An instrument design which describes the design of the array.'
+            -   id: 'EFO:0001736'
+                name: 'funder'
+                description: 'A person or organization that supports (sponsors) something through some kind of financial contribution.'
 
     -   name: 'ero'
         label: 'The Eagle-I Research Resource Ontology models research resources such instruments. protocols, reagents, animal models and biospecimens. It has been developed in the context of the eagle-i project (http://eagle-i.net/).'
@@ -692,6 +695,21 @@ vocabularies:
             -   id: 'NCIT:C164386'
                 name: 'Experimental Factor Value'
                 description: 'A specific type, time period, compound, dose, temperature, magnitude, quantity, element, aspect or other item in a variable manipulated by the experimentalist. (BRIDG)'
+            -   id: 'NCIT:C165210'
+                name: "Data Custodian"
+                description: "The person responsible for a specific data set."
+            -   id: 'NCIT:C69141'
+                name: "Curator"
+                description: "The person in charge of the care and superintendence of something, especially a collection."
+            -   id: 'NCIT:C43611'
+                name: 'License'
+                description: 'Official or legal permission to do or own a specified thing.'
+            -   id: 'NCIT:C41196'
+                name: 'Citation'
+                description: 'An extract or quotation from or reference to an authoritative source, e.g. a book or author, used, for example, to support an idea, theory, or argument.'
+            -   id: 'NCIT:C93448'
+                name: 'Research Organization'
+                description: 'An organization whose purpose is to support systemic, rigorous study and investigation into a particular field or fields.'
     -   name: 'ncbitaxon'
         label: 'NCBI organismal classification. An ontology representation of the NCBI organismal taxonomy'
         url: 'http://www.berkeleybop.org/ontologies/ncbitaxon/'
@@ -705,6 +723,20 @@ vocabularies:
             -   id: 'NCBITaxon:scientific_name'
                 name: 'scientific name'
 
+    -   name: 'AGRO'
+        label: 'Agronomy Ontology'
+        url: 'https://agroportal.lirmm.fr/ontologies/AGRO'
+        idSpaces:
+            -   name: 'AGRO'
+                description: 'Agronomy Ontology'
+                urlPrefix: 'http://purl.obolibrary.org/obo/{db}_{accession}'
+        terms:
+            -   id: 'AGRO:00000360'
+                name: 'experimental site'
+                description: 'Location where the experiment is implemented.'
+            -   id: 'AGRO:00000379'
+                name: 'data collector'
+                description: 'A person that has a role of collecting data related to the experiment.'
 
     -   name: 'rdfs'
         label: 'Resource Description Framework Schema'

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -150,6 +150,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => TRUE,
       'namespace' => self::$chadostorage_namespace,
       'function' => self::$drupal_entity_callback,
+      'ftable' => self::$object_table,
       'fkey' => self::$object_id,
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -280,12 +280,12 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
 
     // Ensure that the linker table has a type_id.
     $has_type_id = FALSE;
+    $schemaObj = \Drupal::service('tripal_chado.database')->schema();
     foreach ($linker_tables as $item) {
 
       [$table_name, $contact_fkey] = $item;
 
       // Check there is a type_id field.
-      $schemaObj = \Drupal::service('tripal_chado.database')->schema();
       $has_type_id = $schemaObj->fieldExists($table_name, 'type_id');
 
       if (!$has_type_id) {

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Drupal\tripal_chado\Plugin\Field\FieldType;
+
+use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
+use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
+use Drupal\tripal\Entity\TripalEntityType;
+
+/**
+ * Plugin implementation of default Tripal contact field type.
+ *
+ * @FieldType(
+ *   id = "chado_contact_by_role_type_default",
+ *   category = "tripal_chado",
+ *   label = @Translation("Chado Contact By Role"),
+ *   description = @Translation("Supports linking contacts fullfilling a certain role to content types."),
+ *   default_widget = "chado_contact_widget_default",
+ *   default_formatter = "chado_contact_formatter_default",
+ * )
+ */
+class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
+
+  public static $id = 'chado_contact_by_role_type_default';
+  protected static $object_table = 'contact';
+  protected static $object_id = 'contact_id';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    // Overrides the default of 'value'
+    return 'contact_name';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
+    $settings = parent::defaultFieldSettings();
+    // If this field needs to set a fixed value, set this to TRUE.
+    // It indicates to the publishing step to include this field.
+    // If not set, then the publishing step may not be able to find matches
+    // for this field based on the fixed value.
+    $settings['fixed_value'] = FALSE;
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultStorageSettings() {
+    $storage_settings = parent::defaultStorageSettings();
+    $storage_settings['storage_plugin_settings']['base_table'] = '';
+    $storage_settings['storage_plugin_settings']['linking_method'] = '';
+    $storage_settings['storage_plugin_settings']['linker_table'] = '';
+    $storage_settings['storage_plugin_settings']['linker_fkey_column'] = '';
+    $storage_settings['storage_plugin_settings']['object_table'] = self::$object_table;
+    return $storage_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tripalTypes($field_definition) {
+
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+    $storage_settings = $field_definition->getSetting('storage_plugin_settings');
+    $base_table = $storage_settings['base_table'];
+
+    if ($base_table === NULL) {
+      return;
+    }
+
+    $terms = [
+      'record_id' => 'SIO:000729',
+    ];
+    $max_lengths = [];
+
+    $schemaObj = \Drupal::service('tripal_chado.database')->schema();
+    $mappingObj = \Drupal::entityTypeManager()->getStorage('chado_term_mapping')->load('core_mapping');
+
+    // Get the column, term and any other schema-related details.
+    // A) BASE TABLE
+    $base_schema_def = $schemaObj->getTableDef($base_table, ['format' => 'Drupal']);
+    //    - primary key
+    $base_pkey_col = $base_schema_def['primary key'];
+    $terms['base_pkey'] = $terms['record_id'];
+    // B) OBJECT TABLE (i.e. contact)
+    $object_table = self::$object_table;
+    $object_schema_def = $schemaObj->getTableDef($object_table, ['format' => 'Drupal']);
+    //    - primary key
+    $object_pkey_col = $object_schema_def['primary key'];
+    $terms['object_pkey'] = $terms['record_id'];
+    //    - name
+    $terms['name'] = $mappingObj->getColumnTermId($object_table, 'name');
+    $max_lengths['name'] = $object_schema_def['fields']['name']['size'];
+    //    - description
+    $terms['description'] = $mappingObj->getColumnTermId($object_table, 'description');
+    $max_lengths['description'] = $object_schema_def['fields']['description']['size'];
+    //    - contact type
+    $cvterm_schema_def = $schemaObj->getTableDef('cvterm', ['format' => 'Drupal']);
+    $terms['contact_type'] = $mappingObj->getColumnTermId('cvterm', 'name');
+    $max_lengths['contact_type'] = $cvterm_schema_def['fields']['name']['size'];
+    // C) LINKING TABLE.
+    [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
+    $linker_schema_def = $schemaObj->getTableDef($linker_table, ['format' => 'Drupal']);
+    //    - primary key
+    $linker_pkey_col = $linker_schema_def['primary key'];
+    $terms['linker_pkey'] = $terms['record_id'];
+    //    - left table foreign key
+    $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
+    $terms['linker_left'] = $mappingObj->getColumnTermId($linker_table, $linker_left_col);
+    //    - right table foreign key
+    $terms['linker_right'] = $mappingObj->getColumnTermId($linker_table, $linker_fkey_column);
+    //    - linking type
+    $terms['linker_type_id'] = $mappingObj->getColumnTermId($linker_table, 'type_id');
+    if (empty($terms['linker_type_id'])) {
+      $terms['linker_type_id'] = $terms['contact_type'];
+    }
+    //    - rank
+    $terms['linker_rank'] = $mappingObj->getColumnTermId($linker_table, 'rank');
+    if (empty($terms['linker_rank'])) {
+      $terms['linker_rank'] = 'OBCS:0000117';
+    }
+
+    // We need to create a table alias for our linker table in order to ensure
+    // contact links with other roles are not combined.
+    // The type used when creating the linking record will be the same as the
+    // type set for the field. As such, we grab that here and use it in our
+    // table alias.
+    $field_settings = $field_definition->getSettings();
+    $term = $field_settings['termIdSpace'] . ':' . $field_settings['termAccession'];
+    $table_alias = $linker_table . '_' . preg_replace( '/[^a-z0-9]+/', '', strtolower( $term ) );
+
+    // FINALLY, THE PROPERTIES!
+    $properties = [];
+
+    // Define the base table record id.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $terms['base_pkey'], [
+      'action' => 'store_id',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col,
+    ]);
+
+    // This property will store the Drupal entity ID of the linked chado
+    // record, if one exists.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'entity_id', self::$drupal_entity_term, [
+      'action' => 'function',
+      'drupal_store' => TRUE,
+      'namespace' => self::$chadostorage_namespace,
+      'function' => self::$drupal_entity_callback,
+      'fkey' => self::$object_id,
+    ]);
+
+    // Define the linker table that links the base table to the object table.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $terms['linker_pkey'], [
+      'action' => 'store_pkey',
+      'drupal_store' => TRUE,
+      'path' => $table_alias . '.' . $linker_pkey_col,
+      'table_alias_mapping' => [$table_alias => $linker_table],
+    ]);
+
+    // Define the link between the base table and the linker table.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'link', $terms['linker_left'], [
+      'action' => 'store_link',
+      'drupal_store' => TRUE,
+      'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $linker_left_col,
+      'table_alias_mapping' => [$table_alias => $linker_table],
+    ]);
+
+    // Define the link between the linker table and the object table.
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, $linker_fkey_column, $terms['linker_right'], [
+      'action' => 'store',
+      'drupal_store' => TRUE,
+      'path' => $table_alias . '.' . $linker_fkey_column,
+      'table_alias_mapping' => [$table_alias => $linker_table],
+      'delete_if_empty' => TRUE,
+      'empty_value' => 0,
+    ]);
+
+    // Linker type_id
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_type_id', $terms['linker_type_id'], [
+      'action' => 'store',
+      'drupal_store' => FALSE,
+      'path' => $table_alias . '.type_id',
+      'table_alias_mapping' => [$table_alias => $linker_table],
+      'as' => 'linker_type_id',
+    ]);
+
+    // Linker Rank
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_rank', $terms['linker_rank'], [
+      'action' => 'store',
+      'drupal_store' => FALSE,
+      'path' => $table_alias . '.rank',
+      'table_alias_mapping' => [$table_alias => $linker_table],
+      'as' => 'linker_rank',
+    ]);
+
+    // The object table, the destination table of the linker table
+    // The contact name
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_name', $terms['name'], $max_lengths['name'], [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
+      'as' => 'contact_name',
+    ]);
+
+    // The contact description
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_description', $terms['description'], $max_lengths['description'], [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
+      'as' => 'contact_description',
+    ]);
+
+    // The type of contact
+    $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'contact_type', $terms['contact_type'], $max_lengths['contact_type'], [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
+        . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
+      'as' => 'contact_type',
+    ]);
+
+    return $properties;
+  }
+
+  /**
+   * We need to set the type_id property value to match the cvterm_id.
+   *
+   * To do this we'll override the tripalValuesTemplate() and give the
+   * `type_id` property a default value.
+   *
+   * {@inheritDoc}
+   * @see \Drupal\tripal\TripalField\TripalFieldItemBase::tripalValuesTemplate()
+   */
+  public function tripalValuesTemplate($field_definition, $default_value = NULL) {
+    $prop_values = parent::tripalValuesTemplate($field_definition, $default_value);
+
+    $settings = $field_definition->getSettings();
+
+    $termIdSpace = $settings['termIdSpace'];
+    $termAccession = $settings['termAccession'];
+
+    /** @var \Drupal\tripal\TripalVocabTerms\PluginManagers\TripalIdSpaceManager $idSpace_manager **/
+    /** @var \Drupal\tripal\TripalVocabTerms\TripalIdSpaceBase $idSpace **/
+    /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term **/
+    $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    $idSpace = $idSpace_manager->loadCollection($termIdSpace);
+    $term = $idSpace->getTerm($termAccession);
+
+    foreach ($prop_values as $index => $prop_value) {
+      if ($prop_value->getKey() == 'linker_type_id') {
+        $prop_values[$index]->setValue($term->getInternalId());
+      }
+    }
+
+    return $prop_values;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @see \Drupal\tripal_chado\TripalField\ChadoFieldItemBase::isCompatible()
+   */
+  public function isCompatible(TripalEntityType $entity_type) : bool {
+    $compatible = TRUE;
+
+    // Get the base table for the content type.
+    $base_table = $entity_type->getThirdPartySetting('tripal', 'chado_base_table');
+    $linker_tables = $this->getLinkerTables(self::$object_table, $base_table);
+    if (count($linker_tables) < 1) {
+      $compatible = FALSE;
+    }
+    return $compatible;
+  }
+}

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -284,17 +284,13 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
 
       [$table_name, $contact_fkey] = $item;
 
-      // Get the definition.
-      $schemaObj = \Drupal::service('tripal_chado.database')->schema();
-      $schemaDef = $schemaObj->getTableDef($table_name, ['format' => 'Drupal']);
       // Check there is a type_id field.
-      if (array_key_exists('type_id', $schemaDef['fields'])) {
-        $has_type_id = TRUE;
-      }
-      else {
+      $schemaObj = \Drupal::service('tripal_chado.database')->schema();
+      $has_type_id = $schemaObj->fieldExists($table_name, 'type_id');
+
+      if (!$has_type_id) {
         \Drupal::messenger()->addError('The Contact By Role field requires a type_id in the linking table. This is not present in Chado 1.31 but will likely be added in subsequent versions. For more information, see https://github.com/GMOD/Chado/pull/144.');
       }
-
     }
 
     // Only compatible if there is a linker and it has a type_id.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -13,8 +13,8 @@ use Drupal\tripal\Entity\TripalEntityType;
  * @FieldType(
  *   id = "chado_contact_by_role_type_default",
  *   category = "tripal_chado",
- *   label = @Translation("Chado Contact By Role"),
- *   description = @Translation("Supports linking contacts fullfilling a specific role to content types."),
+ *   label = @Translation("Chado Contacts: Specific Role"),
+ *   description = @Translation("Supports linking contacts fullfilling a specific role to the current content type."),
  *   default_widget = "chado_contact_widget_default",
  *   default_formatter = "chado_contact_formatter_default",
  * )

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -132,6 +132,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
     $field_settings = $field_definition->getSettings();
     $term = $field_settings['termIdSpace'] . ':' . $field_settings['termAccession'];
     $table_alias = $linker_table . '_' . preg_replace( '/[^a-z0-9]+/', '', strtolower( $term ) );
+    $table_mapping = [$table_alias => $linker_table];
 
     // FINALLY, THE PROPERTIES!
     $properties = [];
@@ -159,7 +160,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_pkey',
       'drupal_store' => TRUE,
       'path' => $table_alias . '.' . $linker_pkey_col,
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
     ]);
 
     // Define the link between the base table and the linker table.
@@ -167,7 +168,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'store_link',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $linker_left_col,
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
     ]);
 
     // Define the link between the linker table and the object table.
@@ -175,7 +176,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'store',
       'drupal_store' => TRUE,
       'path' => $table_alias . '.' . $linker_fkey_column,
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'delete_if_empty' => TRUE,
       'empty_value' => 0,
     ]);
@@ -185,7 +186,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'store',
       'drupal_store' => FALSE,
       'path' => $table_alias . '.type_id',
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'as' => 'linker_type_id',
     ]);
 
@@ -194,7 +195,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'store',
       'drupal_store' => FALSE,
       'path' => $table_alias . '.rank',
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'as' => 'linker_rank',
     ]);
 
@@ -204,8 +205,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'read_value',
       'drupal_store' => FALSE,
       'path' => $table_alias . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';name',
-
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'as' => 'contact_name',
     ]);
 
@@ -214,7 +214,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'action' => 'read_value',
       'drupal_store' => FALSE,
       'path' => $table_alias . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'as' => 'contact_description',
     ]);
 
@@ -224,7 +224,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => FALSE,
       'path' => $table_alias . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
         . ';' . $object_table . '.type_id>cvterm.cvterm_id;name',
-      'table_alias_mapping' => [$table_alias => $linker_table],
+      'table_alias_mapping' => $table_mapping,
       'as' => 'contact_type',
     ]);
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -55,37 +54,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     // CV Term is 'Communication Contact'
     $field_settings['termIdSpace'] = 'NCIT';
     $field_settings['termAccession'] = 'C47954';
-    $field_settings['restrict2type'] = FALSE;
     return $field_settings;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function fieldSettingsForm(array $form, FormStateInterface $form_state) {
-    $elements = parent::fieldSettingsForm($form, $form_state);
-
-    $elements['restrict2type_fieldset'] = [
-      '#type' => 'details',
-      '#title' => t('Filter Contacts by Link Type'),
-      '#open' => TRUE,
-    ];
-
-    $elements['restrict2type_fieldset']['msg'] = [
-      '#markup' => '<p>By default, this field will show all contacts linked to a specific record in the base table. For example, when this field is on a Project Content Type, it would show any contact linked through the project_contact table.</p>'
-        . '<p>However, in some Chado instances, these linking tables have a type_id allowing the type of link to be specified. If this column is available, this field will support only managing contacts linked via a specific link type. This can be indicated by turning on "Restrict to Link Type" below and setting the "Controlled Vocabulary Term" for this field to the link type you would like to restrict to.</p>'
-        .'<p>For example, if you would like this field to only show contacts who are defined as funders of the current project, you would check the "Restrict to Link Type" checkbox and then set the "Controlled Vocabulary Term" for this field to Funder (EFO:0001736). Then when contacts are linked through this field, the project_contact.type_id will reference the "Funder (EFO:0001736)" cvterm.</p>'
-        .'<p><strong>NOTE: The following checkbox will only have an effect if there is a type_id in the linking table. This is not standard as of Chado v1.3 but is currently under review to be included in Chado v1.4. See <a href="https://github.com/GMOD/Chado/pull/144" target="_blank">PR #144</a> for the status on this addition and comment there if you need this functionality.</strong></p>',
-    ];
-
-    $elements['restrict2type_fieldset']['restrict2type'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Restrict to Link Type'),
-      '#description' => t('Restrict the contacts managed by this field to only those where the linking table record type_id matches the cvterm set above.'),
-      '#default_value' => $this->getSetting('restrict2type'),
-    ];
-
-    return $elements;
   }
 
   /**

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -54,7 +55,37 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     // CV Term is 'Communication Contact'
     $field_settings['termIdSpace'] = 'NCIT';
     $field_settings['termAccession'] = 'C47954';
+    $field_settings['restrict2type'] = FALSE;
     return $field_settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldSettingsForm(array $form, FormStateInterface $form_state) {
+    $elements = parent::fieldSettingsForm($form, $form_state);
+
+    $elements['restrict2type_fieldset'] = [
+      '#type' => 'details',
+      '#title' => t('Filter Contacts by Link Type'),
+      '#open' => TRUE,
+    ];
+
+    $elements['restrict2type_fieldset']['msg'] = [
+      '#markup' => '<p>By default, this field will show all contacts linked to a specific record in the base table. For example, when this field is on a Project Content Type, it would show any contact linked through the project_contact table.</p>'
+        . '<p>However, in some Chado instances, these linking tables have a type_id allowing the type of link to be specified. If this column is available, this field will support only managing contacts linked via a specific link type. This can be indicated by turning on "Restrict to Link Type" below and setting the "Controlled Vocabulary Term" for this field to the link type you would like to restrict to.</p>'
+        .'<p>For example, if you would like this field to only show contacts who are defined as funders of the current project, you would check the "Restrict to Link Type" checkbox and then set the "Controlled Vocabulary Term" for this field to Funder (EFO:0001736). Then when contacts are linked through this field, the project_contact.type_id will reference the "Funder (EFO:0001736)" cvterm.</p>'
+        .'<p><strong>NOTE: The following checkbox will only have an effect if there is a type_id in the linking table. This is not standard as of Chado v1.3 but is currently under review to be included in Chado v1.4. See <a href="https://github.com/GMOD/Chado/pull/144" target="_blank">PR #144</a> for the status on this addition and comment there if you need this functionality.</strong></p>',
+    ];
+
+    $elements['restrict2type_fieldset']['restrict2type'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Restrict to Link Type'),
+      '#description' => t('Restrict the contacts managed by this field to only those where the linking table record type_id matches the cvterm set above.'),
+      '#default_value' => $this->getSetting('restrict2type'),
+    ];
+
+    return $elements;
   }
 
   /**

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -13,8 +13,8 @@ use Drupal\tripal\Entity\TripalEntityType;
  * @FieldType(
  *   id = "chado_contact_type_default",
  *   category = "tripal_chado",
- *   label = @Translation("Chado Contact"),
- *   description = @Translation("Add a Chado contact to the content type."),
+ *   label = @Translation("Chado Contacts: All"),
+ *   description = @Translation("Supports linking contacts to the current content type without restricting to a specific type of link (i.e role the contact plays)."),
  *   default_widget = "chado_contact_widget_default",
  *   default_formatter = "chado_contact_formatter_default",
  * )

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -85,17 +85,45 @@ class ChadoContactWidgetDefault extends ChadoWidgetBase {
       '#empty_option' => '-- Select --',
     ];
 
-    // If there are any additional columns present in the linker table,
-    // use a default of 1 which will work for type_id or rank.
-    // or pub_id. Any existing value will pass through as the default.
-    foreach ($property_definitions as $property => $definition) {
-      if (($property != 'linker_id') and preg_match('/^linker_/', $property)) {
-        $default_value = $item_vals[$property] ?? 1;
-        $elements[$property] = [
-          '#type' => 'value',
-          '#default_value' => $default_value,
-        ];
+    // If there is a type_id and the value is not already set, then we want to
+    // use the cvterm of the field as the default.
+    if (array_key_exists('linker_type_id', $property_definitions)) {
+
+      if (empty($item['linker_type_id'])) {
+        $termIdSpace = $this->getFieldSetting('termIdSpace');
+        $termAccession = $this->getFieldSetting('termAccession');
+
+        $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+        $idSpace = $idSpace_manager->loadCollection($termIdSpace);
+        $term = $idSpace->getTerm($termAccession);
+
+        $item['linker_type_id'] = $term->getInternalId();
       }
+
+      $elements['linker_type_id'] = [
+        '#type' => 'value',
+        '#default_value' => $item['linker_type_id'],
+      ];
+    }
+
+    // If there is a rank and it is not already set,
+    // then we want to use 0 as the default.
+    if (array_key_exists('linker_rank', $property_definitions)) {
+      $default_value = $item_vals['linker_rank'] ?? 0;
+      $elements['linker_rank'] = [
+        '#type' => 'value',
+        '#default_value' => $default_value,
+      ];
+    }
+
+    // If there is a pub_id and it is not already set, then we want to use
+    // the null pub which has an id of 1.
+    if (array_key_exists('linker_pub_id', $property_definitions)) {
+      $default_value = $item_vals['linker_pub_id'] ?? 1;
+      $elements['linker_pub_id'] = [
+        '#type' => 'value',
+        '#default_value' => $default_value,
+      ];
     }
 
     return $elements;

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -140,13 +140,6 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'label' => 'The column in the linking table which is a foreign key pointing to the base table (e.g. for feature_synonym this would be feature_id).',
     'nullable' => true
   ];
-
-  // Contact Field specific addition.
-  $definitions['field.field.tripal_entity.*.*']['mapping']['settings']['mapping']['restrict2type'] = [
-    'type' => 'boolean',
-    'label' => 'Flag to indicate to filter the current field by type',
-    'nullable' => true
-  ];
 }
 
 /**

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -140,6 +140,13 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'label' => 'The column in the linking table which is a foreign key pointing to the base table (e.g. for feature_synonym this would be feature_id).',
     'nullable' => true
   ];
+
+  // Contact Field specific addition.
+  $definitions['field.field.tripal_entity.*.*']['mapping']['settings']['mapping']['restrict2type'] = [
+    'type' => 'boolean',
+    'label' => 'Flag to indicate to filter the current field by type',
+    'nullable' => true
+  ];
 }
 
 /**


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #1845 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
It would be good to have a set of attribution-focused fields automatically added to project + analysis based content types to encourage standards. This addition will make it easier for Tripal sites to meet FAIR standards as it will guide them on how to provide proper attribution and licenses for their project/analysis pages which typically describe a dataset as a whole.

This PR provides a specialized contact field type that can use the new type_id column in the _contact linker tables that will be added by https://github.com/GMOD/Chado/pull/144. Specifically, the new field type acts the same way the property field works --allowing multiple contactByRole fields on the same content type where each handles a different *_contact.type_id. **This new field type uses the existing contact widget and formatter.**

Additionally, some changes were made to the existing contact widget to set better defaults for a type_id and rank if it is present.

**NOTE: As this field expects a type_id in the linker tables that is not present in Chado 1.31, the compatibility function has been updated to only allow this field to be added if the type_id update is present and provide context if it is not.**

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Create a fresh docker on this branch (needed because terms are added).
2. Go to Tripal > Page Structure > Project > Manage Fields and attempt to add a Contact By Role Field.
     a. Enter a field name (i.e. "Funder")
     b. Choose "Chado Field"
     c. Choose "Chado Contact By Role"
     d. Click "Continue"
     e. Observe an error that says this field cannot be added.
3. Update you installation of chado to include the type_ids provided in https://github.com/GMOD/Chado/pull/144. This is easiest by using `drush sql:cli` and then copying in the following commands from the PR.
```sql
SET search_path TO chado;
/* https://github.com/GMOD/Chado/issues/140 */
/* Upgrade unique constraints with nullable columns if PostgreSQL version > 15 */
CREATE OR REPLACE PROCEDURE addUniqueLinkerConstraint(table_name varchar, constraint_name varchar, columns varchar[])
  LANGUAGE plpgsql
  AS $$
  DECLARE
    newer_than_15 boolean;
  BEGIN
    -- Determine the version of PostgreSQL
    SELECT CASE WHEN current_setting('server_version_num')::INT > 150000 THEN true ELSE false END AS supported INTO newer_than_15;

    -- IF the version is newer then we can use the new UNIQUE NULLS NOT DISTINCT
    -- which does not treat 2 records that are the same but include NULL as distict.
    IF newer_than_15 THEN
      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s UNIQUE NULLS NOT DISTINCT (%s)', table_name, constraint_name, array_to_string(columns, ','));
    -- IF the version is <15 then we use the original UNIQUE style constraint
    ELSE
      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)', table_name, constraint_name, array_to_string(columns, ','));
    END IF;
  END
$$;
/* Contact Linkers */
/* -- Feature */
ALTER TABLE feature_contact ADD COLUMN type_id bigint;
ALTER TABLE feature_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE feature_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
ALTER TABLE feature_contact DROP CONSTRAINT feature_contact_c1;
CALL addUniqueLinkerConstraint('feature_contact', 'feature_contact_c1', ARRAY['feature_id', 'contact_id', 'type_id', 'rank']);
/* -- Featuremap */
ALTER TABLE featuremap_contact ADD COLUMN type_id bigint;
ALTER TABLE featuremap_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE featuremap_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
ALTER TABLE featuremap_contact DROP CONSTRAINT featuremap_contact_c1;
CALL addUniqueLinkerConstraint('featuremap_contact', 'featuremap_contact_c1', ARRAY['featuremap_id', 'contact_id', 'type_id', 'rank']);
/* -- Library */
ALTER TABLE library_contact ADD COLUMN type_id bigint;
ALTER TABLE library_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE library_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
ALTER TABLE library_contact DROP CONSTRAINT library_contact_c1;
CALL addUniqueLinkerConstraint('library_contact', 'library_contact_c1', ARRAY['library_id', 'contact_id', 'type_id', 'rank']);
/* -- ND Experiment */
ALTER TABLE nd_experiment_contact ADD COLUMN type_id bigint;
ALTER TABLE nd_experiment_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE nd_experiment_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
CALL addUniqueLinkerConstraint('nd_experiment_contact', 'nd_experiment_contact_c1', ARRAY['nd_experiment_id', 'contact_id', 'type_id', 'rank']);
/* -- Project */
ALTER TABLE project_contact ADD COLUMN type_id bigint;
ALTER TABLE project_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE project_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
ALTER TABLE project_contact DROP CONSTRAINT project_contact_c1;
CALL addUniqueLinkerConstraint('project_contact', 'project_contact_c1', ARRAY['project_id', 'contact_id', 'type_id', 'rank']);
/* -- Pubauthor */
ALTER TABLE pubauthor_contact ADD COLUMN type_id bigint;
ALTER TABLE pubauthor_contact ADD COLUMN rank int DEFAULT 0;
ALTER TABLE pubauthor_contact ADD FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE SET NULL;
ALTER TABLE pubauthor_contact DROP CONSTRAINT pubauthor_contact_c1;
CALL addUniqueLinkerConstraint('pubauthor_contact', 'pubauthor_contact_c1', ARRAY['pubauthor_id', 'contact_id', 'type_id', 'rank']);
```
4. Now go back and re-do step 2. This time you will not get the compatibility error and will be able to continue. Set the field to be unlimited and set the term to Funder (EFO:0001736). The field should add without error.
5. Create an additional contact by role field: name "Data Collector", term "AGRO:00000379".
6. Go to Tripal > Content > Add > Contact and create multiple contact pages. Set the contact type to "Organization", etc or leave blank.
7. Go to Tripal > Content > Add > Project and create a generic project. With the two fields above added you should see something like the following screenshot:
![Firefox_Screenshot_2024-05-08T17-04-00 046Z](https://github.com/tripal/tripal/assets/1566301/3db7164f-dcdc-417b-90e6-951b0297b1fa)
8. Confirm that you can enter multiple items each and that you can enter the same item in both. Also confirm that you can edit, remove and rearrange elements.
![image](https://github.com/tripal/tripal/assets/1566301/fe18c1a9-8976-468b-aa45-1b0454dfe16d)
