### PR TITLE
Github workflow forces people to accept chado :-p 

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - trpCore-1997-chadoInNoChado
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - tv4g0-0-dockerBuilds
+      - trpCore-1997-chadoInNoChado
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -125,7 +125,7 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildArgs: "drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}"
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }},installchado=FALSE"
           labels: 'tripal.branch=4.x,drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       ## Build Images tagged drupal{VER} focused on php 8.2 + postgresql 16
       - uses: mr-smithers-excellent/docker-build-push@v6


### PR DESCRIPTION

# Bug Fix

### Issue #1997 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are a number of automatically generated docker images for TripalDocker including a bunch with labels indicating they should not have chado installed. However, at some point, docker started installing chado anyway and no one noticed until now.

This PR just adds back in the argument `installchado=FALSE` for the workflows building the docker images in the section where it builds the `noChado` images.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This is a github workflow so it can't be tested until this is merged 🙈

As such, just a quick code review needed.