### PR TITLE
add formatting settings to ChadoStringType field

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -318,6 +318,18 @@ tripal.tripalfield_collection.*:
                            type: integer
                            label: 'Weight'
                            nullable: false
+                         settings:
+                           type: mapping
+                           label: 'Settings'
+                           mapping:
+                             field_prefix:
+                               type: string
+                               label: 'Field prefix'
+                               nullable: true
+                             field_suffix:
+                               type: string
+                               label: 'Field suffix'
+                               nullable: true
                    form:
                      type: sequence
                      label: 'Edit'

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
@@ -23,15 +23,65 @@ class DefaultTripalStringTypeFormatter extends TripalFormatterBase {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['field_prefix'] = '';
+    $settings['field_suffix'] = '';
+    return $settings;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    $field_prefix = $this->getSetting('field_prefix');
+    $field_suffix = $this->getSetting('field_suffix');
+
     foreach($items as $delta => $item) {
+      $value = $item->get('value')->getString();
       $elements[$delta] = [
-        "#markup" => $item->get("value")->getString(),
+        "#markup" => $field_prefix . $value . $field_suffix,
       ];
     }
 
     return $elements;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['field_prefix'] = [
+      '#title' => $this->t('Text to display before the field value'),
+      '#description' => $this->t('Enter text here that will be displayed before the'
+                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;em&gt;'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_prefix'),
+      '#required' => FALSE,
+    ];
+    $form['field_suffix'] = [
+      '#title' => $this->t('Text to display after the field value'),
+      '#description' => $this->t('Enter text here that will be displayed after the'
+                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;/em&gt;'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_suffix'),
+      '#required' => FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $summary[] = $this->t('Set display format');
+    return $summary;
+  }
+
 }

--- a/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.general_chado.yml
@@ -33,6 +33,9 @@ fields:
                     region: content
                     label: above
                     weight: 10
+                    settings:
+                      field_prefix: '<em>'
+                      field_suffix: '</em>'
             form:
                 default:
                     region: content
@@ -60,6 +63,9 @@ fields:
                     region: content
                     label: above
                     weight: 15
+                    settings:
+                      field_prefix: '<em>'
+                      field_suffix: '</em>'
             form:
                 default:
                     region: content
@@ -114,6 +120,9 @@ fields:
                     region: content
                     label: above
                     weight: 25
+                    settings:
+                      field_prefix: '<em>'
+                      field_suffix: '</em>'
             form:
                 default:
                     region: content

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -3,9 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
-use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**
  * Plugin implementation of default Chado string type formatter.
@@ -22,67 +20,10 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 class ChadoStringFormatterDefault extends DefaultTripalStringTypeFormatter {
 
   /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    $settings = parent::defaultSettings();
-    $settings['field_prefix'] = '';
-    $settings['field_suffix'] = '';
-    return $settings;
-  }
-
-  /**
    * {@inheritDoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
-    $elements = [];
-
-    $field_prefix = $this->getSetting('field_prefix');
-    $field_suffix = $this->getSetting('field_suffix');
-
-    foreach($items as $delta => $item) {
-      $value = $item->get('value')->getString();
-      $elements[$delta] = [
-        "#markup" => $field_prefix . $value . $field_suffix,
-      ];
-    }
-
-    return $elements;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    $form = parent::settingsForm($form, $form_state);
-
-    $form['field_prefix'] = [
-      '#title' => $this->t('Text to display before the field value'),
-      '#description' => $this->t('Enter text here that will be displayed before the'
-                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;em&gt;'),
-      '#type' => 'textfield',
-      '#default_value' => $this->getSetting('field_prefix'),
-      '#required' => FALSE,
-    ];
-    $form['field_suffix'] = [
-      '#title' => $this->t('Text to display after the field value'),
-      '#description' => $this->t('Enter text here that will be displayed after the'
-                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;/em&gt;'),
-      '#type' => 'textfield',
-      '#default_value' => $this->getSetting('field_suffix'),
-      '#required' => FALSE,
-    ];
-
-    return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsSummary() {
-    $summary = parent::settingsSummary();
-    $summary[] = $this->t('Set display format');
-    return $summary;
+    return parent::viewElements($items, $langcode);
   }
 
 }

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
+use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**
  * Plugin implementation of default Chado string type formatter.
@@ -20,9 +22,67 @@ use Drupal\Core\Field\FieldItemListInterface;
 class ChadoStringFormatterDefault extends DefaultTripalStringTypeFormatter {
 
   /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['field_prefix'] = '';
+    $settings['field_suffix'] = '';
+    return $settings;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
-    return parent::viewElements($items, $langcode);
+    $elements = [];
+
+    $field_prefix = $this->getSetting('field_prefix');
+    $field_suffix = $this->getSetting('field_suffix');
+
+    foreach($items as $delta => $item) {
+      $value = $item->get('value')->getString();
+      $elements[$delta] = [
+        "#markup" => $field_prefix . $value . $field_suffix,
+      ];
+    }
+
+    return $elements;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['field_prefix'] = [
+      '#title' => $this->t('Text to display before the field value'),
+      '#description' => $this->t('Enter text here that will be displayed before the'
+                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;em&gt;'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_prefix'),
+      '#required' => FALSE,
+    ];
+    $form['field_suffix'] = [
+      '#title' => $this->t('Text to display after the field value'),
+      '#description' => $this->t('Enter text here that will be displayed after the'
+                     . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;/em&gt;'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_suffix'),
+      '#required' => FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $summary[] = $this->t('Set display format');
+    return $summary;
+  }
+
 }


### PR DESCRIPTION
# New Feature

### Closes #1893

### Tripal Version: 4.x

## Description
This PR adds display settings to the ChadoStringTypeDefault field.
These are used to wrap the value in &lt;em&gt; tags so that on an organism page, the genus,
species, and infraspecific name can be displayed in italics.
![2024-06-13_T _bogusii](https://github.com/tripal/tripal/assets/8419404/2a92f942-dea4-4faf-9c6e-17b7dc098785)

I recycled the existing `field_prefix` and `field_suffix` settings, ~~so no schema additions are needed~~.

A point for discussion can be the "ease of use" - there is not a checkbox for italic, you have to go in and add the HTML tags directly. For example
![2024-06-13_genus_settings](https://github.com/tripal/tripal/assets/8419404/cf73dd42-b065-4af9-9075-b06c93e9ff68)
but the advantage is you have more flexibility, maybe you want a dollar sign prefix or something, or a &lt;span&gt; tag with some css, or you want some units after the value.

And note that I am not using xss::sanitize, I'm wondering about this, so I may need to add something. But I wonder if all fields should be sanitized, since they are getting who knows what from database tables. Maybe this needs some discussion...

## Testing?
 - Build a docker on this branch. This will test the default settings in the YAML.
 - Add an organism with infraspecific type. Verify that the appropriate fields are displayed in italics.
 - Test the settings form. Go to the display settings for organism species, and remove the prefix and suffix, and save.
 - Try adding &lt;strong&gt; tags to the organism common name just for fun.
 - cache rebuild maybe, I didn't need to.
 - Go back to the organism and the species should now not be in italics, common name should be bold.
![2024-06-13_manual_edit_test_1](https://github.com/tripal/tripal/assets/8419404/42d4342f-96a4-4d61-a626-3af1d12ce35e)
![2024-06-13_manual edit test](https://github.com/tripal/tripal/assets/8419404/b4e324fc-0541-45ee-ad1c-3d69784d4fcb)

