### PR TITLE
Implement approach to update Drupal field tables following a chado schema update.

### DIFF
--- a/tripal/src/Commands/TripalCommands.php
+++ b/tripal/src/Commands/TripalCommands.php
@@ -189,4 +189,25 @@ class TripalCommands extends DrushCommands {
     $fields->install($chosen_collection_ids);
 
   }
+
+  /**
+   * Ensures the Drupal field table schema is up to date for all fields.
+   *
+   * @command tripal:trp-sync-field-schema
+   */
+  public function tripalSyncFieldSchema() {
+
+    $types = \Drupal::entityTypeManager()
+    ->getStorage('tripal_entity_type')
+    ->loadMultiple();
+
+    $types['project']->syncStorageSchema();
+    /*
+    foreach ($types as $key => $type) {
+      print "Working on " . $type->id() . " ($key)...\n";
+      $type->syncStorageSchema();
+      break;
+    }
+    */
+  }
 }

--- a/tripal/src/Commands/TripalCommands.php
+++ b/tripal/src/Commands/TripalCommands.php
@@ -197,26 +197,22 @@ class TripalCommands extends DrushCommands {
    */
   public function tripalSyncFieldSchema() {
 
-    $types = \Drupal::entityTypeManager()
-    ->getStorage('tripal_entity_type')
-    ->loadMultiple();
+    $this->output()->writeln("\nChecking  Tripal Entity types for discrepancies between field schema definitions and the underlying Drupal tables...\n");
 
-    $this->output()->writeln("\nChecking " . count($types) . " Tripal Entity types for discrepancies between field schema definitions and the underlying Drupal tables...\n");
+    $columns_added = \Drupal::service('tripal.sync_tripal_field_storage')
+      ->resolveDifferences();
 
-    $columns_added = $types['project']->syncStorageSchema();
-    foreach ($types as $bundle_name => $type_object) {
-      $this->output()->write("$bundle_name... ");
+    foreach ($columns_added as $field_name => $field_differences) {
+      $this->output()->writeln("$field_name needed " . count($field_differences) . " difference(s) fixed.");
+    }
 
-      $columns_added = $type_object->syncStorageSchema();
-
-      $fields_needing_updates = count($columns_added);
-      $num_columns_added = array_sum(array_map("count", $columns_added));
-      if ($fields_needing_updates > 0) {
-        $this->output()->writeln("Added $num_columns_added columns across $fields_needing_updates fields.");
-      }
-      else {
-        $this->output()->writeln("No discrepancies found.");
-      }
+    $fields_needing_updates = count($columns_added);
+    $num_columns_added = array_sum(array_map("count", $columns_added));
+    if ($fields_needing_updates > 0) {
+      $this->output()->writeln("\nAdded $num_columns_added columns across $fields_needing_updates fields.\n");
+    }
+    else {
+      $this->output()->writeln("\nNo discrepancies found.\n");
     }
   }
 }

--- a/tripal/src/Commands/TripalCommands.php
+++ b/tripal/src/Commands/TripalCommands.php
@@ -197,7 +197,7 @@ class TripalCommands extends DrushCommands {
    */
   public function tripalSyncFieldSchema() {
 
-    $this->output()->writeln("\nChecking  Tripal Entity types for discrepancies between field schema definitions and the underlying Drupal tables...\n");
+    $this->output()->writeln("\nChecking Tripal Entity types for discrepancies between field schema definitions and the underlying Drupal tables...\n");
 
     $columns_added = \Drupal::service('tripal.sync_tripal_field_storage')
       ->resolveDifferences();

--- a/tripal/src/Commands/TripalCommands.php
+++ b/tripal/src/Commands/TripalCommands.php
@@ -201,13 +201,22 @@ class TripalCommands extends DrushCommands {
     ->getStorage('tripal_entity_type')
     ->loadMultiple();
 
-    $types['project']->syncStorageSchema();
-    /*
-    foreach ($types as $key => $type) {
-      print "Working on " . $type->id() . " ($key)...\n";
-      $type->syncStorageSchema();
-      break;
+    $this->output()->writeln("\nChecking " . count($types) . " Tripal Entity types for discrepancies between field schema definitions and the underlying Drupal tables...\n");
+
+    $columns_added = $types['project']->syncStorageSchema();
+    foreach ($types as $bundle_name => $type_object) {
+      $this->output()->write("$bundle_name... ");
+
+      $columns_added = $type_object->syncStorageSchema();
+
+      $fields_needing_updates = count($columns_added);
+      $num_columns_added = array_sum(array_map("count", $columns_added));
+      if ($fields_needing_updates > 0) {
+        $this->output()->writeln("Added $num_columns_added columns across $fields_needing_updates fields.");
+      }
+      else {
+        $this->output()->writeln("No discrepancies found.");
+      }
     }
-    */
   }
 }

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -269,7 +269,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *   name. The value is an array defining the column that was added with the
    *   keys: 'drupal_table', 'column_name', 'column_spec'.
    */
-  public function syncStorageSchema() {
+  public function syncStorageSchema(bool $check_only = FALSE) {
     $columns_added = [];
 
     // Get the drupal database schema object.
@@ -309,7 +309,9 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
         // If it is missing then let's just add it ;-p.
         if ($column_exists === FALSE) {
-          $schema->addField($drupal_table, $property_column_name, $column_schema);
+          if ($check_only === FALSE) {
+            $schema->addField($drupal_table, $property_column_name, $column_schema);
+          }
           $columns_added[$field_name][$property_name] = [
             'drupal_table' => $drupal_table,
             'column_name' => $property_column_name,

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -263,9 +263,14 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * schema defined by TripalTypes() for all fields attached to a given
    * TripalEntityType.
    *
-   * @return void
+   * @return array
+   *   An array of the columns that were previously missing and have now beed
+   *   added. This array is keyed first by field name and then by property
+   *   name. The value is an array defining the column that was added with the
+   *   keys: 'drupal_table', 'column_name', 'column_spec'.
    */
   public function syncStorageSchema() {
+    $columns_added = [];
 
     // Get the drupal database schema object.
     $schema = \Drupal::service('database')->schema();
@@ -280,31 +285,41 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $drupal_table_mapping = $sql_storage->getTableMapping();
 
     // Now for each field instance...
-    //foreach ($field_instances as $key => $field_def) {
-      $field_def = $field_instances['project_contact'];
+    foreach ($field_instances as $key => $field_def) {
+      $field_name = $field_def->getName();
       $field_storage_def = $field_def->getFieldStorageDefinition();
 
+      // Only check non-base fields.
+      if ($field_storage_def->isBaseField()) {
+        continue;
+      }
+
       // Get the Drupal field table that we may need to update.
-      $drupal_table = $drupal_table_mapping->getFieldTableName($field_def->getName());
+      $drupal_table = $drupal_table_mapping->getFieldTableName($field_name);
 
       // Get the new schema based on tripalTypes which is dynamically updated
       // based on the backend TripalStorage.
       $current_schema_columns = $field_storage_def->getColumns();
-      // @debug print "Current Schema ($drupal_table): " . print_r($current_schema_columns, TRUE);
 
       // Now for each property of the current field, check to see if the
       // corresponding drupal table column exists.
       foreach($current_schema_columns as $property_name => $column_schema) {
         $property_column_name = $drupal_table_mapping->getFieldColumnName($field_storage_def, $property_name);
         $column_exists = $schema->fieldExists($drupal_table, $property_column_name);
-        // @debug print "$property_name => $property_column_name: " . (($column_exists === TRUE) ? 'Exists' : 'Missing') . "\n";
 
         // If it is missing then let's just add it ;-p.
-        // @todo
+        if ($column_exists === FALSE) {
+          $schema->addField($drupal_table, $property_column_name, $column_schema);
+          $columns_added[$field_name][$property_name] = [
+            'drupal_table' => $drupal_table,
+            'column_name' => $property_column_name,
+            'column_spec' => $column_schema,
+          ];
+        }
       }
+    }
 
-      print "\n\n";
-    //}
+    return $columns_added;
   }
 
   // --------------------------------------------------------------------------

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -264,7 +264,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * TripalEntityType.
    *
    * @return array
-   *   An array of the columns that were previously missing and have now beed
+   *   An array of the columns that were previously missing and have now been
    *   added. This array is keyed first by field name and then by property
    *   name. The value is an array defining the column that was added with the
    *   keys: 'drupal_table', 'column_name', 'column_spec'.

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -267,21 +267,44 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    */
   public function syncStorageSchema() {
 
+    // Get the drupal database schema object.
+    $schema = \Drupal::service('database')->schema();
+
     // Get a list of field instances for the current type.
     $field_instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('tripal_entity', $this->id);
 
+    // Get the SQL Storage instance in order to get the field => table mapping.
+    // We will use this mapping later to check the current state of the drupal
+    // field table for each field.
+    $sql_storage = \Drupal::service('entity_type.manager')->getStorage('tripal_entity');
+    $drupal_table_mapping = $sql_storage->getTableMapping();
+
     // Now for each field instance...
-    foreach ($field_instances as $field_def) {
-      // Get the current schema of the field table.
+    //foreach ($field_instances as $key => $field_def) {
+      $field_def = $field_instances['project_contact'];
+      $field_storage_def = $field_def->getFieldStorageDefinition();
+
+      // Get the Drupal field table that we may need to update.
+      $drupal_table = $drupal_table_mapping->getFieldTableName($field_def->getName());
 
       // Get the new schema based on tripalTypes which is dynamically updated
       // based on the backend TripalStorage.
+      $current_schema_columns = $field_storage_def->getColumns();
+      // @debug print "Current Schema ($drupal_table): " . print_r($current_schema_columns, TRUE);
 
-      // Compare the two to see if the current schema is missing anything defined
-      // in the new schema.
+      // Now for each property of the current field, check to see if the
+      // corresponding drupal table column exists.
+      foreach($current_schema_columns as $property_name => $column_schema) {
+        $property_column_name = $drupal_table_mapping->getFieldColumnName($field_storage_def, $property_name);
+        $column_exists = $schema->fieldExists($drupal_table, $property_column_name);
+        // @debug print "$property_name => $property_column_name: " . (($column_exists === TRUE) ? 'Exists' : 'Missing') . "\n";
 
-      // Add in anything missing.
-    }
+        // If it is missing then let's just add it ;-p.
+        // @todo
+      }
+
+      print "\n\n";
+    //}
   }
 
   // --------------------------------------------------------------------------

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -243,6 +243,48 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
   }
 
   // --------------------------------------------------------------------------
+  //                            FIELD MANAGEMT
+  //
+  // TripalEntity uses mostly TripalFields and any entity-wide functions needed
+  // for TripalFields are below.
+  // --------------------------------------------------------------------------
+
+  /**
+   * Update Drupal field schema to match that defined by each field.
+   *
+   * TripalEntity uses a combination of the default SqlContentEntityStorage
+   * and an associated TripalStorage backend. The linking values are stored
+   * by SqlContentEntityStorage in Drupal and then the canonical version of the
+   * data is stored in the specified TripalStorage databackend.
+   *
+   * If the schema of the TripalStorage data backend is updated then the schema
+   * defined by the tripalTypes() method may be different from the Drupal field
+   * table. This method will update the Drupal field table to match the current
+   * schema defined by TripalTypes() for all fields attached to a given
+   * TripalEntityType.
+   *
+   * @return void
+   */
+  public function syncStorageSchema() {
+
+    // Get a list of field instances for the current type.
+    $field_instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('tripal_entity', $this->id);
+
+    // Now for each field instance...
+    foreach ($field_instances as $field_def) {
+      // Get the current schema of the field table.
+
+      // Get the new schema based on tripalTypes which is dynamically updated
+      // based on the backend TripalStorage.
+
+      // Compare the two to see if the current schema is missing anything defined
+      // in the new schema.
+
+      // Add in anything missing.
+    }
+  }
+
+  // --------------------------------------------------------------------------
   //                          MAIN SETTER / GETTERS
   //
   // The following methods allow the main properties of the Tripal Entity Type

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -40,7 +40,7 @@ class SyncTripalFieldStorage {
    *   If this parameter is ommitted then all TripalEntityType instances
    *   will be checked.
    * @param array $difference_types
-   *   A list of the types of differences to detect. If ommitted then all
+   *   A list of the types of differences to detect. If omitted then all
    *   supported types of differences will be checked.
    *   The supported types include:
    *    - missing_property_column: where a column for a new TripalField property
@@ -111,10 +111,10 @@ class SyncTripalFieldStorage {
    *
    * @param string $entity_type
    *   The id of the entity type whose associated fields we want to fix.
-   *   If this parameter is ommitted then all TripalEntityType instances
+   *   If this parameter is omitted then all TripalEntityType instances
    *   will be fixed.
    * @param array $difference_types
-   *   A list of the types of differences to detect. If ommitted then all
+   *   A list of the types of differences to detect. If omitted then all
    *   supported types of differences will be fixed.
    *   The supported types include:
    *    - missing_property_column: where a column for a new TripalField property

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\tripal\Services;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Resolve discrepancies between the Drupal field tables + Tripal Field schema.
+ */
+class SyncTripalFieldStorage {
+
+  /**
+   * The entity type manager.
+   *
+   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Constructs a SyncTripalFieldStorage object.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Identify discrepancies between drupal field tables and tripal field schema.
+   *
+   * @param string $entity_type
+   *   The id of the entity type whose associated fields we want to check.
+   *   If this parameter is ommitted then all TripalEntityType instances
+   *   will be checked.
+   * @param array $difference_types
+   *   A list of the types of differences to detect. If ommitted then all
+   *   supported types of differences will be checked.
+   *   The supported types include:
+   *    - missing_property_column: where a column for a new TripalField property
+   *      does not have a column in the corresponding Drupal field table.
+   *
+   * @return void
+   */
+  public function detectDifferences(string $entity_type = NULL, array $difference_types = []): void {
+    // @todo Place your code here.
+  }
+
+  /**
+   * Resolve already detected differences.
+   *
+   * @param array $differences
+   *   An array of the form returned by detectDifferences() where you wish all
+   *   the included differences to be fixed.
+   *
+   * @return void
+   */
+  public function resolveDetectedDifferences(array $differences): void {
+    // @todo Place your code here.
+  }
+
+  /**
+   * Identify + resolve differences between drupal tables + tripal field schema.
+   *
+   * @param string $entity_type
+   *   The id of the entity type whose associated fields we want to fix.
+   *   If this parameter is ommitted then all TripalEntityType instances
+   *   will be fixed.
+   * @param array $difference_types
+   *   A list of the types of differences to detect. If ommitted then all
+   *   supported types of differences will be fixed.
+   *   The supported types include:
+   *    - missing_property_column: where a column for a new TripalField property
+   *      does not have a column in the corresponding Drupal field table.
+   */
+  public function resolveDifferences(string $entity_type = NULL, array $difference_types = []) {
+    // @todo Place your code here.
+  }
+
+}

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -120,7 +120,7 @@ class SyncTripalFieldStorage {
    *    - missing_property_column: where a column for a new TripalField property
    *      does not have a column in the corresponding Drupal field table.
    */
-  public function resolveDifferences(string $entity_type = NULL, array $difference_types = []) {
+  public function resolveDifferences(string $entity_type = NULL, array $difference_types = []): array {
     $all_columns_added = [];
 
     if ($entity_type !== NULL) {

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal\Services;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -17,10 +18,18 @@ class SyncTripalFieldStorage {
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
+   * The drupal database connection.
+   *
+   * @var Drupal\Core\Database\Connection
+   */
+  protected Connection $drupal_connection;
+
+  /**
    * Constructs a SyncTripalFieldStorage object.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, Connection $drupal_connection) {
     $this->entityTypeManager = $entityTypeManager;
+    $this->drupal_connection = $drupal_connection;
   }
 
   /**
@@ -43,7 +52,7 @@ class SyncTripalFieldStorage {
     $all_columns_added = [];
 
     if ($entity_type !== NULL) {
-      $type = \Drupal::entityTypeManager()
+      $type = $this->entityTypeManager
         ->getStorage('tripal_entity_type')
         ->load($entity_type);
       if (is_object($type)) {
@@ -54,7 +63,7 @@ class SyncTripalFieldStorage {
       }
     }
     else {
-      $types = \Drupal::entityTypeManager()
+      $types = $this->entityTypeManager
       ->getStorage('tripal_entity_type')
       ->loadMultiple();
     }
@@ -81,7 +90,7 @@ class SyncTripalFieldStorage {
   public function resolveDetectedDifferences(array $differences): void {
 
     // Get the drupal database schema object.
-    $schema = \Drupal::service('database')->schema();
+    $schema = $this->drupal_connection->schema();
 
     foreach ($differences as $field_name => $field_differences) {
       foreach ($field_differences as $property_name => $property_difference) {
@@ -115,7 +124,7 @@ class SyncTripalFieldStorage {
     $all_columns_added = [];
 
     if ($entity_type !== NULL) {
-      $type = \Drupal::entityTypeManager()
+      $type = $this->entityTypeManager
         ->getStorage('tripal_entity_type')
         ->load($entity_type);
       if (is_object($type)) {
@@ -124,7 +133,7 @@ class SyncTripalFieldStorage {
         throw new \Exception("We were unable to retrieve the TripalEntityType $entity_type when trying to detect differences in the field schema.");
       }
     } else {
-      $types = \Drupal::entityTypeManager()
+      $types = $this->entityTypeManager
         ->getStorage('tripal_entity_type')
         ->loadMultiple();
     }

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -60,7 +60,7 @@ class SyncTripalFieldStorage {
     }
 
     foreach ($types as $bundle_name => $type_object) {
-      $columns_added = $type_object->syncStorageSchema();
+      $columns_added = $type_object->syncStorageSchema(TRUE);
       if (is_array($columns_added)) {
         $all_columns_added = $all_columns_added + $columns_added;
       }
@@ -79,7 +79,22 @@ class SyncTripalFieldStorage {
    * @return void
    */
   public function resolveDetectedDifferences(array $differences): void {
-    // @todo Place your code here.
+
+    // Get the drupal database schema object.
+    $schema = \Drupal::service('database')->schema();
+
+    foreach ($differences as $field_name => $field_differences) {
+      foreach ($field_differences as $property_name => $property_difference) {
+        $column_exists = $schema->fieldExists($property_difference['drupal_table'], $property_difference['column_name']);
+        if ($column_exists === FALSE) {
+          $schema->addField(
+            $property_difference['drupal_table'],
+            $property_difference['column_name'],
+            $property_difference['column_spec']
+          );
+        }
+      }
+    }
   }
 
   /**

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -37,10 +37,36 @@ class SyncTripalFieldStorage {
    *    - missing_property_column: where a column for a new TripalField property
    *      does not have a column in the corresponding Drupal field table.
    *
-   * @return void
+   * @return array
    */
-  public function detectDifferences(string $entity_type = NULL, array $difference_types = []): void {
-    // @todo Place your code here.
+  public function detectDifferences(string $entity_type = NULL, array $difference_types = []): array {
+    $all_columns_added = [];
+
+    if ($entity_type === NULL) {
+      $type = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->load($entity_type);
+      if (is_object($type)) {
+        $types = [$entity_type => $type];
+      }
+      else {
+        throw new \Exception("We were unable to retrieve the TripalEntityType $entity_type when trying to detect differences in the field schema.");
+      }
+    }
+    else {
+      $types = \Drupal::entityTypeManager()
+      ->getStorage('tripal_entity_type')
+      ->loadMultiple();
+    }
+
+    foreach ($types as $bundle_name => $type_object) {
+      $columns_added = $type_object->syncStorageSchema();
+      if (is_array($columns_added)) {
+        $all_columns_added = $all_columns_added + $columns_added;
+      }
+    }
+
+    return $all_columns_added;
   }
 
   /**

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -39,10 +39,10 @@ class SyncTripalFieldStorage {
    *
    * @return array
    */
-  public function detectDifferences(string $entity_type = NULL, array $difference_types = []): array {
+  public function detectDifferences(string|null $entity_type = NULL, array $difference_types = []): array {
     $all_columns_added = [];
 
-    if ($entity_type === NULL) {
+    if ($entity_type !== NULL) {
       $type = \Drupal::entityTypeManager()
         ->getStorage('tripal_entity_type')
         ->load($entity_type);

--- a/tripal/src/Services/SyncTripalFieldStorage.php
+++ b/tripal/src/Services/SyncTripalFieldStorage.php
@@ -112,7 +112,31 @@ class SyncTripalFieldStorage {
    *      does not have a column in the corresponding Drupal field table.
    */
   public function resolveDifferences(string $entity_type = NULL, array $difference_types = []) {
-    // @todo Place your code here.
+    $all_columns_added = [];
+
+    if ($entity_type !== NULL) {
+      $type = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->load($entity_type);
+      if (is_object($type)) {
+        $types = [$entity_type => $type];
+      } else {
+        throw new \Exception("We were unable to retrieve the TripalEntityType $entity_type when trying to detect differences in the field schema.");
+      }
+    } else {
+      $types = \Drupal::entityTypeManager()
+        ->getStorage('tripal_entity_type')
+        ->loadMultiple();
+    }
+
+    foreach ($types as $bundle_name => $type_object) {
+      $columns_added = $type_object->syncStorageSchema();
+      if (is_array($columns_added)) {
+        $all_columns_added = $all_columns_added + $columns_added;
+      }
+    }
+
+    return $all_columns_added;
   }
 
 }

--- a/tripal/tripal.services.yml
+++ b/tripal/tripal.services.yml
@@ -54,3 +54,7 @@ services:
     arguments: ['@tripal.logger']
   tripal.tripal_entity.lookup:
     class: Drupal\tripal\Services\TripalEntityLookup
+
+  tripal.sync_tripal_field_storage:
+    class: Drupal\tripal\Services\SyncTripalFieldStorage
+    arguments: ['@entity_type.manager']

--- a/tripal/tripal.services.yml
+++ b/tripal/tripal.services.yml
@@ -57,4 +57,4 @@ services:
 
   tripal.sync_tripal_field_storage:
     class: Drupal\tripal\Services\SyncTripalFieldStorage
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@database']

--- a/tripal_chado/src/Database/ChadoConnection.php
+++ b/tripal_chado/src/Database/ChadoConnection.php
@@ -134,6 +134,7 @@ class ChadoConnection extends TripalDbxConnection {
       ->execute()
       ->fetch();
     if ($result) {
+      $this->version = $result->version;
       return $result->version;
     }
 
@@ -170,6 +171,7 @@ class ChadoConnection extends TripalDbxConnection {
             AND cvt.name = 'version'";
         $v = $this->query($sql_query)->fetchObject();
         if ($v) {
+          $this->version = $v->value;
           return $v->value;
         }
       }
@@ -181,6 +183,7 @@ class ChadoConnection extends TripalDbxConnection {
       }
     }
 
+    $this->version = $version;
     return $version;
   }
 

--- a/tripal_chado/src/Task/ChadoApplyMigrations.php
+++ b/tripal_chado/src/Task/ChadoApplyMigrations.php
@@ -490,6 +490,18 @@ class ChadoApplyMigrations extends ChadoTaskBase {
           }
         }
       }
+
+      // Now update the field storage to match any changes.
+      $this->logger->notice("Updating any fields associated with Chado to ensure they take advantage of the new schema.");
+      $differences = \Drupal::service('tripal.sync_tripal_field_storage')
+      ->resolveDifferences();
+
+      $fields_needing_updates = count($differences);
+      $num_columns_added = array_sum(array_map("count", $differences));
+      if ($fields_needing_updates > 0) {
+        $this->logger->notice("Added $num_columns_added columns across $fields_needing_updates fields.");
+      }
+
       // @todo Only mark the task successfull if no migrations failed.
       $task_success = TRUE;
     }

--- a/tripal_chado/src/Task/ChadoApplyMigrations.php
+++ b/tripal_chado/src/Task/ChadoApplyMigrations.php
@@ -494,7 +494,7 @@ class ChadoApplyMigrations extends ChadoTaskBase {
       // Now update the field storage to match any changes.
       $this->logger->notice("Updating any fields associated with Chado to ensure they take advantage of the new schema.");
       $differences = \Drupal::service('tripal.sync_tripal_field_storage')
-      ->resolveDifferences();
+        ->resolveDifferences();
 
       $fields_needing_updates = count($differences);
       $num_columns_added = array_sum(array_map("count", $differences));

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -94,7 +94,11 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
     $this->createContentTypeFromConfig($bundle_category, $bundle_name, TRUE);
 
     // Upgrade the test environment to the specified chado version.
-    // @todo implement a way to do this.
-    // $this->upgradeTestSchema('1.3', $chado_verison_under_test);
+    $this->upgradeTestSchema($this->chado_connection, '1.3', $chado_verison_under_test);
+    $this->assertEquals(
+      $chado_verison_under_test,
+      $this->chado_connection->getVersion(),
+      "We were unable to upgrade our test schema to the version we intended to."
+    );
   }
 }

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -130,7 +130,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Tests SyncTripalFieldStorage::detectDifferences().
+   * Tests detectDifferences() + resolveDetectedDifferences().
    *
    * @dataProvider provideChadoVersionsToTest
    *
@@ -210,5 +210,69 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
       }
     }
     */
+  }
+
+  /**
+   * Tests detectDifferences() + resolveDetectedDifferences().
+   *
+   * @dataProvider provideChadoVersionsToTest
+   *
+   * @param string $chado_verison_under_test
+   *   The version of chado we want to test for differences from Chado 1.3.
+   * @param array $bundles_to_create
+   *   An array of bundles to create for the test. The bundles should be a
+   *   string of the format CATEGORY.BUNDLENAME. Each bundle will be created
+   *   when the test schema is at 1.3 using createContentTypeFromConfig().
+   * @param string|null $bundle_under_test
+   *   The bundle name to pass into our test function.
+   * @param array $expectations
+   *   An array of expectations. Specifically,
+   *    - num_fields: the number of fields with detected differences.
+   *    - differences: the keys are field names with differences and the value
+   *      for each is a list of property names with differences for that field.
+   */
+  public function testResolveDifferences(string $chado_verison_under_test, array $bundles_to_create, string|null $bundle_under_test, array $expectations) {
+
+    // Create an instance of the specified bundle(s) with all associated fields.
+    foreach ($bundles_to_create as $bundle_details) {
+      [$bundle_category, $bundle_name] = explode('.', $bundle_details);
+      $this->createContentTypeFromConfig($bundle_category, $bundle_name, TRUE);
+    }
+
+    // Upgrade the test environment to the specified chado version.
+    $this->upgradeTestSchema($this->chado_connection, '1.3', $chado_verison_under_test);
+    $this->assertEquals(
+      $chado_verison_under_test,
+      $this->chado_connection->getVersion(),
+      "We were unable to upgrade our test schema to the version we intended to."
+    );
+
+    // Now actually call the method!
+    $syncTripalFieldStorageService = \Drupal::service('tripal.sync_tripal_field_storage');
+    $differences = $syncTripalFieldStorageService->resolveDifferences($bundle_under_test);
+    $this->assertNotEmpty($differences, "We expected some differences based on the version under test.");
+
+    $this->assertCount($expectations['num_fields'], $differences, "We expected this many fields to have differences detected.");
+
+    // Now check all the expected differences are present.
+    $schema = $this->chado_connection->schema();
+    foreach ($expectations['differences'] as $expected_field => $expected_properties) {
+      $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
+      foreach ($expected_properties as $expected_property) {
+        $this->assertArrayHasKey($expected_property, $differences[$expected_field], "We expected this property of $expected_field to have a difference but it did not.");
+
+        // Confirm that this field WAS added to the drupal table
+        // since we asked to resolve the differences directly.
+        /* Currently failing
+        $property_difference = $differences[$expected_field][$expected_property];
+        $column_exists = $schema->fieldExists(
+          $property_difference['drupal_table'],
+          $property_difference['column_name']
+        );
+        $column = $property_difference['drupal_table'] . '.' . $property_difference['column_name'];
+        $this->assertFalse($column_exists, "The $column column should still not exist because we checked for differences but did not choose to resolve them.");
+        */
+      }
+    }
   }
 }

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -100,5 +100,25 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
       $this->chado_connection->getVersion(),
       "We were unable to upgrade our test schema to the version we intended to."
     );
+
+    // Now actually call the method!
+    $syncTripalFieldStorageService = \Drupal::service('tripal.sync_tripal_field_storage');
+    $differences = $syncTripalFieldStorageService->detectDifferences($bundle_name);
+    $this->assertNotEmpty($differences, "We expected some differences based on the version under test.");
+
+    $this->assertCount(4, $differences, "We expected this many fields to have differences detected.");
+
+    $expected_differences = [
+      'project_analysis' => ['linker_type_id'],
+      'project_contact' => ['linker_type_id', 'linker_rank'],
+      'project_pub' => ['linker_type_id', 'linker_rank'],
+      'project_dbxref' => ['linker_type_id'],
+    ];
+    foreach ($expected_differences as $expected_field => $expected_properties) {
+      $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
+      foreach ($expected_properties as $expected_property) {
+        $this->assertArrayHasKey($expected_property, $differences[$expected_field], "We expected this property of $expected_field to have a difference but it did not.");
+      }
+    }
   }
 }

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -80,6 +80,21 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
       ],
     ];
 
+    $scenarios[] = [
+      '1.3.3.013',
+      ['general_chado.project'],
+      NULL,
+      [
+        'num_fields' => 4,
+        'differences' => [
+          'project_analysis' => ['linker_type_id'],
+          'project_contact' => ['linker_type_id', 'linker_rank'],
+          'project_pub' => ['linker_type_id', 'linker_rank'],
+          'project_dbxref' => ['linker_type_id'],
+        ],
+      ],
+    ];
+
     return $scenarios;
   }
 
@@ -125,7 +140,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
    *   An array of bundles to create for the test. The bundles should be a
    *   string of the format CATEGORY.BUNDLENAME. Each bundle will be created
    *   when the test schema is at 1.3 using createContentTypeFromConfig().
-   * @param string $bundle_under_test
+   * @param string|null $bundle_under_test
    *   The bundle name to pass into our test function.
    * @param array $expectations
    *   An array of expectations. Specifically,
@@ -133,7 +148,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
    *    - differences: the keys are field names with differences and the value
    *      for each is a list of property names with differences for that field.
    */
-  public function testDetectDifferences(string $chado_verison_under_test, array $bundles_to_create, string $bundle_under_test, array $expectations) {
+  public function testDetectDifferences(string $chado_verison_under_test, array $bundles_to_create, string|null $bundle_under_test, array $expectations) {
 
     // Create an instance of the specified bundle(s) with all associated fields.
     foreach ($bundles_to_create as $bundle_details) {

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -44,9 +44,41 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
   /**
    * Provides information about specific versions of Chado to test for
    * discrepancies against field installed on Chado 1.3.
+   *
+   * @return array
+   *   Each entry in this array is a specific scenario to be tested.
+   *   Each scenario has the following elements:
+   *   - chado_verison_under_test
+   *   The version of chado we want to test for differences from Chado 1.3.
+   *   - bundles_to_create
+   *   An array of bundles to create for the test. The bundles should be a
+   *   string of the format CATEGORY.BUNDLENAME. Each bundle will be created
+   *   when the test schema is at 1.3 using createContentTypeFromConfig().
+   *   - bundle_under_test
+   *   The bundle name to pass into our test function.
+   *   - expectations
+   *   An array of expectations. Specifically,
+   *     - num_fields: the number of fields with detected differences.
+   *     - differences: the keys are field names with differences and the value
+   *       for each is a list of property names with differences for that field.
    */
   public static function provideChadoVersionsToTest() {
     $scenarios = [];
+
+    $scenarios[] = [
+      '1.3.3.013',
+      ['general_chado.project'],
+      'project',
+      [
+        'num_fields' => 4,
+        'differences' => [
+          'project_analysis' => ['linker_type_id'],
+          'project_contact' => ['linker_type_id', 'linker_rank'],
+          'project_pub' => ['linker_type_id', 'linker_rank'],
+          'project_dbxref' => ['linker_type_id'],
+        ],
+      ],
+    ];
 
     return $scenarios;
   }
@@ -84,14 +116,30 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
 
   /**
    * Tests SyncTripalFieldStorage::detectDifferences().
+   *
+   * @dataProvider provideChadoVersionsToTest
+   *
+   * @param string $chado_verison_under_test
+   *   The version of chado we want to test for differences from Chado 1.3.
+   * @param array $bundles_to_create
+   *   An array of bundles to create for the test. The bundles should be a
+   *   string of the format CATEGORY.BUNDLENAME. Each bundle will be created
+   *   when the test schema is at 1.3 using createContentTypeFromConfig().
+   * @param string $bundle_under_test
+   *   The bundle name to pass into our test function.
+   * @param array $expectations
+   *   An array of expectations. Specifically,
+   *    - num_fields: the number of fields with detected differences.
+   *    - differences: the keys are field names with differences and the value
+   *      for each is a list of property names with differences for that field.
    */
-  public function testDetectDifferences() {
-    $chado_verison_under_test = '1.3.3.013';
-    $bundles_under_test = ['general_chado.project'];
+  public function testDetectDifferences(string $chado_verison_under_test, array $bundles_to_create, string $bundle_under_test, array $expectations) {
 
     // Create an instance of the specified bundle(s) with all associated fields.
-    [$bundle_category, $bundle_name] = explode('.', $bundles_under_test[0]);
-    $this->createContentTypeFromConfig($bundle_category, $bundle_name, TRUE);
+    foreach ($bundles_to_create as $bundle_details) {
+      [$bundle_category, $bundle_name] = explode('.', $bundle_details);
+      $this->createContentTypeFromConfig($bundle_category, $bundle_name, TRUE);
+    }
 
     // Upgrade the test environment to the specified chado version.
     $this->upgradeTestSchema($this->chado_connection, '1.3', $chado_verison_under_test);
@@ -103,18 +151,13 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
 
     // Now actually call the method!
     $syncTripalFieldStorageService = \Drupal::service('tripal.sync_tripal_field_storage');
-    $differences = $syncTripalFieldStorageService->detectDifferences($bundle_name);
+    $differences = $syncTripalFieldStorageService->detectDifferences($bundle_under_test);
     $this->assertNotEmpty($differences, "We expected some differences based on the version under test.");
 
-    $this->assertCount(4, $differences, "We expected this many fields to have differences detected.");
+    $this->assertCount($expectations['num_fields'], $differences, "We expected this many fields to have differences detected.");
 
-    $expected_differences = [
-      'project_analysis' => ['linker_type_id'],
-      'project_contact' => ['linker_type_id', 'linker_rank'],
-      'project_pub' => ['linker_type_id', 'linker_rank'],
-      'project_dbxref' => ['linker_type_id'],
-    ];
-    foreach ($expected_differences as $expected_field => $expected_properties) {
+    // Now check all the expected differences are present.
+    foreach ($expectations['differences'] as $expected_field => $expected_properties) {
       $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
       foreach ($expected_properties as $expected_property) {
         $this->assertArrayHasKey($expected_property, $differences[$expected_field], "We expected this property of $expected_field to have a difference but it did not.");

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\tripal\Kernel;
+
+use Drupal\Core\Database\Database;
+use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+
+/**
+ * Tests the SyncTripalFieldStorage service.
+ *
+ * @group SyncTripalFieldStorage
+ */
+class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
+
+  /**
+   * The theme under which testing should be done.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The modules that this test relies on.
+   *
+   * @var array
+   */
+  protected static $modules = ['system', 'user', 'path', 'path_alias', 'tripal', 'tripal_chado', 'views', 'field'];
+
+  /**
+   * Connection to the test chado instance.
+   *
+   * @var \Drupal\tripal_chado\Database\ChadoConnection;
+   */
+  protected ChadoConnection $chado_connection;
+
+  /**
+   * Connection to the test drupal instance.
+   *
+   * @var \Drupal\Core\Database\Database;
+   */
+  protected Database $drupal_connection;
+
+  /**
+   * Provides information about specific versions of Chado to test for
+   * discrepancies against field installed on Chado 1.3.
+   */
+  public static function provideChadoVersionsToTest() {
+    $scenarios = [];
+
+    return $scenarios;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Ensure we see all logging in tests.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Ensure we install the schema/modules we need.
+    $this->prepareEnvironment(['TripalTerm', 'TripalEntity']);
+    // -- additionally we need tripal_chado config to access the yaml files.
+    $this->installConfig('tripal_chado');
+
+    // Create chado 1.3 test instance which will later be upgraded.
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO, '1.3');
+
+    // Add terms needed.
+    // @todo update the createContentType method to add terms needed!
+    // Create the terms for the field property storage types.
+    $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
+    foreach (['local', 'SIO', 'schema', 'data', 'NCIT', 'operation', 'OBCS', 'SWO', 'IAO', 'TPUB', 'SBO', 'sep', 'ERO', 'EFO'] as $termIdSpace) {
+      $idsmanager->createCollection($termIdSpace, "chado_id_space");
+    }
+    $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
+    foreach (['local', 'SIO', 'schema', 'EDAM', 'ncit', 'OBCS', 'swo', 'IAO', 'tripal_pub', 'sbo', 'sep', 'ero', 'efo'] as $termVocab) {
+      $vmanager->createCollection($termVocab, "chado_vocabulary");
+    }
+
+  }
+
+  /**
+   * Tests SyncTripalFieldStorage::detectDifferences().
+   */
+  public function testDetectDifferences() {
+    $chado_verison_under_test = '1.3.3.013';
+    $bundles_under_test = ['general_chado.project'];
+
+    // Create an instance of the specified bundle(s) with all associated fields.
+    [$bundle_category, $bundle_name] = explode('.', $bundles_under_test[0]);
+    $this->createContentTypeFromConfig($bundle_category, $bundle_name, TRUE);
+
+    // Upgrade the test environment to the specified chado version.
+    // @todo implement a way to do this.
+    // $this->upgradeTestSchema('1.3', $chado_verison_under_test);
+  }
+}

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\tripal\Kernel;
 
-use Drupal\Core\Database\Database;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\pgsql\Driver\Database\pgsql\Connection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 
 /**
@@ -25,7 +25,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
    *
    * @var array
    */
-  protected static $modules = ['system', 'user', 'path', 'path_alias', 'tripal', 'tripal_chado', 'views', 'field'];
+  protected static $modules = ['system', 'user', 'path', 'path_alias', 'tripal', 'tripal_chado', 'views', 'field', 'field_ui'];
 
   /**
    * Connection to the test chado instance.
@@ -37,9 +37,9 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
   /**
    * Connection to the test drupal instance.
    *
-   * @var \Drupal\Core\Database\Database;
+   * @var Drupal\pgsql\Driver\Database\pgsql\Connection
    */
-  protected Database $drupal_connection;
+  protected Connection $drupal_connection;
 
   /**
    * Provides information about specific versions of Chado to test for
@@ -114,6 +114,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
 
     // Create chado 1.3 test instance which will later be upgraded.
     $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO, '1.3');
+    $this->drupal_connection = \Drupal::service('database');
 
     // Add terms needed.
     // @todo update the createContentType method to add terms needed!
@@ -172,7 +173,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
     $this->assertCount($expectations['num_fields'], $differences, "We expected this many fields to have differences detected.");
 
     // Now check all the expected differences are present.
-    $schema = $this->chado_connection->schema();
+    $schema = $this->drupal_connection->schema();
     foreach ($expectations['differences'] as $expected_field => $expected_properties) {
       $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
       foreach ($expected_properties as $expected_property) {
@@ -180,7 +181,6 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
 
         // Confirm that this field was NOT added to the drupal table
         // since we asked to check for differences but not to resolve them.
-        /* Currently failing
         $property_difference = $differences[$expected_field][$expected_property];
         $column_exists = $schema->fieldExists(
           $property_difference['drupal_table'],
@@ -188,7 +188,6 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
         );
         $column = $property_difference['drupal_table'] . '.' . $property_difference['column_name'];
         $this->assertFalse($column_exists, "The $column column should still not exist because we checked for differences but did not choose to resolve them.");
-        */
       }
     }
 
@@ -196,7 +195,6 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
     $syncTripalFieldStorageService->resolveDetectedDifferences($differences);
 
     // Now check that the differences were actually fixed.
-    /* Currently failing
     foreach ($expectations['differences'] as $expected_field => $expected_properties) {
       foreach ($expected_properties as $expected_property) {
 
@@ -209,7 +207,6 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
         $this->assertTrue($column_exists, "The $column column should now exist because we asked to resolve the differences.");
       }
     }
-    */
   }
 
   /**
@@ -255,7 +252,7 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
     $this->assertCount($expectations['num_fields'], $differences, "We expected this many fields to have differences detected.");
 
     // Now check all the expected differences are present.
-    $schema = $this->chado_connection->schema();
+    $schema = $this->drupal_connection->schema();
     foreach ($expectations['differences'] as $expected_field => $expected_properties) {
       $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
       foreach ($expected_properties as $expected_property) {
@@ -263,15 +260,13 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
 
         // Confirm that this field WAS added to the drupal table
         // since we asked to resolve the differences directly.
-        /* Currently failing
         $property_difference = $differences[$expected_field][$expected_property];
         $column_exists = $schema->fieldExists(
           $property_difference['drupal_table'],
           $property_difference['column_name']
         );
         $column = $property_difference['drupal_table'] . '.' . $property_difference['column_name'];
-        $this->assertFalse($column_exists, "The $column column should still not exist because we checked for differences but did not choose to resolve them.");
-        */
+        $this->assertTrue($column_exists, "The $column column SHOULD exist because we asked to resolve the differences as we were checking.");
       }
     }
   }

--- a/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/SyncTripalFieldStorage/SyncTripalFieldStorageTest.php
@@ -172,11 +172,43 @@ class SyncTripalFieldStorageTest extends ChadoTestKernelBase {
     $this->assertCount($expectations['num_fields'], $differences, "We expected this many fields to have differences detected.");
 
     // Now check all the expected differences are present.
+    $schema = $this->chado_connection->schema();
     foreach ($expectations['differences'] as $expected_field => $expected_properties) {
       $this->assertArrayHasKey($expected_field, $differences, "We expected this field to have a difference detected but it did not.");
       foreach ($expected_properties as $expected_property) {
         $this->assertArrayHasKey($expected_property, $differences[$expected_field], "We expected this property of $expected_field to have a difference but it did not.");
+
+        // Confirm that this field was NOT added to the drupal table
+        // since we asked to check for differences but not to resolve them.
+        /* Currently failing
+        $property_difference = $differences[$expected_field][$expected_property];
+        $column_exists = $schema->fieldExists(
+          $property_difference['drupal_table'],
+          $property_difference['column_name']
+        );
+        $column = $property_difference['drupal_table'] . '.' . $property_difference['column_name'];
+        $this->assertFalse($column_exists, "The $column column should still not exist because we checked for differences but did not choose to resolve them.");
+        */
       }
     }
+
+    // Now try to fix the already checked differences.
+    $syncTripalFieldStorageService->resolveDetectedDifferences($differences);
+
+    // Now check that the differences were actually fixed.
+    /* Currently failing
+    foreach ($expectations['differences'] as $expected_field => $expected_properties) {
+      foreach ($expected_properties as $expected_property) {
+
+        $property_difference = $differences[$expected_field][$expected_property];
+        $column_exists = $schema->fieldExists(
+          $property_difference['drupal_table'],
+          $property_difference['column_name']
+        );
+        $column = $property_difference['drupal_table'] . '.' . $property_difference['column_name'];
+        $this->assertTrue($column_exists, "The $column column should now exist because we asked to resolve the differences.");
+      }
+    }
+    */
   }
 }

--- a/tripal_chado/tests/src/Traits/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoTestTrait.php
@@ -3,6 +3,7 @@ namespace Drupal\Tests\tripal_chado\Traits;
 
 use Drupal\tripal\TripalDBX\TripalDbx;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * This is a PHP Trait for Chado tests.
@@ -361,27 +362,7 @@ trait ChadoTestTrait  {
 
     // Make sure that the version is correct in the chado property table.
     if (($init_level > 1) && ($version !== '1.3')) {
-      // -- get the version cvterm ID.
-      $result = $tripaldbx_db->select('1:cvterm', 'cvt')
-        ->fields('cvt', ['cvterm_id']);
-      $result->join('1:cv', 'cv', 'cv.cv_id = cvt.cv_id');
-      $result->condition('cv.name', 'chado_properties');
-      $result->condition('cvt.name', 'version');
-      $result = $result->execute();
-      $version_cvterm_id = $result->fetchField();
-      // -- now update the current version.
-      $tripaldbx_db->update('1:chadoprop')
-        ->fields([
-          'value' => $version,
-        ])
-        ->condition('type_id', $version_cvterm_id)
-        ->execute();
-      // -- confirm the version was set properly.
-      $this->assertEquals(
-        $version,
-        $tripaldbx_db->getVersion(),
-        "We expect that the chado version returned by the connection matches what we requested."
-      );
+      $this->setChadoTestSchemaVersion($tripaldbx_db, $version);
     }
 
     // Make sure that any other connections to TripalDBX will see this new test schema as
@@ -398,6 +379,138 @@ trait ChadoTestTrait  {
     $container->set('tripal_chado.database', $tripaldbx_db);
 
     return $tripaldbx_db;
+  }
+
+  /**
+   * Sets the chado version of the test schema.
+   *
+   * @return void
+   */
+  protected function setChadoTestSchemaVersion(ChadoConnection &$chado_connection, string $version) {
+
+    // Get the version cvterm ID.
+    $result = $chado_connection->select('1:cvterm', 'cvt')
+      ->fields('cvt', ['cvterm_id']);
+    $result->join('1:cv', 'cv', 'cv.cv_id = cvt.cv_id');
+    $result->condition('cv.name', 'chado_properties');
+    $result->condition('cvt.name', 'version');
+    $result = $result->execute();
+    $version_cvterm_id = $result->fetchField();
+    $this->assertNotEquals(0, $version_cvterm_id, "We were unable to retrieve the cvterm needed for the chado property verion.");
+
+    // Now update the current version.
+    $chado_connection->update('1:chadoprop')
+      ->fields([
+        'value' => $version,
+      ])
+      ->condition('type_id', $version_cvterm_id)
+      ->execute();
+
+    // Confirm the version was set properly.
+    // Note: we use findVersion() because getVersion() is cached and this
+    // resets the cache.
+    $this->assertEquals(
+      $version,
+      $chado_connection->findVersion($chado_connection->getSchemaName(), TRUE),
+      "We expect that the chado version returned by the connection matches what we requested."
+    );
+  }
+
+  /**
+   * Updates an existing test schema to a new version.
+   *
+   * @param ChadoConnection $chado_connection
+   *   The test schema to migrate.
+   * @param string $current_version
+   *   The current version of the test schema (e.g. 1.3).
+   * @param string $version_to_upgrade_to
+   *   The version to upgrade the test schema to (e.g. 1.3.3.013).
+   *
+   * @return void
+   */
+  protected function upgradeTestSchema(ChadoConnection &$chado_connection, string $current_version, string $version_to_upgrade_to) {
+
+    $target_schema = $chado_connection->getSchemaName();
+    $migrations = $this->getChadoMigrations();
+
+    // Determine which migrations need to be applied.
+    // -- Where to start.
+    // If the current version is 1.3 then we need to start applying at the
+    // beginning of the list. If not, we need to find where to start so lets
+    // do that now.
+    $start_index = 0;
+    if ($current_version !== '1.3') {
+      foreach ($migrations as $key => $details) {
+        if ($details['version'] === $current_version) {
+          $start_index = $key;
+          break;
+        }
+      }
+      if ($start_index === 0) {
+        $this->assertTrue(FALSE, "We were unable to find the '$current_version' in our list of migrations.");
+      }
+    }
+
+    // -- Now apply migrations from there onwards.
+    // Now that we know where to start, lets begin applying migrations to the
+    // current test schema until we reach the version to update to.
+    $last_key_possible = array_key_last($migrations);
+    for ($i = $start_index; $i <= $last_key_possible; $i++) {
+      $migration_file = __DIR__ . '/../../../chado_schema/migrations/' . $migrations[$i]['filename'];
+      $success = $chado_connection->executeSqlFile(
+        $migration_file,
+        FALSE,
+        $target_schema
+      );
+      $this->assertTrue(
+        $success,
+        "We should have been able to apply $migration_file to $target_schema but could not."
+      );
+
+      // Check to see if this is the last migration we should apply.
+      if ($migrations[$i]['version'] === $version_to_upgrade_to) {
+        break;
+      }
+    }
+
+    // Now report the new version.
+    $this->setChadoTestSchemaVersion($chado_connection, $version_to_upgrade_to);
+
+  }
+
+  /**
+   * Retrieve information about the current chado migrations available.
+   *
+   * @return array
+   *   The parsed array structure from the migrations YAML not include the
+   *   file definition but instead only that under `migrations`.
+   */
+  protected function getChadoMigrations() {
+    $yaml_file = __DIR__ . '/../../../chado_schema/migrations/tripal_chado.chado_migrations.yml';
+
+    $this->assertFileIsReadable(
+      $yaml_file,
+      "Cannot open YAML file $yaml_file in order to set the fields for testing chadostorage."
+    );
+
+    $file_contents = file_get_contents($yaml_file);
+    $this->assertNotEmpty(
+      $file_contents,
+      "Unable to retrieve contents for YAML file $yaml_file in order to set the fields for testing chadostorage."
+    );
+
+    $yaml_data = Yaml::parse($file_contents);
+    $this->assertNotEmpty(
+      $yaml_data,
+      "Unable to parse YAML file $yaml_file in order to set the fields for testing chadostorage."
+    );
+    $this->assertArrayHasKey(
+      'migrations',
+      $yaml_data,
+      "The key 'migrations' does not exist in the parsed YAML file: $yaml_file."
+    );
+
+    return $yaml_data['migrations'];
   }
 
   /**


### PR DESCRIPTION
# Bug Fix

### Issue #2100

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Now that we are able to update chado to new migration versions, we also have to ensure that the field schema matches what chado expects. The linked issue shows the bug found when new columns are added to Chado and the field schema is dynamically updated but the Drupal field table is not likewise updated.

This PR implements an approach to update the Drupal field table to match the current field schema. More specifically,

- [x] Add `TripalEntityType->syncStorageSchema()` to update the Drupal field table associated will all fields attached to this bundle.
- [x] Add Drush command to allow admin to easily update the Drupal field tables associated will any Tripal Entity Type.
- [x] Add a service to allow modules to easily update the Drupal field tables associated will any Tripal Entity Type programatically.
- [x] Trigger the above service after applying chado migrations so most people need never worry about this again 😅 
- [x] Add automated testing for all of the above.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Automated Testing

This PR adds tests to cover the new TripalEntityType::syncStorageSchema() method and all methods in the new SyncTripalFieldStorage service.

Coverage from the tests under group `SyncTripalFieldStorage` is as follows:
![Screenshot 2025-02-06 at 10 23 50 AM](https://github.com/user-attachments/assets/bcb37e81-07c2-4494-b068-46afff50138a)
![Screenshot 2025-02-06 at 10 24 01 AM](https://github.com/user-attachments/assets/26307b02-1c33-412b-b7e5-73fab4295fc6)

With the only lines not covered involved in throwing exceptions when the type passed into the method does not exist.

### Manual Testing

1. In a TripalDocker based on this branch, go to Tripal > Data Storage > Chado > Chado Schemas. 
2. Click on "Apply Migrations" beside your default schema to see a summary of the migrations that can be applied.
3. Click "Apply Migrations" again and run the submitted Tripal job on the command-line.
4. Check the Drupal field table associated with the project_contact field (`tripal_entity__project_contact`) and ensure the `project_contact_linker_type_id` and `project_contact_linker_rank` columns are present.
5. Through the UI, create a contact --details do not matter.
6. Through the UI create a new project and link the contact. On this branch, this will pass. On 4.x this would have failed with the WSOD shown in the linked issue.

Note: since the field schema adjustments are now run at the same time as the schema is migrated, it makes it harder to test the Drush command. If you want to test it then comment out lines 495 - 503 in `tripal_chado/src/Task/ChadoApplyMigrations.php` before running the migrations.