### PR TITLE
Create xdebug_output directory for performance profiling results and debugging in general

### DIFF
--- a/tripaldocker/xdebug_output/README.md
+++ b/tripaldocker/xdebug_output/README.md
@@ -1,0 +1,5 @@
+XDebug Output
+===============
+
+This directory is here as a place for XDebug to store various output files. XDebug in TripalDocker 
+is already configured to use this directory.


### PR DESCRIPTION

# Tripal 4 Core Dev Task

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In https://github.com/tripal/tripal_doc/pull/75 we discuss recent versions of TripalDocker creating the configured output directory for xdebug automatically... However, this didn't actually get done -until now. This PR simply creates the directory that Tripaldocker XDebug is configured to use. Thanks to git, a README is needed to get the directory committed and I acquiesced as it is good practice anyway 😜 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
No testing needed but if you wanted, you can follow the instructions in the linked PR to test performance profiling and verify you no longer need to create the xdebug directory as mentioned here:

<img width="967" alt="Screenshot 2024-10-04 at 3 27 03 PM" src="https://github.com/user-attachments/assets/57e986d6-c2f3-440a-b44a-4b3416fa23fd">
