### PR TITLE
Define third-party schema in tripal entity type as well

### DIFF
--- a/tripal_chado/tripal_chado.module
+++ b/tripal_chado/tripal_chado.module
@@ -48,6 +48,8 @@ function tripal_chado_help($route_name, RouteMatchInterface $route_match) {
 function tripal_chado_config_schema_info_alter(&$definitions) {
 
   // Third party settings for entity types
+  // (always add to both collection + content type entity).
+  // -- Collection.
   $definitions['tripal.tripalentitytype_collection.*']['mapping']['content_types']['sequence']['mapping']['settings']['mapping']['chado_base_table'] = [
     'type' => 'string',
     'label' => 'Entity Third Party Setting for Base Chado Table',
@@ -64,9 +66,20 @@ function tripal_chado_config_schema_info_alter(&$definitions) {
     'nullable' => true
   ];
 
+  // -- Content Type Entity.
   $definitions['tripal.content_type.*']['mapping']['third_party_settings']['mapping']['tripal']['mapping']['chado_base_table'] = [
     'type' => 'string',
     'label' => 'Entity Third Party Setting for Base Chado Table',
+    'nullable' => true
+  ];
+  $definitions['tripal.content_type.*']['mapping']['third_party_settings']['mapping']['tripal']['mapping']['bundle_type_table'] = [
+    'type' => 'string',
+    'label' => 'Entity Third Party Setting for Table Specifying Content CV Term',
+    'nullable' => true
+  ];
+  $definitions['tripal.content_type.*']['mapping']['third_party_settings']['mapping']['tripal']['mapping']['bundle_type_column'] = [
+    'type' => 'string',
+    'label' => 'Entity Third Party Setting for Column Specifying Content CV Term',
     'nullable' => true
   ];
 
@@ -228,7 +241,7 @@ function tripal_chado_rebuild() {
 
   $custom_tables_config = $fileStorage->read('config/install/views.view.chado_custom_tables');
   $mviews_config = $fileStorage->read('config/install/views.view.chado_mviews');
-  
+
   $storage = \Drupal::entityTypeManager()->getStorage('view');
 
   // Reload the custom tables view.
@@ -242,7 +255,7 @@ function tripal_chado_rebuild() {
   $view->delete();
   $view = $storage->create($mviews_config);
   $view->save();
-  
+
 }
 
 /**


### PR DESCRIPTION

# Bug Fix

### Issue #2025 

<!--- Enter the Tripal version this PR applies to (i.e. either 3 or 4 ;-p) --->
### Tripal Version: 4

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
We are seeing new schema errors in our extension module automated tests related to the third-party settings added in #1992. It looks like that PR added the new settings to the schema for the Tripal Entity Type Collection but not to the Tripal Entity itself 🙈 

See https://github.com/TripalCultivate/TripalCultivate/actions/runs/11706982342/job/32605306740?pr=30#step:3:1260 for the failures I'm referring to.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
We don't have an automated test for this in core 🙈 and should probably add one. In the meantime I'm hoping a simple code review is sufficient?