### PR TITLE
Make sure the contact widget/formatter know they are compatible with both fields

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoContactFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoContactFormatterDefault.php
@@ -13,7 +13,8 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
  *   label = @Translation("Chado contact formatter"),
  *   description = @Translation("A chado contact formatter"),
  *   field_types = {
- *     "chado_contact_type_default"
+ *     "chado_contact_type_default",
+ *     "chado_contact_by_role_type_default"
  *   },
  *   valid_tokens = {
  *     "[name]",

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -14,7 +14,8 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
  *   label = @Translation("Chado Contact Widget"),
  *   description = @Translation("The default contact widget."),
  *   field_types = {
- *     "chado_contact_type_default"
+ *     "chado_contact_type_default",
+ *     "chado_contact_by_role_type_default"
  *   }
  * )
  */


### PR DESCRIPTION

# Bug Fix

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Simple fix that adds the Contact by role field to the supported fields for the contact widget + formatter.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This is such a small change I don't know that its worth the effort to test manually as it's not straightforward. 

Essentially if you create contact by role fields via the YAML without this fix then you see the following on the form manage and display manage pages. These fields are automatically disabled because Drupal doesn't know what compatible widget/formatters there are and the drop down to select one is empty. This does not happen if you add the field through the UI.

<img width="1040" alt="Screenshot 2024-08-02 at 10 36 25 AM" src="https://github.com/user-attachments/assets/20b8fc0d-45b4-42f0-a8ad-e8ce87d018f6">

With this PR, you can add them via the YAML and they are correctly enabled with the supported contact widget/formatter.