### PR TITLE
Fix docker build failing as of Drush 13.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG modules='devel devel_php field_group field_group_table'
 ARG tripalmodules='tripal tripal_biodb tripal_chado tripal_layout'
 ARG chadoschema='chado'
 ARG installchado=TRUE
-# see issue #2000 for the reason for this argument:
-ARG COMPOSER_RUNTIME_BIN_DIR=/var/www/drupal/vendor/bin
+# see issue #2000 for the reason for updating the PATH:
+ENV PATH="/var/www/drupal/vendor/drush/drush:$PATH"
 
 # Label docker image
 LABEL tripal.version="4.x-dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ARG modules='devel devel_php field_group field_group_table'
 ARG tripalmodules='tripal tripal_biodb tripal_chado tripal_layout'
 ARG chadoschema='chado'
 ARG installchado=TRUE
+# see issue #2000 for the reason for this argument:
+ARG COMPOSER_RUNTIME_BIN_DIR=/var/www/drupal/vendor/bin
 
 # Label docker image
 LABEL tripal.version="4.x-dev"


### PR DESCRIPTION
# Bug Fix

### Closes #2000 

### Tripal Version: 4.x

## Description
With this Drush commit https://github.com/drush-ops/drush/commit/c3a70a119f0cd05bb69a2ce68c487375343c8126 the file `/usr/local/bin/drush` was changed significantly, and our tripal docker builds are now failing.

The generated path to `drush.php` is no longer valid.

~~This PR explicitly sets an environment variable that resolves this.~~

~~It is a simple fix, but I am not 100% sure if there is not a better way to fix it, though.~~

This is fixed by making sure the location of the `drush` binary is earlier in the search PATH than the symlink to it.

## Testing?
1. Build a docker on this branch and verify that it is built successfully!
2. At a bash prompt inside the docker verify that the `drush` command gives help info instead of an error.
```
root@ba1061a12fa3:/var/www/drupal/web# drush
Drush Commandline Tool 13.3.0.0

Run `drush help [command]` to view command-specific help.  Run `drush topic` to read even more documentation.

Available commands:              
etc.
```
