### PR TITLE
Ensure it's not the same field when checking for existing terms.

### DIFF
--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -419,10 +419,13 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
       return FALSE;
     }
 
-    // Verify that the term for this field is not already used by another field
+    // Verify that the term for this field is not already used by another field.
+    // To do this we check if any fields on this content type have a field with
+    // the same term and that any existing field is not the same field we are
+    // validating.
     $existing_terms = $this->getExistingFieldTerms($field_def['content_type']);
     $new_term = $field_def['settings']['termIdSpace'] . ':' . $field_def['settings']['termAccession'];
-    if (array_key_exists($new_term, $existing_terms)) {
+    if (array_key_exists($new_term, $existing_terms) && ($existing_terms[$new_term] !== $field_def['name'])) {
       $reason = t('The term "@new_term" for field "@name" in bundle "@bundle" is already'
           . ' being used by another field, so this field cannot be added.',
           ['@new_term' => $new_term, '@name' => $field_def['name'], '@bundle' => $field_def['content_type']]);


### PR DESCRIPTION
# Bug Fix

### Issue #2092 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The check to ensure that FieldCollection doesn't insert fields that have the same term showed an error when re-importing an existing collection for each field already existing -incorrectly claiming a different field with the same term already existed.

This PR adds an extra condition to the check so that we only see an error if a) the term is used for an existing field on the same content type and b) that existing field is not the same one we are looking to add.

**Note: The second problem mentioned in the linked issue is no longer an problem. It turns out it I made an incorrect diagnosis on my extension site and both cases where the same.**

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

1. Go to Top Admin Bar > Tripal > Page Structure and click "Import content type collection"
2. Choose to import a collection that has already been imported (e.g. "General Content Types (Chado)")
3. Run the Tripal job and ensure there are no duplicate term errors.

<img width="1257" alt="Screenshot 2025-01-22 at 10 33 08 AM" src="https://github.com/user-attachments/assets/566e92bf-5f2b-4187-a909-b9ee2d5eef44" />

Before this PR, the same steps looked like this when running the tripal job:

<img width="1337" alt="Screenshot 2025-01-22 at 10 33 31 AM" src="https://github.com/user-attachments/assets/36514c99-1a78-4432-b062-ad5c9bb01d40" />
