### PR TITLE
Handle inline template and link for HTML replacements in the title

### DIFF
--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -627,15 +627,28 @@ function tripal_form_field_config_edit_form_alter(&$form, \Drupal\Core\Form\Form
  */
 function tripal_preprocess_field(&$variables) {
   if ($variables['element']['#field_name'] == 'title') {
+    // We can configure which tags are allowed at /admin/tripal/config
+    $tag_string = \Drupal::config('tripal.settings')->get('tripal_entity_type.allowed_title_tags');
+    $tripal_allowed_tags = explode(' ', $tag_string ?? '');
+
+    // Now for each item (usually only a single one)...
     foreach ($variables['items'] as $delta => $item) {
-      $value = $item['content']['#context']['value'];
-      // Convert strings into markup, this will cause HTML tags to be rendered.
-      if (is_string($value)) {
-        // We can configure which tags are allowed at /admin/tripal/config
-        $tag_string = \Drupal::config('tripal.settings')->get('tripal_entity_type.allowed_title_tags');
-        $tripal_allowed_tags = explode(' ', $tag_string ?? '');
-        $sanitized_value = Xss::filter($value, $tripal_allowed_tags);
-        $variables['items'][$delta]['content']['#context']['value'] = Drupal\Core\Render\Markup::create($sanitized_value);
+      // The title can be either a simple inline template or a link.
+      if ($item['content']['#type'] == 'inline_template') {
+        $value = $item['content']['#context']['value'];
+        // Convert strings into markup, this will cause HTML tags to be rendered.
+        if (is_string($value)) {
+          $sanitized_value = Xss::filter($value, $tripal_allowed_tags);
+          $variables['items'][$delta]['content']['#context']['value'] = Drupal\Core\Render\Markup::create($sanitized_value);
+        }
+      }
+      elseif ($item['content']['#type'] == 'link') {
+        $value = $item['content']['#title']['#context']['value'];
+        // Convert strings into markup, this will cause HTML tags to be rendered.
+        if (is_string($value)) {
+          $sanitized_value = Xss::filter($value, $tripal_allowed_tags);
+          $variables['items'][$delta]['content']['#title']['#context']['value'] = Drupal\Core\Render\Markup::create($sanitized_value);
+        }
       }
     }
   }


### PR DESCRIPTION

# Bug Fix

### Issue #1964 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
PR https://github.com/tripal/tripal/pull/1878 implemented `hook_preprocess_field` to preprocess the title field to allow it to render HTML tags in the title. Unfortunately this implementation made an assumption that turns out not to be true when you embed one entity inside another and the title of the embedded entity is a link 🙈 This is a bit of a pain to configure to demonstrate the issue...

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Go to Tripal > Page Structure > Project > Manage fields and add a new field by clicking "Create a new field".
2. Choose "Reference" as the type, add a label (e.g. "Organism") and choose "Other" for the type of content this field will reference.
3. In the field/storage settings, choose "Tripal Content" as the "Type of item to reference", select "Organism" under Tripal Content Type" and set a term.
  ![image](https://github.com/user-attachments/assets/13977c07-8f76-4b95-ad66-afd31807f5d0)
4. Then go to "Manage Display" for the project content type, and change the "Format" to "Rendered Entity" for the organism field you added.
5. Next, go to "Manage Display" for the organism content type, click the gear beside the title and select "Link to the Tripal Content". Save these changes.
6. Now that you've added/configured this field, create an organism page by going to Tripal > Content > "Add Tripal Content" > Organism. The values for your organism do not matter.
7. Then create a project that references that organism by going to Tripal > Content > "Add Tripal Content" > Project, filling out the name with some html tags and choose the organism you created previously for the "Organism" field. 
  ![image](https://github.com/user-attachments/assets/f438af96-8301-417a-a4ab-f42faa93d4e1)
8. When you view the project page, on this branch, you will see both the titles changed appropriately. On the 4.x branch you will see an error.

### On this branch
![image](https://github.com/user-attachments/assets/5a7ecdd7-71e1-42ab-83fe-5862648581fe)

### On 4.x
![image](https://github.com/user-attachments/assets/4f946fe4-9ba9-42bf-9943-7e3b8f718606)