### PR TITLE
Set default for chado storage selector when there is only one option

### DIFF
--- a/tripal/src/Form/TripalEntityPublishForm.php
+++ b/tripal/src/Form/TripalEntityPublishForm.php
@@ -63,6 +63,14 @@ class TripalEntityPublishForm extends FormBase {
         'wrapper' => 'storage-options'
       ],
     ];
+
+    // If there is only one datastore available, set it as the default.
+    if (count($datastores) == 1) {
+      $datastore = array_key_first($datastores);
+      $form_state->setValue('datastore', $datastore);
+      $form['datastore']['#default_value'] = $datastore;
+    }
+
     $form['storage-options'] = [
       '#type' => 'details',
       '#description' => 'Please select a storage backend for additional options.',


### PR DESCRIPTION
# New Feature

### Closes #1922 

### Tripal Version: 4.x

## Description
One simple change for publishing. If there is only one storage backend, which will be the case for the majority of users, then you no longer have to select it from the list (which only contained one option)

## Testing?
 1. You don't even need a new docker or anything, you can just checkout this branch (assuming you only have one storage backend)
 2. Go to Tripal -> Content -> "+ Publish Tripal Content"
 3. You should now see the first two selectors pre-populated with values. Before you had to select the storage backend.
![2024-06-30_default-now-set](https://github.com/tripal/tripal/assets/8419404/d532d5d7-558c-430d-88df-6070fe5ab1a9)
