### PR TITLE
Add new third party settings needed by publish

### DIFF
--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -235,17 +235,9 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
 
           // If the CV term for the discovered field is currently used by an
           // existing field, then mark it as existing.
-          $existing = FALSE;
           $discoveredIdSpace = $discovered_field['settings']['termIdSpace'];
           $discoveredAccession = $discovered_field['settings']['termAccession'];
-          foreach ($entity_field_defs as $name => $def) {
-            $settings = $def->getSettings();
-            if ( (($settings['termIdSpace'] ?? '') == $discoveredIdSpace)
-              and (($settings['termAccession'] ?? '') == $discoveredAccession) ) {
-              $existing = TRUE;
-              break;
-            }
-          }
+          $existing = $this->checkDiscoveredTerm($discoveredIdSpace, $discoveredAccession, $entity_field_defs);
           if ($existing) {
             $field_status['existing'][$discovered_field['name']] = $discovered_field;
             continue;
@@ -265,6 +257,32 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
       }
     }
     return $field_status;
+  }
+
+  /**
+   * Helper function to determine if any existing fields use a particular CV term.
+   *
+   * @param string $idSpace
+   *   ID space of term we want to check
+   * @param string $accession
+   *   Accession of term we want to check
+   * @param array $entity_field_defs
+   *   Array of field definitions returned from getFieldDefinitions()
+   *
+   * @return bool
+   *   TRUE if term already used by a field, FALSE otherwise
+   */
+  private function checkDiscoveredTerm($idSpace, $accession, $entity_field_defs) {
+    $existing = FALSE;
+    foreach ($entity_field_defs as $name => $def) {
+      $settings = $def->getSettings();
+      if ( (($settings['termIdSpace'] ?? '') == $idSpace)
+          and (($settings['termAccession'] ?? '') == $accession) ) {
+        $existing = TRUE;
+        break;
+      }
+    }
+    return $existing;
   }
 
   /**

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -563,6 +563,21 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
         $field->setSettings($field_def['settings']);
         $field->save();
 
+        // If the additional type field specifies a fixed_value, this
+        // is used to define the bundle type. Add this setting directly
+        // to the entity for efficient access when publishing.
+        if ($field_def['type'] == 'chado_additional_type_type_default') {
+          if (!$entity_type->getThirdPartySetting('tripal', 'bundle_type_column')) {
+            $fixed_value = $field_def['settings']['fixed_value'] ?? NULL;
+            if ($fixed_value) {
+              $term_parts = explode(':', $fixed_value, 2);
+              $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $term_parts[0]);
+              $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $term_parts[1]);
+              $entity_type->save();
+            }
+          }
+        }
+
         // Add field to the default display modes.
         $entity_display = \Drupal::service('entity_display.repository');
         $bundle_id = $entity_type->id();

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -233,8 +233,20 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
         $discovered = $field_class::discover($tripal_entity_type, $field_id, $all_field_defs);
         foreach ($discovered as $discovered_field) {
 
-          // If the discovered field already exists then mark it as existing.
-          if (array_key_exists($discovered_field['name'], $entity_field_defs)) {
+          // If the CV term for the discovered field is currently used by an
+          // existing field, then mark it as existing.
+          $existing = FALSE;
+          $discoveredIdSpace = $discovered_field['settings']['termIdSpace'];
+          $discoveredAccession = $discovered_field['settings']['termAccession'];
+          foreach ($entity_field_defs as $name => $def) {
+            $settings = $def->getSettings();
+            if ( (($settings['termIdSpace'] ?? '') == $discoveredIdSpace)
+              and (($settings['termAccession'] ?? '') == $discoveredAccession) ) {
+              $existing = TRUE;
+              break;
+            }
+          }
+          if ($existing) {
             $field_status['existing'][$discovered_field['name']] = $discovered_field;
             continue;
           }

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -704,7 +704,7 @@ EOD;
    */
   public function getForeignKeyDef(string $left_table, string $right_table) {
     $left_def = $this->getTableDef($left_table, ['format' => 'Drupal']);
-    if (!array_key_exists($right_table, $left_def['foreign keys'])) {
+    if (!array_key_exists($right_table, $left_def['foreign keys'] ?? [])) {
       return NULL;
     }
     return $left_def['foreign keys'][$right_table];

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.genetic_chado.yml
@@ -14,6 +14,8 @@ content_types:
             - bio_data_16
         settings:
             chado_base_table: featuremap
+            chado_type_table: featuremapprop
+            chado_type_column: type_id
 
     -   label: QTL
         term: SO:0000771
@@ -26,6 +28,8 @@ content_types:
             - bio_data_17
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id
 
     -   label: Sequence Variant
         term: SO:0001060
@@ -38,6 +42,8 @@ content_types:
             - bio_data_18
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id
 
     -   label: Genetic Marker
         term: SO:0001645
@@ -50,6 +56,8 @@ content_types:
             - bio_data_19
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id
 
     -   label: Heritable Phenotypic Marker
         term: SO:0001500
@@ -62,3 +70,5 @@ content_types:
             - bio_data_20
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.genetic_chado.yml
@@ -14,8 +14,8 @@ content_types:
             - bio_data_16
         settings:
             chado_base_table: featuremap
-            chado_type_table: featuremapprop
-            chado_type_column: type_id
+            bundle_type_table: featuremapprop
+            bundle_type_column: type_id
 
     -   label: QTL
         term: SO:0000771
@@ -28,8 +28,8 @@ content_types:
             - bio_data_17
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id
 
     -   label: Sequence Variant
         term: SO:0001060
@@ -42,8 +42,8 @@ content_types:
             - bio_data_18
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id
 
     -   label: Genetic Marker
         term: SO:0001645
@@ -56,8 +56,8 @@ content_types:
             - bio_data_19
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id
 
     -   label: Heritable Phenotypic Marker
         term: SO:0001500
@@ -70,5 +70,5 @@ content_types:
             - bio_data_20
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
@@ -14,8 +14,8 @@ content_types:
             - bio_data_8
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id
 
     -   label: mRNA
         term: SO:0000234
@@ -28,8 +28,8 @@ content_types:
             - bio_data_9
         settings:
             chado_base_table: feature
-            chado_type_table: feature
-            chado_type_column: type_id
+            bundle_type_table: feature
+            bundle_type_column: type_id
 
     -   label: Phylogenetic Tree
         term: data:0872
@@ -54,8 +54,8 @@ content_types:
             - bio_data_11
         settings:
             chado_base_table: featuremap
-            chado_type_table: featuremapprop
-            chado_type_column: type_id
+            bundle_type_table: featuremapprop
+            bundle_type_column: type_id
 
     -   label: DNA Library
         term: NCIT:C16223
@@ -80,8 +80,8 @@ content_types:
             - bio_data_13
         settings:
             chado_base_table: analysis
-            chado_type_table: analysisprop
-            chado_type_column: type_id
+            bundle_type_table: analysisprop
+            bundle_type_column: type_id
 
     -   label: Genome Annotation
         term: operation:0362
@@ -94,8 +94,8 @@ content_types:
             - bio_data_14
         settings:
             chado_base_table: analysis
-            chado_type_table: analysisprop
-            chado_type_column: type_id
+            bundle_type_table: analysisprop
+            bundle_type_column: type_id
 
     -   label: Genome Project
         term: local:Genome Project
@@ -108,5 +108,5 @@ content_types:
             - bio_data_15
         settings:
             chado_base_table: project
-            chado_type_table: projectprop
-            chado_type_column: type_id
+            bundle_type_table: projectprop
+            bundle_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.genomic_chado.yml
@@ -14,6 +14,8 @@ content_types:
             - bio_data_8
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id
 
     -   label: mRNA
         term: SO:0000234
@@ -26,6 +28,8 @@ content_types:
             - bio_data_9
         settings:
             chado_base_table: feature
+            chado_type_table: feature
+            chado_type_column: type_id
 
     -   label: Phylogenetic Tree
         term: data:0872
@@ -50,6 +54,8 @@ content_types:
             - bio_data_11
         settings:
             chado_base_table: featuremap
+            chado_type_table: featuremapprop
+            chado_type_column: type_id
 
     -   label: DNA Library
         term: NCIT:C16223
@@ -74,6 +80,8 @@ content_types:
             - bio_data_13
         settings:
             chado_base_table: analysis
+            chado_type_table: analysisprop
+            chado_type_column: type_id
 
     -   label: Genome Annotation
         term: operation:0362
@@ -86,6 +94,8 @@ content_types:
             - bio_data_14
         settings:
             chado_base_table: analysis
+            chado_type_table: analysisprop
+            chado_type_column: type_id
 
     -   label: Genome Project
         term: local:Genome Project
@@ -98,3 +108,5 @@ content_types:
             - bio_data_15
         settings:
             chado_base_table: project
+            chado_type_table: projectprop
+            chado_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
@@ -14,6 +14,8 @@ content_types:
             - bio_data_21
         settings:
             chado_base_table: stock
+            chado_type_table: stock
+            chado_type_column: type_id
 
     -   label: Breeding Cross
         term: CO_010:0000255
@@ -26,6 +28,8 @@ content_types:
             - bio_data_22
         settings:
             chado_base_table: stock
+            chado_type_table: stock
+            chado_type_column: type_id
 
     -   label: Germplasm Variety
         term: CO_010:0000029
@@ -38,6 +42,8 @@ content_types:
             - bio_data_23
         settings:
             chado_base_table: stock
+            chado_type_table: stock
+            chado_type_column: type_id
 
     -   label: Recombinant Inbred Line
         term: CO_010:0000162
@@ -50,3 +56,5 @@ content_types:
             - bio_data_24
         settings:
             chado_base_table: stock
+            chado_type_table: stock
+            chado_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalentitytype_collection.germplasm_chado.yml
@@ -14,8 +14,8 @@ content_types:
             - bio_data_21
         settings:
             chado_base_table: stock
-            chado_type_table: stock
-            chado_type_column: type_id
+            bundle_type_table: stock
+            bundle_type_column: type_id
 
     -   label: Breeding Cross
         term: CO_010:0000255
@@ -28,8 +28,8 @@ content_types:
             - bio_data_22
         settings:
             chado_base_table: stock
-            chado_type_table: stock
-            chado_type_column: type_id
+            bundle_type_table: stock
+            bundle_type_column: type_id
 
     -   label: Germplasm Variety
         term: CO_010:0000029
@@ -42,8 +42,8 @@ content_types:
             - bio_data_23
         settings:
             chado_base_table: stock
-            chado_type_table: stock
-            chado_type_column: type_id
+            bundle_type_table: stock
+            bundle_type_column: type_id
 
     -   label: Recombinant Inbred Line
         term: CO_010:0000162
@@ -56,5 +56,5 @@ content_types:
             - bio_data_24
         settings:
             chado_base_table: stock
-            chado_type_table: stock
-            chado_type_column: type_id
+            bundle_type_table: stock
+            bundle_type_column: type_id

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -85,6 +85,34 @@ fields:
               region: content
               weight: 10
 
+    -   name: genetic_map_type
+        content_type: genetic_map
+        label: Type
+        type: chado_additional_type_type_default
+        description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: featuremap
+                type_table: featuremapprop
+                type_column: type_id
+        settings:
+            termIdSpace: "data"
+            termAccession: "1278"
+            fixed_value: "data:1278"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
+
     -   name: genetic_map_contact
         content_type: genetic_map
         label: Contact

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -1056,6 +1056,34 @@ fields:
               region: content
               weight: 10
 
+    -   name: physical_map_type
+        content_type: physical_map
+        label: Type
+        type: chado_additional_type_type_default
+        description: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.
+        cardinality: 1
+        required: true
+        storage_settings:
+            storage_plugin_id: chado_storage
+            storage_plugin_settings:
+                base_table: featuremap
+                type_table: featuremapprop
+                type_column: type_id
+        settings:
+            termIdSpace: "data"
+            termAccession: "1280"
+            fixed_value: "data:1280"
+        display:
+          view:
+            default:
+              region: content
+              label: above
+              weight: 10
+          form:
+            default:
+              region: content
+              weight: 10
+
     -   name: physical_map_contact
         content_type: physical_map
         label: Contact

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -307,7 +307,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
     // publish will be able to restrict by the term.
     $type_fkey = $settings['storage_plugin_settings']['type_fkey'] ?? NULL;
     if ($type_fkey) {
-      $type_table = $entity_type->getThirdPartySetting('tripal', 'chado_type_table');
+      $type_table = $entity_type->getThirdPartySetting('tripal', 'bundle_type_table');
       if (!$type_table) {
         $form_state_storage = $form_state->getStorage();
         $bundle = $form_state_storage['bundle'];
@@ -317,8 +317,8 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
         $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
 
         list($type_table, $type_column) = explode(self::$table_column_delimiter, $type_fkey, 2);
-        $entity_type->setThirdPartySetting('tripal', 'chado_type_table', $type_table);
-        $entity_type->setThirdPartySetting('tripal', 'chado_type_column', $type_column);
+        $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $type_table);
+        $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $type_column);
         $entity_type->save();
       }
     }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -504,7 +504,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
         $prop_type_id = $prop_table_def['fields'][$prop_type_column] ?? NULL;
         if ($prop_type_id) {
           $type_table = $prop_table;
-          $type_column = $prop_type_columns;
+          $type_column = $prop_type_column;
         }
       }
     }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -291,37 +291,74 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
   }
 
   /**
-   * {@inheritDoc}
+   * Saves the location of the bundle term in the entity for easy access by publish.
+   *
+   * @param string $bundle
+   *   The bundle identifier, e.g. "analysis" or "project"
+   * @param string $type_table
+   *   The table where the term is stored, usually the base table or else a property table.
+   * @param string $type_column
+   *   The name of the column where the term is stored. Usually this is "type_id".
    */
-  public static function storageSettingsFormSubmitBaseTable(array $form, FormStateInterface $form_state) {
-    parent::storageSettingsFormSubmitBaseTable($form, $form_state);
+  public static function setEntityBundleType(string $bundle, string $type_table, string $type_column) {
+    /** @var \Drupal\Core\Entity\EntityTypeManager $entity_type_manager **/
+    $entity_type_manager = \Drupal::entityTypeManager();
+    /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
+    $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
 
-    $settings = self::getFormStateSettings($form_state);
-    if (!array_key_exists('storage_plugin_settings', $settings)) {
-      return;
-    }
-    // This field is used to specify a subset of a chado table for the bundle,
-    // e.g. for feature table it could be 'gene'.
-    // The first time this field is entered, store third party settings in the
-    // entity for the table and column where this term will be stored, so that
-    // publish will be able to restrict by the term.
-    $type_fkey = $settings['storage_plugin_settings']['type_fkey'] ?? NULL;
-    if ($type_fkey) {
-      $type_table = $entity_type->getThirdPartySetting('tripal', 'bundle_type_table');
-      if (!$type_table) {
-        $form_state_storage = $form_state->getStorage();
-        $bundle = $form_state_storage['bundle'];
-        /** @var \Drupal\Core\Entity\EntityTypeManager $entity_type_manager **/
-        $entity_type_manager = \Drupal::entityTypeManager();
-        /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
-        $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
+    $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $type_table);
+    $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $type_column);
+    $entity_type->save();
+  }
 
-        list($type_table, $type_column) = explode(self::$table_column_delimiter, $type_fkey, 2);
-        $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $type_table);
-        $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $type_column);
-        $entity_type->save();
-      }
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldSettingsForm(array $form, FormStateInterface $form_state) {
+    $elements = parent::fieldSettingsForm($form, $form_state);
+
+    // We add a checkbox to allow specifying that this field will be used
+    // to specify a term that is used to define the bundle, allowing a subset
+    // of content from a given base table to be published.
+    $fixed_value = $this->getSetting('fixed_value');
+    $elements['field_term_fs']['fixed_value'] = [
+      '#type' => 'checkbox',
+      '#title' => t('This term defines the bundle'),
+      '#description' => t('Check this box to indicate that the term for this field is'
+        . ' used to define the term for the bundle. For example, the "gene (SO:0000704)"'
+        . ' term defines the "Gene" bundle based on the "feature" table.'),
+      '#default_value' => $fixed_value?1:0,
+      '#element_validate' => [[static::class, 'fixedValueFieldValidate']],
+    ];
+    return $elements;
+  }
+
+ /**
+   * {@inheritdoc}
+   */
+  public static function fixedValueFieldValidate(array $form, FormStateInterface $form_state) {
+
+    $settings = $form_state->getValue('settings');
+    $storage_settings = $settings['storage_plugin_settings'] ?? [];
+    $type_table = $storage_settings['type_table'] ?? '';
+    $type_column = $storage_settings['type_column'] ?? '';
+    $fixed_value = $settings['field_term_fs']['fixed_value'];
+
+    if ($fixed_value) {
+      // The fixed value from the form checkbox is just a boolean,
+      // convert it to the term when saving.
+      $fixed_value = $settings['termIdSpace'] . ':' . $settings['termAccession'];
+      $form_state_storage = $form_state->getStorage();
+      $bundle = $form_state_storage['bundle'];
+      $form_state->setValue(['settings', 'fixed_value'], $fixed_value);
+      // Also store the fixed value storage location in the entity
+      self::setEntityBundleType($bundle, $type_table, $type_column);
     }
+    else {
+      $form_state->setValue(['settings', 'fixed_value'], 0);
+      self::setEntityBundleType($bundle, '', '');
+    }
+
   }
 
   /**
@@ -502,7 +539,6 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       'settings' => [
         'termIdSpace' => $termIdSpace,
         'termAccession' => $termAccession,
-        'fixed_value' => $fixed_value,
       ],
       'display' => [
         'view' => [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -539,6 +539,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       'settings' => [
         'termIdSpace' => $termIdSpace,
         'termAccession' => $termAccession,
+        'fixed_value' => $fixed_value,
       ],
       'display' => [
         'view' => [

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -411,6 +411,22 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
       $entity_type->setThirdPartySetting('tripal', 'chado_base_table', $base_table);
       $entity_type->save();
     }
+
+    // If this is the additional type field, it is used to specify a subset of
+    // a chado table for this bundle, e.g. for feature table it could be 'gene'.
+    // The first time this field is entered, store third party settings in the
+    // entity for the table and column where this term will be stored, so that
+    // publish will be able to restrict by the term.
+    $type_fkey = $settings['storage_plugin_settings']['type_fkey'] ?? NULL;
+    if ($type_fkey) {
+      $type_table = $entity_type->getThirdPartySetting('tripal', 'chado_type_table');
+      if (!$type_table) {
+        list($type_table, $type_column) = explode(self::$table_column_delimiter, $type_fkey, 2);
+        $entity_type->setThirdPartySetting('tripal', 'chado_type_table', $type_table);
+        $entity_type->setThirdPartySetting('tripal', 'chado_type_column', $type_column);
+        $entity_type->save();
+      }
+    }
   }
 
   /**

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -411,22 +411,6 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
       $entity_type->setThirdPartySetting('tripal', 'chado_base_table', $base_table);
       $entity_type->save();
     }
-
-    // If this is the additional type field, it is used to specify a subset of
-    // a chado table for this bundle, e.g. for feature table it could be 'gene'.
-    // The first time this field is entered, store third party settings in the
-    // entity for the table and column where this term will be stored, so that
-    // publish will be able to restrict by the term.
-    $type_fkey = $settings['storage_plugin_settings']['type_fkey'] ?? NULL;
-    if ($type_fkey) {
-      $type_table = $entity_type->getThirdPartySetting('tripal', 'chado_type_table');
-      if (!$type_table) {
-        list($type_table, $type_column) = explode(self::$table_column_delimiter, $type_fkey, 2);
-        $entity_type->setThirdPartySetting('tripal', 'chado_type_table', $type_table);
-        $entity_type->setThirdPartySetting('tripal', 'chado_type_column', $type_column);
-        $entity_type->save();
-      }
-    }
   }
 
   /**

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -7,6 +7,7 @@
 use \Drupal\Core\Database\Database;
 use \Drupal\Core\Utility\UpdateException;
 use \Drupal\tripal_chado\Entity\ChadoTermMapping;
+use Drupal\Component\Serialization\Yaml;
 
 /**
  * Implements hook_install().
@@ -402,6 +403,24 @@ function tripal_chado_field_reload(array $upgradable_types, array $upgradable_pr
 }
 
 /**
+ * Reads a YAML file and adds the specified fields.
+ *
+ * @param string $yaml_path
+ *   Path to the YAML file to parse.
+ * @param array $field_names
+ *   One or more fields to add.
+ */
+function addFieldFromYaml(string $yaml_path, array $field_names) {
+  $fields_service = \Drupal::service('tripal.tripalfield_collection');
+  $fields = Yaml::decode(file_get_contents($yaml_path));
+  foreach ($fields['fields'] as $field) {
+    if (in_array($field['name'], $field_names)) {
+      $fields_service->addBundleField($field);
+    }
+  }
+}
+
+/**
  * Adds third party settings for Tripal content types to Chado base tables.
  */
 function tripal_chado_update_10401() {
@@ -588,8 +607,9 @@ function tripal_chado_update_10407() {
     $entityFieldManager = \Drupal::service('entity_field.manager');
     $entityTypeManager = \Drupal::entityTypeManager();
 
-    // Add missing additional type field in yaml for the two featuremap bundles
-    // @todo 'chado_additional_type_type_default', ['genetic_map', 'physical_map']
+    // Add missing additional type fields in yaml for the two featuremap bundles
+    addFieldFromYaml(__DIR__ . '/config/install/tripal.tripalfield_collection.genetic_chado.yml', ['genetic_map_type']);
+    addFieldFromYaml(__DIR__ . '/config/install/tripal.tripalfield_collection.genomic_chado.yml', ['physical_map_type']);
 
     // Add third party settings for bundle type using fixed_value term
     $entity_type_id = 'tripal_entity';

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -578,7 +578,7 @@ function tripal_chado_update_10406() {
 
 /**
  * Adds third party settings for content types that have multiple
- * content types derived from one Chado base table. PR#1991
+ * content types derived from one base table. PR#1991
  */
 function tripal_chado_update_10407() {
   $settings = [
@@ -610,8 +610,8 @@ function tripal_chado_update_10407() {
     /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
     $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
     if ($entity_type) {
-      $entity_type->setThirdPartySetting('tripal', 'chado_type_table', $type_table);
-      $entity_type->setThirdPartySetting('tripal', 'chado_type_column', 'type_id');
+      $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $type_table);
+      $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', 'type_id');
       $entity_type->save();
     }
   }

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -424,7 +424,7 @@ function tripal_chado_update_10401() {
     'sequence_variant' => 'feature',
     'genetic_marker' => 'feature',
     'phenotypic_marker' => 'feature',
-    // Germplams types.
+    // Germplasm types.
     'germplasm' => 'stock',
     'breeding_cross' => 'stock',
     'germplasm_variety' => 'stock',
@@ -440,10 +440,10 @@ function tripal_chado_update_10401() {
     'genome_project' => 'project'
   ];
 
-  /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
   /** @var \Drupal\Core\Entity\EntityTypeManager $entity_type_manager **/
   $entity_type_manager = \Drupal::entityTypeManager();
   foreach ($settings as $bundle => $chado_base_table) {
+    /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
     $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
     if ($entity_type) {
       $entity_type->setThirdPartySetting('tripal', 'chado_base_table', $chado_base_table);
@@ -574,4 +574,45 @@ function tripal_chado_update_10406() {
   $upgradable_types = ['chado_synonym_type_default'];
   $upgradable_properties = ['linker_synonym_fkey_id'];
   tripal_chado_field_reload($upgradable_types, $upgradable_properties, TRUE);
+}
+
+/**
+ * Adds third party settings for content types that have multiple
+ * content types derived from one Chado base table. PR#1991
+ */
+function tripal_chado_update_10407() {
+  $settings = [
+    // analysis table
+    'genome_assembly' => 'analysisprop',
+    'genome_annotation' => 'analysisprop',
+    // feature table
+    'gene' => 'feature',
+    'mrna' => 'feature',
+    'QTL' => 'feature',
+    'sequence_variant' => 'feature',
+    'genetic_marker' => 'feature',
+    'phenotypic_marker' => 'feature',
+    // featuremap table
+    'genetic_map' => 'featuremapprop',
+    'physical_map' => 'featuremapprop',
+    // project table
+    'genome_project' => 'projectprop',
+    // stock table
+    'germplasm' => 'stock',
+    'breeding_cross' => 'stock',
+    'germplasm_variety' => 'stock',
+    'ril' => 'stock',
+  ];
+
+  /** @var \Drupal\Core\Entity\EntityTypeManager $entity_type_manager **/
+  $entity_type_manager = \Drupal::entityTypeManager();
+  foreach ($settings as $bundle => $type_table) {
+    /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
+    $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
+    if ($entity_type) {
+      $entity_type->setThirdPartySetting('tripal', 'chado_type_table', $type_table);
+      $entity_type->setThirdPartySetting('tripal', 'chado_type_column', 'type_id');
+      $entity_type->save();
+    }
+  }
 }

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -581,38 +581,41 @@ function tripal_chado_update_10406() {
  * content types derived from one base table. PR#1991
  */
 function tripal_chado_update_10407() {
-  $settings = [
-    // analysis table
-    'genome_assembly' => 'analysisprop',
-    'genome_annotation' => 'analysisprop',
-    // feature table
-    'gene' => 'feature',
-    'mrna' => 'feature',
-    'QTL' => 'feature',
-    'sequence_variant' => 'feature',
-    'genetic_marker' => 'feature',
-    'phenotypic_marker' => 'feature',
-    // featuremap table
-    'genetic_map' => 'featuremapprop',
-    'physical_map' => 'featuremapprop',
-    // project table
-    'genome_project' => 'projectprop',
-    // stock table
-    'germplasm' => 'stock',
-    'breeding_cross' => 'stock',
-    'germplasm_variety' => 'stock',
-    'ril' => 'stock',
-  ];
 
-  /** @var \Drupal\Core\Entity\EntityTypeManager $entity_type_manager **/
-  $entity_type_manager = \Drupal::entityTypeManager();
-  foreach ($settings as $bundle => $type_table) {
-    /** @var \Drupal\tripal\Entity\TripalEntityType $entity_type **/
-    $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
-    if ($entity_type) {
-      $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $type_table);
-      $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', 'type_id');
-      $entity_type->save();
+  try {
+    $messenger = \Drupal::messenger();
+    $bundleManager = \Drupal::service('entity_type.bundle.info');
+    $entityFieldManager = \Drupal::service('entity_field.manager');
+    $entityTypeManager = \Drupal::entityTypeManager();
+
+    // Add missing additional type field in yaml for the two featuremap bundles
+    // @todo 'chado_additional_type_type_default', ['genetic_map', 'physical_map']
+
+    // Add third party settings for bundle type using fixed_value term
+    $entity_type_id = 'tripal_entity';
+    $bundle_info = $bundleManager->getBundleInfo($entity_type_id);
+    foreach (array_keys($bundle_info) as $bundle) {
+      $fields = $entityFieldManager->getFieldDefinitions($entity_type_id, $bundle);
+      foreach ($fields as $field) {
+        $field_type = $field->getType();
+        if ($field_type == 'chado_additional_type_type_default') {
+          $fixed_value = $field->getSetting('fixed_value');
+          if ($fixed_value) {
+            $entity_type = $entityTypeManager->getStorage('tripal_entity_type')->load($bundle);
+            if (!$entity_type->getThirdPartySetting('tripal', 'bundle_type_column')) {
+              $term_parts = explode(':', $fixed_value, 2);
+              $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $term_parts[0]);
+              $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $term_parts[1]);
+              $entity_type->save();
+              $messenger->addMessage(t("Added entity third party setting for bundle @bundle term @fixed_value",
+                  ['@bundle' => $bundle, '@fixed_value' => $fixed_value]));
+            }
+          }
+        }
+      }
     }
+  }
+  catch (\Exception $e) {
+    throw new UpdateException('Could not add third party settings: ' . $e->getMessage());
   }
 }

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -53,14 +53,14 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'label' => 'Entity Third Party Setting for Base Chado Table',
     'nullable' => true
   ];
-  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['chado_type_table'] = [
+  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['bundle_type_table'] = [
     'type' => 'string',
-    'label' => 'Entity Third Party Setting for Chado Table Specifying Content CV Term',
+    'label' => 'Entity Third Party Setting for Table Specifying Content CV Term',
     'nullable' => true
   ];
-  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['chado_type_column'] = [
+  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['bundle_type_column'] = [
     'type' => 'string',
-    'label' => 'Entity Third Party Setting for Chado Column Specifying Content CV Term',
+    'label' => 'Entity Third Party Setting for Column Specifying Content CV Term',
     'nullable' => true
   ];
 

--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -53,6 +53,16 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'label' => 'Entity Third Party Setting for Base Chado Table',
     'nullable' => true
   ];
+  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['chado_type_table'] = [
+    'type' => 'string',
+    'label' => 'Entity Third Party Setting for Chado Table Specifying Content CV Term',
+    'nullable' => true
+  ];
+  $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['chado_type_column'] = [
+    'type' => 'string',
+    'label' => 'Entity Third Party Setting for Chado Column Specifying Content CV Term',
+    'nullable' => true
+  ];
 
   $definitions['tripal.content_type.*']['mapping']['third_party_settings']['mapping']['tripal']['mapping']['chado_base_table'] = [
     'type' => 'string',


### PR DESCRIPTION
# New Feature

### Issue #1924

### ~~Depends on #2001~~ (merged)

### Closes #1994

### Tripal Version: 4.x

## Description
This PR adds two new third party settings intended for use by the publish service.
These two settings are used for publishing content types where more than one bundle is based on a single chado base table. For example, both the "gene" and "mRNA" content types are derived from the `feature` table.
The third party settings allow publish to know where to find the term that defines the bundle, whether in the base table, or in a property table.


## Testing?
This PR isolates the described changes from other changes in the publish PR #1991 to simplify review.

Testing involves:
1. Build a docker on 4.x branch
2. Import all of the type collections
3. Switch to this branch and test the update hook `drush updatedb`
4. Verify that the settings have now been added
```
$bundles = ['genetic_map', 'QTL', 'sequence_variant', 'genetic_marker', 'phenotypic_marker',
            'gene', 'mrna', 'physical_map', 'genome_assembly', 'genome_annotation', 'genome_project',
            'germplasm', 'breeding_cross', 'germplasm_variety', 'ril'];
foreach ($bundles as $bundle) {
  $entity_type_manager = \Drupal::entityTypeManager();
  $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
  $entity_type_chado_base_table = $entity_type->getThirdPartySetting('tripal', 'chado_base_table');
  $entity_type_bundle_type_table = $entity_type->getThirdPartySetting('tripal', 'bundle_type_table');
  $entity_type_bundle_type_column = $entity_type->getThirdPartySetting('tripal', 'bundle_type_column');
  print "bundle=\"$bundle\"\n";
  print "  base_table=\"$entity_type_chado_base_table\"\n";
  print "  type_table=\"$entity_type_bundle_type_table\"\n";
  print "  type_column=\"$entity_type_bundle_type_column\"\n";
}
```
expected output
```
bundle="genetic_map"
  base_table="featuremap"
  type_table="featuremapprop"
  type_column="type_id"
bundle="QTL"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="sequence_variant"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="genetic_marker"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="phenotypic_marker"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="gene"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="mrna"
  base_table="feature"
  type_table="feature"
  type_column="type_id"
bundle="physical_map"
  base_table="featuremap"
  type_table="featuremapprop"
  type_column="type_id"
bundle="genome_assembly"
  base_table="analysis"
  type_table="analysisprop"
  type_column="type_id"
bundle="genome_annotation"
  base_table="analysis"
  type_table="analysisprop"
  type_column="type_id"
bundle="genome_project"
  base_table="project"
  type_table="projectprop"
  type_column="type_id"
bundle="germplasm"
  base_table="stock"
  type_table="stock"
  type_column="type_id"
bundle="breeding_cross"
  base_table="stock"
  type_table="stock"
  type_column="type_id"
bundle="germplasm_variety"
  base_table="stock"
  type_table="stock"
  type_column="type_id"
bundle="ril"
  base_table="stock"
  type_table="stock"
  type_column="type_id"
```
5. And for good measure, a docker built on this branch should already include these settings.

### Test creating a new content type - adding type field manually
1. Creating a new content type. Tripal -> Page Structure -> "+ Add custom type"
2. I created a "Tripal Project" content type based on the project table.
3. Add a "Tripal Project Name" field using the "Chado String Field Type" field - this gets the base table populated.
4. Add a "Tripal Project Type" field using the "Chado Type Reference" field. Term should match the bundle term. You will want to check the new box "This term defines the bundle"
![issue1924_gui-term-defines-bundle](https://github.com/user-attachments/assets/54696450-d24b-4cb3-bc18-2972b3c9e337)

### Test creating a new content type - adding type field manually
1-3. Repeat the steps 1-3 above, but then
4. Discover new fields
5. Edit the type field and you can then check the  "This term defines the bundle" box and save.
