### PR TITLE
Add Drupal 10.3 to automated testing

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -22,6 +22,7 @@ jobs:
           - "10.0.x-dev"
           - "10.1.x-dev"
           - "10.2.x-dev"
+          - "10.3.x-dev"
         exclude:
           - php-version: "8.3"
             pgsql-version: "13"

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - tv4g9-1829-bumpActionVersion
+      - tv4g9-issue1888-drupal-10-3
 
 jobs:
   push_to_registry:
@@ -23,6 +23,7 @@ jobs:
           - "10.0.x-dev"
           - "10.1.x-dev"
           - "10.2.x-dev"
+          - "10.3.x-dev"
         exclude:
           - php-version: "8.3"
             pgsql-version: "13"
@@ -79,8 +80,8 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: mr-smithers-excellent/docker-build-push@v6
-        name: Build latest using 10.2.x-dev, PHP 8.3, PgSQL 16
-        if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '16' }}
+        name: Build latest using 10.3.x-dev, PHP 8.3, PgSQL 16
+        if: ${{ matrix.drupal-version == '10.3.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '16' }}
         with:
           image: tripalproject/tripaldocker
           tags: latest

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_3x.yml
@@ -1,0 +1,23 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - tv4g9-issue1888-drupal-10-3
+jobs:
+  running-tests:
+    name: "Drupal 10.3: PHP 8.1"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.5
+        with:
+          directory-name: 'tripal'
+          modules: 'tripal tripal_biodb tripal_chado'
+          php-version: '8.1'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'
+          build-image: true
+          dockerfile: "UseTripalDockerBackupClause"

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_3x.yml
@@ -1,0 +1,23 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - tv4g9-issue1888-drupal-10-3
+jobs:
+  running-tests:
+    name: "Drupal 10.3: PHP 8.2"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.5
+        with:
+          directory-name: 'tripal'
+          modules: 'tripal tripal_biodb tripal_chado'
+          php-version: '8.2'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'
+          build-image: true
+          dockerfile: "UseTripalDockerBackupClause"

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_3x.yml
@@ -1,0 +1,23 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - tv4g9-issue1888-drupal-10-3
+jobs:
+  running-tests:
+    name: "Drupal 10.3: PHP 8.3"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.5
+        with:
+          directory-name: 'tripal'
+          modules: 'tripal tripal_biodb tripal_chado'
+          php-version: '8.3'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'
+          build-image: true
+          dockerfile: "UseTripalDockerBackupClause"

--- a/README.md
+++ b/README.md
@@ -18,21 +18,24 @@
 
 Tested on ![PostgreSQL 13](https://img.shields.io/badge/PostreSQL-13-success) + ![PostgreSQL 16](https://img.shields.io/badge/PostreSQL-16-success)
 
-| Drupal      | 10.0.x          | 10.1.x          | 10.2.x          |
-|-------------|-----------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
-| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
+| Drupal      | 10.0.x          | 10.1.x          | 10.2.x          | 10.3.x          |
+|-------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] | ![Grid1D-Badge] |
+| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] | ![Grid2D-Badge] |
+| **PHP 8.3** |                 |                 | ![Grid3C-Badge] | ![Grid3D-Badge] |
 
 [Grid1A-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg
 [Grid1B-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_1x.yml/badge.svg
 [Grid1C-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_2x.yml/badge.svg
+[Grid1D-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_3x.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_0x.yml/badge.svg
 [Grid2B-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_1x.yml/badge.svg
 [Grid2C-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_2x.yml/badge.svg
+[Grid2D-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_3x.yml/badge.svg
 
 [Grid3C-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_2x.yml/badge.svg
+[Grid3D-Badge]: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_3x.yml/badge.svg
 
 ### Code Coverage
 

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -1183,7 +1183,7 @@ EOD;
    * We needed to override it because core Drupal makes some assumptions
    * when building the where condition that do not match our multi-schema setup.
    */
-  public function tableExists($table) {
+  public function tableExists($table, $add_prefix = true) {
 
     // We can't use \Drupal::database()->select() here
     // because it would prefix information_schema.tables


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #1888 

### Tripal Version: 4.x

## Description
The first commit adds Drupal 10.3 to automated testing. Once we see what fails more may be needed.

## Testing?
Automated testing.
Code review.
Actually create a Drupal 10.3 site and try the usual stuff out.
