### PR TITLE
Fields move record_id_term to parent class

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -90,7 +90,6 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // from Chado tables if appropriate.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $type_id_term = $mapping->getColumnTermId($type_table, $type_column);
     $name_term = $mapping->getColumnTermId('cvterm', 'name');
     $idspace_term = 'SIO:000067';
@@ -99,7 +98,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // Always store the record id of the base record that this field is
     // associated with in Chado.
     $properties = [];
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -117,7 +116,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       $value_term = $mapping->getColumnTermId($type_table, 'value');
 
       // (e.g., analysisprop.analysisprop_id)
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $type_table  . '.' . $type_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -81,7 +81,6 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -140,7 +139,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -171,7 +170,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     else {
       // Define the linker table that links the base table to the object table.
       // (e.g., project_analysis.project_analysis_id)
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -149,7 +148,7 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -179,7 +178,7 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -79,7 +79,6 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -136,7 +135,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'chado_table' => $base_table,
@@ -167,7 +166,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -152,7 +151,7 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -182,7 +181,7 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -62,11 +62,10 @@ class ChadoBooleanTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
 
     return [
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -73,7 +73,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
     }
 
     $terms = [
-      'record_id' => 'SIO:000729',
+      'record_id' => self::$record_id_term,
     ];
     $max_lengths = [];
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -79,7 +79,6 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -132,7 +131,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -162,7 +161,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -141,7 +140,7 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -160,7 +159,7 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col . '>' . $linker_table . '.' . $linker_left_col . ';' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -132,7 +131,7 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -162,7 +161,7 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -85,7 +85,6 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -157,7 +156,7 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -187,7 +186,7 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -69,11 +69,10 @@ class ChadoIntegerTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
 
     return [
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -79,7 +79,6 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $chado->schema()->getTableDef($base_table, ['format' => 'Drupal']);
@@ -144,7 +143,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -174,7 +173,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -131,7 +130,7 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -161,7 +160,7 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -75,7 +75,6 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $link_term = $mapping->getColumnTermId($prop_table, $prop_fk_col);
     $value_term = $mapping->getColumnTermId($prop_table, 'value');
     $rank_term = $mapping->getColumnTermId($prop_table, 'rank');
@@ -93,12 +92,12 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
 
     // Create the property types.
     return [
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,
       ]),
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col . '>' . $table_alias . '.' . $prop_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -80,7 +80,6 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -137,7 +136,7 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -168,7 +167,7 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     // have any protocol linker tables, but a site may wish to add one)
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -81,7 +81,6 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -149,7 +148,7 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -179,7 +178,7 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -59,7 +59,6 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum');
     $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
 
@@ -71,7 +70,7 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
 
     // Return the properties for this field.
     $properties = [];
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -89,19 +89,19 @@ class ChadoSequenceCoordinatesDefault extends ChadoFieldItemBase {
     // Get property terms using Chado table columns they map to. Return the properties for this field.
     $properties = [];
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => 'feature.feature_id',
     ]);
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'featureloc_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'featureloc_id', self::$record_id_term, [
       'action' => 'store_pkey',
       'drupal_store' => TRUE,
       'path' => 'featureloc.featureloc_id',
     ]);
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'fkey', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'fkey', self::$record_id_term, [
       'action' => 'store_link',
       'drupal_store' => TRUE,
       'path' => 'feature.feature_id>featureloc.feature_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -70,11 +70,11 @@ class ChadoSequenceCoordinatesDefault extends ChadoFieldItemBase {
 
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
-    $mapping = $storage->load( 'core_mapping' );
+    $mapping = $storage->load('core_mapping');
 
-    $record_id_term = $mapping->getColumnTermId( 'feature', 'feature_id' );
-    $ft_uniqname_term = $mapping->getColumnTermId( 'feature', 'name' );
+    $ft_uniqname_term = $mapping->getColumnTermId('feature', 'name');
 
+    $feature_id_term = $mapping->getColumnTermId('featureloc', 'feature_id');
     $srcfeature_id_term = $mapping->getColumnTermId('featureloc', 'srcfeature_id');
     $fmin_term = $mapping->getColumnTermId('featureloc', 'fmin');
     $is_fmin_partial_term = $mapping->getColumnTermId('featureloc', 'is_fmin_partial');
@@ -101,7 +101,7 @@ class ChadoSequenceCoordinatesDefault extends ChadoFieldItemBase {
       'path' => 'featureloc.featureloc_id',
     ]);
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'fkey', self::$record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'fkey', $feature_id_term, [
       'action' => 'store_link',
       'drupal_store' => TRUE,
       'path' => 'feature.feature_id>featureloc.feature_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -60,12 +60,11 @@ class ChadoSequenceLengthTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
 
     // Return the properties for this field.
     $properties = [];
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -61,14 +61,13 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $residues_term = $mapping->getColumnTermId('feature', 'residues');
     $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
     $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum');
 
     // Return the properties for this field.
     $properties = [];
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => 'feature.feature_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -72,7 +72,7 @@ class ChadoSourceDataTypeDefault extends ChadoFieldItemBase {
     // Get property terms using Chado table columns they map to. Return the properties for this field.
     $properties = [];
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => 'analysis.analysis_id',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -63,8 +63,6 @@ class ChadoSourceDataTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
 
-    $record_id_term = $mapping->getColumnTermId('analysis', 'analysis_id');
-
     $src_uri_term = $mapping->getColumnTermId('analysis', 'sourceuri');
     $src_name_term = $mapping->getColumnTermId('analysis', 'sourcename');
     $src_vers_term = $mapping->getColumnTermId('analysis', 'sourceversion');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -83,7 +83,6 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -149,7 +148,7 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -179,7 +178,7 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -108,11 +108,10 @@ class ChadoStringTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
 
     return [
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -79,7 +79,6 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
     $entity_type_id = $field_definition->getTargetEntityTypeId();
-    $record_id_term = 'SIO:000729';
 
     // Base table
     $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
@@ -131,7 +130,7 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $properties = [];
 
     // Define the base table record id.
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,
@@ -161,7 +160,7 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     // An intermediate linker table is used
     else {
       // Define the linker table that links the base table to the object table.
-      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', $record_id_term, [
+      $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'linker_id', self::$record_id_term, [
         'action' => 'store_pkey',
         'drupal_store' => TRUE,
         'path' => $linker_table . '.' . $linker_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -131,7 +131,6 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
     // from Chado tables if appropriate.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
 
     // Synonym table fields
     $syn_name_term = $mapping->getColumnTermId('synonym', 'name');
@@ -150,7 +149,7 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
     // Always store the record id of the base record that this field is
     // associated with in Chado.
     $properties = [];
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => $base_table . '.' . $base_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -63,11 +63,10 @@ class ChadoTextTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = 'SIO:000729';
     $value_term = $mapping->getColumnTermId($base_table, $base_column);
 
     return [
-      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+      new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
         'action' => 'store_id',
         'drupal_store' => TRUE,
         'path' => $base_table . '.' . $base_pkey_col,

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -70,7 +70,6 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
 
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $record_id_term = $mapping->getColumnTermId('featuremap', 'featuremap_id');
     $unittype_id_term = $mapping->getColumnTermId('featuremap', 'unittype_id');
     $cv_name_term = $mapping->getColumnTermId('cvterm', 'name');
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -76,7 +76,7 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
 
     $properties = [];
 
-    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', $record_id_term, [
+    $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
       'path' => 'featuremap.featuremap_id',

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  */
 abstract class ChadoFieldItemBase extends TripalFieldItemBase {
 
+  // The standard record identifier term for all fields.
+  protected static $record_id_term = 'SIO:000729';
+
   // A child class can use these static variables to indicate
   // that it needs a base table column selector in the form.
   protected static $select_base_column = FALSE;


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #1879

### Tripal Version: 4.x

## Description
We have a hardcoded `$record_id_term = 'SIO:000729';` in most fields.
This moves this to the parent `ChadoFieldItemBase` class.

Three fields weren't consistent so they now also use this term, they can get extra careful code review 😼
ChadoSourceDataTypeDefault
ChadoUnitTypeDefault
ChadoSequenceCoordinatesDefault

## Testing?
Automated testing will test some of this. But I suppose ideally we need to create at least one instance of every field type. Importing all of the field type collections should do this.

To test these three fields, create an organism and analysis.
The analysis will test the source data field.
Run the GFF3 importer. I used this file for testing from issue #1824
[issue1824.gff3.txt](https://github.com/tripal/tripal/files/15109905/issue1824.gff3.txt)
Publish gene
Check the sequence coordinates field, should be `NC_001133.9:1806..2169-`
Create a genetic map to test the unit field.