### PR TITLE
implement is_required check

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -36,6 +36,14 @@ class ChadoPublish extends TripalBackendPublishBase {
   protected $field_info = [];
 
   /**
+   * A list of the main properties for each field.
+   * The key is the field name, and the value is the name of the main property.
+   *
+   * @var array $main_property_names
+   */
+  protected $main_property_names = [];
+
+  /**
    * Stores the bundle (entity type) object.
    *
    * @var \Drupal\tripal\Entity\TripalEntityType $entity_type
@@ -151,6 +159,8 @@ class ChadoPublish extends TripalBackendPublishBase {
           }
           $this->field_info[$field_name] = $field_info;
 
+          // Store the main properties for later
+          $this->main_property_names[$field_name] = $instance->mainPropertyName();
         }
       }
     }
@@ -951,7 +961,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
 
       $this->logger->notice($batch_prefix . 'Step 1 of 6: Find matching records');
-      $matches = $this->storage->findValues($this->search_values, $record_id_batch[0], end($record_id_batch));
+      $matches = $this->storage->findValues($this->search_values, $this->main_property_names, $record_id_batch[0], end($record_id_batch));
 
       if (!count($matches)) {
         $this->logger->notice($batch_prefix . 'No matching records found, skipping remaining steps');

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -384,7 +384,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           $tables = $this->records->getAncillaryTablesWithCond($base_table);
           foreach ($tables as $table_alias) {
 
-
             // Now find any items for this linked table.
             $num_items_found = $match->selectItems($base_table, $table_alias);
             if ($num_items_found == 0) {
@@ -609,13 +608,14 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    * @param integer $delta
    *   The field item's delta value.
    * @param array $values
-   *  An array of field values.
+   *   An array of field values.
    * @return boolean
    *   returns TRUE if the field has all necessary elements for inserting
    *   into the Drupal tables for publishing. FALSE otherwise.
    */
   protected function isFieldValid($field_name, $delta, $values) {
 
+    $is_required = $this->getFieldDefinition($field_name)->isRequired();
     foreach ($values[$field_name][$delta] as $key => $prop_value) {
       /** @var \Drupal\tripal\TripalStorage\StoragePropertyTypeBase $prop_type **/
       $prop_type = $this->getPropertyType($field_name, $key);
@@ -623,11 +623,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       $action = $prop_settings['action'];
       $is_store = preg_match('/^store/', $action);
       $value = $prop_value['value']->getValue();
-      $is_required = $prop_type->getRequired();
-      if ($is_store and $value === NULL) {
-        return FALSE;
-      }
-      if ($is_required and $value === NULL) {
+      if ($is_store and $is_required and $value === NULL) {
         return FALSE;
       }
     }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -341,12 +341,14 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   /**
    * @{inheritdoc}
    *
+   * @param array $main_property_names
+   *   Associative array where key is field name, value is name of the main property.
    * @param int|null $minimum_id
    *   When specified, only return records where the primary key is >= this value
    * @param int|null $maximum_id
    *   When specified, only return records where the primary key is <= this value
    */
-  public function findValues($values, $minimum_id = NULL, $maximum_id = NULL) {
+  public function findValues($values, array $main_property_names = [], ?int $minimum_id = NULL, ?int $maximum_id = NULL) {
 
     // Setup field debugging.
     $this->field_debugger->printHeader('Find');
@@ -358,7 +360,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     // Start an array to keep track of the results we find.
     // Each element in this array will be a clone of the full $values array
-    // passed into this method with it's propertyValue objects set to match
+    // passed into this method with its propertyValue objects set to match
     // the values in chado for a single record.
     $found_list = [];
 
@@ -408,7 +410,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           // Remove any values that are not valid.
           foreach ($new_values as $field_name => $deltas) {
             foreach ($deltas as $delta => $properties) {
-              $is_valid = $this->isFieldValid($field_name, $delta, $new_values);
+              $main_prop = $main_property_names[$field_name] ?? 'value';
+              $is_valid = $this->isFieldValid($field_name, $delta, $main_prop, $new_values);
               if (!$is_valid) {
                 unset($new_values[$field_name][$delta]);
               }
@@ -607,13 +610,15 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    *   The name of the field.
    * @param integer $delta
    *   The field item's delta value.
+   * @param string $main_property_name
+   *   The name of the field's main property.
    * @param array $values
    *   An array of field values.
    * @return boolean
    *   returns TRUE if the field has all necessary elements for inserting
    *   into the Drupal tables for publishing. FALSE otherwise.
    */
-  protected function isFieldValid($field_name, $delta, $values) {
+  protected function isFieldValid($field_name, $delta, $main_property_name, $values) {
 
     $is_required = $this->getFieldDefinition($field_name)->isRequired();
     foreach ($values[$field_name][$delta] as $key => $prop_value) {
@@ -623,7 +628,10 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       $action = $prop_settings['action'];
       $is_store = preg_match('/^store/', $action);
       $value = $prop_value['value']->getValue();
-      if ($is_store and $is_required and $value === NULL) {
+      if ($is_store and $is_required and ($value === NULL)) {
+        return FALSE;
+      }
+      if (($key == $main_property_name) and ($value === NULL)) {
         return FALSE;
       }
     }
@@ -708,7 +716,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           $context['property_settings'] = $prop_storage_settings;
           $context['delta'] = $delta;
           $context['action'] = $action;
-
 
           // Get the path array for this field and add any joins if any are needed.
           if (array_key_exists('path', $prop_storage_settings)) {


### PR DESCRIPTION
# Bug Fix

### Issue #1823
### Closes #2042 

## Description
For publishing of Chado content, we call the Chado storage function `findValues()`, and inside this function we call the function `$this->isFieldValid()`, which is used to remove any fields that don't have all of the required values for publishing
https://github.com/tripal/tripal/blob/0229c9149076fe57b406a7a60395186c9c014f5e/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php#L617-L636

In 4.x, the called `getRequired()` always returns FALSE because that function was never implemented, there are comments about this
https://github.com/tripal/tripal/blob/0229c9149076fe57b406a7a60395186c9c014f5e/tripal/src/TripalStorage/StoragePropertyTypeBase.php#L213-L225

The fix here is to actually look up the required status, and combine this with the existing check, so that now a NULL value is valid on fields if they are not required.
The exception is for the field that represents the mainPropertyName. This one cannot be NULL.

## Testing?
1. Repeat the test described in the issue
```
INSERT INTO pub (title, uniquename, type_id) VALUES ('test pub', 'P1', (SELECT cvterm_id FROM cvterm WHERE name='Journal Article'));
INSERT INTO pubprop (pub_id, type_id, value) VALUES (2, (SELECT cvterm_id FROM cvterm WHERE name='ISSN'), 'PropCannotPublishWithoutRank');
INSERT INTO pubprop (pub_id, type_id, value, rank) VALUES (2, (SELECT cvterm_id FROM cvterm WHERE name='eISSN'), 'PropCanPublishWithRank', 1);
\pset null '<NULL>'
SELECT * FROM pubprop;
 pubprop_id | pub_id | type_id |            value             |  rank  
------------+--------+---------+------------------------------+--------
          1 |      2 |    3006 | PropCannotPublishWithoutRank | <NULL>
          2 |      2 |    3021 | PropCanPublishWithRank       |      1
(2 rows)
```
Now publish "Publication" content type. You will see
` [notice] Publish completed. Published 2 new entities, and added 10 field values.`
(the null publication also got published, 4 field values are from that)
![issue8042 2](https://github.com/user-attachments/assets/0b07d881-3122-4c91-a5f9-640f352ad4fc)

2. Test for this bug as encountered loading a gff from issue #1823. First Tripal -> Page structure -> Import type collection -> Genomic Content Types
3. Create Organism: Saccharomyces cerevisiae
4. Create Analyses: "Genome assembly" and "Genome annotation"
5. Import a small test version of the FASTA file from the issue, I used `chromosome (SO:0000340)` as the type: 
[GCF_000146045.2_R64_genomic.twogenes.fna.txt](https://github.com/user-attachments/files/17969405/GCF_000146045.2_R64_genomic.twogenes.fna.txt)
6. Import a small test version of the GFF file from the issue:
[GCF_000146045.2_R64_genomic.twogenes.gff.txt](https://github.com/user-attachments/files/17969408/GCF_000146045.2_R64_genomic.twogenes.gff.txt)
7. Publish gene content type. The sequence coordinates field should now be populated.
![issue8042 1](https://github.com/user-attachments/assets/31392e2c-1127-42df-932c-a0eef8bcb524)


