### PR TITLE
Add field values to drupal upon publish (#1828)

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -958,11 +958,15 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
       $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
     }
-    // Non-required types never have a value stored, just a placeholder.
+    // If we want views filter this needs to be changed. Now, both required and non-required types 
+    // get their : values added.
+    // PreviouslyNon-required types never have a value stored, just a placeholder.
+    // Alternatively, add types to the required times group
+    // ICICIC: This isn't optimal. Also residue fields would e copied, better to move fields to required_types
     foreach ($this->non_required_types[$field_name] as $key => $properties) {
       $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
       $sql .=  $placeholder . ', ';
-      $args[$placeholder] = $properties->getDefaultValue();
+      $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue() ?? $properties->getDefaultValue();
     }
     $sql = rtrim($sql, ", ");
     $sql .= "),\n";

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -815,9 +815,9 @@ class ChadoPublish extends TripalBackendPublishBase {
     // Generate the insert SQL and add the field-specific columns to it.
     $init_sql = "
       INSERT INTO {" . $field_table . "}
-        (bundle, deleted, entity_id, revision_id, langcode, delta, ";
-    foreach (array_keys(array_merge($this->required_types[$field_name],
-                                    $this->non_required_types[$field_name])) as $key) {
+        (bundle, deleted, entity_id, revision_id, langcode, delta, "; 
+    foreach (array_keys(array_merge($this->required_types[$field_name] ?? [], // might be empty, avoid type error
+                                    $this->non_required_types[$field_name] ?? [] )) as $key) {
       $init_sql .= $field_name . '_'. $key . ', ';
     }
     $init_sql = rtrim($init_sql, ', ') . ") VALUES\n";
@@ -958,15 +958,14 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
       $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
     }
-    // If we want views filter this needs to be changed. Now, both required and non-required types 
-    // get their : values added.
-    // PreviouslyNon-required types never have a value stored, just a placeholder.
-    // Alternatively, add types to the required times group
-    // ICICIC: This isn't optimal. Also residue fields would e copied, better to move fields to required_types
-    foreach ($this->non_required_types[$field_name] as $key => $properties) {
-      $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
-      $sql .=  $placeholder . ', ';
-      $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue() ?? $properties->getDefaultValue();
+    // Non-required types never have a value stored, just a placeholder.
+    // There might not be non_required_types for this field
+    if (isset($this->non_required_types[$field_name])) {
+      foreach ($this->non_required_types[$field_name] as $key => $properties) { 
+        $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
+        $sql .=  $placeholder . ', ';
+        $args[$placeholder] = $properties->getDefaultValue();
+      }
     }
     $sql = rtrim($sql, ", ");
     $sql .= "),\n";

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -144,19 +144,29 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       foreach ($keys as $key => $prop_type) {
         $storage_settings = $prop_type->getStorageSettings();
 
+        // $is_required = true; // default: all fields are required by default
+        // in chado, all table coloumns containing sequence are named residues 
+        // we want to exclude sequences from drupal storage
+        //var_dump($storage_settings);
+        $is_required = ! (array_key_exists('path', $storage_settings) and 
+        str_ends_with($storage_settings['path'],  '.residues')); 
         // Any field that stores a base record id, a primary key,
         // or a foreign key link is required.
-        $is_required = FALSE;
         if (($storage_settings['action'] == 'store_id') or
             ($storage_settings['action'] == 'store_pkey') or
             ($storage_settings['action'] == 'store_link')) {
           $is_required = TRUE;
         }
-        // For any other fields that have 'drupal_store' set,
-        // it is required too.
-        elseif ((array_key_exists('drupal_store', $storage_settings)) and
-                ($storage_settings['drupal_store'] === TRUE)) {
-          $is_required = TRUE;
+        // For any other fields that have 'drupal_exclude' set,
+        // it is _excluded_ too.
+        elseif ((array_key_exists('drupal_exclude', $storage_settings)) and
+                ($storage_settings['drupal_exclude'] === TRUE)) {
+          $is_required = false;
+        }
+        // stay compatible with the original behavior and allow to force drupal storage
+        elseif ((array_key_exists('drupal_include', $storage_settings)) and
+                ($storage_settings['drupal_include'] === TRUE)) {
+          $is_required = true;
         }
         if (($is_required and $required) or (!$is_required and !$required)) {
           $ret_types[$field_name][$key] = $prop_type;


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# New Feature

### Issue #1828 

## Description
<!--- Describe your changes in detail -->
This PR affects the way chado data is published.
The logic determining which field data are to be copied into Drupal Entity tables from the chado base tables has been changed by modifying function `getStoredTypesFilter` in `ChadoStorage.php`. Now, by default most data is copied.
Fields with storage path ending in ".residues" are now automatically exempt from redundant storage. While there was already an option to add a storage parameter "drupal_store" to annotate a field to cause it to be copied, this wasn't used anywhere and would have required extensive editing of the yaml files containing field type collections. 

<!--- Why is this change required? What problem does it solve? -->
These changes address #1828 to allow proper filtering and sorting of chado-derived data in Views, according to Solution 1 described there: 

> The first approach involves ensuring that while publishing Tripal content, fields like organism_common_name_value are populated with meaningful values rather than left empty. This would allow the Views filter to function correctly without modifying its logic. However, this approach could introduce redundancy and might conflict with the current design, where these fields are likely left empty intentionally.

## Testing?
<!--- Please describe in detail how to test these changes. -->
 - Import new chado data, e.g. genes, mRNA, via the GFF importer.  
 - Alternatively, unpublish already published Tripal content.
 - Go to /admin/content/bio_data/publish and select the content type (e.g. gene, mRNA)
 -  Run the jobs drush trp-run-jobs

<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
