### PR TITLE
Fix install issue when Tripal is installed by a distribution (profile)

### DIFF
--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -4,6 +4,7 @@
  * Contains functions used to install/uninstall tripal.
  */
 
+use Drupal\Core\Database\ConnectionNotDefinedException;
 use \Drupal\Core\Database\Database;
 
 /**
@@ -125,7 +126,12 @@ function tripal_uninstall() {
 function tripal_requirements($phase) {
   $checks = [];
   // Make sure the current install does not use per-table prefixes.
-  $connection_options = \Drupal::database()->getConnectionOptions();
+  try {
+    $connection_options = \Drupal::database()->getConnectionOptions();
+  }
+  catch (ConnectionNotDefinedException $ex) {
+    $connection_options = [];
+  }
   if (!empty($connection_options['extra_prefix'])
       || ((!empty($connection_options['prefix']))
           && (is_array($connection_options['prefix']))


### PR DESCRIPTION
# Bug Fix

### Issue #

## Description
When Tripal is installed by a distribution (profile), no database parameters are set in settings.php yet, resulting in a "The specified database connection is not defined: default" error because of "\Drupal::database()->getConnectionOptions()" being called. To avoid that issue, a try-catch statement has been added to return an empty array when the $databases variable is not set.

## Testing?
Hard to test because you would need to create a Drupal distribution. Maybe (but not tested) by altering a Drupal profile such as "standard" or "demo_umami" (in core/profiles) and adding "  - tripal" in the "install:" section of the ".info.yml".
Anyway, I tested the change on my side (with a distribution I'm working on) and it works.