### PR TITLE
Fix the creation of duplicate aliases every time an entity is edited

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -175,12 +175,20 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // Make sure the path alias is URL friendly.
     $path_alias = str_replace(['%2F', '+'], ['/', '-'], urlencode($path_alias));
 
-    // Now finally, set the alias.
-    $path = \Drupal::entityTypeManager()->getStorage('path_alias')->create([
-      'path' => $system_path,
-      'alias' => $path_alias,
-    ]);
-    $path->save();
+    // Check if this alias already exists.
+    $alias_exists = FALSE;
+    if (\Drupal::service('path_alias.repository')->lookupByAlias($path_alias, 'und')) {
+      $alias_exists = TRUE;
+    }
+
+    // If the alias does not exist, then create it.
+    if (!$alias_exists) {
+      $path = \Drupal::entityTypeManager()->getStorage('path_alias')->create([
+        'path' => $system_path,
+        'alias' => $path_alias,
+      ]);
+      $path->save();
+    }
   }
 
   /**


### PR DESCRIPTION
# Bug Fix

### Closes #1973 

### Tripal Version: 4.x

## Description
Currently, every time an entity is edited, another copy of the path alias is created. This PR fixes that by first checking if an alias already exists.

## Testing?
1. Create an entity of any content type. Here I used "project".
2. Check the alias table (or go to `/admin/config/search/path`):
```
sitedb=> select * from path_alias;
 id | revision_id |                 uuid                 | langcode |    path     |   alias    | status 
----+-------------+--------------------------------------+----------+-------------+------------+--------
  1 |           1 | 997dfd5b-7ebf-4079-8d35-f7b60202c5a9 | und      | /bio_data/1 | /project/1 |      1
(1 row)
```
3. Edit the entity, you don't need to make any changes, and save it again.
4. Verify that there is still only one alias:
```
sitedb=> select * from path_alias;
 id | revision_id |                 uuid                 | langcode |    path     |   alias    | status 
----+-------------+--------------------------------------+----------+-------------+------------+--------
  1 |           1 | 997dfd5b-7ebf-4079-8d35-f7b60202c5a9 | und      | /bio_data/1 | /project/1 |      1
(1 row)
```