### PR TITLE
Handle new DB or CV created by importer, add to collections

### DIFF
--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -43,8 +43,10 @@ class TripalEntityTypeForm extends EntityForm {
       $term = $tripal_entity_type->getTerm();
       if ($term) {
         $vocab = $term->getVocabularyObject();
+        if ($vocab) {
+          $vocab_label = $vocab->getLabel();
+        }
 
-        $vocab_label = $vocab->getLabel();
         $term_name = $term->getName();
         $term_accession = $term->getTermId();
 

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -401,8 +401,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
     // plugin is specified, then we can create it.
     $collection_plugin_id = $field_def['settings']['id_space_plugin_id'] ?? '';
     /** @var Drupal\tripal_chado\Plugin\TripalIdSpace\ChadoIdSpace */
-    $idSpace = $this->idSpaceManager->loadCollection($field_def['settings']['termIdSpace'],
-        ['collection_plugin_id' => $collection_plugin_id]);
+    $idSpace = $this->idSpaceManager->loadCollection($field_def['settings']['termIdSpace'], $collection_plugin_id);
     if (!$idSpace) {
       $reason = t('The term Id Space "@idspace" is not known. Check the "termIdSpace" element.',
           ['@idspace' => $field_def['settings']['termIdSpace']]);

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -397,8 +397,12 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
       return FALSE;
     }
 
-    // Make sure the term exists.
-    $idSpace = $this->idSpaceManager->loadCollection($field_def['settings']['termIdSpace']);
+    // Make sure the ID space exists. If it is not yet a collection, and a
+    // plugin is specified, then we can create it.
+    $collection_plugin_id = $field_def['settings']['id_space_plugin_id'] ?? '';
+    /** @var Drupal\tripal_chado\Plugin\TripalIdSpace\ChadoIdSpace */
+    $idSpace = $this->idSpaceManager->loadCollection($field_def['settings']['termIdSpace'],
+        ['collection_plugin_id' => $collection_plugin_id]);
     if (!$idSpace) {
       $reason = t('The term Id Space "@idspace" is not known. Check the "termIdSpace" element.',
           ['@idspace' => $field_def['settings']['termIdSpace']]);

--- a/tripal/src/TripalVocabTerms/PluginManagers/TripalCollectionPluginManager.php
+++ b/tripal/src/TripalVocabTerms/PluginManagers/TripalCollectionPluginManager.php
@@ -147,11 +147,18 @@ class TripalCollectionPluginManager extends DefaultPluginManager {
    *
    * @param string $name
    *   The name.
+   * @param array $options
+   *   Optional parameters.
+   *     string 'collection_plugin_id': An optional name of a collection plugin,
+   *       e.g. 'chado_id_space', 'chado_vocabulary'. When this is specified,
+   *       an ID space or a vocabulary that is not yet a collection can be
+   *       automatically made into a collection.
    *
    * @return \Drupal\tripal\TripalVocabTerms\TripalCollectionPluginBase|NULL
    *   The loaded collection plugin or NULL.
    */
-  public function loadCollection($name) {
+  public function loadCollection($name, array $options = []) {
+    $collection = NULL;
     if (!is_string($name)) {
       return NULL;
     }
@@ -161,15 +168,19 @@ class TripalCollectionPluginManager extends DefaultPluginManager {
       ->fields('n', ['name', 'plugin_id'])
       ->execute();
     $first = $result->fetchAssoc();
-    if (!$first) {
-      return NULL;
+    if ($first) {
+      $collection = $this->createInstance($first["plugin_id"], ["collection_name" => $name]);
     }
-    $collection = $this->createInstance($first["plugin_id"], ["collection_name" => $name]);
-
-    if ($collection->isValid() and $collection->recordExists() == False) {
-      $collection->createRecord();
+    else {
+      if ($options['collection_plugin_id'] ?? '') {
+        $collection = $this->createCollection($name, $options['collection_plugin_id']);
+      }
     }
-
+    if ($collection) {
+      if ($collection->isValid() and $collection->recordExists() == FALSE) {
+        $collection->createRecord();
+      }
+    }
     return $collection;
   }
 

--- a/tripal/src/TripalVocabTerms/PluginManagers/TripalCollectionPluginManager.php
+++ b/tripal/src/TripalVocabTerms/PluginManagers/TripalCollectionPluginManager.php
@@ -147,17 +147,16 @@ class TripalCollectionPluginManager extends DefaultPluginManager {
    *
    * @param string $name
    *   The name.
-   * @param array $options
-   *   Optional parameters.
-   *     string 'collection_plugin_id': An optional name of a collection plugin,
-   *       e.g. 'chado_id_space', 'chado_vocabulary'. When this is specified,
-   *       an ID space or a vocabulary that is not yet a collection can be
-   *       automatically made into a collection.
+   * @param string $pluginId
+   *   An optional name of a collection plugin, e.g. 'chado_id_space',
+   *   'chado_vocabulary'. When this is specified, an ID space or a
+   *   vocabulary that is not yet a collection can be automatically
+   *   made into a collection.
    *
    * @return \Drupal\tripal\TripalVocabTerms\TripalCollectionPluginBase|NULL
    *   The loaded collection plugin or NULL.
    */
-  public function loadCollection($name, array $options = []) {
+  public function loadCollection($name, string $pluginId = '') {
     $collection = NULL;
     if (!is_string($name)) {
       return NULL;
@@ -172,8 +171,8 @@ class TripalCollectionPluginManager extends DefaultPluginManager {
       $collection = $this->createInstance($first["plugin_id"], ["collection_name" => $name]);
     }
     else {
-      if ($options['collection_plugin_id'] ?? '') {
-        $collection = $this->createCollection($name, $options['collection_plugin_id']);
+      if ($pluginId) {
+        $collection = $this->createCollection($name, $pluginId);
       }
     }
     if ($collection) {

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -185,7 +185,7 @@ class TripalTerm {
    * @param string $id_space_plugin_id
    *   The name of the ID space plugin, e.g. "chado_id_space".
    */
-  public function setVocabularyPlugin(string $id_space_plugin_id) {
+  public function setIdSpacePlugin(string $id_space_plugin_id) {
     $this->id_space_plugin_id = $id_space_plugin_id;
   }
 

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -201,8 +201,7 @@ class TripalTerm {
     // An ID space added to a site by an importer may not yet have been added
     // to the appropriate Tripal collection, so configure the load to optionally
     // create it. This requires $this->id_space_plugin_id has been previously set.
-    $idsp = $manager->loadCollection($idSpace,
-        ['collection_plugin_id' => $this->id_space_plugin_id]);
+    $idsp = $manager->loadCollection($idSpace, $this->id_space_plugin_id);
     if (!$idsp) {
       $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
           ['@idSpace' => $idSpace]));
@@ -230,23 +229,14 @@ class TripalTerm {
   public function setVocabulary(string $vocabulary) {
 
     $manager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
-    $vocab = $manager->loadCollection($vocabulary);
+    // A vocabulary added to a site by an importer may not yet have been added
+    // to the appropriate Tripal collection, so configure the load to optionally
+    // create it. This requires $this->vocabulary_plugin_id has been previously set.
+    $vocab = $manager->loadCollection($vocabulary, $this->vocabulary_plugin_id);
     if (!$vocab) {
-      // A vocabulary added to a site by an importer or used for a new content
-      // type may not yet have been added to the appropriate Tripal collection,
-      // so add it, but this requires $this->vocabulary_plugin_id has been set.
-      if ($this->vocabulary_plugin_id and $manager->createCollection($vocabulary, $this->vocabulary_plugin_id)) {
-        $vocab = $manager->loadCollection($vocabulary);
-      }
-      if ($vocab) {
-        $this->messageLogger->notice(t('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" has been added.',
-            ['@vocab' => $vocabulary]));
-      }
-      else {
-        $this->messageLogger->error(t('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" does not exist.',
-            ['@vocab' => $vocabulary]));
-        return;
-      }
+      $this->messageLogger->error(t('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" does not exist.',
+          ['@vocab' => $vocabulary]));
+      return;
     }
     $this->vocabulary = $vocabulary;
   }

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -57,6 +57,7 @@ class TripalTerm {
     $this->is_relationship_type = False;
     $this->idSpace = '';
     $this->vocabulary = '';
+    $this->vocabulary_plugin_id = '';
     $this->parents = [];
     $this->altIds = [];
     $this->synonyms = [];
@@ -97,6 +98,9 @@ class TripalTerm {
     if (array_key_exists('idSpace', $details)) {
       $this->setIdSpace($details['idSpace']);
     }
+    if (array_key_exists('vocabulary_plugin_id', $details)) {
+      $this->setVocabularyPlugin($details['vocabulary_plugin_id']);
+    }
     if (array_key_exists('vocabulary', $details)) {
       $this->setVocabulary($details['vocabulary']);
     }
@@ -104,7 +108,7 @@ class TripalTerm {
       foreach ($details['synonyms'] as $entry) {
         if (is_array($entry)) {
           if (count($entry) != 2) {
-            $this->messageLogger->error('TripalTerm::__construct(). An synonym tuple is not the correct size.');
+            $this->messageLogger->error('TripalTerm::__construct(). A synonym tuple is not the correct size.');
             continue;
           }
           $this->addSynonym($entry[0], $entry[1]);
@@ -192,6 +196,16 @@ class TripalTerm {
   /**
    * Sets the vocabulary for the term.
    *
+   * @param string $vocabulary_plugin_id
+   *   The name of the vocabulary plugin, e.g. "chado_vocabulary".
+   */
+  public function setVocabularyPlugin(string $vocabulary_plugin_id) {
+    $this->vocabulary_plugin_id = $vocabulary_plugin_id;
+  }
+
+  /**
+   * Sets the vocabulary for the term.
+   *
    * @param string $vocabulary
    *   The name of the vocabulary.
    */
@@ -200,9 +214,21 @@ class TripalTerm {
     $manager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
     $vocab = $manager->loadCollection($vocabulary);
     if (!$vocab) {
-      $this->messageLogger->error(T('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" does not exist.',
-          ['@vocab' => $vocabulary]));
-      return;
+      // A vocabulary added to a site by an importer or used for a new content
+      // type may not yet have been added to the appropriate Tripal collection,
+      // so add it, but this requires $this->vocabulary_plugin_id has been set.
+      if ($this->vocabulary_plugin_id and $manager->createCollection($vocabulary, $this->vocabulary_plugin_id)) {
+        $vocab = $manager->loadCollection($vocabulary);
+      }
+      if ($vocab) {
+        $this->messageLogger->notice(t('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" has been added.',
+            ['@vocab' => $vocabulary]));
+      }
+      else {
+        $this->messageLogger->error(t('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" does not exist.',
+            ['@vocab' => $vocabulary]));
+        return;
+      }
     }
     $this->vocabulary = $vocabulary;
   }
@@ -801,6 +827,13 @@ class TripalTerm {
    * @var string
    */
   private $accession;
+
+  /**
+   * The vocabulary plugin, e.g. "chado_vocabulary".
+   *
+   * @var string
+   */
+  private $vocabulary_plugin_id;
 
   /**
    * The vocabulary this term belongs to.

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -58,6 +58,7 @@ class TripalTerm {
     $this->idSpace = '';
     $this->vocabulary = '';
     $this->vocabulary_plugin_id = '';
+    $this->id_space_plugin_id = '';
     $this->parents = [];
     $this->altIds = [];
     $this->synonyms = [];
@@ -94,6 +95,9 @@ class TripalTerm {
     }
     if (array_key_exists('definition', $details)) {
       $this->setDefinition($details['definition'] ?? '');
+    }
+    if (array_key_exists('id_space_plugin', $details)) {
+      $this->setIdSpacePlugin($details['id_space_plugin']);
     }
     if (array_key_exists('idSpace', $details)) {
       $this->setIdSpace($details['idSpace']);
@@ -176,6 +180,16 @@ class TripalTerm {
   }
 
   /**
+   * Sets the ID space plugin for the term.
+   *
+   * @param string $id_space_plugin_id
+   *   The name of the ID space plugin, e.g. "chado_id_space".
+   */
+  public function setVocabularyPlugin(string $id_space_plugin_id) {
+    $this->id_space_plugin_id = $id_space_plugin_id;
+  }
+
+  /**
    * Sets the ID space for the term.
    *
    * @param string setIdSpace
@@ -186,15 +200,27 @@ class TripalTerm {
     $manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $idsp = $manager->loadCollection($idSpace);
     if (!$idsp) {
-      $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
-          ['@idSpace' => $idSpace]));
-      return;
+      // An ID space added to a site by an importer may not yet have been added
+      // to the appropriate Tripal collection, so add it, but this requires
+      // $this->id_space_plugin_id has been set.
+      if ($this->id_space_plugin_id and $manager->createCollection($idSpace, $this->id_space_plugin_id)) {
+        $idsp = $manager->loadCollection($idSpace);
+      }
+      if ($idsp) {
+        $this->messageLogger->notice(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", has been added.',
+            ['@idSpace' => $idSpace]));
+      }
+      else {
+        $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
+            ['@idSpace' => $idSpace]));
+        return;
+      }
     }
     $this->idSpace = $idSpace;
   }
 
   /**
-   * Sets the vocabulary for the term.
+   * Sets the vocabulary plugin for the term.
    *
    * @param string $vocabulary_plugin_id
    *   The name of the vocabulary plugin, e.g. "chado_vocabulary".
@@ -813,6 +839,13 @@ class TripalTerm {
    * @var string
    */
   private $definition;
+
+  /**
+   * The ID space plugin, e.g. "chado_id_space".
+   *
+   * @var string
+   */
+  private $id_space_plugin_id;
 
   /**
    * The ID space this terms belongs to.

--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -198,23 +198,15 @@ class TripalTerm {
   public function setIdSpace(string $idSpace) {
 
     $manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
-    $idsp = $manager->loadCollection($idSpace);
+    // An ID space added to a site by an importer may not yet have been added
+    // to the appropriate Tripal collection, so configure the load to optionally
+    // create it. This requires $this->id_space_plugin_id has been previously set.
+    $idsp = $manager->loadCollection($idSpace,
+        ['collection_plugin_id' => $this->id_space_plugin_id]);
     if (!$idsp) {
-      // An ID space added to a site by an importer may not yet have been added
-      // to the appropriate Tripal collection, so add it, but this requires
-      // $this->id_space_plugin_id has been set.
-      if ($this->id_space_plugin_id and $manager->createCollection($idSpace, $this->id_space_plugin_id)) {
-        $idsp = $manager->loadCollection($idSpace);
-      }
-      if ($idsp) {
-        $this->messageLogger->notice(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", has been added.',
-            ['@idSpace' => $idSpace]));
-      }
-      else {
-        $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
-            ['@idSpace' => $idSpace]));
-        return;
-      }
+      $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
+          ['@idSpace' => $idSpace]));
+      return;
     }
     $this->idSpace = $idSpace;
   }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -572,6 +572,8 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       ],
     ];
 
+    // The parent class adds collection plugin IDs
+    $field_list = self::discoverPostprocess($field_list);
     return $field_list;
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -360,6 +360,9 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
         ],
       ],
     ];
+
+    // The parent class adds collection plugin IDs
+    $field_list = self::discoverPostprocess($field_list);
     return $field_list;
   }
 }

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -326,6 +326,8 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
       ];
     }
 
+    // The parent class adds collection plugin IDs
+    $field_list = self::discoverPostprocess($field_list);
     return $field_list;
   }
 

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -274,6 +274,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
       'accession' => $accession,
       'idSpace' => $this->getName(),
       'vocabulary' => $cvterm->CV_name ? $cvterm->CV_name : $this->getDefaultVocabulary(),
+      'vocabulary_plugin_id' => 'chado_vocabulary',
       'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,
       'is_relationship_type' => $cvterm->is_relationshiptype == 1 ? True : False,
     ]);

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -273,6 +273,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
       'definition' => $cvterm->definition,
       'accession' => $accession,
       'idSpace' => $this->getName(),
+      'id_space_plugin_id' => 'chado_id_space',
       'vocabulary' => $cvterm->CV_name ? $cvterm->CV_name : $this->getDefaultVocabulary(),
       'vocabulary_plugin_id' => 'chado_vocabulary',
       'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -792,9 +792,6 @@ class OBOImporter extends ChadoImporterBase {
   private function getIdSpace($name) {
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $idSpace = $idsmanager->loadCollection($name, 'chado_id_space');
-    if (!$idSpace) {
-      $idSpace = $idsmanager->createCollection($name, 'chado_id_space');
-    }
     return $idSpace;
   }
 
@@ -809,9 +806,6 @@ class OBOImporter extends ChadoImporterBase {
   private function getVocabulary($name) {
     $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
     $vocabulary = $vmanager->loadCollection($name, 'chado_vocabulary');
-    if (!$vocabulary) {
-      $vocabulary = $vmanager->createCollection($name, 'chado_vocabulary');
-    }
     return $vocabulary;
   }
 

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -751,4 +751,22 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
       $fields[$machine_name]->delete();
     }
   }
+
+  /**
+   * Adds tripal term plugin IDs for the field's term.
+   * Used for the field discovery process if a DB or CV
+   * is not a tripal collection yet.
+   *
+   * @param array $field_list
+   *   Discoverd field definitions.
+   * @return array
+   *   The same array with plugin IDs added.
+   */
+  static public function discoverPostprocess(array $field_list): array {
+    foreach ($field_list as $key => $field) {
+      $field_list[$key]['settings']['id_space_plugin_id'] = 'chado_id_space';
+      $field_list[$key]['settings']['vocabulary_plugin_id'] = 'chado_vocabulary';
+    }
+    return $field_list;
+  }
 }

--- a/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
@@ -919,5 +919,46 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
     // Try to save a term that doesn't belong to the idSpace
     $this->assertFalse($rdfs_id->saveTerm($dummy), 'A term that did not belong to an idSpace should not have been saved.');
 
+    //
+    // Testing idSpace and Vocabulary collection with new db or cv.
+    // Importers may create new ID spaces and vocabularies. Test that these work (issue #2032).
+    //
+    $chado = $this->getTestSchema();
+    $db_name = 'imported_db';
+    $cv_name = 'imported_cv';
+
+    $query = $chado->insert('1:db');
+    $query->fields(['name' => $db_name]);
+    $db_id = $query->execute();
+    $this->assertTrue(is_numeric($db_id), "Unable to insert new DB $db_name");
+
+    $query = $chado->insert('1:cv');
+    $query->fields(['name' => $cv_name]);
+    $cv_id = $query->execute();
+    $this->assertTrue(is_numeric($cv_id), "Unable to insert new vocabulary $cv_name");
+
+    $imported_term = new TripalTerm();
+    $this->assertIsObject($imported_term, "Failure to create an empty TripalTerm");
+    $imported_term->setName('imported_term');
+    $imported_term->setIdSpace($db_name);
+    $imported_term->setVocabulary($cv_name);
+    $imported_term->setAccession('imported_term');
+    // Expect not valid because plugins are not yet specified
+    $is_valid = $imported_term->isValid();
+    $this->assertFalse($is_valid, "Term is valid but should not be valid");
+
+    // Now specify the plugins and try again
+    $imported_term->setIdSpacePlugin('chado_id_space');
+    $imported_term->setVocabularyPlugin('chado_vocabulary');
+    $imported_term->setIdSpace($db_name);
+    $imported_term->setVocabulary($cv_name);
+    // Expect things to work now
+    $id_space = $imported_term->getIdSpace();
+    $this->assertEquals($db_name, $id_space, "ID space does not match DB name");
+    $vocabulary = $imported_term->getVocabulary();
+    $this->assertEquals($cv_name, $vocabulary, "Vocabulary does not match CV name");
+    $is_valid = $imported_term->isValid();
+    $this->assertTrue($is_valid, "Term is not valid but should be");
+
   }
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2032

## Description
This adds automated handling of adding a DB or CV to its appropriate tripal ID space or vocabulary collection.
These are generated by importers when they encounter something new, but for tripal terms to work correctly, they need to be added to the `tripal_id_space_collection` table or `tripal_vocabulary_collection` table, respectively.
This is now done by `loadCollection()` in the `TripalCollectionPluginManager` class.
To do this, we need to pass the appropriate plugin ID from the discover() function, or from chado's getTerm().

## Testing?
1. Try the procedure described in this comment, it should work now
https://github.com/tripal/tripal/issues/2032#issuecomment-2525328676
2. Quick way to reproduce the importer bug, first create a study, you can use the null contact for this
3. Next, some SQL:
```
INSERT INTO DB (name) VALUES ('PR2054DB');
INSERT INTO CV (name) VALUES ('PR2054CV');
INSERT INTO dbxref (db_id, accession) VALUES ((SELECT db_id FROM db WHERE name='PR2054DB'), 'PR2054acc');
INSERT INTO cvterm (cv_id, name, dbxref_id) VALUES ((SELECT cv_id FROM cv WHERE name='PR2054CV'), 'PR2054cvterm', (SELECT dbxref_id FROM dbxref WHERE accession='PR2054acc'));
INSERT INTO studyprop (study_id, type_id, value) VALUES (1, (SELECT cvterm_id FROM cvterm WHERE name='PR2054cvterm'), 'PR2054prop');
```
5. Check for new terms on study. On 4.x you would see
![PR2054 on4 x](https://github.com/user-attachments/assets/0742b6cf-6718-4c9a-adeb-818d9d406cd1)
On this branch you should see
![PR2054 2](https://github.com/user-attachments/assets/9493b3d5-4b13-4e33-a309-9057a50e6888)

6. Verify the collections were added
```
sitedb=> select * from tripal_vocabulary_collection where name='iao';
 name |    plugin_id     
------+------------------
 iao  | chado_vocabulary
(1 row)

sitedb=> select * from tripal_vocabulary_collection where name='PR2054CV';
   name   |    plugin_id     
----------+------------------
 PR2054CV | chado_vocabulary
(1 row)

sitedb=> select * from tripal_id_space_collection where name='PR2054DB';
   name   |   plugin_id    
----------+----------------
 PR2054DB | chado_id_space
(1 row)
```