### PR TITLE
Resolves duplicated field names during discover

### DIFF
--- a/tripal/src/Form/TripalContentFieldsForm.php
+++ b/tripal/src/Form/TripalContentFieldsForm.php
@@ -138,7 +138,7 @@ class TripalContentFieldsForm implements FormInterface {
     ];
     $invalid_fields_desc = t('The following fields do not pass validation tests. '
       . 'They need correction by the module developer and cannot be added.');
-    if (empty($invalid_fields_desc)) {
+    if (empty($invalid_fields)) {
       $invalid_fields_desc = t('All fields passed validation tests!');
     }
     $form['invalid_fields_details']['invalid_fields_list'] = [

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -227,19 +227,27 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
 
     $all_field_defs = $field_type_manager->getDefinitions();
     $entity_field_defs = $entity_field_manager->getFieldDefinitions('tripal_entity', $bundle_name);
+    $field_names = [];
     foreach ($all_field_defs as $field_id => $field_def) {
       $field_class = $field_def['class'];
       if (is_subclass_of($field_class, 'Drupal\tripal\TripalField\TripalFieldItemBase')) {
         $discovered = $field_class::discover($tripal_entity_type, $field_id, $all_field_defs, $entity_field_defs);
         foreach ($discovered as $discovered_field) {
+          $discovered_field_name = $discovered_field['name'];
+          $field_names[$discovered_field_name] = ($field_names[$discovered_field_name] ?? 0) + 1;
 
           // If the CV term for the discovered field is currently used by an
           // existing field, then mark it as existing.
           $discoveredIdSpace = $discovered_field['settings']['termIdSpace'];
           $discoveredAccession = $discovered_field['settings']['termAccession'];
-          $existing = $this->checkDiscoveredTerm($discoveredIdSpace, $discoveredAccession, $entity_field_defs);
-          if ($existing) {
-            $field_status['existing'][$discovered_field['name']] = $discovered_field;
+          $existing_field_name = $this->checkDiscoveredTerm($discoveredIdSpace, $discoveredAccession, $entity_field_defs);
+          if ($existing_field_name) {
+            // Note that the existing name may differ from the name proposed by discover()
+            $discovered_field['name'] = $existing_field_name;
+            $field_status['existing'][$existing_field_name] = $discovered_field;
+            // We may have already added a new field with this existing field's name
+            // earlier in the loop. If so, go back and update that new field.
+            $this->recheckTerms($field_status, $existing_field_name);
             continue;
           }
 
@@ -247,16 +255,64 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
           $reason = '';
           $is_valid = $this->validate($discovered_field, $reason);
           if (!$is_valid) {
-            $field_status['invalid'][$discovered_field['name']] = $discovered_field;
-            $field_status['invalid'][$discovered_field['name']]['invalid_reason'] = $reason;
+            $field_status['invalid'][$discovered_field_name] = $discovered_field;
+            $field_status['invalid'][$discovered_field_name]['invalid_reason'] = $reason;
             continue;
           }
 
-          $field_status['new'][$discovered_field['name']] = $discovered_field;
+          // If the field name already exists, then adjust it to be unique
+          if ($field_names[$discovered_field_name] > 1) {
+            $discovered_field['name'] = $this->updateFieldName($discovered_field);
+          }
+          $field_status['new'][$discovered_field_name] = $discovered_field;
         }
       }
     }
     return $field_status;
+  }
+
+  /**
+   * Updates a field name if it is already used for a different field.
+   *
+   * @param string $discovered_field
+   *   Current field with duplicated name
+   *
+   * @return string
+   *   The updated field name
+   */
+  protected function updateFieldName(array $discovered_field): string {
+    $max_length = FieldStorageConfig::NAME_MAX_LENGTH;
+    // CV term id is currently only available for property fields
+    $suffix = strtolower($discovered_field['cvterm_id'] ?? $discovered_field['termIdSpace'] ?? uniqid());
+    $field_name = $discovered_field['name'] . '_' . $suffix;
+    // If name is now longer than Drupal allows, shorten the original
+    // name before adding the suffix.
+    if (mb_strlen($field_name) > $max_length) {
+      $truncate_to = $max_length - strlen($suffix) - 1;
+      $field_name = mb_substr($discovered_field['name'], 0, $truncate_to) . '_' . $suffix;
+    }
+    $field_name = preg_replace('/[^\w]/u', '_', $field_name);
+    return $field_name;
+  }
+
+  /**
+   * If a new field's name conflicts with an existing one, update
+   * the new field's name to eliminate the duplication.
+   *
+   * @param array &$field_status
+   *   Holds the status of each field. Will be updated if necessary.
+   * @param string $field_name
+   *   Name of one existing field to check against
+   * @return void
+   */
+  protected function recheckTerms(array &$field_status, string $field_name) {
+    if (array_key_exists($field_name, $field_status['new'])) {
+      $def = $field_status['new'][$field_name];
+      $new_name = $this->updateFieldName($def);
+      $def['name'] = $new_name;
+      $field_status['new'][$new_name] = $def;
+      unset($field_status['new'][$field_name]);
+    }
   }
 
   /**
@@ -301,16 +357,16 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
    * @param array $entity_field_defs
    *   Array of field definitions returned from getFieldDefinitions()
    *
-   * @return bool
-   *   TRUE if term already used by a field, FALSE otherwise
+   * @return string
+   *   The name of the field if term already used by a field, empty string otherwise
    */
   private function checkDiscoveredTerm($idSpace, $accession, $entity_field_defs) {
-    $existing = FALSE;
+    $existing = '';
     foreach ($entity_field_defs as $name => $def) {
       $settings = $def->getSettings();
       if ( (($settings['termIdSpace'] ?? '') == $idSpace)
           and (($settings['termAccession'] ?? '') == $accession) ) {
-        $existing = TRUE;
+        $existing = $name;
         break;
       }
     }

--- a/tripal/src/Services/TripalFieldCollection.php
+++ b/tripal/src/Services/TripalFieldCollection.php
@@ -264,7 +264,7 @@ class TripalFieldCollection implements ContainerInjectionInterface  {
           if ($field_names[$discovered_field_name] > 1) {
             $discovered_field['name'] = $this->updateFieldName($discovered_field);
           }
-          $field_status['new'][$discovered_field_name] = $discovered_field;
+          $field_status['new'][$discovered_field['name']] = $discovered_field;
         }
       }
     }

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -701,8 +701,8 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
    * A helper function to create an appropriate field name.
    *
    * This function can be used by a field's `discover()` method to generate
-   * an appropriate field name. It removes will always include the bundle
-   * type as the prefix, followed by an underscore, followed by extra text
+   * an appropriate field name. It will always include the bundle type
+   * as the prefix, followed by an underscore, followed by extra text
    * provided. It ensures that only alphanumeric values are present in the
    * name and that it doesn't exceed Drupal's maximum length.
    *

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -295,6 +295,7 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
         'description' => $recprop->definition ? 'A record property with the following definition: ' . $recprop->definition : '',
         'cardinality' => -1,
         'required' => False,
+        'cvterm_id' => $recprop->cvterm_id,
         'storage_settings' => [
           'storage_plugin_id' => 'chado_storage',
           'storage_plugin_settings' => [

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -766,7 +766,7 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    */
   protected static function createFieldEntry(TripalEntityType $bundle, array $options): array {
     $field_item = [
-      'name' => self::generateFieldName($bundle, $options['table'], 0),
+      'name' => $options['name'] ?? self::generateFieldName($bundle, $options['table'], 0),
       'content_type' => $bundle->getID(),
       'label' => $options['label'],
       'type' => $options['id'],
@@ -830,6 +830,8 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    * @param array $options
    *   Specific options from the field's discover() function. Required keys:
    *   - id: the field id, e.g. 'chado_organism_type_default'
+   *   - name: the unique name for a specific field instance. The default is
+   *     generated using generateFieldName().
    *   - base_table: the base table of the entity
    *   - table: the field's table, e.g. 'organism'
    *   - label: the field's label, e.g. 'Organism'
@@ -895,6 +897,8 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    * @param array $options
    *   Specific options from the field's discover() function. Required keys:
    *   - id: the field id, e.g. 'chado_organism_type_default'
+   *   - name: the unique name for a specific field instance. The default is
+   *     generated using generateFieldName().
    *   - base_table: the base table of the entity
    *   - table: the field's table, e.g. 'organism'
    *   - label: the field's label, e.g. 'Organism'
@@ -998,6 +1002,8 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    * @param array $options
    *   Specific options from the field's discover() function. Required keys:
    *   - id: the field id, e.g. 'chado_organism_type_default'
+   *   - name: the unique name for a specific field instance. The default is
+   *     generated using generateFieldName().
    *   - table: the field's table, e.g. 'organism'
    *   - label: the field's label, e.g. 'Organism'
    *   - termIdSpace: The field term's DB


### PR DESCRIPTION
# Bug Fix

### Issue #2033

## Description
This resolves the problem of duplicated field names from the `discover()` process, when two properties share a CV term, but the term is in a different CV.
Previously only one could be added by discover because discover generated the exact same field name for both fields.

## Testing?
Follow procedure described in this issue comment
https://github.com/tripal/tripal/issues/2033#issuecomment-2610564548

On initial "+Check for new fields" on this branch you will now see
![2033 4](https://github.com/user-attachments/assets/c6dbe13c-6b96-46a6-b77c-7b5284055a0d)

And doing it a second time
![2033 5](https://github.com/user-attachments/assets/103395d4-f444-442c-9a10-9bcfd6636421)
