### PR TITLE
Add in schema for options all supported tripal_layout field group options.

### DIFF
--- a/tripal_layout/config/schema/tripal_layout.schema.yml
+++ b/tripal_layout/config/schema/tripal_layout.schema.yml
@@ -87,13 +87,13 @@ tripal_layout_field_group_item:
       label: "The label of this field group"
     label_visibility:
       type: string
-      label: "Indicates if the label should be visable."
+      label: "Indicates if the label should be visible."
     empty_label_behavior:
       type: string
       label: "Indicates how to handle an empty label"
     region:
       type: string
-      label: "Region to put the field group in (i.e. 'Content')"
+      label: "Region to put the field group in (e.g. 'Content')"
     weight:
       type: integer
       label: "The weight to give this field group.  Field groups will be displayed in order of their weights with larger weights being lower on the list."
@@ -111,7 +111,7 @@ tripal_layout_field_group_item:
       label: "Field group caption or text description."
     desc_visibility:
       type: string
-      label: "Indicates if the description should be visable."
+      label: "Indicates if the description should be visible."
     first_column:
       type: string
       label: "First Column Header; only applies to field group tables."

--- a/tripal_layout/config/schema/tripal_layout.schema.yml
+++ b/tripal_layout/config/schema/tripal_layout.schema.yml
@@ -85,15 +85,51 @@ tripal_layout_field_group_item:
     label:
       type: string
       label: "The label of this field group"
+    label_visibility:
+      type: string
+      label: "Indicates if the label should be visable."
+    empty_label_behavior:
+      type: string
+      label: "Indicates how to handle an empty label"
+    region:
+      type: string
+      label: "Region to put the field group in (i.e. 'Content')"
     weight:
       type: integer
       label: "The weight to give this field group.  Field groups will be displayed in order of their weights with larger weights being lower on the list."
+    classes:
+      type: string
+      label: "space separated list of classes to apply."
     show_empty:
       type: boolean
       label: "Set to true if this field group should be shown even if all of it's children are empty"
     open:
       type: boolean
       label: "Set to true if this field group should be open by default. False if closed"
+    description:
+      type: string
+      label: "Field group caption or text description."
+    desc_visibility:
+      type: string
+      label: "Indicates if the description should be visable."
+    first_column:
+      type: string
+      label: "First Column Header; only applies to field group tables."
+    second_column:
+      type: string
+      label: "Second Column Header; only applies to field group tables."
+    table_row_striping:
+      type: string
+      label: "Indicates whether to alternate colours per row of a table."
+    always_show_field_label:
+      type: string
+      label: "If true, ignores label visibility and always shows the label; only applies to tables."
+    always_show_field_value:
+      type: string
+      label: "If true, even fields with no value will be shown in the table; otherwise they are removed."
+    empty_field_placeholder:
+      type: string
+      label: "The value to display in place of an empty value (e.g. 'n/a'); only applies to tables where always_show_field_value is true."
     children:
       type: sequence
       label: "The names of fields or field groups that are children of this field group. Use the format 'type:<field type>' to include all fields of a given type (e.g., 'type:chado_property_type_default')"


### PR DESCRIPTION

# Bug Fix

### Issue #1862

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I missed this in the original PR referenced 🙈 We need schema definitions for all options supported in the YAML but the original PR only included the main ones we had previously used and that are represented in the test yamls. This PR adds all the supported ones.

Note: this came about because we are using the Tripal Layout in our TripalCultivate extension module and it's test yamls have a description. As such all our tests are failing with a missing schema note about the description. 
<img width="1129" alt="Screenshot 2024-10-07 at 4 40 57 PM" src="https://github.com/user-attachments/assets/843d4684-f2f7-4635-b4d5-df7307d87539">

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This is a schema only change. It is much more difficult to test manually then it is worth. As such, code review and confirm it doesn't break existing tests.