### PR TITLE
Published content now has an author & anonymous no longer WSODs

### DIFF
--- a/tripal/src/Form/TripalEntityForm.php
+++ b/tripal/src/Form/TripalEntityForm.php
@@ -119,10 +119,12 @@ class TripalEntityForm extends ContentEntityForm {
       '#wrapper_attributes' => ['class' => ['entity-meta__last-saved']],
       '#weight' => -5,
     ];
+    $owner = $entity->getOwner();
+    $author = $owner?$owner->getAccountName():'';
     $form['meta']['author'] = [
       '#type' => 'item',
       '#title' => $this->t('Author'),
-      '#markup' => $entity->getOwner()->getAccountName(),
+      '#markup' => $author,
       '#wrapper_attributes' => ['class' => ['entity-meta__author']],
       '#weight' => -4,
     ];

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -43,6 +43,13 @@ class ChadoPublish extends TripalBackendPublishBase {
   protected $entity_type = NULL;
 
   /**
+   * Stores the user that is publishing content.
+   *
+   * @var int $uid
+   **/
+  protected $uid = NULL;
+
+  /**
    * The TripalStorage object.
    *
    * @var \Drupal\tripal\TripalStorage\TripalStorageBase $storage
@@ -475,14 +482,13 @@ class ChadoPublish extends TripalBackendPublishBase {
 
     $timestamp = time();
     $query = $this->connection->insert('tripal_entity', [])
-      -> fields(['type', 'title', 'status', 'created', 'changed']);
+      -> fields(['type', 'uid', 'title', 'status', 'created', 'changed']);
     $added_record_ids = [];
     foreach ($matches as $match) {
-      //$i++;
       $record_id = $this->getChadoRecordID($match);
       $title = $titles[$record_id];
       $added_record_ids[] = $record_id;
-      $query->values([$this->bundle, $title, 1, $timestamp, $timestamp]);
+      $query->values([$this->bundle, $this->uid, $title, 1, $timestamp, $timestamp]);
     }
     $first_added_entity_id = $query->execute();
 
@@ -815,6 +821,9 @@ class ChadoPublish extends TripalBackendPublishBase {
     if ($options['batch_size'] ?? 0) {
       $this->batch_size = $options['batch_size'];
     }
+
+    // Current user will be the author of newly published entitites
+    $this->uid = \Drupal::currentUser()->id();
 
     // Initialize class variables that may persist between consecutive jobs
     $this->field_info = [];


### PR DESCRIPTION
# Bug Fix

### Closes #2022

### Tripal Version: 4.x

## Description
1. This brings Tripal 4 publish to be the same as Tripal 3 in that published content is assigned an author. The author will be the user running the publish job.
2. If an entity does not have an author, the edit will no longer generate a WSOD.

## Testing?
1. Build on 4.x
1. `INSERT INTO organism (genus, species) VALUES ('Tripalus', 'bugii');`
2. Publish organism
3. Go to this organism
4. Select Edit - see WSOD
5. Switch to this branch
6. Add another organism `INSERT INTO organism (genus, species) VALUES ('Tripalus', 'worksrealgood');`
7. Publish organism
8. Try editing both organisms, both should be editable
