### PR TITLE
re-add updated importer prepareEnvironment

### DIFF
--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ImporterFormTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ImporterFormTest.php
@@ -59,6 +59,7 @@ class ImporterFormTest extends ChadoTestKernelBase {
 
     // Ensure we install the schema/modules we need.
     $this->prepareEnvironment(['TripalImporter']);
+    $this->installSchema('tripal_chado', ['tripal_cv_obo']);
   }
 
   /**

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ImporterFormTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/ImporterFormTest.php
@@ -57,16 +57,8 @@ class ImporterFormTest extends ChadoTestKernelBase {
     // Open connection to Chado
     $this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
-    // Ensure we can access file_managed related functionality from Drupal.
-    // ... users need access to system.action config?
-    $this->installConfig('system');
-    // ... managed files are associated with a user.
-    $this->installEntitySchema('user');
-    // ... Finally the file module + tables itself.
-    $this->installEntitySchema('file');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('tripal_chado', ['tripal_cv_obo']);
-
+    // Ensure we install the schema/modules we need.
+    $this->prepareEnvironment(['TripalImporter']);
   }
 
   /**


### PR DESCRIPTION
# Bug Fix

### Issue #1799 

### Tripal Version: 4.x

## Description
While the importer was waiting for review, some changes were made in PR #1981 to the importer tests.
To remove duplication, all of the importer form tests were merged into one file in PR #1927 but the change from PR #1981 was not added and so was reverted.
This PR puts that specific change back in.
I labelled urgent because this is causing test failures!

## Testing?
This is a change to automated testing so verify those work, and code review.
