### PR TITLE
Fix minor assay field bug

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -136,8 +136,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoIntStoragePropertyType($entity_type_id, self::$id, 'record_id', self::$record_id_term, [
       'action' => 'store_id',
       'drupal_store' => TRUE,
-      'chado_table' => $base_table,
-      'chado_column' => $base_pkey_col,
+      'path' => $base_table . '.' . $base_pkey_col,
     ]);
 
     // This property will store the Drupal entity ID of the linked chado

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -213,7 +213,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_description', $description_term, [
       'action' => 'read_value',
       'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . $object_pkey_col . ';description',
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';description',
       'as' => 'assay_description',
     ]);
 

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -806,3 +806,14 @@ function tripal_chado_update_10411() {
     throw new UpdateException('Could not perform update: ' . $e->getMessage());
   }
 }
+
+/**
+ * Adds missing 'path' setting to the 'record_id'
+ * property in the 'chado_assay_type_default' field
+ */
+function tripal_chado_update_10412() {
+  // This hook added by PR 2099
+  $upgradable_types = ['chado_assay_type_default'];
+  $upgradable_properties = ['record_id'];
+  tripal_chado_field_reload($upgradable_types, $upgradable_properties, TRUE);
+}

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -814,6 +814,6 @@ function tripal_chado_update_10411() {
 function tripal_chado_update_10412() {
   // This hook added by PR 2099
   $upgradable_types = ['chado_assay_type_default'];
-  $upgradable_properties = ['record_id'];
+  $upgradable_properties = ['record_id', 'assay_description'];
   tripal_chado_field_reload($upgradable_types, $upgradable_properties, TRUE);
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2098 

## Description
Fix the minor inconsistency in the definition of the chado_assay_default field, see linked issue.
Unfortunately we need an update hook too.

## Testing?
1. Build a docker on the 4.x branch
2. Tripal -> Page structure -> +Import type collection -> Expression content types
3. Run the job `drush trp-run-jobs --username=drupaladmin --root=/var/www/drupal/web`
4. Go to "Project" content and check for new fields and add them. This one should be found and added: Assay (project_assay): A planned process with the objective to produce information about the material entity that is the evaluant, by physically examining it or its proxies.
5. Switch to this branch `git checkout tv4g1-2098-assay-field-bug`
6. Examine the field definition from 4.x using `/devel/php` to run this code
```
$bundle = 'project';
$field_name = 'project_assay';

// services
$entity_field_manager = \Drupal::service('entity_field.manager');
$field_type_manager = \Drupal::service('plugin.manager.field.field_type');

// create an instance
$field_defs = $entity_field_manager->getFieldDefinitions('tripal_entity', $bundle);
$field_definition = $field_defs[$field_name];
$field_type = $field_definition->getType();
$configuration = [
  'field_definition' => $field_definition,
  'name' => $field_name,
  'parent' => NULL,
];
$instance = $field_type_manager->createInstance($field_type, $configuration);

// print out the storage settings
$prop_types = $instance->tripalTypes($field_definition);
foreach ($prop_types as $prop_type) {
  $key = $prop_type->getKey();
  if ($key == 'record_id') {
     $prop_storage_settings = $prop_type->getStorageSettings();
     print "Settings for $key: ";
     print_r($prop_storage_settings);
  }
}
```
![PR2099 1](https://github.com/user-attachments/assets/acd853fc-4d7a-4db6-bf7e-3c6138bebb8d)
7. Run the update hook `drush updatedb`
```
 -------------- ----------- --------------- ---------------------------------- 
  Module         Update ID   Type            Description                       
 -------------- ----------- --------------- ---------------------------------- 
  tripal_chado   10412       hook_update_n   10412 - Adds missing 'path'       
                                             setting to the 'record_id'        
                                             property in the                   
                                             'chado_assay_type_default' field  
 -------------- ----------- --------------- ---------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ ● Yes / ○ No                                                 │
 └──────────────────────────────────────────────────────────────┘
>  [notice] Update started: tripal_chado_update_10412
>  [notice] Update completed: tripal_chado_update_10412
>  [notice] Message: Updating properties for Drupal table "tripal_entity__project_assay", field  
> "project_assay"
> 
>  [notice] Message: Updated 1 properties
> 
 [success] Finished performing updates.
```
8. Examine the field definition now
![PR2099 2](https://github.com/user-attachments/assets/b729ec3e-e7de-459f-ab96-d2278babb453)
