### PR TITLE
Chado sequence length formatter can now hide zero length

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
@@ -18,83 +18,35 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class ChadoSequenceLengthFormatterDefault extends ChadoFormatterBase {
+class ChadoSequenceLengthFormatterDefault extends ChadoIntegerFormatterDefault {
 
   /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    $settings = parent::defaultSettings();
-    $settings['field_prefix'] = '';
-    $settings['field_suffix'] = '';
-    $settings['thousand_separator'] = '';
-    return $settings;
-  }
-
-  /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $elements['#attached']['library'][] = 'tripal_chado/tripal_chado.field.ChadoSequenceLengthFormatterDefault';
     $field_prefix = $this->getSetting('field_prefix');
     $field_suffix = $this->getSetting('field_suffix');
     $thousand_separator = $this->getSetting('thousand_separator');
+    $hide_condition = $this->getSetting('hide_condition') ?? '';
+    $hide_value = $this->getSetting('hide_value') ?? '';
 
     foreach($items as $delta => $item) {
-      $value = $item->get('seqlen')->getString();
-      if (strlen($thousand_separator)) {
-        // For an integer we can hardcode the unused decimal setting
-        $value = number_format(floatval($value), 0, '.', $thousand_separator);
+      $value = $item->get('seqlen')->getValue() ?? '';
+      $hide = ((($hide_condition == '') and !$value)
+           or (($hide_condition == 'if_value') and ($value == $hide_value)));
+      if (!$hide) {
+        if (strlen($value) and strlen($thousand_separator)) {
+          // For an integer we can hardcode the unused decimal setting to 0
+          $value = number_format(floatval($value), 0, '.', $thousand_separator);
+        }
+        $elements[$delta] = [
+          "#markup" => $field_prefix . $value . $field_suffix,
+        ];
       }
-      $elements[$delta] = [
-        "#markup" => $field_prefix . $value . $field_suffix,
-      ];
     }
 
     return $elements;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    $form = parent::settingsForm($form, $form_state);
-
-    $form['field_prefix'] = [
-      '#title' => $this->t('Text to display before the sequence length'),
-      '#description' => $this->t('Enter text here that will be displayed before the'
-                     . ' sequence length value, or leave blank for no additional text'),
-      '#type' => 'textfield',
-      '#default_value' => $this->getSetting('field_prefix'),
-      '#required' => FALSE,
-    ];
-    $form['field_suffix'] = [
-      '#title' => $this->t('Text to display after the sequence length'),
-      '#description' => $this->t('Enter text here that will be displayed after the'
-                     . ' sequence length value, e.g. " b.p.", or leave blank for no additional text'),
-      '#type' => 'textfield',
-      '#default_value' => $this->getSetting('field_suffix'),
-      '#required' => FALSE,
-    ];
-    $form['thousand_separator'] = [
-      '#title' => $this->t('Thousand Separator'),
-      '#description' => $this->t('Character to display every three digits'),
-      '#type' => 'textfield',
-      '#default_value' => $this->getSetting('thousand_separator'),
-      '#required' => FALSE,
-    ];
-
-    return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsSummary() {
-    $summary = parent::settingsSummary();
-    $summary[] = $this->t('Set display format');
-    return $summary;
   }
 
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2058 

## Description
This allows sequence lengths of zero to be hidden.

This changes the sequence length field class to inherit from the Chado integer field, which in turn inherits from the Tripal integer field, which has support for hiding zero values.

The only thing preventing the sequence length field from inheriting 100% is that instead of "value" it uses "seqlen" for the key.

## Testing?
1. Import genomic content types
2. Create a new gene with no sequence residues. The length should not appear
3. Edit and add sequence residues. The length should now be shown.
4. Test the settings at Tripal -> Page Structure -> Gene -> Manage display
5. Under "Set display format you can add a suffix, e.g. " .b.p" and set to always show
6. Edit the gene again and remove the sequence residues. The zero should appear again
![0bp](https://github.com/user-attachments/assets/fdab7dc5-8c7e-40fa-9893-45cd0a170269)
