### PR TITLE
EBI obo ontology fix for automated tests

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -1361,7 +1361,7 @@ class OBOImporter extends ChadoImporterBase {
       // array with the correct style
       foreach ($ontology_results['response']['docs'] as $each ) {
         $obo_id = $each['obo_id'];
-        $defining_ontology = $each['is_defining_ontology'];
+        $defining_ontology = $each['is_defining_ontology'] ?? $each['isDefiningOntology'] ?? 'false';
         // First result should have defining_ontology=true, but if
         // it doesn't, use the first result with obo_id=$id
         if ($defining_ontology == 'false' and $obo_id != $id) {
@@ -1386,7 +1386,7 @@ class OBOImporter extends ChadoImporterBase {
       if ($ontology_results) {
         foreach ($ontology_results['response']['docs'] as $each ){
           $obo_id = $each['obo_id'];
-          $defining_ontology = $each['is_defining_ontology'];
+          $defining_ontology = $each['is_defining_ontology'] ?? $each['isDefiningOntology'] ?? 'false';
           if (!$defining_ontology and $obo_id != $id ) {
             continue;
           }
@@ -1418,7 +1418,7 @@ class OBOImporter extends ChadoImporterBase {
     }
 
     // What do we do if the term is not defined by this ontology?
-    if ($results['is_defining_ontology'] != 1) {
+    if (($results['is_defining_ontology'] ?? $results['isDefiningOntology'] ?? 'false') != 1) {
 
     }
 


### PR DESCRIPTION
# Bug Fix

### Closes #2050

## Description
Automated tests are failing starting Dec. 3
It seems to be a change in the response for EBI term lookup, what seems to have been  `is_defining_ontology` is now `isDefiningOntology`, but I don't know how to confirm that.

The simple fix here is that both `is_defining_ontology` and `isDefiningOntology` are supported.

## Testing?
1. Code review
2. Automated tests should now pass
