### PR TITLE
remove redundant preg_split

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -396,7 +396,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
 
       // Get a list of tables with foreign keys to selected $base_table.
       $base_schema_def = $schema->getTableDef($base_table, ['format' => 'Drupal']);
-      $fkey_list = preg_split('/[ ,]+/', ($base_schema_def['referring_tables']??''));
+      $fkey_list = $base_schema_def['referring_tables']??[];
       asort($fkey_list);
 
       // Include the base table at the top of the sorted list


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #2090

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Updates the ChadoAdditionalTypeTypeDefault class' `getTypeFKeys()` function to expect an array already since the `getTableDef()` always returns an array now as of https://github.com/tripal/tripal/commit/6afa0c04706e3b073c3e279e32fcc6b6858c5d71

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
On a content type that has a Chado Type Reference field or after adding a Chado Type Reference field to a content type that does not have this field already, and then trying to edit it, the site would WSOD.

Then switch to this branch and try the same and observe that the site does not WSOD.