### PR TITLE
Fix publish leak-through from content types sharing a chado table

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -790,14 +790,9 @@ class ChadoPublish extends TripalBackendPublishBase {
    * @return array
    *   Original array values divided into a 2-D array of several batches.
    *   First level array key is a delta value starting at zero.
-   *   Array values are in ascending order, so that the first and last
-   *   elements can later be used to define a range.
    */
   protected function divideIntoBatches($record_ids) {
     $batches = [];
-    // This sort is fairly quick, only around 20 ms for 30,000 records,
-    // but needed to later perform the sql query limiting to a range.
-    sort($record_ids);
     $num_batches = (int) ((count($record_ids) + $this->batch_size - 1) / $this->batch_size);
     for ($delta = 0; $delta < $num_batches; $delta++) {
       $batches[$delta] = array_slice($record_ids, $delta * $this->batch_size, $this->batch_size);
@@ -966,7 +961,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
 
       $this->logger->notice($batch_prefix . 'Step 1 of 6: Find matching records');
-      $matches = $this->storage->findValues($this->search_values, $this->main_property_names, $record_id_batch[0], end($record_id_batch));
+      $matches = $this->storage->findValues($this->search_values, $this->main_property_names, $record_id_batch);
 
       if (!count($matches)) {
         $this->logger->notice($batch_prefix . 'No matching records found, skipping remaining steps');

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -343,12 +343,11 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    *
    * @param array $main_property_names
    *   Associative array where key is field name, value is name of the main property.
-   * @param int|null $minimum_id
-   *   When specified, only return records where the primary key is >= this value
-   * @param int|null $maximum_id
-   *   When specified, only return records where the primary key is <= this value
+   * @param array $record_ids
+   *   When specified, only return records where the primary key is present in this array.
+   *   Used by publish to publish in batches.
    */
-  public function findValues($values, array $main_property_names = [], ?int $minimum_id = NULL, ?int $maximum_id = NULL) {
+  public function findValues($values, array $main_property_names = [], array $record_ids = []) {
 
     // Setup field debugging.
     $this->field_debugger->printHeader('Find');
@@ -373,7 +372,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       foreach ($base_tables as $base_table) {
 
         // First we find all matching base records.
-        $entity_matches = $this->records->findRecords($base_table, $base_table, $minimum_id, $maximum_id);
+        $entity_matches = $this->records->findRecords($base_table, $base_table, $record_ids);
 
         // Now for each matching base record we need to select
         // the ancillary tables.

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1648,10 +1648,8 @@ class ChadoRecords  {
    *   The name of the Chado table used as a base table.
    * @param string $base_table_alias
    *   The alias of the base table.
-   * @param int|null $minimum_id
-   *   When specified, only return records where the primary key is >= this value
-   * @param int|null $maximum_id
-   *   When specified, only return records where the primary key is <= this value
+   * @param array $record_ids
+   *   When specified, only return records where the primary key is present in this array.
    *   Used by publish to publish in batches.
    *
    * @return array
@@ -1659,7 +1657,7 @@ class ChadoRecords  {
    *
    * @throws \Exception
    */
-  public function findRecords(string $base_table, string $base_table_alias, int|null $minimum_id, int|null $maximum_id) {
+  public function findRecords(string $base_table, string $base_table_alias, array $record_ids) {
 
     $found_records = [];
 
@@ -1710,17 +1708,12 @@ class ChadoRecords  {
         $select->condition($base_table_alias . '.' . $column_alias, $value['value'], $value['operation']);
       }
 
-      // If limiting results by using a range of primary keys, restrict
-      // the query by adding this as acondition.
-      if ($minimum_id or $maximum_id) {
+      // If limiting results to a set of primary keys, restrict the
+      // query by adding this as acondition.
+      if ($record_ids) {
         $chado_table_def = $this->connection->schema()->getTableDef($chado_table, ['format' => 'drupal']);
         $chado_table_pkey = $chado_table_def['primary key'];
-        if ($minimum_id) {
-          $select->condition($base_table_alias . '.' . $chado_table_pkey, $minimum_id, '>=');
-        }
-        if ($maximum_id) {
-          $select->condition($base_table_alias . '.' . $chado_table_pkey, $maximum_id, '<=');
-        }
+        $select->condition($base_table_alias . '.' . $chado_table_pkey, $record_ids, 'IN');
       }
 
       $this->field_debugger->reportQuery($select, "Select Query for $chado_table ($delta)");


### PR DESCRIPTION
# Bug Fix

### Closes #2068 

## Description
When publishing content types that share a single chado table, we get leakage between content types
because our batch logic only uses a minimun and maximum to define a batch. Within that range, there
can be records of various content types.
This PR changes this (back) to using an IN condition.
This is less efficient, but it is only a few milliseconds more, so we will accept that.

## Testing?
The simplest test would be to create a genome annotation, then a "plain" analysis, then another genome annotation, in that order.
Unpublish all three, and publish genome annotation
Only two records should be published, the "plain" analysis should not be published.

As a "before" check, if you then checkout the 4.x branch and try publishing again (need to check republish) the middle analysis will be published as a genome annotation
