### PR TITLE
configurable mechanism for hiding fields when they have an "empty" value

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -392,6 +392,14 @@ field.formatter.settings.*:
       type: string
       label: 'Field suffix'
       nullable: true
+    hide_condition:
+      type: string
+      label: 'Hide condition'
+      nullable: true
+    hide_value:
+      type: string
+      label: 'Hide value'
+      nullable: true
     thousand_separator:
       type: string
       label: 'Thousand marker'

--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -330,6 +330,14 @@ tripal.tripalfield_collection.*:
                                type: string
                                label: 'Field suffix'
                                nullable: true
+                             hide_condition:
+                               type: string
+                               label: 'Hide condition'
+                               nullable: true
+                             hide_value:
+                               type: string
+                               label: 'Hide value'
+                               nullable: true
                    form:
                      type: sequence
                      label: 'Edit'

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -561,8 +561,9 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
 
           // Keep track of elements that have no value.
-          foreach ($prop_values as $prop_value) {
-            if (!$prop_value->getValue()) {
+          foreach ($prop_values as $i => $prop_value) {
+            $prop_value_value = $prop_value->getValue();
+            if (is_null($prop_value_value)) {
               // A given delta should only be present once here.
               if (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name])) {
                 $delta_remove[$field_name][] = $delta;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
@@ -27,6 +27,7 @@ class DefaultTripalBooleanTypeFormatter extends TripalFormatterBase {
     $settings = parent::defaultSettings();
     $settings['true_string'] = t('True');
     $settings['false_string'] = t('False');
+    $settings['hide_condition'] = '';
     return $settings;
   }
 
@@ -36,11 +37,14 @@ class DefaultTripalBooleanTypeFormatter extends TripalFormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $true_string = $this->getSetting('true_string');
     $false_string = $this->getSetting('false_string');
+    $hide_condition = $this->getSetting('hide_condition') ?? '';
     $elements = [];
 
     foreach($items as $delta => $item) {
-      $value = $item->get("value")->getValue();
-      if (!is_null($value) and strlen($value)) {
+      $value = $item->get("value")->getValue() ?? '';
+      $hide = ((($hide_condition == 'if_true') and $value)
+            or (($hide_condition == 'if_false') and !$value));
+      if (!$hide) {
         $elements[$delta] = [
           "#markup" => $value ? $true_string : $false_string,
         ];
@@ -73,6 +77,16 @@ class DefaultTripalBooleanTypeFormatter extends TripalFormatterBase {
       '#default_value' => $this->getSetting('false_string'),
       '#required' => TRUE,
       '#element_validate' => [[static::class, 'settingsFormValidateBoolean']],
+    ];
+    $form['hide_condition'] = [
+      '#title' => $this->t('You may provide a condition when the field is not displayed'),
+      '#type' => 'radios',
+      '#options' => [
+        '' => $this->t('Never hide'),
+        'if_true' => $this->t('Hide if TRUE'),
+        'if_false' => $this->t('Hide if FALSE'),
+      ],
+      '#default_value' => $this->getSetting('hide_condition') ?? '',
     ];
 
     return $form;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
@@ -46,8 +46,8 @@ class DefaultTripalIntegerTypeFormatter extends TripalFormatterBase {
 
     foreach($items as $delta => $item) {
       $value = $item->get("value")->getValue() ?? '';
-      $hide = ((($hide_condition == 'if_value') and ($value == $hide_value))
-            or (($hide_condition == 'if_zero') and !$value));
+      $hide = ((($hide_condition == '') and !$value)
+           or (($hide_condition == 'if_value') and ($value == $hide_value)));
       if (!$hide) {
         if (strlen($value) and strlen($thousand_separator)) {
           // For an integer we can hardcode the unused decimal setting to 0
@@ -95,9 +95,9 @@ class DefaultTripalIntegerTypeFormatter extends TripalFormatterBase {
       '#title' => $this->t('You may provide a condition when the field is not displayed'),
       '#type' => 'radios',
       '#options' => [
-        '' => $this->t('Never hide'),
-        'if_zero' => $this->t('Hide if zero'),
+        '' => $this->t('Hide if zero'),
         'if_value' => $this->t('Hide if equal to a specific value'),
+        'never_hide' => $this->t('Never hide'),
       ],
       '#default_value' => $this->getSetting('hide_condition') ?? '',
     ];

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
@@ -28,6 +28,8 @@ class DefaultTripalIntegerTypeFormatter extends TripalFormatterBase {
     $settings['field_prefix'] = '';
     $settings['field_suffix'] = '';
     $settings['thousand_separator'] = '';
+    $settings['hide_condition'] = '';
+    $settings['hide_value'] = '';
     return $settings;
   }
 
@@ -39,12 +41,16 @@ class DefaultTripalIntegerTypeFormatter extends TripalFormatterBase {
     $field_prefix = $this->getSetting('field_prefix');
     $field_suffix = $this->getSetting('field_suffix');
     $thousand_separator = $this->getSetting('thousand_separator');
+    $hide_condition = $this->getSetting('hide_condition') ?? '';
+    $hide_value = $this->getSetting('hide_value') ?? '';
 
     foreach($items as $delta => $item) {
-      $value = $item->get("value")->getValue();
-      if (!is_null($value) and strlen($value)) {
-        if (strlen($thousand_separator)) {
-          // For an integer we can hardcode the unused decimal setting
+      $value = $item->get("value")->getValue() ?? '';
+      $hide = ((($hide_condition == 'if_value') and ($value == $hide_value))
+            or (($hide_condition == 'if_zero') and !$value));
+      if (!$hide) {
+        if (strlen($value) and strlen($thousand_separator)) {
+          // For an integer we can hardcode the unused decimal setting to 0
           $value = number_format(floatval($value), 0, '.', $thousand_separator);
         }
         $elements[$delta] = [
@@ -83,6 +89,23 @@ class DefaultTripalIntegerTypeFormatter extends TripalFormatterBase {
       '#description' => $this->t('Character to display every three digits'),
       '#type' => 'textfield',
       '#default_value' => $this->getSetting('thousand_separator'),
+      '#required' => FALSE,
+    ];
+    $form['hide_condition'] = [
+      '#title' => $this->t('You may provide a condition when the field is not displayed'),
+      '#type' => 'radios',
+      '#options' => [
+        '' => $this->t('Never hide'),
+        'if_zero' => $this->t('Hide if zero'),
+        'if_value' => $this->t('Hide if equal to a specific value'),
+      ],
+      '#default_value' => $this->getSetting('hide_condition') ?? '',
+    ];
+    $form['hide_value'] = [
+      '#title' => $this->t('Specific value to be hidden'),
+      '#description' => $this->t('A value that you do not want displayed, e.g. "0" or "-1"'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('hide_value') ?? '',
       '#required' => FALSE,
     ];
 

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
@@ -27,6 +27,8 @@ class DefaultTripalStringTypeFormatter extends TripalFormatterBase {
     $settings = parent::defaultSettings();
     $settings['field_prefix'] = '';
     $settings['field_suffix'] = '';
+    $settings['hide_condition'] = '';
+    $settings['hide_value'] = '';
     return $settings;
   }
 
@@ -38,10 +40,14 @@ class DefaultTripalStringTypeFormatter extends TripalFormatterBase {
 
     $field_prefix = $this->getSetting('field_prefix');
     $field_suffix = $this->getSetting('field_suffix');
+    $hide_condition = $this->getSetting('hide_condition') ?? '';
+    $hide_value = $this->getSetting('hide_value') ?? '';
 
     foreach($items as $delta => $item) {
-      $value = $item->get('value')->getString();
-      if (!is_null($value) and strlen($value)) {
+      $value = $item->get('value')->getString() ?? '';
+      $hide = ((($hide_condition == 'if_value') and ($value == $hide_value))
+            or (($hide_condition == '') and !strlen($value)));
+      if (!$hide) {
         $elements[$delta] = [
           "#markup" => $field_prefix . $value . $field_suffix,
         ];
@@ -71,6 +77,23 @@ class DefaultTripalStringTypeFormatter extends TripalFormatterBase {
                      . ' value. This may include HTML for formatting, <em>e.g.</em> for italics use &lt;/em&gt;'),
       '#type' => 'textfield',
       '#default_value' => $this->getSetting('field_suffix'),
+      '#required' => FALSE,
+    ];
+    $form['hide_condition'] = [
+      '#title' => $this->t('You may provide a condition when the field is not displayed'),
+      '#type' => 'radios',
+      '#options' => [
+        '' => $this->t('Hide if empty'),
+        'never' => $this->t('Never hide'),
+        'if_value' => $this->t('Hide if empty or equal to a specific value'),
+      ],
+      '#default_value' => $this->getSetting('hide_condition') ?? '',
+    ];
+    $form['hide_value'] = [
+      '#title' => $this->t('Specific value to be hidden'),
+      '#description' => $this->t('A value that you do not want displayed, e.g. "N/A" for a string, or "0" for a number'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('hide_value') ?? '',
       '#required' => FALSE,
     ];
 

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -23,29 +23,43 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['field_prefix'] = '';
+    $settings['field_suffix'] = '';
+    $settings['hide_condition'] = '';
+    $settings['hide_value'] = '';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
-    // Default filter format.
-    $filter_format = 'basic_html';
+    $field_prefix = $this->getSetting('field_prefix');
+    $field_suffix = $this->getSetting('field_suffix');
+    $hide_condition = $this->getSetting('hide_condition') ?? '';
+    $hide_value = $this->getSetting('hide_value') ?? '';
 
-    // We need to get the format which was set in the widget settings
-    // because they need to match.
+    // We need to get the filter format which is set in the widget settings
+    // because widget and formatter must match.
     $entity_type = $this->fieldDefinition->get('entity_type');
     $bundle = $this->fieldDefinition->get('bundle');
-    $field_name = $this->fieldDefinition->get('field_name');
     $form_display = \Drupal::service('entity_display.repository')->getFormDisplay($entity_type, $bundle);
+    $field_name = $this->fieldDefinition->get('field_name');
     $widget = $form_display->getComponent($field_name);
-    if (array_key_exists('filter_format', $widget['settings'])) {
-      $filter_format = $widget['settings']['filter_format'];
-    }
+    $filter_format = $widget['settings']['filter_format'] ?? 'basic_html';
 
     foreach($items as $delta => $item) {
-      $value_string = $item->get('value')->getValue();
-      if (!is_null($value_string) and strlen($value_string)) {
+      $value = $item->get('value')->getValue() ?? '';
+      $hide = ((($hide_condition == 'if_value') and ($value == $hide_value))
+            or (($hide_condition == '') and !strlen($value)));
+      if (!$hide) {
         $elements[$delta] = [
           '#type' => 'processed_text',
-          '#text' => $value_string,
+          '#text' => $value,
           '#format' => $filter_format,
           '#langcode' => $item->getLangcode(),
         ];
@@ -53,5 +67,57 @@ class DefaultTripalTextTypeFormatter extends TripalFormatterBase {
     }
 
     return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['field_prefix'] = [
+      '#title' => $this->t('Text to display before the field value'),
+      '#description' => $this->t('Enter text here that will be displayed before the'
+                     . ' field value, or leave blank for no additional text'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_prefix'),
+      '#required' => FALSE,
+    ];
+    $form['field_suffix'] = [
+      '#title' => $this->t('Text to display after the field value'),
+      '#description' => $this->t('Enter text here that will be displayed after the'
+                     . ' field value, or leave blank for no additional text'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('field_suffix'),
+      '#required' => FALSE,
+    ];
+    $form['hide_condition'] = [
+      '#title' => $this->t('You may provide a condition when the field is not displayed'),
+      '#type' => 'radios',
+      '#options' => [
+        '' => $this->t('Hide if empty'),
+        'never' => $this->t('Never hide'),
+        'if_value' => $this->t('Hide if empty or equal to a specific value'),
+      ],
+      '#default_value' => $this->getSetting('hide_condition') ?? '',
+    ];
+    $form['hide_value'] = [
+      '#title' => $this->t('Specific value to be hidden'),
+      '#description' => $this->t('A value that you do not want displayed, e.g. "N/A" for a string, or "0" for a number'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('hide_value') ?? '',
+      '#required' => FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $summary[] = $this->t('Set display format');
+    return $summary;
   }
 }


### PR DESCRIPTION
# New Feature

### Closes #1970 

### Tripal Version: 4.x

## Description
This PR provides a configurable mechanism for hiding fields when they have an "empty" value.
For text fields this would generally be an empty string, for integer fields it might be zero or -1,
for boolean fields it might be FALSE.
Being configurable, however, we can specify some other value, for example, there is a CV term `no_rank` that can be used for the infraspecific type on an organism, and we might want to hide that.

## Testing?
Note - because the change in commit https://github.com/tripal/tripal/pull/1971/commits/44d3dce11e1e6120560e95e524976541cc63a774 could have unintended consequences, I recommend putting a `dpm()` in `tripal/src/Entity/TripalEntity.php` line 566 so we know when the change is having an effect, do this after step 5 below
```
          // Keep track of elements that have no value.
          foreach ($prop_values as $i => $prop_value) {
            $prop_value_value = $prop_value->getValue();
if (!$prop_value_value and !is_null($prop_value_value)) {
  dpm($prop_value_value, "This value would have been removed in 4.x for field $field_name delta $delta");
}
            if (is_null($prop_value_value)) {
              // A given delta should only be present once here.
              if (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name])) {
                $delta_remove[$field_name][] = $delta;
              }
              continue;
            }
          }
```
1. Build docker on `4.x` branch
2. Import type collection "Expression Content Types"
3. Enter a publication (tests text, string, and boolean (Is Obsolete) fields). Only enter required fields, leave others blank.
![2024-09-13_pub1](https://github.com/user-attachments/assets/f939c284-e707-4d25-a5db-ada64abe99b8)
4. Enter an array design which has lots of integer fields. Enter various values including zero, and leave some blank.
![2024-09-13_ad1](https://github.com/user-attachments/assets/f9e11864-1b6e-4269-9e77-94ed87ec8e07)
5. Checkout this branch `git checkout tv4g1-issue1970-hide-field-configuration` and make the `dpm()` addition described above
6. Clear cache just to be safe `docker exec -it CONTAINERNAME /bin/bash -c "drush cache:rebuild"`
6. View the publication, it should appear the same as before by default.
7. Try changing some of the settings Tripal -> Page Structure -> Publication -> Manage display
for example 
- series name change to "Never Hide"
- change the "Is Obsolete" as shown here to not display if FALSE
![2024-09-13_pub3](https://github.com/user-attachments/assets/e944900d-b96d-4ae4-95f6-193e144c6ed9)
- Unique local identifier change to "Hide if empty or equal to a specific value" and for the value use what you entered.
![2024-09-13_pub4](https://github.com/user-attachments/assets/29092bd0-a3d6-4cc9-ab0c-10e9dceeaa20)
- Don't forget to hit save
8. Note that Series name now appears even though it has no value, and Unique local identifier is hidden.
![2024-09-13_pub2](https://github.com/user-attachments/assets/09ba81dd-5686-4ed8-8655-79a5f591f861)
9. For array design, change the settings for an integer field containing a zero to not be displayed
These are the test values I used
![1970_AD0](https://github.com/user-attachments/assets/5fd2a243-e2ee-43b6-966a-0bc9a67d1c14)
![2024-09-13_ad2](https://github.com/user-attachments/assets/6be9cb43-156c-4452-a1af-039a74d9370c)
10. Change the settings for an integer field containing a specific value to not be displayed
![2024-09-13_ad3](https://github.com/user-attachments/assets/22012948-099e-42c1-870b-d0417726c81c)
11. View the array design to confirm they are no longer displayed
![2024-09-13_ad4](https://github.com/user-attachments/assets/2c3efe11-49b8-4dcc-99ab-1a8cce4c5202)
12. Add a **Tripal** boolean field to some simple content type, for example contact.
13. Create a contact each with true and false
14. On 4.x the false value will not appear, because it is not stored in the drupal field table. On this branch it will be present.
15. Similarly test a tripal integer field and enter the value zero. On 4.x it will not be there, on this branch it will. This should be the only time that the dpm we added triggers
![1970_dpm](https://github.com/user-attachments/assets/d3398ec3-624f-431e-8f11-91a9e54c7f6c)
![1970_tripalfieldsfalse](https://github.com/user-attachments/assets/49450935-dfd9-42cc-b8e9-6c80ddfae5b3)
16. Unpublish and republish to make sure that works correctly.
😬 Null integers are published as zero. This is not related to this PR but is a new issue #1972
