### PR TITLE
Update ChadoProperty Text widget to support filtered HTML

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -403,3 +403,6 @@ field.widget.settings.*:
     filter_format:
       type: string
       label: 'Filter format for a filtered text field'
+    num_rows:
+      type: integer
+      label: 'Number of Rows to display in the text widget'

--- a/tripal/tests/src/Traits/TripalTestTrait.php
+++ b/tripal/tests/src/Traits/TripalTestTrait.php
@@ -99,7 +99,7 @@ trait TripalTestTrait {
    * @return TripalTerm
    *   Returns the tripal term that was created.
    */
-  public function createTripalTerm($values, $idspace_plugin_id, $vocab_plugin_id) {
+  public function createTripalTerm(&$values, $idspace_plugin_id, $vocab_plugin_id) {
 
     // Setting the default values:
     $random = $this->getRandomGenerator();
@@ -122,6 +122,7 @@ trait TripalTestTrait {
       $vocabulary = $vmanager->createCollection($values['vocab_name'], $vocab_plugin_id);
       $this->assertInstanceOf(TripalVocabularyInterface::class, $vocabulary, "Unable to create the Vocabulary.");
     }
+    $this->assertInstanceOf(TripalVocabularyInterface::class, $vocabulary, "Unable to load the Vocabulary.");
 
     // Create the ID Space.
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
@@ -131,13 +132,13 @@ trait TripalTestTrait {
       $this->assertInstanceOf(TripalIdSpaceInterface::class, $idSpace, "Unable to create the ID Space.");
       $idSpace->setDefaultVocabulary($vocabulary->getName());
     }
-
+    $this->assertInstanceOf(TripalIdSpaceInterface::class, $idSpace, "Unable to load the ID Space.");
 
     $term = $idSpace->getTerm($values['term']['accession']);
     if (!$term) {
       // Now create the term.
-      $values['term']['idSpace'] = $idSpace->getName();
-      $values['term']['vocabulary'] = $vocabulary->getName();
+      $values['term']['idSpace'] = $values['id_space_name'];
+      $values['term']['vocabulary'] = $values['vocab_name'];
       $term = new TripalTerm($values['term']);
       $this->assertInstanceOf(TripalTerm::class, $term, "Unable to create the term object.");
       // and save it to the ID Space.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
@@ -28,15 +28,34 @@ class ChadoPropertyFormatterDefault extends ChadoFormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    // Default filter format.
+    $filter_format = 'basic_html';
+
+    // We need to get the format which was set in the widget settings
+    // because they need to match.
+    // Note: the default filter is used when the widget does not support
+    // filter formats (i.e. String and Select widgets).
+    $entity_type = $this->fieldDefinition->get('entity_type');
+    $bundle = $this->fieldDefinition->get('bundle');
+    $field_name = $this->fieldDefinition->get('field_name');
+    $form_display = \Drupal::service('entity_display.repository')->getFormDisplay($entity_type, $bundle);
+    $widget = $form_display->getComponent($field_name);
+    if (array_key_exists('filter_format', $widget['settings'])) {
+      $filter_format = $widget['settings']['filter_format'];
+    }
+
     $list = [];
     foreach($items as $delta => $item) {
-      $value = $item->get('value')->getString();
+      $value = $item->get('value')->getValue();
       // any URLs are made into clickable links
       if (UrlHelper::isExternal($value)) {
         $value = Link::fromTextAndUrl($value, Url::fromUri($value))->toString();
       }
       $list[$delta] = [
-        '#markup' => $value,
+        '#type' => 'processed_text',
+        '#text' => $value,
+        '#format' => $filter_format,
+        '#langcode' => $item->getLangcode(),
       ];
     }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -7,6 +7,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\core\Field\FieldDefinitionInterface;
 
 /**
  * Plugin implementation of Tripal linker property field type.
@@ -44,6 +45,23 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
     // for this field based on the fixed value.
     $settings['fixed_value'] = FALSE;
     return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
+    $values = [];
+
+    $random = new \Drupal\Component\Utility\Random();
+    $values['record_id'] = 1;
+    $values['prop_id'] = 1;
+    $values['link_id'] = 1;
+    $values['value'] = 'fred';
+    $values['type_id'] = 4;
+    $values['rank'] = 0;
+
+    return $values;
   }
 
   /**

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -56,7 +56,7 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
     $random = new \Drupal\Component\Utility\Random();
     $values['record_id'] = 1;
     $values['prop_id'] = 1;
-    $values['link_id'] = 1;
+    $values['linker_id'] = 1;
     $values['value'] = 'fred';
     $values['type_id'] = 4;
     $values['rank'] = 0;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -98,8 +98,12 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
     // We do this because any changes here are not actually saved and thus
     // having it enabled is misleading.
     // Note: We couldn't disable it or the text format element would stop working ;-)
+    // This loops through the delta.
     foreach (\Drupal\Core\Render\Element::children($element) as $key) {
-      $element[$key]['value']['format']['#attributes']['class'][] = 'hidden';
+      // We only want to change the text_format subelement.
+      if (array_key_exists('value', $element[$key]) && array_key_exists('format', $element[$key]['value'])) {
+        $element[$key]['value']['format']['#attributes']['class'][] = 'hidden';
+      }
     }
 
     return $element;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -74,7 +74,7 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
       '#type' => 'text_format',
       '#format' => $this->getSetting('filter_format'),
       '#default_value' => $default_value,
-      '#rows' => 5,
+      '#rows' => $this->getSetting('num_rows'),
       '#required' => $required,
     ];
     $elements['rank'] = [
@@ -135,6 +135,7 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
   public static function defaultSettings() {
     return [
       'filter_format' => 'basic_html',
+      'num_rows' => 3,
     ] + parent::defaultSettings();
   }
 
@@ -148,6 +149,16 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
     foreach (filter_formats() as $name => $object) {
       $options[$name] = $object->get('name');
     }
+
+    $element['num_rows'] = [
+      '#type' => 'number',
+      '#title' => t('Number of Rows'),
+      '#description' => t('Indicate the number of lines to display in the widget by default. A larger number will make for a longer textarea.'),
+      '#required' => TRUE,
+      '#default_value' => $this->getSetting('num_rows'),
+      '#min' => 1,
+      '#max' => 100,
+    ];
 
     $element['filter_format'] = [
       '#type' => 'select',
@@ -176,7 +187,10 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
     $all_formats = filter_formats();
     $format_label = $all_formats[$format]->get('name');
 
+    $num_rows = $this->getSetting('num_rows');
+
     $summary[] = $this->t("Text Format: @format", ['@format' => $format_label]);
+    $summary[] = $this->t("Number of Rows: @rows", ['@rows' => $num_rows]);
 
     return $summary;
   }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -29,7 +29,8 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
     // Get the field settings.
     $field_definition = $items[$delta]->getFieldDefinition();
     $field_settings = $field_definition->getSettings();
-    $field_name = $items->getFieldDefinition()->get('field_name');
+    $field_name = $field_definition->get('field_name');
+    $required = $field_definition->get('required');
 
     // Get the default values.
     $item_vals = $items[$delta]->getValue();
@@ -69,12 +70,12 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
       '#default_value' => $field_name,
     ];
     $elements['value'] = $element + [
-      '#type' => 'textarea',
+      '#base_type' => 'textarea',
+      '#type' => 'text_format',
+      '#format' => $this->getSetting('filter_format'),
       '#default_value' => $default_value,
-      '#title' => '',
-      '#description' => '',
-      '#rows' => '',
-      '#required' => FALSE,
+      '#rows' => 5,
+      '#required' => $required,
     ];
     $elements['rank'] = [
       '#type' => 'value',
@@ -88,9 +89,32 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public static function afterBuild(array $element, FormStateInterface $form_state) {
+    parent::afterBuild($element, $form_state);
+
+    // Alter the format drop down so that it is hidden.
+    // We do this because any changes here are not actually saved and thus
+    // having it enabled is misleading.
+    // Note: We couldn't disable it or the text format element would stop working ;-)
+    foreach (\Drupal\Core\Render\Element::children($element) as $key) {
+      $element[$key]['value']['format']['#attributes']['class'][] = 'hidden';
+    }
+
+    return $element;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+
+    // The text_format element returns an item consisting of both a value and a
+    // format. We only want to keep the format.
+    foreach ($values as $key => $item) {
+      $values[$key]['value'] = $item['value']['value'];
+    }
 
     // Look up the rank term
     $storage = \Drupal::entityTypeManager()->getStorage('chado_term_mapping');
@@ -103,5 +127,57 @@ class ChadoPropertyWidgetDefault extends ChadoWidgetBase {
     $values = $this->massagePropertyFormValues('value', $values, $form_state, $rank_term, 'prop_id');
 
     return $values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'filter_format' => 'basic_html',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+
+    // Get all the filter formats available for the current site.
+    $options = [];
+    foreach (filter_formats() as $name => $object) {
+      $options[$name] = $object->get('name');
+    }
+
+    $element['filter_format'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Text Filter Format'),
+      '#options' => $options,
+      '#description' => $this->t("Select the text filter format you want applied
+        to this field. Everyone will use the same format. If a user does not have
+        permission to the format chosen for this field then they won't be able to
+        edit it. Please keep in mind there are security concerns with choosing
+        'full_html' and thus this should only be your choice if you have
+        restricted all people able to edit this field to those you trust."),
+      '#default_value' => $this->getSetting('filter_format'),
+      '#required' => TRUE,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $format = $this->getSetting('filter_format');
+    $all_formats = filter_formats();
+    $format_label = $all_formats[$format]->get('name');
+
+    $summary[] = $this->t("Text Format: @format", ['@format' => $format_label]);
+
+    return $summary;
   }
 }

--- a/tripal_chado/tests/src/Functional/Plugin/Fields/CreateEditFieldForms/BasicDataTypeChadoFieldTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/Fields/CreateEditFieldForms/BasicDataTypeChadoFieldTest.php
@@ -70,61 +70,53 @@ class BasicDataTypeChadoFieldTest extends ChadoTestBrowserBase {
 
     // Create the Tripal Terms we need.
     // -- SIO:000729
-    $this->createTripalTerm([
+    $term_details = [
       'vocab_name' => 'SIO',
       'id_space_name' => 'SIO',
       'term' => [
         'name' => 'record identifier',
         'definition' => 'A record identifier is an identifier for a database entry.',
         'accession' =>'000729',
-      ]],
-      'chado_id_space', 'chado_vocabulary'
-    );
-    $this->createTripalTerm([
+      ]
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
+    $term_details = [
       'vocab_name' => 'SO',
       'id_space_name' => 'SO',
       'term' => [
         'name' => 'sequence_feature',
         'definition' => 'Any extent of continuous biological sequence.',
         'accession' => '0000110',
-        ]
-      ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
-    $this->createTripalTerm([
+      ]
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
+    $term_details = [
       'vocab_name' => 'local',
       'id_space_name' => 'local',
       'term' => [
         'name' => 'is_analysis',
         'accession' => 'is_analysis',
-        ]
-      ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
-    $this->createTripalTerm([
+      ]
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
+    $term_details = [
       'vocab_name' => 'schema',
       'id_space_name' => 'schema',
       'term' => [
         'name' => 'name',
         'accession' => 'name',
-        ]
-      ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
-    $this->createTripalTerm([
+      ]
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
+    $term_details = [
       'vocab_name' => 'edam',
       'id_space_name' => 'data',
       'term' => [
         'name' => 'Identifier',
         'accession' => '0842',
-        ]
-      ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
+      ]
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
   }
 
   /**

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeCRUDTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeCRUDTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\tripal_chado\Kernel\ChadoField\FieldType;
 
-use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
-use Drupal\Tests\tripal\Traits\TripalFieldTestTrait;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Traits\ChadoFieldTestTrait;
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\tripal\Entity\TripalEntity;
@@ -16,12 +16,19 @@ use Drupal\Core\Form\FormState;
  * @group TripalField
  * @group ChadoField
  */
-class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
+class ChadoPropertyTypeCRUDTest extends ChadoTestKernelBase {
   protected $defaultTheme = 'stark';
 
   protected static $modules = ['system', 'user', 'field', 'tripal', 'tripal_chado'];
 
-  use TripalFieldTestTrait;
+  use ChadoFieldTestTrait;
+
+  /**
+   * The test chado connection. It is also set in the container.
+   *
+   * @var ChadoConnection
+   */
+  protected object $chado_connection;
 
   /**
    * Details for the field type to test.
@@ -31,8 +38,59 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
    *   field type id for the field being tested.
    */
   protected array $field_type = [
-    'class' => 'ChadoPropertyTypeDefault',
+    'class' => 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPropertyTypeDefault',
     'id' => 'chado_property_type_default'
+  ];
+
+  protected array $property_type_terms = [
+    'record_id' => [
+      'key' => 'record_id',
+      'vocab_name' => 'SIO',
+      'id_space_name' => 'SIO',
+      'term' => [
+        'accession' => '000729',
+      ]
+    ],
+    'prop_id' => [
+      'key' => 'prop_id',
+      'vocab_name' => 'SIO',
+      'id_space_name' => 'SIO',
+      'term' => [
+        'accession' => '000729',
+      ],
+    ],
+    'linker_id' => [
+      'key' => 'linker_id',
+      'vocab_name' => 'SIO',
+      'id_space_name' => 'SIO',
+      'term' => [
+        'accession' => '000729',
+      ],
+    ],
+    'value' => [
+      'key' => 'value',
+      'vocab_name' => 'ncit',
+      'id_space_name' => 'NCIT',
+      'term' => [
+        'accession' => 'C25712',
+      ],
+    ],
+    'rank' => [
+      'key' => 'rank',
+      'vocab_name' => 'OBCS',
+      'id_space_name' => 'OBCS',
+      'term' => [
+        'accession' => '0000117',
+      ],
+    ],
+    'type_id' => [
+      'key' => 'type_id',
+      'vocab_name' => 'schema',
+      'id_space_name' => 'schema',
+      'term' => [
+        'accession' => 'additionalType',
+      ],
+    ],
   ];
 
   /**
@@ -46,15 +104,15 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
    */
   protected array $widgets = [
     'long_text' => [
-      'class' => 'ChadoPropertyWidgetDefault',
+      'class' => 'Drupal\tripal_chado\Plugin\Field\FieldWidget\ChadoPropertyWidgetDefault',
       'id' => 'chado_property_type_default',
     ],
     'short_text' => [
-      'class' => 'ChadoPropertyStringWidgetDefault',
+      'class' => 'Drupal\tripal_chado\Plugin\Field\FieldWidget\ChadoPropertyStringWidgetDefault',
       'id' => 'chado_property_string_widget_default',
     ],
     'select' => [
-      'class' => 'ChadoPropertySelectWidgetDefault',
+      'class' => 'Drupal\tripal_chado\Plugin\Field\FieldWidget\ChadoPropertySelectWidgetDefault',
       'id' => 'chado_property_string_widget_default',
     ],
   ];
@@ -70,7 +128,7 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
    */
   protected array $formatters = [
     'ul_list' => [
-      'class' => 'ChadoPropertyFormatterDefault',
+      'class' => 'Drupal\tripal_chado\Plugin\Field\FieldFormatter\ChadoPropertyFormatterDefault',
       'id' => 'chado_property_formatter_default',
     ],
   ];
@@ -81,7 +139,12 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
   protected function setUp(): void {
     parent::setUp();
 
+    // Get Chado in place
+    $this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+
+    // Prepare kernel environment for field testing.
     $this->setupFieldTestEnvironment();
+
   }
 
   /**
@@ -91,8 +154,10 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
 
     // Setup the field to be tested based on the data provider values.
     $field_name = $this->randomMachineName();
+
     $fieldConfig = $this->createFieldInstance(
       'tripal_entity',
+      $this->property_type_terms,
       [
         'field_name' => $field_name,
         'field_type' => $this->field_type['id'],
@@ -102,20 +167,20 @@ class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
 
     // Create an entity with a specific value for this field
     // -- use the sample value generating to get a value for this field.
-    $field_value = $field_type['class']::generateSampleValue($fieldConfig);
+    $field_value = $this->field_type['class']::generateSampleValue($fieldConfig);
     $this->assertIsArray($field_value,
-      "The ".$field_type['class']."::generateSampleValue() method for this field type did not return a valid value.");
+      "The ".$this->field_type['class']."::generateSampleValue() method for this field type did not return a valid value.");
     // -- create the entity with that value set
     $entity = TripalEntity::create([
       'title' => $this->randomString(),
       'type' => $this->TripalEntityType->getID(),
       $field_name => $field_value,
     ]);
-    $this->assertInstanceOf(TripalEntity::class, $entity, "We were not able to create a piece of tripal content to test our " . $field_type['id'] . " field.");
+    $this->assertInstanceOf(TripalEntity::class, $entity, "We were not able to create a piece of tripal content to test our " . $this->field_type['id'] . " field.");
     // -- confirm the values in the created entity match those we set.
     foreach ($field_value as $property_key => $expected_property_value) {
       $this->assertEquals($expected_property_value, $entity->{$field_name}->{$property_key},
         "The value of the property $property_key was not what we expected for this field.");
-    }
+      }
   }
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeCRUDTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeCRUDTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\tripal_chado\Kernel\ChadoField\FieldType;
+
+use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use Drupal\Tests\tripal\Traits\TripalFieldTestTrait;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\tripal\Entity\TripalEntity;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\Core\Form\FormState;
+
+/**
+ * Tests the ChadoPropertyTypeDefault Field Type.
+ *
+ * @group TripalField
+ * @group ChadoField
+ */
+class ChadoPropertyTypeCRUDTest extends TripalTestKernelBase {
+  protected $defaultTheme = 'stark';
+
+  protected static $modules = ['system', 'user', 'field', 'tripal', 'tripal_chado'];
+
+  use TripalFieldTestTrait;
+
+  /**
+   * Details for the field type to test.
+   *
+   * @var array
+   *   contains the keys 'class' and 'id' which indicate the class name and
+   *   field type id for the field being tested.
+   */
+  protected array $field_type = [
+    'class' => 'ChadoPropertyTypeDefault',
+    'id' => 'chado_property_type_default'
+  ];
+
+  /**
+   * Details for the field widgets valid to be used with the $field_type.
+   *
+   * @var array
+   *   A list of widgets supported by the field type. Each item in the list is
+   *   and array with the keys 'class' and 'id' which indicate the class name and
+   *   field widget id for that specific widget. The key of the list is a short
+   *   name indicating that specific widget.
+   */
+  protected array $widgets = [
+    'long_text' => [
+      'class' => 'ChadoPropertyWidgetDefault',
+      'id' => 'chado_property_type_default',
+    ],
+    'short_text' => [
+      'class' => 'ChadoPropertyStringWidgetDefault',
+      'id' => 'chado_property_string_widget_default',
+    ],
+    'select' => [
+      'class' => 'ChadoPropertySelectWidgetDefault',
+      'id' => 'chado_property_string_widget_default',
+    ],
+  ];
+
+  /**
+   * Details for the field formatters valid to be used with the $field_type.
+   *
+   * @var array
+   *   A list of formatters supported by the field type. Each item in the list is
+   *   and array with the keys 'class' and 'id' which indicate the class name and
+   *   field formatter id for that specific formatter. The key of the list is
+   *   a short name indicating that specific formatter.
+   */
+  protected array $formatters = [
+    'ul_list' => [
+      'class' => 'ChadoPropertyFormatterDefault',
+      'id' => 'chado_property_formatter_default',
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->setupFieldTestEnvironment();
+  }
+
+  /**
+   * This method tests that we can create an entity with multiple property fields.
+   */
+  public function testCreateEntityWithField() {
+
+    // Setup the field to be tested based on the data provider values.
+    $field_name = $this->randomMachineName();
+    $fieldConfig = $this->createFieldInstance(
+      'tripal_entity',
+      [
+        'field_name' => $field_name,
+        'field_type' => $this->field_type['id'],
+        'formatter_id' => $this->formatters['ul_list']['id'],
+      ]
+    );
+
+    // Create an entity with a specific value for this field
+    // -- use the sample value generating to get a value for this field.
+    $field_value = $field_type['class']::generateSampleValue($fieldConfig);
+    $this->assertIsArray($field_value,
+      "The ".$field_type['class']."::generateSampleValue() method for this field type did not return a valid value.");
+    // -- create the entity with that value set
+    $entity = TripalEntity::create([
+      'title' => $this->randomString(),
+      'type' => $this->TripalEntityType->getID(),
+      $field_name => $field_value,
+    ]);
+    $this->assertInstanceOf(TripalEntity::class, $entity, "We were not able to create a piece of tripal content to test our " . $field_type['id'] . " field.");
+    // -- confirm the values in the created entity match those we set.
+    foreach ($field_value as $property_key => $expected_property_value) {
+      $this->assertEquals($expected_property_value, $entity->{$field_name}->{$property_key},
+        "The value of the property $property_key was not what we expected for this field.");
+    }
+  }
+}

--- a/tripal_chado/tests/src/Kernel/Services/TripalPublishServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalPublishServiceTest.php
@@ -81,32 +81,27 @@ class TripalPublishServiceTest extends ChadoTestKernelBase {
     }
 
     // Create terms for organism_dbxref since it seems to be missing.
-    $this->createTripalTerm(
-      [
-        'vocab_name' => 'sbo',
-        'id_space_name' => 'SBO',
-        'term' => [
-          'name' => 'reference annotation',
-          'definition' => 'Additional information that supplements existing data, usually in a document, by providing a link to more detailed information, which is held externally, or elsewhere.',
-          'accession' => '0000552',
-        ],
+    $term_details = [
+      'vocab_name' => 'sbo',
+      'id_space_name' => 'SBO',
+      'term' => [
+        'name' => 'reference annotation',
+        'definition' => 'Additional information that supplements existing data, usually in a document, by providing a link to more detailed information, which is held externally, or elsewhere.',
+        'accession' => '0000552',
       ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
-     $this->createTripalTerm(
-      [
-        'vocab_name' => 'ero',
-        'id_space_name' => 'ERO',
-        'term' => [
-          'name' => 'database',
-          'definition' => 'A database is an organized collection of data, today typically in digital form.',
-          'accession' => '0001716',
-        ],
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
+
+    $term_details = [
+      'vocab_name' => 'ero',
+      'id_space_name' => 'ERO',
+      'term' => [
+        'name' => 'database',
+        'definition' => 'A database is an organized collection of data, today typically in digital form.',
+        'accession' => '0001716',
       ],
-      'chado_id_space',
-      'chado_vocabulary'
-    );
+    ];
+    $this->createTripalTerm($term_details, 'chado_id_space', 'chado_vocabulary');
 
     // Create the content types + fields that we need.
     $this->createContentTypeFromConfig('general_chado', 'organism', TRUE);

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -15,10 +15,33 @@ trait ChadoFieldTestTrait {
 
   use UserCreationTrait;
 
-  protected FieldStorageConfig $fieldStorage;
-  protected FieldConfig $fieldConfig;
-  protected TripalEntityType $TripalEntityType;
-  protected TripalEntity $tripalEntity;
+  /**
+   * An array of FieldStorageConfig objects keyed by the field name.
+   *
+   * @var FieldStorageConfig[]
+   */
+  protected array $fieldStorage = [];
+
+  /**
+   * An array of FieldConfig objects keyed by the field name.
+   *
+   * @var FieldConfig[]
+   */
+  protected array $fieldConfig = [];
+
+  /**
+   * An array of TripalEntityType objects keyed by the bundle name.
+   *
+   * @var TripalEntityType[]
+   */
+  protected array $tripalEntityType = [];
+
+  /**
+   * An array of display objects keyed by Tripal Content Type bundle name.
+   *
+   * @var EntityViewDisplay[]
+   */
+  protected array $entityViewDisplay = [];
 
   /**
    * Called in the test setUp() for kernel tests to ensure all the needed
@@ -142,7 +165,7 @@ trait ChadoFieldTestTrait {
     $fieldStorage
       ->save();
 
-    $this->fieldStorage = $fieldStorage;
+    $this->fieldStorage[$values['field_name']] = $fieldStorage;
     return $fieldStorage;
   }
 
@@ -186,6 +209,7 @@ trait ChadoFieldTestTrait {
         'tripal_entity',
         $values
       );
+      $this->fieldStorage[$values['field_name']] = $values['fieldStorage'];
     }
 
     $fieldConfig = FieldConfig::create([
@@ -200,17 +224,23 @@ trait ChadoFieldTestTrait {
       'label' => 'hidden',
       'settings' => [],
     ];
-    $display = EntityViewDisplay::create([
-      'targetEntityType' => $fieldConfig->getTargetEntityTypeId(),
-      'bundle' => $values['bundle_name'],
-      'mode' => 'default',
-      'status' => TRUE,
-    ]);
+    if (array_key_exists($values['bundle_name'], $this->entityViewDisplay)) {
+      $display = $this->entityViewDisplay[$values['bundle_name']];
+    }
+    else {
+      $display = EntityViewDisplay::create([
+        'targetEntityType' => $fieldConfig->getTargetEntityTypeId(),
+        'bundle' => $values['bundle_name'],
+        'mode' => 'default',
+        'status' => TRUE,
+      ]);
+      $this->entityViewDisplay[$values['bundle_name']] = $display;
+    }
     $display->setComponent($values['fieldStorage']->getName(), $display_options);
     $display->save();
 
-    $this->fieldConfig = $fieldConfig;
-    $this->TripalEntityType = $bundle;
+    $this->fieldConfig[$values['field_name']] = $fieldConfig;
+    $this->tripalEntityType[$values['bundle_name']] = $bundle;
     return $fieldConfig;
   }
 }

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -1,0 +1,183 @@
+<?php
+namespace Drupal\Tests\tripal_chado\Traits;
+
+use \Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\tripal\Entity\TripalEntity;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\tripal\Entity\TripalEntityType;
+
+/**
+ * Provides functions related to testing Chado Fields.
+ */
+trait ChadoFieldTestTrait {
+
+  use UserCreationTrait;
+
+  protected FieldStorageConfig $fieldStorage;
+  protected FieldConfig $fieldConfig;
+  protected TripalEntityType $TripalEntityType;
+  protected TripalEntity $tripalEntity;
+
+  /**
+   * Called in the test setUp() for kernel tests to ensure all the needed
+   * resources are available.
+   */
+  public function setupFieldTestEnvironment() {
+
+    // Ensure we see all logging in tests.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Setup the test environment based on the Entity kernel test base.
+    $this->installSchema('system', 'sequences');
+    // -- we need terms for TripalEntityType, fields and field properties.
+    $this->installSchema('tripal', ['tripal_id_space_collection', 'tripal_terms_idspaces', 'tripal_vocabulary_collection', 'tripal_terms_vocabs', 'tripal_terms']);
+    // -- we need a user to create an entity.
+    $this->installEntitySchema('user');
+    $this->setUpCurrentUser();
+    // -- we need our tripal content entity to attach the fields to.
+    $this->installEntitySchema('tripal_entity');
+    // -- we need a tripal content type for our tripal content entity to belong to.
+    $this->installEntitySchema('tripal_entity_type');
+    // -- we need the field module configuration.
+    $this->installConfig(['field']);
+
+  }
+
+  /**
+   * Create a FieldStorage object for a given field type.
+   *
+   * @param string $entity_type
+   *   The machine name of the entity to add the field to (e.g., organism)
+   * @param array $property_type_terms
+   *   A list of the property types this field uses. The key will be the key of
+   *   the property type and the value is an array defining:
+   *    - key (string)
+   *    - id_space_name (string)
+   *    - accession (string)
+   * @param array $values
+   *   These values are passed directly to the create() method. Suggested values are:
+   *    - field_name (string)
+   *    - field_type (string)
+   *    - termIdSpace (string)
+   *    - termAccession (string)
+   * @return FieldStorageConfig
+   *   The field storage object that was just created.
+   */
+  public function createFieldType(string $entity_type, array $property_type_terms, array $values = []) {
+
+    // Defaults
+    $random = $this->getRandomGenerator();
+    $values['field_name'] = $values['field_name'] ?? $random->word(6) . '_' . $random->word(15);
+    $values['field_type'] = $values['field_type'] ?? 'tripal_string_type';
+    // -- Term
+    $term_values = [];
+    if (array_key_exists('termIdSpace', $values)) {
+      $term_values['id_space_name'] = $values['termIdSpace'];
+    }
+    if (array_key_exists('termAccession', $values)) {
+      $term_values['term'] = [];
+      $term_values['term']['accession'] = $values['termAccession'];
+    }
+
+    // Now create the main term for the field.
+    $term = $this->createTripalTerm($term_values, 'chado_id_space', 'chado_vocabulary');
+
+    // Next create the terms for the properies this field will use.
+    foreach ($property_type_terms as $key => $prop_term) {
+      $this->createTripalTerm($prop_term, 'chado_id_space', 'chado_vocabulary');
+    }
+
+    // Now for the field storage.
+    $fieldStorage = FieldStorageConfig::create([
+      'field_name' => $values['field_name'],
+      'entity_type' => $entity_type,
+      'type' => $values['field_type'],
+      'settings' => [
+        'termIdSpace' => $term_values['id_space_name'],
+        'termAccession' => $term_values['term']['accession'],
+      ],
+    ]);
+    $fieldStorage
+      ->save();
+
+    $this->fieldStorage = $fieldStorage;
+    return $fieldStorage;
+  }
+
+  /**
+   * Create a FieldConfig object for a given field type on a given entity.
+   *
+   * @param string $entity_type
+   *   The machine name of the entity to add the field to (e.g., organism)
+   * @param array $properties
+   *   A list of the property types this field uses. The key will be the key of
+   *   the property type and the value is an array defining:
+   *    - key (string)
+   *    - id_space_name (string)
+   *    - accession (string)
+   * @param array $values
+   *   These values are passed directly to the create() method. Suggested values are:
+   *    - field_name (string)
+   *    - field_type (string)
+   *    - term_id_space (string)
+   *    - term_accession (string)
+   *    - bundle_name (string)
+   *    - formatter_id (string)
+   *    - fieldStorage (FieldStorageConfig)
+   * @return FieldConfig
+   *   The field object that was just created.
+   */
+  public function createFieldInstance(string $entity_type, array $properties, array $values = []) {
+
+    // Defaults
+    $random = $this->getRandomGenerator();
+    $values['formatter_id'] = $values['formatter_id'] ?? 'default_tripal_string_type_formatter';
+    $values['field_type'] = $values['field_type'] ?? 'tripal_string_type';
+    // -- Bundle
+    if (!array_key_exists('bundle_name', $values)) {
+      $bundle = $this->createTripalContentType();
+      $values['bundle_name'] = $bundle->getID();
+    }
+    else {
+      $bundle = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->loadByProperties(['id' => $values['bundle_name']]);
+      $bundle = array_pop($bundle);
+    }
+    // -- Field Storage Config
+    if (!array_key_exists('fieldStorage', $values)) {
+      $values['fieldStorage'] = $this->createFieldType(
+        'tripal_entity',
+        $properties,
+        $values
+      );
+    }
+
+    $fieldConfig = FieldConfig::create([
+      'field_storage' => $values['fieldStorage'],
+      'bundle' => $values['bundle_name'],
+      'required' => TRUE,
+    ]);
+    $fieldConfig
+      ->save();
+    $display_options = [
+      'type' => $values['formatter_id'],
+      'label' => 'hidden',
+      'settings' => [],
+    ];
+    $display = EntityViewDisplay::create([
+      'targetEntityType' => $fieldConfig->getTargetEntityTypeId(),
+      'bundle' => $values['bundle_name'],
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $display->setComponent($values['fieldStorage']->getName(), $display_options);
+    $display->save();
+
+    $this->fieldConfig = $fieldConfig;
+    $this->TripalEntityType = $bundle;
+    return $fieldConfig;
+  }
+}


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #1974 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
With PR #1862 we added support for the WYSIWYG toolbar for text fields, and now we need to do the same thing for property fields. Furthermore, it would be good to allow admin to configure the number of rows for the textarea.

This is needed because properties are often used to store metadata which can be more then a single value. For example, ActivatingCrops uses properties to store methodology and experimental design for research studies. This are often long text and sometimes even include links and tables.

Additionally, ensure that all the other property widgets return filtered text because on 4.x curators can enter HTML into the property field even if they do not have the appropriate permissions.

Specifically, this PR
 - adds a filter setting to the "Chado Property: Long Text" widget that defaults to basic.
 - ensures that the Chado Property formatter uses this setting.
 - since all Chado Property widgets share the same formatter, ensure that basic_html is used for all other widgets or if the "Chado Property: Long Text" was not configured.
 - ensures the property widgets respect the "Required" setting set in the field settings.
 - allows admin to choose the number of rows shown in the "Chado Property: Long Text" widget

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
### Manual

1. Add 4 different property fields to the organism content type. The terms do not matter. Set all to unlimited values.
2. Configure the form display and set two of these fields to use the long text widget and the other two to use the other widgets. Configure the long text widgets to use "Basic" for one and "Full" for the other. Add some options to the select list widget.
3. Create content. Enter the same block of HTML into both long text widgets. Ensure this includes an HTML. Also enter values in the other two widgets.
4. Save and confirm that the long text with "Basic" setting has stripped out the table/list formatting but the one using "Full" has not. We have two fields here to also confirm that the setting is on a per field basis.
5. Check that no errors were thrown for the other two property fields (ie. string and select widget) even though they did not have a filter format configured.

Other things to test:
- set some of the fields to required and others not and confirm the form respects this.
- change the format from "Full" to "Basic" and confirm the formatter/page strips tables without you needing to edit the page. Also check that when you do edit the page, the HTML is stripped.
- change the setting to indicate the number of rows for the "Long Text" widget and confirm the widget reflects this setting.
- enter an HTML table one-liner (e.g. `<table><thead><tr><th>H1</th><th>H2</th></tr></thead><tbody><tr><td>D1</td><td>D2</td></tr></tbody></table>`) as an option for the "Select" widget when configuring it and confirm that while you can select it, when the page is viewed, the HTML is stripped. You should be able to use basic html in a select option (i.e. bold or italics)

### Automated Testing

I started adding automated testing for the property field based on the model I used for Tripal fields lately. My progress is included here and, while not complete, it is fully functioning and better coverage then we had previously.

Includes
 - ChadoFieldTestTrait: this is the Chado-focused version of the TripalFieldTestTrait. It includes methods for creating field types + instances as well as an assert to confirm the values match what was expected. It also includes a method to make setting up the test environment for field kernel tests easier.
 - ChadoPropertyTypeSimpleCRUDTest: focuses on testing a single property field on a project-based content type with only one delta. It provides 44% test coverage of the ChadoPropertyTypeDefault field type class and tests creating a TripalEntity with a property field attached. Specifically, it checks that
   - the property field can be created programatically and attached to a tripal entity type.
   - a tripal entity can be created programatically with values for a property field supplied.
   - the property field values are set properly in the tripal entity class
   - tripal entity can retrieve the values successfully which checks basic interactions between the fields and the TripalStorage backend
   - that the entity can be saved without throwing any errors
   - that tripalTypes can be called without error and all the property type objects are created as expected.

Test coverage shows that this test is travelling the expected paths through the ChadoPropertyTypeDefault, TripalFieldItemBase, TripalEntity, and ChadoStorage for inserting field data.

Next steps are to check the field values are inserted into chado; however, this is not producing the expected results... Since I have already spent more time then I should have, I am moving on. These tests are included because they provide a good model for moving forward on testing fields.