### PR TITLE
Fixes bug in discovery, cv should have been db for termIdSpace

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -305,7 +305,7 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
           ],
         ],
         'settings' => [
-          'termIdSpace' => $recprop->cv_name,
+          'termIdSpace' => $recprop->db_name,
           'termAccession' => $recprop->accession,
         ],
         'display' => [


### PR DESCRIPTION
# Bug Fix

### Closes #2017

### Tripal Version: 4.x

## Description
This is a 1-line PR
This was a small bug in field discovery, termIdSpace should refer to the DB name, but the CV name was used instead.

## Testing?
Not sure of an easy set of steps, this showed up on trying to migrate Tripal 3 sites, and then discovering new property fields.