### PR TITLE
Add term validation when using fixed type on Additional Type field

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -351,9 +351,19 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       $fixed_value = $settings['termIdSpace'] . ':' . $settings['termAccession'];
       $form_state_storage = $form_state->getStorage();
       $bundle = $form_state_storage['bundle'];
-      $form_state->setValue(['settings', 'fixed_value'], $fixed_value);
-      // Also store the fixed value storage location in the entity
-      self::setEntityBundleType($bundle, $type_table, $type_column);
+      $bundle_entity = \Drupal\tripal\Entity\TripalEntityType::load($bundle);
+      $bundle_term = $bundle_entity->getTermIdSpace() . ':' . $bundle_entity->getTermAccession();
+      if ($fixed_value != $bundle_term) {
+        $form_state->setErrorByName('settings][field_term_fs][vocabulary_term',
+            t('The "Controlled Vocabulary Term" must be the same term as the'
+            . ' bundle term (@bundle_term) when "This term defines the bundle" is set',
+            ['@bundle_term' => $bundle_term]));
+      }
+      else {
+        $form_state->setValue(['settings', 'fixed_value'], $fixed_value);
+        // Also store the fixed value storage location in the entity
+        self::setEntityBundleType($bundle, $type_table, $type_column);
+      }
     }
     else {
       $form_state->setValue(['settings', 'fixed_value'], 0);


### PR DESCRIPTION
# New Feature

### Issue #1924

## Description
This add a simple validation to the additional type field.
When it is used to define the term for a content type, the term in the field needs to be the same as the term for the bundle.

## Testing?
1. Tripal -> Page Structure -> Analysis -> Manage fields
2. \+ Create a new field
3. Chado fields -> Continue
4. Enter any label, select "Chado Type Reference" -> Continue
5. For "Type Table and Column" select "analysisprop -> type_id"
6. For "Controlled Vocabulary Term" select some random term
7. Activate "This term defines the bundle"
8. "Save settings" - on this branch you should get an error and the form field should be highlighted
![1992 1](https://github.com/user-attachments/assets/ff4152ff-0c76-44c7-9cd6-e95ac57394cc)
![1992 2](https://github.com/user-attachments/assets/c58185b1-8812-40b0-84bd-8aee4700ff46)

