### PR TITLE
Fix url template for custom content types

### DIFF
--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -494,7 +494,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       return $this->url_format;
     }
     else {
-      return '[type]/[TripalEntity__entity_id]';
+      return 'bio_data/[TripalEntity__entity_id]';
     }
   }
 

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -528,10 +528,10 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
     // ID Tokens:
     if ($options['include id'] == TRUE) {
-      $token = '[TripalBundle__bundle_id]';
+      $token = '[TripalEntityType__entity_id]';
       $tokens[$token] = [
-        'label' => 'Bundle ID',
-        'description' => 'The unique identifier for this Tripal Content Type.',
+        'label' => 'Content Type/Bundle ID',
+        'description' => 'The machine name for this Tripal Content Type. By default this will be similar to the label you entered. For example, if you created a content type with the label "Genome Annoation" then it\'s machine name/id would be "genome_annotation".',
         'token' => $token,
         'field_name' => NULL,
         'required' => TRUE,

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -494,7 +494,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       return $this->url_format;
     }
     else {
-      return '[TripalBundle__bundle_id]/[TripalEntity__entity_id]';
+      return '[TripalEntityType__term_label]/[TripalEntity__entity_id]';
     }
   }
 
@@ -540,7 +540,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       $token = '[TripalEntity__entity_id]';
       $tokens[$token] = [
         'label' => 'Content/Entity ID',
-        'description' => 'The unique identifier for an individual piece of Tripal Content.',
+        'description' => 'The unique identifier for an individual piece of Tripal Content. This will be unique for each Tripal Content page and is an integer.',
         'token' => $token,
         'field_name' => NULL,
         'required' => TRUE,
@@ -548,8 +548,8 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
       $token = '[TripalEntityType__term_namespace]';
       $tokens[$token] = [
-        'label' => 'Tripal Entity Term Name',
-        'description' => 'The database name describing the term for this Tripal Content Type.',
+        'label' => 'Content Type Term Namespace',
+        'description' => 'The database name describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the namespace is "SO".',
         'token' => $token,
         'field_name' => NULL,
         'required' => TRUE,
@@ -557,8 +557,17 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
       $token = '[TripalEntityType__term_accession]';
       $tokens[$token] = [
-        'label' => 'Tripal Entity Term Accession',
-        'description' => 'The database accession describing the term for this Tripal Content Type.',
+        'label' => 'Content Type Term Accession',
+        'description' => 'The database accession describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the accession is "0000704".',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
+
+      $token = '[TripalEntityType__term_label]';
+      $tokens[$token] = [
+        'label' => 'Content Type Term Label',
+        'description' => 'The human readable label of the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the label is "gene".',
         'token' => $token,
         'field_name' => NULL,
         'required' => TRUE,
@@ -569,7 +578,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $token = '[TripalEntityType__label]';
     $tokens[$token] = [
       'label' => 'Tripal Entity Type',
-      'description' => 'The human-readable label for this Tripal Content Type.',
+      'description' => 'The human-readable label for this Tripal Content Type (e.g. "Genome Annotation").',
       'token' => $token,
       'field_name' => NULL,
       'required' => TRUE,

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -557,32 +557,37 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       'required' => TRUE,
     ];
 
-    $token = '[TripalEntityType__term_namespace]';
-    $tokens[$token] = [
-      'label' => 'Content Type Term Namespace',
-      'description' => 'The database name describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the namespace is "SO".',
-      'token' => $token,
-      'field_name' => NULL,
-      'required' => TRUE,
-    ];
+    // @todo currently we are only including these for URLS due to issue #2009
+    //       This if should be removed when that issue is closed, to allow these
+    //       tokens to be used in titles.
+    if ($options['include id'] == TRUE) {
+      $token = '[TripalEntityType__term_namespace]';
+      $tokens[$token] = [
+        'label' => 'Content Type Term Namespace',
+        'description' => 'The database name describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the namespace is "SO".',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
 
-    $token = '[TripalEntityType__term_accession]';
-    $tokens[$token] = [
-      'label' => 'Content Type Term Accession',
-      'description' => 'The database accession describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the accession is "0000704".',
-      'token' => $token,
-      'field_name' => NULL,
-      'required' => TRUE,
-    ];
+      $token = '[TripalEntityType__term_accession]';
+      $tokens[$token] = [
+        'label' => 'Content Type Term Accession',
+        'description' => 'The database accession describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the accession is "0000704".',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
 
-    $token = '[TripalEntityType__term_label]';
-    $tokens[$token] = [
-      'label' => 'Content Type Term Label',
-      'description' => 'The human readable label of the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the label is "gene".',
-      'token' => $token,
-      'field_name' => NULL,
-      'required' => TRUE,
-    ];
+      $token = '[TripalEntityType__term_label]';
+      $tokens[$token] = [
+        'label' => 'Content Type Term Label',
+        'description' => 'The human readable label of the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the label is "gene".',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
+    }
 
     $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('tripal_entity', $this->id);
     foreach ($instances as $instance_name => $instance) {

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -494,7 +494,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       return $this->url_format;
     }
     else {
-      return 'bio_data/[TripalEntity__entity_id]';
+      return '[TripalBundle__bundle_id]/[TripalEntity__entity_id]';
     }
   }
 
@@ -541,6 +541,24 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       $tokens[$token] = [
         'label' => 'Content/Entity ID',
         'description' => 'The unique identifier for an individual piece of Tripal Content.',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
+
+      $token = '[TripalEntityType__term_namespace]';
+      $tokens[$token] = [
+        'label' => 'Tripal Entity Term Name',
+        'description' => 'The database name describing the term for this Tripal Content Type.',
+        'token' => $token,
+        'field_name' => NULL,
+        'required' => TRUE,
+      ];
+
+      $token = '[TripalEntityType__term_accession]';
+      $tokens[$token] = [
+        'label' => 'Tripal Entity Term Accession',
+        'description' => 'The database accession describing the term for this Tripal Content Type.',
         'token' => $token,
         'field_name' => NULL,
         'required' => TRUE,

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -545,33 +545,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
         'field_name' => NULL,
         'required' => TRUE,
       ];
-
-      $token = '[TripalEntityType__term_namespace]';
-      $tokens[$token] = [
-        'label' => 'Content Type Term Namespace',
-        'description' => 'The database name describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the namespace is "SO".',
-        'token' => $token,
-        'field_name' => NULL,
-        'required' => TRUE,
-      ];
-
-      $token = '[TripalEntityType__term_accession]';
-      $tokens[$token] = [
-        'label' => 'Content Type Term Accession',
-        'description' => 'The database accession describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the accession is "0000704".',
-        'token' => $token,
-        'field_name' => NULL,
-        'required' => TRUE,
-      ];
-
-      $token = '[TripalEntityType__term_label]';
-      $tokens[$token] = [
-        'label' => 'Content Type Term Label',
-        'description' => 'The human readable label of the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the label is "gene".',
-        'token' => $token,
-        'field_name' => NULL,
-        'required' => TRUE,
-      ];
     }
 
     // Term/Type Tokens:
@@ -579,6 +552,33 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $tokens[$token] = [
       'label' => 'Tripal Entity Type',
       'description' => 'The human-readable label for this Tripal Content Type (e.g. "Genome Annotation").',
+      'token' => $token,
+      'field_name' => NULL,
+      'required' => TRUE,
+    ];
+
+    $token = '[TripalEntityType__term_namespace]';
+    $tokens[$token] = [
+      'label' => 'Content Type Term Namespace',
+      'description' => 'The database name describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the namespace is "SO".',
+      'token' => $token,
+      'field_name' => NULL,
+      'required' => TRUE,
+    ];
+
+    $token = '[TripalEntityType__term_accession]';
+    $tokens[$token] = [
+      'label' => 'Content Type Term Accession',
+      'description' => 'The database accession describing the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the accession is "0000704".',
+      'token' => $token,
+      'field_name' => NULL,
+      'required' => TRUE,
+    ];
+
+    $token = '[TripalEntityType__term_label]';
+    $tokens[$token] = [
+      'label' => 'Content Type Term Label',
+      'description' => 'The human readable label of the term for this Tripal Content Type. For example, if this content type uses the term "gene (SO:0000704)" then the label is "gene".',
       'token' => $token,
       'field_name' => NULL,
       'required' => TRUE,

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -230,9 +230,7 @@ class TripalEntityTypeForm extends EntityForm {
 
     $term_str = $form_state->getValue('term');
     $matches = [];
-    $term_name = NULL;
     if (preg_match('/(.+?) \((.+?):(.+?)\)/', $term_str, $matches)) {
-      $term_name = $matches[1];
       $idSpace = $matches[2];
       $accession = $matches[3];
 
@@ -290,15 +288,8 @@ class TripalEntityTypeForm extends EntityForm {
           "The token \"$invalid_token\" is not a valid title token");
     }
 
-    // For the url, replace the generic 'bio_data' placeholder, if
-    // still present, with the name of the content type
-    $url_format = $form_state->getValue('url_format');
-    if ($term_name and preg_match('/^bio_data\//', $url_format)) {
-      $url_format = preg_replace('/^bio_data/', $term_name, $url_format);
-      $form_state->setValue('url_format', $url_format);
-    }
-
     // Make sure all url tokens used are valid
+    $url_format = $form_state->getValue('url_format');
     $invalid_token = $this->validateTokens($url_format, $url_tokens);
     if ($invalid_token) {
       $form_state->setErrorByName('url_format',

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -230,7 +230,9 @@ class TripalEntityTypeForm extends EntityForm {
 
     $term_str = $form_state->getValue('term');
     $matches = [];
+    $term_name = NULL;
     if (preg_match('/(.+?) \((.+?):(.+?)\)/', $term_str, $matches)) {
+      $term_name = $matches[1];
       $idSpace = $matches[2];
       $accession = $matches[3];
 
@@ -288,8 +290,15 @@ class TripalEntityTypeForm extends EntityForm {
           "The token \"$invalid_token\" is not a valid title token");
     }
 
-    // Make sure all url tokens used are valid
+    // For the url, replace the generic 'bio_data' placeholder, if
+    // still present, with the name of the content type
     $url_format = $form_state->getValue('url_format');
+    if ($term_name and preg_match('/^bio_data\//', $url_format)) {
+      $url_format = preg_replace('/^bio_data/', $term_name, $url_format);
+      $form_state->setValue('url_format', $url_format);
+    }
+
+    // Make sure all url tokens used are valid
     $invalid_token = $this->validateTokens($url_format, $url_tokens);
     if ($invalid_token) {
       $form_state->setErrorByName('url_format',

--- a/tripal/src/Services/TripalTokenParser.php
+++ b/tripal/src/Services/TripalTokenParser.php
@@ -220,7 +220,7 @@ class TripalTokenParser {
         $token = preg_replace('/\]/', '', $token);
 
         // Look for values for bundle or entity related tokens.
-        if ($token === 'TripalBundle__bundle_id') {
+        if (($token === 'TripalEntityType__entity_id') OR ($token === 'TripalBundle__bundle_id')) {
           $value = $this->bundle->getID();
           $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
         }

--- a/tripal/src/Services/TripalTokenParser.php
+++ b/tripal/src/Services/TripalTokenParser.php
@@ -232,6 +232,14 @@ class TripalTokenParser {
           $value = $this->entity->getID();
           $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
         }
+        elseif ($token == 'TripalEntityType__term_namespace') {
+          $value = $this->bundle->get('termIdSpace');
+          $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
+        }
+        elseif ($token == 'TripalEntityType__term_accession') {
+          $value = $this->bundle->get('termAccession');
+          $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
+        }
         // Look for values for field related tokens
         elseif (in_array($token, array_keys($this->fields))) {
           $field = $this->fields[$token];

--- a/tripal/src/Services/TripalTokenParser.php
+++ b/tripal/src/Services/TripalTokenParser.php
@@ -240,6 +240,10 @@ class TripalTokenParser {
           $value = $this->bundle->get('termAccession');
           $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
         }
+        elseif ($token == 'TripalEntityType__term_label') {
+          $value = $this->bundle->getTerm()->getName();
+          $replaced[$index] = trim(preg_replace("/\[$token\]/", $value,  $replaced[$index]));
+        }
         // Look for values for field related tokens
         elseif (in_array($token, array_keys($this->fields))) {
           $field = $this->fields[$token];


### PR DESCRIPTION
# Bug Fix

### Closes #1996

### Depends on #2001 (merged)

### Tripal Version: 4.x

## Description
The current default URL template `[type]/[TripalEntity__entity_id]` is not valid when you create a new custom content type.
This PR does two things
1. Change the default URL template to `[TripalBundle__bundle_id]/[TripalEntity__entity_id]`, which will now work as expected.
2. Adds two more tokens `[TripalEntityType__term_namespace]` and `[TripalEntityType__term_accession]`

## Testing?
1. Create a new content type. I used "Primer" based on the "feature" table. However I would recommend a two-word type to test something with spaces, i.e. "Oligonucleotide Primer" would be great. For example
![PR2002finishedprimer](https://github.com/user-attachments/assets/d425a7eb-931a-4b02-b556-b2c2755bb1af)
2. You can go ahead and add the required fields for a content type based on the feature table: name, uniquename, organism, type_reference
3. Create the required organism
4. Create a primer entity and confirm that the url alias is, in this case, `oligonucleotide_primer/2`
