### PR TITLE
Entity lookup for tables with multiple content types

### DIFF
--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -17,6 +17,13 @@ use Drupal\Core\Render\Markup;
 class TripalEntityLookup {
 
   /**
+   * Caches bundle IDs used for a base table
+   *
+   * @var array $bundle_cache
+   */
+  protected array $bundle_cache = [];
+
+  /**
    * This is used by field formatters to get a ready-to-use render
    * array item to link to an entity.
    *
@@ -62,6 +69,7 @@ class TripalEntityLookup {
    *   The bundle's CV Term namespace e.g. for gene "SO"
    * @param string $termAccession
    *   The bundle's CV term accession e.g. for gene "0000704"
+   *   If IdSpace and Accession are NULL, then any bundle using the base table is checked.
    * @param string $base_table
    *   The Chado base table for the requested entity e.g. for gene "feature".
    *   Only needed if term does not map to a content type.
@@ -80,9 +88,12 @@ class TripalEntityLookup {
 
     // Perform the lookup steps
     $entity_id = NULL;
-    $bundle_id = $this->getBundleFromCvTerm($termIdSpace, $termAccession);
+    $bundle_id = NULL;
+    if ($termIdSpace and $termAccession) {
+      $bundle_id = $this->getBundleFromCvTerm($termIdSpace, $termAccession);
+    }
 
-    // in most cases we will have a bundle ID
+    // When we have a bundle ID, only check that bundle
     if ($bundle_id) {
       $entity_ids = $this->getEntityIdFromRecordId($record_id, $bundle_id, $entity_type);
       if ($entity_ids) {
@@ -91,8 +102,9 @@ class TripalEntityLookup {
         $entity_id = reset($entity_ids);
       }
     }
-    // If the term does not have a content type, the fallback is
-    // to check all bundles derived from the base table.
+    // If the term does not have a content type, or we did not
+    // specify a term, then the fallback is to check all bundles
+    // derived from the base table.
     else {
       $bundle_ids = [];
       if ($base_table) {
@@ -143,14 +155,16 @@ class TripalEntityLookup {
    * @return array
    *   The bundle ids, or an empty array if no matches found.
    */
-  protected function getBundles($base_table) {
-    $bundles = \Drupal::entityTypeManager()
-      ->getStorage('tripal_entity_type')
-      ->getQuery()
-      ->condition('third_party_settings.tripal.chado_base_table', $base_table)
-      ->execute();
-    $bundle_ids = array_keys($bundles);
-    return $bundle_ids;
+  protected function getBundles(string $base_table): array {
+    if (!array_key_exists($base_table, $this->bundle_cache)) {
+      $bundles = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->getQuery()
+        ->condition('third_party_settings.tripal.chado_base_table', $base_table)
+        ->execute();
+      $this->bundle_cache[$base_table] = array_keys($bundles);
+    }
+    return $this->bundle_cache[$base_table];
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1435,14 +1435,25 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       return -1;
     }
 
-    // Given the Chado record ID and bundle term, we can lookup the Drupal entity ID.
+    // Given the Chado record ID and bundle term, we can lookup the Drupal entity ID,
+    // but some tables have multiple bundles. To support those, we can pass a NULL
+    // term and let the entity lookup manager find the bundle(s).
     $ftable = $prop_storage_settings['ftable'] ?? NULL;
-    $entity_id = $lookup_manager->getEntityId(
-      $record_id,
-      $context['field_settings']['termIdSpace'],
-      $context['field_settings']['termAccession'],
-      $ftable
-    );
+    if ($ftable) {
+      $entity_id = $lookup_manager->getEntityId(
+        $record_id,
+        NULL,
+        NULL,
+        $ftable
+      );
+    }
+    else {
+      $entity_id = $lookup_manager->getEntityId(
+        $record_id,
+        $context['field_settings']['termIdSpace'],
+        $context['field_settings']['termAccession']
+      );
+    }
 
     // In the TripalEntity class, the preSave function will flag all falsey
     // property values for deletion when drupal_store is set to TRUE.

--- a/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalEntityLookupServiceTest.php
@@ -237,6 +237,15 @@ class TripalEntityLookupServiceTest extends ChadoTestKernelBase {
     );
     $this->assertContains($entity_id, $expected_contact_entity_ids, "We did not retrieve the expected entity_id for manufacturer_id $chado_contact_id");
 
+    // Likewise it should work the same if we omit the term entirely
+    $entity_id = $lookup_manager->getEntityId(
+      $chado_contact_id,
+      NULL,
+      NULL,
+      $base_table
+    );
+    $this->assertContains($entity_id, $expected_contact_entity_ids, "We did not retrieve the expected entity_id for manufacturer_id $chado_contact_id");
+
     // Also check that the contact_id (as manufacturer_id) is in the Drupal table
     $entity_table_name = 'tripal_entity__array_design_manufacturer';
     $entity_column_name = 'array_design_manufacturer_record_id';


### PR DESCRIPTION
# Bug Fix

### Closes #2085

## Description
This change uses the existing "fallback" entity lookup method, which looks up all bundles for a given base table, in all cases.
This allows us to easily support fields that link to tables that have more than one content type.
For example, the `analysis` table has a "generic" analysis, plus "Genome Assembly" and "Genome Annotation".
The `stock` table has four content types. The `project` table has two. The `feature` table has a bunch.

This involves not using the bundle as we had done, but just use the existing lookup to find all bundles for a table.
This lookup takes around 7 ms on my test docker, but it is cached in a class variable, so subsequent cached calls take only a couple of microseconds.

## Testing?
1. Import the genomic content type collection
2. Create a "plain" analysis
3. Create a "Genome Assembly"
4. Create a "Genome Annotation"
5. Create a project, and add each of these three
6. Observe that on this branch, all three types of analysis get working links
![issue2085 2](https://github.com/user-attachments/assets/6bb85388-8ba2-4c6e-a5ef-9d907fbabfcd)
7. Unpublish the project, then publish project
8. Should work here also
