### PR TITLE
Ensure field has settings for view mode before adding them.

### DIFF
--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -660,16 +660,18 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
         $bundle_id = $entity_type->id();
         $view_modes = $entity_display->getViewModeOptionsByBundle('tripal_entity', $bundle_id);
         foreach (array_keys($view_modes) as $view_mode) {
+          $view_mode_options = $field_def['display']['view'][$view_mode] ?? [];
           \Drupal::service('entity_display.repository')
             ->getViewDisplay('tripal_entity', $bundle_id, $view_mode)
-            ->setComponent($field_def['name'], $field_def['display']['view'][$view_mode])
+            ->setComponent($field_def['name'], $view_mode_options)
             ->save();
         }
         $form_modes = $entity_display->getFormModeOptionsByBundle('tripal_entity', $bundle_id);
         foreach (array_keys($form_modes) as $form_mode) {
+          $form_mode_options = $field_def['display']['form'][$form_mode] ?? [];
           \Drupal::service('entity_display.repository')
             ->getFormDisplay('tripal_entity', $bundle_id, $form_mode)
-            ->setComponent($field_def['name'], $field_def['display']['form'][$form_mode])
+            ->setComponent($field_def['name'], $form_mode_options)
             ->save();
         }
 


### PR DESCRIPTION

# Bug Fix

### Issue #2094 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

When there are view or form modes in the site that are not defined in the field collection yaml, an undefined variable is accessed and the job pukes. This PR checks if the variable is defined and sets a default if not for both view and form modes.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Go to side admin bar > Structure > Display Modes > View Modes.
2. Click "Add view mode", select "Tripal Content" and provide a name plus select "organism" in the type list.
  <img width="1196" alt="Image" src="https://github.com/user-attachments/assets/863e4c16-a6f5-4da5-bc52-de09e115e10b" />
3. Click "Add form mode" on side admin bar > Structure > Display Modes > Form Modes and do the same thing.
4. Go to top admin bar > Tripal > Page Structure and click "Manage fields" for the organism content type.
5. Delete 1+ fields from the content type.
6. Go back to the page structure listing and click "Import type collection". 
7. Select the "General" type collection to be imported and run the tripal job. On this branch it will happily add the deleted fields; on 4.x it will puke epically when it tries to access settings for the view/form modes you created but they are not in the yaml.

On this branch:
<img width="1198" alt="Screenshot 2025-01-22 at 4 59 13 PM" src="https://github.com/user-attachments/assets/98765192-a22c-4a4e-a4e0-537bb07a0ee5" />

On 4.x:
<img width="1236" alt="Screenshot 2025-01-22 at 4 57 16 PM" src="https://github.com/user-attachments/assets/7a9b8a4d-f6c6-4ccd-aa41-e68af635966b" />

