### PR TITLE
OBO importer - fix unsubstituted message

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2468,12 +2468,11 @@ class OBOImporter extends ChadoImporterBase {
     }
 
     // Make sure there are CV records for all namespaces.
-    $message = t('Found the following namespaces: @namespaces.',
-      ['@namespaces' => implode(', ', array_keys($this->obo_namespaces))]);
     foreach ($this->obo_namespaces as $namespace => $cv) {
       $this->insertChadoCv($namespace);
     }
-    $this->logger->notice($message->getUntranslatedString());
+    $this->logger->notice('Found the following namespaces: @namespaces.',
+      ['@namespaces' => implode(', ', array_keys($this->obo_namespaces))]);
   }
 
   /**


### PR DESCRIPTION
# Bug Fix

### Closes #1904

### Tripal Version: 4.x

## Description

During step 1 of importing an OBO file, the namespaces message does not have the actual namespaces substituted for the placeholder. This fixes that.

## Testing?

 1. Build a docker

### Output before
```
grep -n 'Found the following namespaces' /tmp/4.x.log
2713:#28 86.38  [notice] Found the following namespaces: @namespaces.
2864:#28 136.9  [notice] Found the following namespaces: @namespaces.
2966:#28 138.5  [notice] Found the following namespaces: @namespaces.
3036:#28 139.4  [notice] Found the following namespaces: @namespaces.
```

### Output on this branch
```
grep -n 'Found the following namespaces' /tmp/1904.log
2713:#28 86.38  [notice] Found the following namespaces: sequence.
2864:#28 136.9  [notice] Found the following namespaces: taxonomic_rank.
2966:#28 138.5  [notice] Found the following namespaces: tripal_contact.
3036:#28 139.4  [notice] Found the following namespaces: tripal_pub.
```