### PR TITLE
Inhibit additional type field discovery if field already exists

### DIFF
--- a/tripal/src/Form/TripalContentFieldsForm.php
+++ b/tripal/src/Form/TripalContentFieldsForm.php
@@ -117,7 +117,7 @@ class TripalContentFieldsForm implements FormInterface {
       . 'discovered but which are already attached to this content type. They '
       . 'are shown here but cannot be added again.');
     if (empty($existing_fields)) {
-      $existing_fields_desc = t('No new fields were found for this content type');
+      $existing_fields_desc = t('No existing fields were found for this content type');
     }
     $form['existing_fields_details']['existing_fields_list'] = [
       '#type' => 'checkboxes',

--- a/tripal/src/Form/TripalContentFieldsForm.php
+++ b/tripal/src/Form/TripalContentFieldsForm.php
@@ -54,29 +54,11 @@ class TripalContentFieldsForm implements FormInterface {
           . 'validation checks are also shown but cannot be added'),
     ];
 
-    // Add the vertical tab element.
+    // Add the vertical tab element for discovered fields.
     $form['field_type_tabs'] = [
       '#type' => 'vertical_tabs',
       '#title' => 'Discovered Fields',
     ];
-
-    // Add the tabs.
-    $form['new_fields_details'] = [
-      '#type' => 'details',
-      '#title' => 'New Fields',
-      '#group' => 'field_type_tabs',
-    ];
-    $form['existing_fields_details'] = [
-      '#type' => 'details',
-      '#title' => 'Existing Fields',
-      '#group' => 'field_type_tabs',
-    ];
-    $form['invalid_fields_details'] = [
-      '#type' => 'details',
-      '#title' => 'Invalid Fields',
-      '#group' => 'field_type_tabs',
-    ];
-
 
     // Add elements for the new fields tab.
     $new_fields = [];
@@ -88,6 +70,11 @@ class TripalContentFieldsForm implements FormInterface {
       }
       $new_defaults[] = $field['name'];
     }
+    $form['new_fields_details'] = [
+      '#type' => 'details',
+      '#title' => 'New Fields (' . ($new_fields?number_format(count($new_fields)):t('None')) . ')',
+      '#group' => 'field_type_tabs',
+    ];
     $new_fields_desc = t('The following is a list of new fields that are '
       . 'compatible with this content type. Select those you want to add.');
     if (empty($new_fields)) {
@@ -113,6 +100,11 @@ class TripalContentFieldsForm implements FormInterface {
       }
       $existing_defaults[] = $field['name'];
     }
+    $form['existing_fields_details'] = [
+      '#type' => 'details',
+      '#title' => 'Existing Fields (' . ($existing_fields?number_format(count($existing_fields)):t('None')) . ')',
+      '#group' => 'field_type_tabs',
+    ];
     $existing_fields_desc = t('The following is a list of fields that were '
       . 'discovered but which are already attached to this content type. They '
       . 'are shown here but cannot be added again.');
@@ -139,6 +131,11 @@ class TripalContentFieldsForm implements FormInterface {
       }
       $invalid_fields[$field['name']] .= '. Invalid Reason: ' . $field['invalid_reason'];
     }
+    $form['invalid_fields_details'] = [
+      '#type' => 'details',
+      '#title' => 'Invalid Fields (' . ($invalid_fields?number_format(count($invalid_fields)):t('None')) . ')',
+      '#group' => 'field_type_tabs',
+    ];
     $invalid_fields_desc = t('The following fields do not pass validation tests. '
       . 'They need correction by the module developer and cannot be added.');
     if (empty($invalid_fields_desc)) {

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -279,7 +279,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
       'name' => $instance->getName(),
       'content_type' => $instance->getTargetBundle(),
       'label' => $instance->getLabel(),
-      'type' => self::$id,
+      'type' => $instance->getType(),
       'description' => $instance->getDescription(),
       'cardinality' => $field_storage->getCardinality(),
       'required' => $instance->isRequired(),

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -230,7 +230,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     foreach ($all_field_defs as $field_id => $field_def) {
       $field_class = $field_def['class'];
       if (is_subclass_of($field_class, 'Drupal\tripal\TripalField\TripalFieldItemBase')) {
-        $discovered = $field_class::discover($tripal_entity_type, $field_id, $all_field_defs);
+        $discovered = $field_class::discover($tripal_entity_type, $field_id, $all_field_defs, $entity_field_defs);
         foreach ($discovered as $discovered_field) {
 
           // If the CV term for the discovered field is currently used by an
@@ -257,6 +257,38 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
       }
     }
     return $field_status;
+  }
+
+  /**
+   * Provides a compatible array for a field based on it's Field Config.
+   *
+   * This is to be used in the discover process to add existing fields to the
+   * field list in a standardized way.
+   *
+   * @param FieldConfig $instance
+   *   The existing field to generate an array for so it can be added to the
+   *   field list as an existing field.
+   * @return array
+   *   An array which matches the form expected to be a single item in the
+   *   discover method.
+   */
+  public static function getFieldArrayFromFieldInstance(FieldConfig $instance) {
+    $field_storage = $instance->getFieldStorageDefinition();
+    $settings = $instance->getSettings();
+    return [
+      'name' => $instance->getName(),
+      'content_type' => $instance->getTargetBundle(),
+      'label' => $instance->getLabel(),
+      'type' => self::$id,
+      'description' => $instance->getDescription(),
+      'cardinality' => $field_storage->getCardinality(),
+      'required' => $instance->isRequired(),
+      'storage_settings' => [
+        'storage_plugin_id' => $settings['storage_plugin_id'],
+        'storage_plugin_settings' => $settings['storage_plugin_settings'],
+      ],
+      'settings' => $settings,
+    ];
   }
 
   /**

--- a/tripal/src/TripalField/Interfaces/TripalFieldItemInterface.php
+++ b/tripal/src/TripalField/Interfaces/TripalFieldItemInterface.php
@@ -131,10 +131,10 @@ interface TripalFieldItemInterface extends FieldItemInterface {
    * configuration file during installation of a module.  In some cases,
    * however, not all possible instances of a field can be added to a content
    * type at installation of the module.  This function can be called to discover
-   * if new instances of a field are appropraite for a given content type.  An
+   * if new instances of a field are appropriate for a given content type.  An
    * example of this is the `chado_property_type_default` field.  This function
    * should examine its storage backend and return a list of new fields
-   * instnaces that could be added to the content type (i.e., bundle).
+   * instances that could be added to the content type (i.e., bundle).
    *
    * @param \Drupal\tripal\Entity\TripalEntityType $bundle
    *   The entity type object for which new field instances should be found.
@@ -142,12 +142,22 @@ interface TripalFieldItemInterface extends FieldItemInterface {
    * @param string $field_id
    *   The id of the field.
    *
-   * @param array $field_definitions
-   *   The field definition array.
+   * @param array $field_types
+   *   An array where each item defines a field type that is attached to this
+   *   bundle. Each item is itself an array of the annotation defined at the top
+   *   of that particular field type class.
+   *
+   * @param array $field_instances
+   *   An array of FieldConfig objects where each object defines a field attached
+   *   to this content type. This differs from $field_types in that (1) there
+   *   will be multiple entries if there a multiple instances of a single field
+   *   type and (2) it includes the specific settings needed to create the field.
+   *   As such, the FieldConfig object can be used to add existing fields to the
+   *   field list returned by this method.
    *
    * @return array
-   *   An associative array that follows the same structure as expected by `
+   *   An associative array that follows the same structure as expected by
    *   tripal.tripalfield_collection.* configuration.
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array;
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array;
 }

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -692,7 +692,7 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
    * {@inheritDoc}
    * @see \Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface::discover()
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array{
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array {
 
     return [];
   }

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -92,7 +92,7 @@ class TripalTerm {
       $this->setAccession($details['accession']);
     }
     if (array_key_exists('definition', $details)) {
-      $this->setDefinition($details['definition']);
+      $this->setDefinition($details['definition'] ?? '');
     }
     if (array_key_exists('idSpace', $details)) {
       $this->setIdSpace($details['idSpace']);

--- a/tripal/tests/modules/tripal_test/src/Plugin/Field/FieldType/TripalTestTextTypeItem.php
+++ b/tripal/tests/modules/tripal_test/src/Plugin/Field/FieldType/TripalTestTextTypeItem.php
@@ -42,7 +42,7 @@ class TripalTestTextTypeItem extends TripalFieldItemBase {
    * {@inheritDoc}
    * @see \Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface::discover()
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array {
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array {
 
     $base_field = [
       'name' => self::generateFieldName($bundle, 'test_field', 0),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -515,6 +515,15 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       return $field_list;
     }
 
+    // If any instance of this field already exists on this content type,
+    // we will not suggest it for discovery. If there is a need for multiple
+    // instances, then they will need to be added manually through the GUI.
+    // Note that this will also block the existing field from showing up in
+    // the "Existing Fields" list, though.
+    if (array_key_exists(self::$id, $field_definitions)) {
+      return $field_list;
+    }
+
     // Create a field entry in the list
     $termIdSpace = $bundle->getTermIdSpace();
     $termAccession = $bundle->getTermAccession();

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -10,6 +10,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\tripal\Services\TripalFieldCollection;
 
 /**
  * Plugin implementation of Tripal additional type field type.
@@ -469,7 +470,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
    * {@inheritDoc}
    * @see \Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface::discover()
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array {
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array {
 
     /** @var \Drupal\tripal_chado\Database\ChadoConnection $chado **/
     $chado = \Drupal::service('tripal_chado.database');
@@ -515,12 +516,14 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       return $field_list;
     }
 
-    // If any instance of this field already exists on this content type,
-    // we will not suggest it for discovery. If there is a need for multiple
-    // instances, then they will need to be added manually through the GUI.
-    // Note that this will also block the existing field from showing up in
-    // the "Existing Fields" list, though.
-    if (array_key_exists(self::$id, $field_definitions)) {
+    // Check for existing fields of this type.
+    if (array_key_exists(self::$id, $field_types)) {
+      // If yes, then add it to the field list.
+      foreach ($field_instances as $instance) {
+        if ($instance->getType() == self::$id) {
+          $field_list[] = TripalFieldCollection::getFieldArrayFromFieldInstance($instance);
+        }
+      }
       return $field_list;
     }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -518,13 +518,15 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
 
     // Check for existing fields of this type.
     if (array_key_exists(self::$id, $field_types)) {
-      // If yes, then add it to the field list.
+      // If an existing field exists, then add it to the field list and return.
       foreach ($field_instances as $instance) {
         if ($instance->getType() == self::$id) {
           $field_list[] = TripalFieldCollection::getFieldArrayFromFieldInstance($instance);
         }
       }
-      return $field_list;
+      if ($field_list) {
+        return $field_list;
+      }
     }
 
     // Create a field entry in the list

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -305,7 +305,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       return $field_list;
     }
 
-    // Make sure the base table has a foriegn key to the organism table.
+    // Make sure the base table has a foreign key to the organism table.
     if (!$chado->schema()->foreignKeyExists($base_table, 'organism')) {
       return $field_list;
     }
@@ -319,7 +319,9 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
           $field_list[] = TripalFieldCollection::getFieldArrayFromFieldInstance($instance);
         }
       }
-      return $field_list;
+      if ($field_list) {
+        return $field_list;
+      }
     }
 
     // Create a field entry in the list.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -7,6 +7,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal\Entity\TripalEntityType;
+use Drupal\tripal\Services\TripalFieldCollection;
 
 /**
  * Plugin implementation of default Tripal organism field type.
@@ -290,7 +291,7 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
    * {@inheritDoc}
    * @see \Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface::discover()
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array {
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array {
 
     /** @var \Drupal\tripal_chado\Database\ChadoConnection $chado **/
     $chado = \Drupal::service('tripal_chado.database');
@@ -309,6 +310,17 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
       return $field_list;
     }
     $fk_def = $chado->schema()->getForeignKeyDef($base_table, 'organism');
+
+    // Check for existing fields of this type.
+    if (array_key_exists(self::$id, $field_types)) {
+      // If yes, then add it to the field list.
+      foreach ($field_instances as $instance) {
+        if ($instance->getType() == self::$id) {
+          $field_list[] = TripalFieldCollection::getFieldArrayFromFieldInstance($instance);
+        }
+      }
+      return $field_list;
+    }
 
     // Create a field entry in the list.
     $field_list[] = [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -253,7 +253,7 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
    * {@inheritDoc}
    * @see \Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface::discover()
    */
-  public static function discover(TripalEntityType $bundle, string $field_id, array $field_definitions) : array {
+  public static function discover(TripalEntityType $bundle, string $field_id, array $field_types, array $field_instances): array {
 
     /** @var \Drupal\tripal_chado\Database\ChadoConnection $chado **/
     $chado = \Drupal::service('tripal_chado.database');


### PR DESCRIPTION
# New Feature - or - Bug Fix depending on your interpretation ...

### Closes #2012

### Tripal Version: 4.x

## Description
For the additional type field, this PR will no longer discover the field if an instance of the field already exists for the bundle.

The reason behind this is that this field is **usually** used to indicate the CV term for multiple bundles based on a single chado table. For example, "gene' and "mRNA" bundles from the "feature" table.

But in some cases the field is used to indicate a type. For organism, the indicated type is the infraspecific type (subspecies, cultivar, etc.), or for contact the type is the contact type (Person, Institute, etc.)

If we discover a second field, then we are effectively defining a new bundle type, and this is likely not the intention in these latter cases. And doing this may break publishing later.

So, this PR does the following: if the field already exists on the bundle, we shall choose to not automatically discover this field. This does not prevent it from being added through the GUI, however, if we really did want to separate the "organism" table into more than one bundle.

The only problem with the changes here, is that if discovery is "inhibited" as is done here, then the existing field does not show up in the "Existing fields" list, mainly because it uses a different CV term. This is a "discovery", not a "list what's there". Is that bad? Please discuss.

![pr2013 1](https://github.com/user-attachments/assets/e9866099-1818-4999-ab4c-50821050a15f)


## Testing?
1. Tripal -> Page Structure -> Contact -> Manage Fields
2. "+Check for New Fields"
3. No new fields will be suggested on this branch. On 4.x the "Type" field will be offered for addition. See Issue #2012 for screenshot.