### PR TITLE
Fix the "Remove" button on edit form on linker fields

### DIFF
--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -213,7 +213,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       foreach ($base_tables as $base_table) {
         $tables = $this->records->getAncillaryTables($base_table);
         foreach ($tables as $table_alias) {
-          $this->records->deleteRecords($base_table, $table_alias, TRUE);
+          $this->records->deleteRecords($base_table, $table_alias, TRUE, TRUE);
         }
       }
 


### PR DESCRIPTION
# Bug Fix

### Closes #1913

### Tripal Version: 4.x

## Description

When you have a field with cardinality more than one, in the edit form there is a "Remove" button on the right.
The bug is that if you use the Remove button on an existing item, when you save, the underlying chado table is not updated, because this item was removed from the form state.

I fixed this by removing the primary key from the conditions in the `deleteRecords()` function when used on a linker table

This is submitted as draft for discussion of whether my approach is suitable

## Testing?
1. Create two analyses
2. Create a project and link one analysis when creating
3. Edit the project and add the second analysis
4. Edit the project and click the "Remove" button next to the second analysis, and save
5. Edit the project and add the same second analysis
Before, step 5 would crash and burn
