### PR TITLE
Publish update - no drupal records when no chado records

### DIFF
--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -304,7 +304,7 @@ class TripalEntityTypeForm extends EntityForm {
    * @param object $tripal_entity_type
    *
    * @return array
-   *   The list of valid tokens
+   *   The list of valid tokens for URLs, and the list of valid tokens for entity titles.
    */
   protected function getValidTokens($tripal_entity_type) {
     $url_tokens = $tripal_entity_type->getTokens();
@@ -316,6 +316,17 @@ class TripalEntityTypeForm extends EntityForm {
   }
 
   /**
+   * Validate that all tokens present in a passed string are valid.
+   * A token is anything enclosed in square brackets [xxx].
+   *
+   * @param string $format_string
+   *   The string to be validated containing any number of tokens.
+   * @param array $valid_tokens
+   *   A list of valid tokens. The token is the array key.
+   *
+   * @return string
+   *   An empty string if all tokens are valid, otherwise return
+   *   the first invalid token found.
    */
   protected function validateTokens($format_string, $valid_tokens) {
     $invalid_token = '';

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -331,9 +331,9 @@ class TripalEntityTypeForm extends EntityForm {
   protected function validateTokens($format_string, $valid_tokens) {
     $invalid_token = '';
     preg_match_all('/(\[[^\]]+\])/', $format_string, $matches);
-    foreach ($matches as $match) {
-      if ($match and !array_key_exists($match[0], $valid_tokens)) {
-        $invalid_token = $match[0];
+    foreach ($matches[0] as $match) {
+      if ($match and !array_key_exists($match, $valid_tokens)) {
+        $invalid_token = $match;
         break;
       }
     }

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -135,12 +135,6 @@ class TripalEntityTypeForm extends EntityForm {
       '#title' => t('Advanced Settings'),
     );
 
-    $tokens = $tripal_entity_type->getTokens();
-    $title_tokens = $tokens;
-    unset($title_tokens['[title]']);
-    unset($title_tokens['[TripalBundle__bundle_id]']);
-    unset($title_tokens['[TripalEntity__entity_id]']);
-
     // Page title options:
     $form['title_settings'] = [
       '#type' => 'details',
@@ -151,7 +145,7 @@ class TripalEntityTypeForm extends EntityForm {
     $form['title_settings']['msg'] = [
       '#type' => 'item',
       '#markup' => t('
-<p>The format below is used to determine the title displayed on content pages of the current type. This ensures all content of this type is consistent while still allowing you to indicate which data you want represented in the title (ie: which data would most identify your content).</p>
+<p>The format below is used to determine the title displayed on content pages of the current type. This ensures all content of this type is consistent while still allowing you to indicate which data you want represented in the title (i.e.: which data would most identify your content).</p>
 
 <p>Keep in mind that it might be confusing to users if more than one page has the same title. <strong>We recommend you choose a combination of tokens that will uniquely identify your content</strong>.</p>'),
     ];
@@ -172,6 +166,7 @@ class TripalEntityTypeForm extends EntityForm {
       '#markup' => 'Copy the token and paste it into the "Page Title Format" text field above.'
     ];
 
+    $title_tokens = $this->getTitleTokens($tripal_entity_type);
     $form['title_settings']['tokens']['content'] =
       theme_token_list($title_tokens);
 
@@ -283,6 +278,23 @@ class TripalEntityTypeForm extends EntityForm {
       $form_state->setErrorByName('term',
           'Please select a term from the autocomplete drop-down. It must have the ID space and accession in parenthesis.');
     }
+  }
+
+  /**
+   * Returns an array of valid tokens that may be used in an entity title.
+   *
+   * @param object $tripal_entity_type
+   *
+   * @return array
+   *   The list of valid tokens
+   */
+  protected function getTitleTokens($tripal_entity_type) {
+    $tokens = $tripal_entity_type->getTokens();
+    $title_tokens = $tokens;
+    unset($title_tokens['[title]']);
+    unset($title_tokens['[TripalBundle__bundle_id]']);
+    unset($title_tokens['[TripalEntity__entity_id]']);
+    return $title_tokens;
   }
 
   /**

--- a/tripal/src/Services/TripalPublish.php
+++ b/tripal/src/Services/TripalPublish.php
@@ -1014,7 +1014,7 @@ class TripalPublish {
     $this->addNonRequiredValues($search_values);
 
     $this->logger->notice("Step  1 of 6: Find matching records... ");
-    $matches = $this->storage->findValues($search_values, ['check_valid' => FALSE]);
+    $matches = $this->storage->findValues($search_values);
 
     $this->logger->notice("Step  2 of 6: Generate page titles...");
     $titles = $this->getEntityTitles($matches);

--- a/tripal/src/Services/TripalTokenParser.php
+++ b/tripal/src/Services/TripalTokenParser.php
@@ -236,18 +236,19 @@ class TripalTokenParser {
         elseif (in_array($token, array_keys($this->fields))) {
           $field = $this->fields[$token];
           $key = $field->mainPropertyName();
+          $value = NULL;
           if (array_key_exists($token, $this->values)) {
-            $value = @$this->values[$token][$key];
-            if (!is_null($value)) {
-              $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
-            }
-            else {
-              // If the value is null then we remove the token.
-              $replaced[$index] = trim(preg_replace("/\[$token\]/", '',  $replaced[$index]));
-            }
+            $value = $this->values[$token][$key] ?? NULL;
           }
-          // If we get here then this is a field related token but the token
-          // value wasn't set with addFieldValue() method. Leave the token as-is.
+          if (!is_null($value)) {
+            $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
+          }
+          else {
+            // A token value may be missing either because there is no value, or
+            // because there is a typo in the token. In any case, remove the token.
+            // @todo add validation when editing title tokens to prevent the latter case.
+            $replaced[$index] = trim(preg_replace("/\[$token\]/", '',  $replaced[$index]));
+          }
         }
       }
     }

--- a/tripal/tests/src/Functional/Services/TripalTokenParserTest.php
+++ b/tripal/tests/src/Functional/Services/TripalTokenParserTest.php
@@ -470,8 +470,9 @@ class TripalTokenParserTest extends TripalTestBrowserBase {
       '[organism_genus] [organism_species] [organism_infraspecific_type] [organism_infraspecific_name]'
     ]);
     $this->assertTrue(count($replaced) == 2, 'TripalTokenParser::replaceTokens() should have returned only two replaced string');
-    $this->assertTrue($replaced[0] == 'Oryza sativa', 'TripalTokenParser did not return a correctly replaced string when multiple were provided..');
-    $this->assertTrue($replaced[1] == 'Oryza sativa [organism_infraspecific_type] [organism_infraspecific_name]', 'TripalTokenParser did not return unparsed tokens in the input string.');
+    $this->assertTrue($replaced[0] == 'Oryza sativa', 'TripalTokenParser did not return a correctly replaced string when multiple were provided.');
+    // As of PR#1977 tokens with no value are removed
+    $this->assertTrue($replaced[1] == 'Oryza sativa', 'TripalTokenParser did not remove unparsed tokens in the input string.');
 
     $token_parser->addFieldValue('organism_infraspecific_type', 'value', '');
     $replaced = $token_parser->replaceTokens([

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -138,22 +138,27 @@ class ChadoAdditionalTypeWidgetDefault extends ChadoWidgetBase {
 
     $idSpace_manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     foreach ($values as $delta => $item) {
-       $matches = [];
-       $values[$delta]['type_id'] = NULL;
-       if (preg_match('/(.+?)\(([^\(]+?):(.+?)\)/', $item['term_autoc'], $matches)) {
-         $termIdSpace = $matches[2];
-         $termAccession = $matches[3];
+      if ($item['term_autoc']) {
+        $matches = [];
+        $values[$delta]['type_id'] = NULL;
+        if (preg_match('/(.+?)\(([^\(]+?):(.+?)\)/', $item['term_autoc'], $matches)) {
+          $termIdSpace = $matches[2];
+          $termAccession = $matches[3];
 
-         /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term **/
-         $idSpace = $idSpace_manager->loadCollection($termIdSpace);
-         $term = $idSpace->getTerm($termAccession);
-         $cvterm_id = $term->getInternalId();
-         $values[$delta]['type_id'] = $cvterm_id;
-         $values[$delta]['value'] = $term->getName();
-         $values[$delta]['term_name'] = $term->getName();
-         $values[$delta]['id_space'] = $term->getIdSpace();
-         $values[$delta]['accession'] = $term->getAccession();
-       }
+          /** @var \Drupal\tripal\TripalVocabTerms\TripalTerm $term **/
+          $idSpace = $idSpace_manager->loadCollection($termIdSpace);
+          $term = $idSpace->getTerm($termAccession);
+          $cvterm_id = $term->getInternalId();
+          $values[$delta]['type_id'] = $cvterm_id;
+          $values[$delta]['value'] = $term->getName();
+          $values[$delta]['term_name'] = $term->getName();
+          $values[$delta]['id_space'] = $term->getIdSpace();
+          $values[$delta]['accession'] = $term->getAccession();
+        }
+      }
+      else {
+        unset($values[$delta]);
+      }
     }
     return $values;
   }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -342,7 +342,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   /**
    * @{inheritdoc}
    */
-  public function findValues($values, $options = []) {
+  public function findValues($values) {
 
     // Setup field debugging.
     $this->field_debugger->printHeader('Find');
@@ -402,14 +402,12 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           // Now set the values.
           $this->setPropValues($new_values, $match);
 
-          // Remove any values that are not valid. This is omitted for publish.
-          if ($options['check_valid'] ?? TRUE) {
-            foreach ($new_values as $field_name => $deltas) {
-              foreach ($deltas as $delta => $properties) {
-                $is_valid = $this->isFieldValid($field_name, $delta, $new_values);
-                if (!$is_valid) {
-                  unset($new_values[$field_name][$delta]);
-                }
+          // Remove any values that are not valid.
+          foreach ($new_values as $field_name => $deltas) {
+            foreach ($deltas as $delta => $properties) {
+              $is_valid = $this->isFieldValid($field_name, $delta, $new_values);
+              if (!$is_valid) {
+                unset($new_values[$field_name][$delta]);
               }
             }
           }

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -449,13 +449,14 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         ['record_id' => $organism_id2],
         ['bundle' => 'organism', 'entity_id' => 2, 'value' => '']);
 
-    $this->checkFieldItem('organism', 'organism_infraspecific_name', 1,
+    // We expect no infraspecies here, so expected count is zero
+    $this->checkFieldItem('organism', 'organism_infraspecific_name', 0,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => 2, 'value' => '']);
+        []);
 
-    $this->checkFieldItem('organism', 'organism_infraspecific_type', 1,
+    $this->checkFieldItem('organism', 'organism_infraspecific_type', 0,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => 2, 'type_id' => 0]);
+        []);
 
     //
     // Test publishing properties.


### PR DESCRIPTION
# Bug Fix
### Closes #1972 

### Tripal Version: 4.x

## Description
As described in the linked issue #1972, integer fields with no value in chado are getting published as zero.

I had been blindly assuming that entities entered manually through the GUI were the "correct" example of how the Drupal field tables should look. While mostly correct, I have realized that the ChadoAdditionalType widget behaves differently, and does not remove empty values as the other widgets do. This meant that publish was leaving out this field, while GUI entered entities included a blank field (field title but no value). Realizing that this should be changed makes the changes here easier.

I have made several changes here:
1. I reverted changes to `findValues()`, so as before, any value deemed as "invalid" is removed. That means, if any required field is NULL then it is invalid. 
2. I updated the ChadoAdditionalType widget to, as other widgets do, remove from the `$values` array any record that is "empty". In this case that means if there is no accession.
3. This would break the title for organism, since the infraspecific type might be null. I changed the tripal token parser so that a token with no value is _always_ removed. This removes the "feedback" if you enter an invalid token, it is just silently removed. However, I think this would be better handed by validation back when you enter content title tokens, rather than later seeing you have fat thumbs and have to go back and fix, ~~so as of the posting of this PR this validation still needs to be added to `tripal/src/Form/TripalEntityTypeForm.php`~~
4. This token validation has been added

## Testing?
1. Redo the testing from PR #1952
2. Redo the steps from issue #1972
