### PR TITLE
fix issue #2010

### DIFF
--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -570,10 +570,12 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
           if (!$entity_type->getThirdPartySetting('tripal', 'bundle_type_column')) {
             $fixed_value = $field_def['settings']['fixed_value'] ?? NULL;
             if ($fixed_value) {
-              $term_parts = explode(':', $fixed_value, 2);
-              $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $term_parts[0]);
-              $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $term_parts[1]);
-              $entity_type->save();
+              $storage_plugin_settings = $field_def['storage_settings']['storage_plugin_settings'] ?? [];
+              if (array_key_exists('type_table', $storage_plugin_settings) and array_key_exists('type_column', $storage_plugin_settings)) {
+                $entity_type->setThirdPartySetting('tripal', 'bundle_type_table', $storage_plugin_settings['type_table']);
+                $entity_type->setThirdPartySetting('tripal', 'bundle_type_column', $storage_plugin_settings['type_column']);
+                $entity_type->save();
+              }
             }
           }
         }


### PR DESCRIPTION
# Bug Fix

### Closes #2010

### Tripal Version: 4.x

## Description
I introduced a bug in PR #1992 and stored the term instead of the table and column

## Testing?
1. Go to Tripal -> Page Structure -> Organism -> Manage fields
2. Check for new fields
![issue2010 1](https://github.com/user-attachments/assets/4242d766-40a4-4d36-aa3e-b4bc3bb47b33)
3. Add the field
4. Run this bit of code
```
$bundles = ['organism'];
foreach ($bundles as $bundle) {
  $entity_type_manager = \Drupal::entityTypeManager();
  $entity_type = $entity_type_manager->getStorage('tripal_entity_type')->load($bundle);
  $entity_type_chado_base_table = $entity_type->getThirdPartySetting('tripal', 'chado_base_table');
  $entity_type_bundle_type_table = $entity_type->getThirdPartySetting('tripal', 'bundle_type_table');
  $entity_type_bundle_type_column = $entity_type->getThirdPartySetting('tripal', 'bundle_type_column');
  print "bundle=\"$bundle\"\n";
  print "  base_table=\"$entity_type_chado_base_table\"\n";
  print "  type_table=\"$entity_type_bundle_type_table\"\n";
  print "  type_column=\"$entity_type_bundle_type_column\"\n";
}
```
Output should now be
![issue2010 3](https://github.com/user-attachments/assets/ec352fa2-5ecc-4a3d-b316-381d866be97a)


Note that this field with its default is not appropriate to add to the organism content type, and it will eventually break publish of organisms if added. This is one of the cases where the additional type field is not used to define the bundle, here on organisms it is specifying the infraspecific type. See issue #2012 
Of course, we could manually add this field using the `organismprop.type_id` column if we wanted to define a bundle based on the organism table. An example might if we wanted "Pathogen" organisms in a separate bundle.

This also affects at least the `dna_library` bundle.