### PR TITLE
Set default terms for field properties when chado mapping is missing.

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -112,8 +112,8 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       $type_table_def = $schema->getTableDef($type_table, ['format' => 'Drupal']);
       $type_pkey_col = $type_table_def['primary key'];
       $type_fkey_col = array_keys($type_table_def['foreign keys'][$base_table]['columns'])[0];
-      $link_term = $mapping->getColumnTermId($type_table, $type_fkey_col);
-      $value_term = $mapping->getColumnTermId($type_table, 'value');
+      $link_term = $mapping->getColumnTermId($type_table, $type_fkey_col) ?: self::$record_id_term;
+      $value_term = $mapping->getColumnTermId($type_table, 'value') ?: 'NCIT:C25712';
 
       // (e.g., analysisprop.analysisprop_id)
       $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'prop_id', self::$record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -90,10 +90,10 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // from Chado tables if appropriate.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $type_id_term = $mapping->getColumnTermId($type_table, $type_column);
-    $name_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_id_term = $mapping->getColumnTermId($type_table, $type_column) ?: 'rdfs:type';
+    $name_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:name';
     $idspace_term = 'SIO:000067';
-    $accession_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $accession_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
 
     // Always store the record id of the base record that this field is
     // associated with in Chado.
@@ -216,9 +216,9 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // If this is an existing field, retrieve its storage settings.
     $storage_settings = $this->getSetting('storage_plugin_settings');
 
-    $type_table = $storage_settings['type_table'] ?? '';
-    $type_column = $storage_settings['type_column'] ?? '';
-    $type_fkey = $storage_settings['type_fkey'] ?? '';
+    $type_table = $storage_settings['type_table'] ?: '';
+    $type_column = $storage_settings['type_column'] ?: '';
+    $type_fkey = $storage_settings['type_fkey'] ?: '';
 
     // In the form, table and column will be selected together as a single unit
     $type_select = $type_fkey;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -91,20 +91,20 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $name_len = $object_schema_def['fields']['name']['size'];
-    $description_term = $mapping->getColumnTermId($object_table, 'description'); // text
-    $program_term = $mapping->getColumnTermId($object_table, 'program');
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description'; // text
+    $program_term = $mapping->getColumnTermId($object_table, 'program') ?: 'SWO:0000001';
     $program_len = $object_schema_def['fields']['program']['size'];
-    $programversion_term = $mapping->getColumnTermId($object_table, 'programversion');
+    $programversion_term = $mapping->getColumnTermId($object_table, 'programversion') ?: 'IAO:0000129';
     $programversion_len = $object_schema_def['fields']['programversion']['size'];
-    $algorithm_term = $mapping->getColumnTermId($object_table, 'algorithm');
+    $algorithm_term = $mapping->getColumnTermId($object_table, 'algorithm') ?: 'IAO:0000064';
     $algorithm_len = $object_schema_def['fields']['algorithm']['size'];
-    $sourcename_term = $mapping->getColumnTermId($object_table, 'sourcename');
+    $sourcename_term = $mapping->getColumnTermId($object_table, 'sourcename') ?: 'schema:name';
     $sourcename_len = $object_schema_def['fields']['sourcename']['size'];
-    $sourceversion_term = $mapping->getColumnTermId($object_table, 'sourceversion');
+    $sourceversion_term = $mapping->getColumnTermId($object_table, 'sourceversion') ?: 'IAO:0000129';
     $sourceversion_len = $object_schema_def['fields']['sourceversion']['size'];
-    $sourceuri_term = $mapping->getColumnTermId($object_table, 'sourceuri'); // text    
+    $sourceuri_term = $mapping->getColumnTermId($object_table, 'sourceuri') ?: 'data:1047'; // text
     // @todo timeexecuted not yet implemented
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -116,15 +116,15 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -132,7 +132,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -90,31 +90,31 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
-    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
-    $version_term = $mapping->getColumnTermId($object_table, 'version');  // text
-    $array_dimensions_term = $mapping->getColumnTermId($object_table, 'array_dimensions');  // text
-    $element_dimensions_term = $mapping->getColumnTermId($object_table, 'element_dimensions');  // text
-    $num_of_elements_term = $mapping->getColumnTermId($object_table, 'num_of_elements');
-    $num_array_rows_term = $mapping->getColumnTermId($object_table, 'num_array_rows');
-    $num_array_columns_term = $mapping->getColumnTermId($object_table, 'num_array_columns');
-    $num_grid_columns_term = $mapping->getColumnTermId($object_table, 'num_grid_columns');
-    $num_grid_rows_term = $mapping->getColumnTermId($object_table, 'num_grid_rows');
-    $num_sub_columns_term = $mapping->getColumnTermId($object_table, 'num_sub_columns');
-    $num_sub_rows_term = $mapping->getColumnTermId($object_table, 'num_sub_rows');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';  // text
+    $version_term = $mapping->getColumnTermId($object_table, 'version') ?: 'IAO:0000129';  // text
+    $array_dimensions_term = $mapping->getColumnTermId($object_table, 'array_dimensions') ?: 'local:array_dimensions';  // text
+    $element_dimensions_term = $mapping->getColumnTermId($object_table, 'element_dimensions') ?: 'local:element_dimensions';  // text
+    $num_of_elements_term = $mapping->getColumnTermId($object_table, 'num_of_elements') ?: 'local:num_of_elements';
+    $num_array_rows_term = $mapping->getColumnTermId($object_table, 'num_array_rows') ?: 'local:num_array_rows';
+    $num_array_columns_term = $mapping->getColumnTermId($object_table, 'num_array_columns') ?: 'local:num_array_columns';
+    $num_grid_columns_term = $mapping->getColumnTermId($object_table, 'num_grid_columns') ?: 'local:num_grid_columns';
+    $num_grid_rows_term = $mapping->getColumnTermId($object_table, 'num_grid_rows') ?: 'local:num_grid_rows';
+    $num_sub_columns_term = $mapping->getColumnTermId($object_table, 'num_sub_columns') ?: 'local:num_sub_columns';
+    $num_sub_rows_term = $mapping->getColumnTermId($object_table, 'num_sub_rows') ?: 'local:num_sub_rows';
 
     // Columns from linked tables
     // both platformtype and substratetype reference the cvterm table
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'rdfs:type';
     $type_len = $cvterm_schema_def['fields']['name']['size'];
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
-    $manufacturer_term = $mapping->getColumnTermId('contact', 'name');
+    $manufacturer_term = $mapping->getColumnTermId('contact', 'name') ?: 'EFO:0001728';
     $manufacturer_len = $contact_schema_def['fields']['name']['size'];
-    $protocol_term = $mapping->getColumnTermId('protocol', 'name');  // text
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $protocol_term = $mapping->getColumnTermId('protocol', 'name') ?: 'sep:00101';  // text
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'schema:name';
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
@@ -125,15 +125,15 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -141,7 +141,7 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -89,19 +89,19 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
-    $description_term = $mapping->getColumnTermId($object_table, 'description');
-    $arrayidentifier_term = $mapping->getColumnTermId($object_table, 'arrayidentifier');
-    $arraybatchidentifier_term = $mapping->getColumnTermId($object_table, 'arraybatchidentifier');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema_description';
+    $arrayidentifier_term = $mapping->getColumnTermId($object_table, 'arrayidentifier') ?: 'data:0842';
+    $arraybatchidentifier_term = $mapping->getColumnTermId($object_table, 'arraybatchidentifier') ?: 'local:array_batch_identifier';
 
     // Columns from linked tables
-    $arraydesign_term = $mapping->getColumnTermId('arraydesign', 'name');
-    $protocol_term = $mapping->getColumnTermId('protocol', 'name');
+    $arraydesign_term = $mapping->getColumnTermId('arraydesign', 'name') ?: 'schema:name';
+    $protocol_term = $mapping->getColumnTermId('protocol', 'name') ?: 'sep:00101';
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
-    $operator_term = $mapping->getColumnTermId('contact', 'name');
+    $operator_term = $mapping->getColumnTermId('contact', 'name') ?: 'schema:name';
     $operator_len = $contact_schema_def['fields']['name']['size'];
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
@@ -112,15 +112,15 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -128,7 +128,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -88,28 +88,28 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
-    $description_term = $mapping->getColumnTermId($object_table, 'description');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';
 
     // Columns from linked tables
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
     $contact_schema_def = $schema->getTableDef('contact', ['format' => 'Drupal']);
-    $biosourceprovider_term = $mapping->getColumnTermId('contact', 'name');
+    $biosourceprovider_term = $mapping->getColumnTermId('contact', 'name') ?: 'NCIT:C47954';
     $biosourceprovider_len = $contact_schema_def['fields']['name']['size'];
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'local:infraspecific_type';
     $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
     $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
-    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_term = $mapping->getColumnTermId('organism', 'genus') ?: 'TAXRANK:0000005';
     $genus_len = $organism_schema_def['fields']['genus']['size'];
-    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_term = $mapping->getColumnTermId('organism', 'species') ?: 'TAXRANK:0000006';
     $species_len = $organism_schema_def['fields']['species']['size'];
-    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name') ?: 'TAXRANK:0000045';
     $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
-    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation') ?: 'local:abbreviation';
     $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
-    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name') ?: 'NCBITaxon:common_name';
     $common_name_len = $organism_schema_def['fields']['common_name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -121,8 +121,8 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
@@ -136,7 +136,7 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
           if ($column == 'channel_id') {
             continue;
           }
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -144,7 +144,7 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -62,7 +62,7 @@ class ChadoBooleanTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+    $value_term = $mapping->getColumnTermId($base_table, $base_column) ?: 'NCIT:C25712';
 
     return [
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -92,14 +92,14 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
     $terms['object_pkey'] = $terms['record_id'];
     //    - name
-    $terms['name'] = $mappingObj->getColumnTermId($object_table, 'name');
+    $terms['name'] = $mappingObj->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $max_lengths['name'] = $object_schema_def['fields']['name']['size'];
     //    - description
-    $terms['description'] = $mappingObj->getColumnTermId($object_table, 'description');
+    $terms['description'] = $mappingObj->getColumnTermId($object_table, 'description') ?: 'schema:description';
     $max_lengths['description'] = $object_schema_def['fields']['description']['size'];
     //    - contact type
     $cvterm_schema_def = $schemaObj->getTableDef('cvterm', ['format' => 'Drupal']);
-    $terms['contact_type'] = $mappingObj->getColumnTermId('cvterm', 'name');
+    $terms['contact_type'] = $mappingObj->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $max_lengths['contact_type'] = $cvterm_schema_def['fields']['name']['size'];
     // C) LINKING TABLE.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
@@ -109,19 +109,16 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
     $terms['linker_pkey'] = $terms['record_id'];
     //    - left table foreign key
     $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-    $terms['linker_left'] = $mappingObj->getColumnTermId($linker_table, $linker_left_col);
+    $terms['linker_left'] = $mappingObj->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
     //    - right table foreign key
-    $terms['linker_right'] = $mappingObj->getColumnTermId($linker_table, $linker_fkey_column);
+    $terms['linker_right'] = $mappingObj->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
     //    - linking type
-    $terms['linker_type_id'] = $mappingObj->getColumnTermId($linker_table, 'type_id');
+    $terms['linker_type_id'] = $mappingObj->getColumnTermId($linker_table, 'type_id') ?: 'schema:AdditionalType';
     if (empty($terms['linker_type_id'])) {
       $terms['linker_type_id'] = $terms['contact_type'];
     }
     //    - rank
-    $terms['linker_rank'] = $mappingObj->getColumnTermId($linker_table, 'rank');
-    if (empty($terms['linker_rank'])) {
-      $terms['linker_rank'] = 'OBCS:0000117';
-    }
+    $terms['linker_rank'] = $mappingObj->getColumnTermId($linker_table, 'rank') ?: 'OBCS:0000117';
 
     // We need to create a table alias for our linker table in order to ensure
     // contact links with other roles are not combined.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -113,7 +113,7 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
     //    - right table foreign key
     $terms['linker_right'] = $mappingObj->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
     //    - linking type
-    $terms['linker_type_id'] = $mappingObj->getColumnTermId($linker_table, 'type_id') ?: 'schema:AdditionalType';
+    $terms['linker_type_id'] = $mappingObj->getColumnTermId($linker_table, 'type_id') ?: 'schema:additionalType';
     if (empty($terms['linker_type_id'])) {
       $terms['linker_type_id'] = $terms['contact_type'];
     }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -89,14 +89,14 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $name_len = $object_schema_def['fields']['name']['size'];
-    $description_term = $mapping->getColumnTermId($object_table, 'description');
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';
     $description_len = $object_schema_def['fields']['description']['size'];
 
     // Cvterm table, to retrieve the name for the contact type
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $contact_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $contact_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $contact_type_len = $cvterm_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -108,15 +108,15 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -124,7 +124,7 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -90,22 +90,22 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $db_term = $mapping->getColumnTermId($object_table, 'db_id');
-    $accession_term = $mapping->getColumnTermId($object_table, 'accession');
+    $db_term = $mapping->getColumnTermId($object_table, 'db_id') ?: 'ERO:0001716';
+    $accession_term = $mapping->getColumnTermId($object_table, 'accession') ?: 'data:2091';
     $accession_len = $object_schema_def['fields']['accession']['size'];
-    $version_term = $mapping->getColumnTermId($object_table, 'version');
+    $version_term = $mapping->getColumnTermId($object_table, 'version') ?: 'IAO:0000129';
     $version_len = $object_schema_def['fields']['version']['size'];
-    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';  // text
 
     // Columns from linked tables
     $db_schema_def = $schema->getTableDef('db', ['format' => 'Drupal']);
-    $db_name_term = $mapping->getColumnTermId('db', 'name');
+    $db_name_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
     $db_name_len = $db_schema_def['fields']['name']['size'];
-    $db_description_term = $mapping->getColumnTermId('db', 'description');
+    $db_description_term = $mapping->getColumnTermId('db', 'description') ?: 'schema:description';
     $db_description_len = $db_schema_def['fields']['description']['size'];
-    $db_urlprefix_term = $mapping->getColumnTermId('db', 'urlprefix');
+    $db_urlprefix_term = $mapping->getColumnTermId('db', 'urlprefix') ?: 'schema:ItemPage';
     $db_urlprefix_len = $db_schema_def['fields']['urlprefix']['size'];
-    $db_url_term = $mapping->getColumnTermId('db', 'url');
+    $db_url_term = $mapping->getColumnTermId('db', 'url') ?: 'schema:url';
     $db_url_len = $db_schema_def['fields']['url']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -117,15 +117,15 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -133,7 +133,7 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -90,13 +90,13 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $name_len = $object_schema_def['fields']['name']['size'];
-    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';  // text
 
     // Cvterm table, to retrieve the name for the unit type
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $featuremap_unittype_term = $mapping->getColumnTermId('cvterm', 'name');
+    $featuremap_unittype_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'UO:0000000';
     $featuremap_unittype_len = $cvterm_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -108,15 +108,15 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -124,7 +124,7 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -95,33 +95,33 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $name_len = $object_schema_def['fields']['name']['size'];
-    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename'); // text
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename') ?: 'data:0842'; // text
     // residues is not implemented in this field since it can be millions of characters long
-    $seqlen_term = $mapping->getColumnTermId($object_table, 'seqlen');
-    $md5checksum_term = $mapping->getColumnTermId($object_table, 'md5checksum');
+    $seqlen_term = $mapping->getColumnTermId($object_table, 'seqlen') ?: 'data:1249';
+    $md5checksum_term = $mapping->getColumnTermId($object_table, 'md5checksum') ?: 'data:2190';
     $md5checksum_len = $object_schema_def['fields']['md5checksum']['size'];
-    $is_analysis_term = $mapping->getColumnTermId($object_table, 'is_analysis'); // boolean
-    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete'); // boolean
+    $is_analysis_term = $mapping->getColumnTermId($object_table, 'is_analysis') ?: 'local:is_analysis'; // boolean
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete') ?: 'local:is_obsolete'; // boolean
     // @todo timeaccessioned, timelastmodified not yet implemented
 
     // Columns from linked tables
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
     $db_term = $mapping->getColumnTermId('db', 'name');
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $type_len = $cvterm_schema_def['fields']['name']['size'];
     $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
-    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_term = $mapping->getColumnTermId('organism', 'genus') ?: 'TAXRANK:0000005';
     $genus_len = $organism_schema_def['fields']['genus']['size'];
-    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_term = $mapping->getColumnTermId('organism', 'species') ?: 'TAXRANK:0000006';
     $species_len = $organism_schema_def['fields']['species']['size'];
-    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name') ?: 'TAXRANK:0000045';
     $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
-    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation') ?: 'local:abbreviation';
     $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
-    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name') ?: 'TAXRANK:0000045';
     $common_name_len = $organism_schema_def['fields']['common_name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -133,15 +133,15 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -149,7 +149,7 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -108,7 +108,7 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
 
     // Columns from linked tables
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -69,7 +69,7 @@ class ChadoIntegerTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+    $value_term = $mapping->getColumnTermId($base_table, $base_column) ?: 'NCIT:C25712';
 
     return [
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -100,7 +100,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $comment_term = $mapping->getColumnTermId($object_table, 'comment') ?: 'schema:description';
 
     // Other columns specific to this object table
-    $comment_term = $mapping->getColumnTermId($object_table, 'comment');
+    $comment_term = $mapping->getColumnTermId($object_table, 'comment') ?: 'schema:description';
 
     // Cvterm table, to retrieve the name for the organism type
     $cvterm_schema_def = $chado->schema()->getTableDef('cvterm', ['format' => 'Drupal']);

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -87,24 +87,24 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $chado->schema()->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $genus_term = $mapping->getColumnTermId($object_table, 'genus');
+    $genus_term = $mapping->getColumnTermId($object_table, 'genus') ?: 'TAXRANK:0000005';
     $genus_len = $object_schema_def['fields']['genus']['size'];
-    $species_term = $mapping->getColumnTermId($object_table, 'species');
+    $species_term = $mapping->getColumnTermId($object_table, 'species') ?: 'TAXRANK:0000006';
     $species_len = $object_schema_def['fields']['species']['size'];
-    $infraspecific_name_term = $mapping->getColumnTermId($object_table, 'infraspecific_name');
+    $infraspecific_name_term = $mapping->getColumnTermId($object_table, 'infraspecific_name') ?: 'TAXRANK:0000045';
     $infraspecific_name_len = $object_schema_def['fields']['infraspecific_name']['size'];
-    $abbreviation_term = $mapping->getColumnTermId($object_table, 'abbreviation');
+    $abbreviation_term = $mapping->getColumnTermId($object_table, 'abbreviation') ?: 'local:abbreviation';
     $abbreviation_len = $object_schema_def['fields']['abbreviation']['size'];
-    $common_name_term = $mapping->getColumnTermId($object_table, 'common_name');
+    $common_name_term = $mapping->getColumnTermId($object_table, 'common_name') ?: 'NCBITaxon:common_name';
     $common_name_len = $object_schema_def['fields']['common_name']['size'];
-    $comment_term = $mapping->getColumnTermId($object_table, 'comment');
+    $comment_term = $mapping->getColumnTermId($object_table, 'comment') ?: 'schema:description';
 
     // Other columns specific to this object table
     $comment_term = $mapping->getColumnTermId($object_table, 'comment');
 
     // Cvterm table, to retrieve the name for the organism type
     $cvterm_schema_def = $chado->schema()->getTableDef('cvterm', ['format' => 'Drupal']);
-    $infraspecific_type_term = $mapping->getColumnTermId('organism', 'type_id');
+    $infraspecific_type_term = $mapping->getColumnTermId('organism', 'type_id') ?: 'local:infraspecific_type';
     $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
 
     // Scientific name is built from several fields combined with space characters
@@ -120,15 +120,15 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -136,7 +136,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -90,9 +90,9 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
     $name_len = $object_schema_def['fields']['name']['size'];
-    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';  // text
 
     // Linker table, when used, requires specifying the linker table and column.
     // For single hop, in the yaml we support using the usual 'base_table'
@@ -107,15 +107,15 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: seld::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -123,7 +123,7 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -75,10 +75,10 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $link_term = $mapping->getColumnTermId($prop_table, $prop_fk_col);
-    $value_term = $mapping->getColumnTermId($prop_table, 'value');
-    $rank_term = $mapping->getColumnTermId($prop_table, 'rank');
-    $type_id_term = $mapping->getColumnTermId($prop_table, 'type_id');
+    $link_term = $mapping->getColumnTermId($prop_table, $prop_fk_col) ?: self::$record_id_term;
+    $value_term = $mapping->getColumnTermId($prop_table, 'value') ?: 'NCIT:C25712';
+    $rank_term = $mapping->getColumnTermId($prop_table, 'rank') ?: 'OBCS:0000117';
+    $type_id_term = $mapping->getColumnTermId($prop_table, 'type_id') ?: 'schema:additionalType';
 
     // We need to create a table alias for our prop table in order to ensure
     // values of other property types are not combined.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -90,19 +90,19 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');  // text
-    $uri_term = $mapping->getColumnTermId($object_table, 'uri');  // text
-    $protocoldescription_term = $mapping->getColumnTermId($object_table, 'protocoldescription');  // text
-    $hardwaredescription_term = $mapping->getColumnTermId($object_table, 'hardwaredescription');  // text
-    $softwaredescription_term = $mapping->getColumnTermId($object_table, 'softwaredescription');  // text
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';  // text
+    $uri_term = $mapping->getColumnTermId($object_table, 'uri') ?: 'data:1047';  // text
+    $protocoldescription_term = $mapping->getColumnTermId($object_table, 'protocoldescription') ?: 'schema:description';  // text
+    $hardwaredescription_term = $mapping->getColumnTermId($object_table, 'hardwaredescription') ?: 'EFO:0000548';  // text
+    $softwaredescription_term = $mapping->getColumnTermId($object_table, 'softwaredescription') ?: 'SWO:0000001';  // text
 
     // Columns from linked tables
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $protocol_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $protocol_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:aditionalType';
     $protocol_type_len = $cvterm_schema_def['fields']['name']['size'];
-    $pub_title_term = $mapping->getColumnTermId('pub', 'title');
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $pub_title_term = $mapping->getColumnTermId('pub', 'title') ?: 'schema:publication';
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
@@ -113,15 +113,15 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -129,7 +129,7 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -91,30 +91,30 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $title_term = $mapping->getColumnTermId($object_table, 'title'); // text
-    $volumetitle_term = $mapping->getColumnTermId($object_table, 'volumetitle'); // text
-    $volume_term = $mapping->getColumnTermId($object_table, 'volume');
+    $title_term = $mapping->getColumnTermId($object_table, 'title') ?: 'TPUB:0000039'; // text
+    $volumetitle_term = $mapping->getColumnTermId($object_table, 'volumetitle') ?: 'TPUB:0000243'; // text
+    $volume_term = $mapping->getColumnTermId($object_table, 'volume') ?: 'TPUB:0000042';
     $volume_len = $object_schema_def['fields']['volume']['size'];
-    $series_name_term = $mapping->getColumnTermId($object_table, 'series_name');
+    $series_name_term = $mapping->getColumnTermId($object_table, 'series_name') ?: 'TPUB:0000256';
     $series_name_len = $object_schema_def['fields']['series_name']['size'];
-    $issue_term = $mapping->getColumnTermId($object_table, 'issue');
+    $issue_term = $mapping->getColumnTermId($object_table, 'issue') ?: 'TPUB:0000043';
     $issue_len = $object_schema_def['fields']['issue']['size'];
-    $pyear_term = $mapping->getColumnTermId($object_table, 'pyear');
+    $pyear_term = $mapping->getColumnTermId($object_table, 'pyear') ?: 'TPUB:0000059';
     $pyear_len = $object_schema_def['fields']['pyear']['size'];
-    $pages_term = $mapping->getColumnTermId($object_table, 'pages');
+    $pages_term = $mapping->getColumnTermId($object_table, 'pages') ?: 'TPUB:0000044';
     $pages_len = $object_schema_def['fields']['pages']['size'];
-    $miniref_term = $mapping->getColumnTermId($object_table, 'miniref');
+    $miniref_term = $mapping->getColumnTermId($object_table, 'miniref') ?: 'local:miniref';
     $miniref_len = $object_schema_def['fields']['miniref']['size'];
-    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename'); // text
-    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete'); // boolean
-    $publisher_term = $mapping->getColumnTermId($object_table, 'publisher');
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename') ?: 'data:0842'; // text
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete') ?: 'local:is_obsolete'; // boolean
+    $publisher_term = $mapping->getColumnTermId($object_table, 'publisher') ?: 'TPUB:0000244';
     $publisher_len = $object_schema_def['fields']['publisher']['size'];
-    $pubplace_term = $mapping->getColumnTermId($object_table, 'pubplace');
+    $pubplace_term = $mapping->getColumnTermId($object_table, 'pubplace') ?: 'TPUB:0000245';
     $pubplace_len = $object_schema_def['fields']['pubplace']['size'];
 
     // Cvterm table, to retrieve the name for the publication type
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionaType';
     $type_len = $cvterm_schema_def['fields']['name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -125,15 +125,15 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
       $linker_schema_def = $schema->getTableDef($linker_table, ['format' => 'Drupal']);
       $linker_pkey_col = $linker_schema_def['primary key'];
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -141,7 +141,7 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -59,8 +59,8 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum');
-    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
+    $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum') ?: 'data:2190';
+    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen') ?: 'data:1249';
 
     // Get the length of the database fields so we don't go over the size limit.
     $chado = \Drupal::service('tripal_chado.database');

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -72,19 +72,19 @@ class ChadoSequenceCoordinatesDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
 
-    $ft_uniqname_term = $mapping->getColumnTermId('feature', 'name');
+    $ft_uniqname_term = $mapping->getColumnTermId('feature', 'name') ?: 'schema_name';
 
-    $feature_id_term = $mapping->getColumnTermId('featureloc', 'feature_id');
-    $srcfeature_id_term = $mapping->getColumnTermId('featureloc', 'srcfeature_id');
-    $fmin_term = $mapping->getColumnTermId('featureloc', 'fmin');
-    $is_fmin_partial_term = $mapping->getColumnTermId('featureloc', 'is_fmin_partial');
-    $fmax_term = $mapping->getColumnTermId('featureloc', 'fmax');
-    $is_fmax_partial_term = $mapping->getColumnTermId('featureloc', 'is_fmax_partial');
-    $strand_term = $mapping->getColumnTermId('featureloc', 'strand');
-    $phase_term = $mapping->getColumnTermId('featureloc', 'phase');
-    $residue_info_term = $mapping->getColumnTermId('featureloc', 'residue_info');
-    $locgroup_term = $mapping->getColumnTermId('featureloc', 'locgroup');
-    $rank_term = $mapping->getColumnTermId('featureloc', 'rank');
+    $feature_id_term = $mapping->getColumnTermId('featureloc', 'feature_id') ?: 'SO:0000110';
+    $srcfeature_id_term = $mapping->getColumnTermId('featureloc', 'srcfeature_id') ?: 'data:3002';
+    $fmin_term = $mapping->getColumnTermId('featureloc', 'fmin') ?: 'local:fmin';
+    $is_fmin_partial_term = $mapping->getColumnTermId('featureloc', 'is_fmin_partial') ?: 'local:is_fmin_partial';
+    $fmax_term = $mapping->getColumnTermId('featureloc', 'fmax') ?: 'local:fmax';
+    $is_fmax_partial_term = $mapping->getColumnTermId('featureloc', 'is_fmax_partial') ?: 'local:is_fmax_partial';
+    $strand_term = $mapping->getColumnTermId('featureloc', 'strand') ?: 'data:0853';
+    $phase_term = $mapping->getColumnTermId('featureloc', 'phase') ?: 'data:2336';
+    $residue_info_term = $mapping->getColumnTermId('featureloc', 'residue_info') ?: 'local:residue_info';
+    $locgroup_term = $mapping->getColumnTermId('featureloc', 'locgroup') ?: 'local:locgroup';
+    $rank_term = $mapping->getColumnTermId('featureloc', 'rank') ?: 'OBCS:0000117';
 
     // Get property terms using Chado table columns they map to. Return the properties for this field.
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -60,7 +60,7 @@ class ChadoSequenceLengthTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
+    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen') ?: 'data:1249';
 
     // Return the properties for this field.
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -61,9 +61,9 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $residues_term = $mapping->getColumnTermId('feature', 'residues');
-    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen');
-    $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum');
+    $residues_term = $mapping->getColumnTermId('feature', 'residues') ?: 'data:2044';
+    $seqlen_term = $mapping->getColumnTermId('feature', 'seqlen') ?: 'data:1249';
+    $md5checksum_term = $mapping->getColumnTermId('feature', 'md5checksum') ?: 'data:2190';
 
     // Return the properties for this field.
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -63,9 +63,9 @@ class ChadoSourceDataTypeDefault extends ChadoFieldItemBase {
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
 
-    $src_uri_term = $mapping->getColumnTermId('analysis', 'sourceuri');
-    $src_name_term = $mapping->getColumnTermId('analysis', 'sourcename');
-    $src_vers_term = $mapping->getColumnTermId('analysis', 'sourceversion');
+    $src_uri_term = $mapping->getColumnTermId('analysis', 'sourceuri') ?: 'data:1047';
+    $src_name_term = $mapping->getColumnTermId('analysis', 'sourcename') ?: 'schema:name';
+    $src_vers_term = $mapping->getColumnTermId('analysis', 'sourceversion') ?: 'IAO:0000129';
 
     // Get property terms using Chado table columns they map to. Return the properties for this field.
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -91,29 +91,29 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
     $object_table = self::$object_table;
     $object_schema_def = $schema->getTableDef($object_table, ['format' => 'Drupal']);
     $object_pkey_col = $object_schema_def['primary key'];
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
-    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename');  // text
-    $description_term = $mapping->getColumnTermId($object_table, 'description');  // text
-    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete');  // boolean
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
+    $uniquename_term = $mapping->getColumnTermId($object_table, 'uniquename') ?: 'data:0842';  // text
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';  // text
+    $is_obsolete_term = $mapping->getColumnTermId($object_table, 'is_obsolete') ?: 'local:is_obsolete';  // boolean
 
     // Columns from linked tables
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
     $db_term = $mapping->getColumnTermId('db', 'name');
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
-    $stock_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $stock_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $stock_type_len = $cvterm_schema_def['fields']['name']['size'];
-    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name');
+    $infraspecific_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'local:infraspecific_type';
     $infraspecific_type_len = $cvterm_schema_def['fields']['name']['size'];
     $organism_schema_def = $schema->getTableDef('organism', ['format' => 'Drupal']);
-    $genus_term = $mapping->getColumnTermId('organism', 'genus');
+    $genus_term = $mapping->getColumnTermId('organism', 'genus') ?: 'TAXRANK:0000005';
     $genus_len = $organism_schema_def['fields']['genus']['size'];
-    $species_term = $mapping->getColumnTermId('organism', 'species');
+    $species_term = $mapping->getColumnTermId('organism', 'species') ?: 'TAXRANK:0000006';
     $species_len = $organism_schema_def['fields']['species']['size'];
-    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name');
+    $infraspecific_name_term = $mapping->getColumnTermId('organism', 'infraspecific_name') ?: 'TAXRANK:0000045';
     $infraspecific_name_len = $organism_schema_def['fields']['infraspecific_name']['size'];
-    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation');
+    $abbreviation_term = $mapping->getColumnTermId('organism', 'abbreviation') ?: 'local:abbreviation';
     $abbreviation_len = $organism_schema_def['fields']['abbreviation']['size'];
-    $common_name_term = $mapping->getColumnTermId('organism', 'common_name');
+    $common_name_term = $mapping->getColumnTermId('organism', 'common_name') ?: 'NCBITaxon:common_name';
     $common_name_len = $organism_schema_def['fields']['common_name']['size'];
 
     // Linker table, when used, requires specifying the linker table and column.
@@ -125,15 +125,15 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -141,7 +141,7 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -98,7 +98,7 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
 
     // Columns from linked tables
     $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
     $cvterm_schema_def = $schema->getTableDef('cvterm', ['format' => 'Drupal']);
     $stock_type_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:additionalType';
     $stock_type_len = $cvterm_schema_def['fields']['name']['size'];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -108,7 +108,7 @@ class ChadoStringTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+    $value_term = $mapping->getColumnTermId($base_table, $base_column) ?: 'NCIT:C25712';
 
     return [
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -89,14 +89,14 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
     $object_pkey_col = $object_schema_def['primary key'];
 
     // Columns specific to the object table
-    $name_term = $mapping->getColumnTermId($object_table, 'name');
-    $description_term = $mapping->getColumnTermId($object_table, 'description');
+    $name_term = $mapping->getColumnTermId($object_table, 'name') ?: 'schema:name';
+    $description_term = $mapping->getColumnTermId($object_table, 'description') ?: 'schema:description';
 
     // Columns from linked tables
-    $contact_term = $mapping->getColumnTermId('contact', 'name');
-    $pub_title_term = $mapping->getColumnTermId('pub', 'title');
-    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession');
-    $db_term = $mapping->getColumnTermId('db', 'name');
+    $contact_term = $mapping->getColumnTermId('contact', 'name') ?: 'NCIT:C47954';
+    $pub_title_term = $mapping->getColumnTermId('pub', 'title') ?: 'schema:publication';
+    $dbxref_term = $mapping->getColumnTermId('dbxref', 'accession') ?: 'data:2091';
+    $db_term = $mapping->getColumnTermId('db', 'name') ?: 'ERO:0001716';
 
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
@@ -107,15 +107,15 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
       $linker_pkey_col = $linker_schema_def['primary key'];
       // the following should be the same as $base_pkey_col @todo make sure it is
       $linker_left_col = array_keys($linker_schema_def['foreign keys'][$base_table]['columns'])[0];
-      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col);
-      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
+      $linker_left_term = $mapping->getColumnTermId($linker_table, $linker_left_col) ?: self::$record_id_term;
+      $linker_fkey_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
 
       // Some but not all linker tables contain rank, type_id, and maybe other columns.
       // These are conditionally added only if they exist in the linker
       // table, and if a term is defined for them.
       foreach (array_keys($linker_schema_def['fields']) as $column) {
         if (($column != $linker_pkey_col) and ($column != $linker_left_col) and ($column != $linker_fkey_column)) {
-          $term = $mapping->getColumnTermId($linker_table, $column);
+          $term = $mapping->getColumnTermId($linker_table, $column) ?: 'NCIT:C25712';
           if ($term) {
             $extra_linker_columns[$column] = $term;
           }
@@ -123,7 +123,7 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
       }
     }
     else {
-      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column);
+      $linker_fkey_term = $mapping->getColumnTermId($base_table, $linker_fkey_column) ?: self::$record_id_term;
     }
 
     $properties = [];

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -142,17 +142,17 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
     $mapping = $storage->load('core_mapping');
 
     // Synonym table fields
-    $syn_name_term = $mapping->getColumnTermId('synonym', 'name');
+    $syn_name_term = $mapping->getColumnTermId('synonym', 'name') ?: 'schema:name';
     $syn_name_len = $synonym_table_def['fields']['name']['size'];
-    $syn_type_id_term = $mapping->getColumnTermId('synonym', 'type_id');
+    $syn_type_id_term = $mapping->getColumnTermId('synonym', 'type_id') ?: 'schema:additionalType';
     $syn_type_name_len = $cvterm_table_def['fields']['name']['size'];
 
     // Synonym linker table fields
-    $linker_fkey_id_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column);
-    $linker_synonym_id_term = $mapping->getColumnTermId($linker_table, 'synonym_id');
-    $linker_is_current_term = $mapping->getColumnTermId($linker_table, 'is_current');
-    $linker_is_internal_term = $mapping->getColumnTermId($linker_table, 'is_internal');
-    $linker_pub_id_term = $mapping->getColumnTermId($linker_table, 'pub_id');
+    $linker_fkey_id_term = $mapping->getColumnTermId($linker_table, $linker_fkey_column) ?: self::$record_id_term;
+    $linker_synonym_id_term = $mapping->getColumnTermId($linker_table, 'synonym_id') ?: 'schema:alternateName';
+    $linker_is_current_term = $mapping->getColumnTermId($linker_table, 'is_current') ?: 'local:is_current';
+    $linker_is_internal_term = $mapping->getColumnTermId($linker_table, 'is_internal') ?: 'local:is_internal';
+    $linker_pub_id_term = $mapping->getColumnTermId($linker_table, 'pub_id') ?: 'schema:publication';
 
     // Always store the record id of the base record that this field is
     // associated with in Chado.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -63,7 +63,7 @@ class ChadoTextTypeDefault extends ChadoFieldItemBase {
     // Get the property terms by using the Chado table columns they map to.
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $value_term = $mapping->getColumnTermId($base_table, $base_column);
+    $value_term = $mapping->getColumnTermId($base_table, $base_column) ?: 'NCIT:C25712';
 
     return [
       new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -70,8 +70,8 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
 
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
     $mapping = $storage->load('core_mapping');
-    $unittype_id_term = $mapping->getColumnTermId('featuremap', 'unittype_id');
-    $cv_name_term = $mapping->getColumnTermId('cvterm', 'name');
+    $unittype_id_term = $mapping->getColumnTermId('featuremap', 'unittype_id') ?: 'UO:0000000';
+    $cv_name_term = $mapping->getColumnTermId('cvterm', 'name') ?: 'schema:name';
 
     $properties = [];
 


### PR DESCRIPTION
# Bug Fix

### Issue #1939 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Many field properties do not have defaults set for when chado mapping is not present. This causes field addition to fail whenever the column doesn't exist in the chado mapping. Instead this PR add a default for all properties and then if chado mapping provides a more specific term, we use it.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Start a new Tripaldocker container
2. Add a type_id to the project table so that we have a column without a chado mapping.
```
docker exec CONTAINERNAME drush sql:query "ALTER TABLE chado.project ADD COLUMN type_id bigint"
docker exec CONTAINERNAME drush sql:query "ALTER TABLE chado.project ADD FOREIGN KEY (type_id) REFERENCES chado.cvterm (cvterm_id) ON DELETE SET NULL;"
```
3. Update the chado schema yaml to ensure Tripal knows about this field. This is needed due to the bug mentioned in issue #1936. Apply the following patch to tripal_chado/chado_schema/chado_schema-1.3.yml.
```diff
diff --git a/tripal_chado/chado_schema/chado_schema-1.3.yml b/tripal_chado/chado_schema/chado_schema-1.3.yml
index 7f482d32f..a73cb9c9d 100644
--- a/tripal_chado/chado_schema/chado_schema-1.3.yml
+++ b/tripal_chado/chado_schema/chado_schema-1.3.yml
@@ -4898,6 +4898,13 @@ project:
     description:
       type: text
       not null: FALSE
+    type_id:
+      type: integer
+  foreign keys:
+    cvterm:
+      table: cvterm
+      columns:
+        type_id: cvterm_id
   unique keys:
     project_c1: name
   primary key: project_id
```
4. Clear the cache using `drush cr`
5. Now in the UI, go to Tripal > Page Structure > Project > Manage Fields in the administrative toolbar.
6. Click on "Create a new field" and add a label of "type", select "Chado Fields", then "Chado Integer Field Type" and click Continue.
7. Thanks to the changes in step 2/3 you now see a "type_id" in the "table column" drop down. Select it and set a term for the field such as "rdfs:type".
8. On 4.x you will now see a WSOD and error message as indicated in the linked issue. On this branch the field will add without error.
9. Now create a project page and confirm the page saves without error and that you can set the type_id :-)
