### PR TITLE
regex fix for issue #1945

### DIFF
--- a/.github/workflows/PR-branchNameCheck.yml
+++ b/.github/workflows/PR-branchNameCheck.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
       - uses: deepakputhraya/action-branch-name@v1.0.0
         with:
-          regex: 'tv4g[0-9]-(issue){0,1}\d+-{0,1}\w*' # Regex the branch should match. 
+          regex: 'tv4g\d+-(issue){0,1}\d+-{0,1}\w*' # Regex the branch should match. 
           ignore: 4.x # Ignore exactly matching branch names from convention


### PR DESCRIPTION
# Bug Fix

### Closes #1945

### Tripal Version: 4.x 

## Description
This allows using group 10 in a branch name, for example
`tv4g10-issue1925-gff-importer-use-buddy`
in PR #1944 


## Testing?
This can only be tested by automated testing. To do so, I made the branch number for this PR to be two digits
`tv4g09-issue1945-branch-regex`

If you see this, it is working as intended
![20240808pass](https://github.com/user-attachments/assets/25638e4a-0b91-4239-92d4-16e9bcad0945)
