### PR TITLE
Drush command to apply Chado migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG modules='devel devel_php field_group field_group_table'
 ARG tripalmodules='tripal tripal_biodb tripal_chado tripal_layout'
 ARG chadoschema='chado'
 ARG installchado=TRUE
+ARG migratechado=FALSE
 # see issue #2000 for the reason for updating the PATH:
 ENV PATH="/var/www/drupal/vendor/drush/drush:$PATH"
 
@@ -37,9 +38,13 @@ RUN service apache2 start \
 
 RUN service apache2 start \
   && service postgresql start \
-  && if [ "$installchado" = "TRUE" ]; then \
-  vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
-  && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema}; \
+  && if [ "$installchado" = "TRUE" ] && [ "$migratechado" = "TRUE" ]; then \
+    vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
+    && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \
+    && vendor/bin/drush trp-migrate-chado --schema-name=${chadoschema}; \
+  elif [ "$installchado" = "TRUE" ]; then \
+    vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
+    && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema}; \
   fi \
   && service apache2 stop \
   && service postgresql stop

--- a/tripal_chado/src/Commands/ChadoManageCommands.php
+++ b/tripal_chado/src/Commands/ChadoManageCommands.php
@@ -2,6 +2,7 @@
 namespace Drupal\tripal_chado\Commands;
 
 use Drush\Commands\DrushCommands;
+use Drupal\tripal\TripalDBX\TripalDbx;
 
 /**
  * Drush commands
@@ -50,10 +51,22 @@ class ChadoManageCommands extends DrushCommands {
    * @aliases trp-migrate-chado
    * @options schema-name
    *   The name of the schema to apply chado migrations to.
-   * @usage drush trp-install-chado --schema-name='teapot'
+   * @usage drush trp-migrate-chado --schema-name='teapot'
    *   Applies all pending migrations to a schema named "teapot".
    */
   public function migrateChado($options = ['schema-name' => 'chado']) {
+
+    // Confirm the schema exists.
+    $tripaldbx = \Drupal::service('tripal.dbx');
+    $schema_exists = $tripaldbx->schemaExists($options['schema-name']);
+    if (!$schema_exists) {
+      throw new \Exception(dt(
+        'The \'@schema\' does not exist and therefore cannot be migrated.',
+        [
+          '@schema' => $options['schema-name'],
+        ]
+      ));
+    }
 
     // First setup our task.
     $migrator = \Drupal::service('tripal_chado.apply_migrations');
@@ -62,7 +75,7 @@ class ChadoManageCommands extends DrushCommands {
     ]);
 
     // Look up the install ID
-    // @todo lookup the install ID.
+    $migrator->lookupInstallID();
 
     // Determine what work is to be done and format into a table.
     $all_migrations = $migrator->checkMigrationStatus();
@@ -72,7 +85,7 @@ class ChadoManageCommands extends DrushCommands {
     foreach ($all_migrations as $migration) {
       $formatted_date = '';
       if ($migration->applied_on) {
-        $formatted_date = \Drupal::service('date.formatter')->format($migration->applied_on, 'medium');
+        $formatted_date = \Drupal::service('date.formatter')->format($migration->applied_on, 'html_date');
       }
       $rows[] = [
         $migration->version,
@@ -90,22 +103,27 @@ class ChadoManageCommands extends DrushCommands {
     $this->io()->table($header, $rows);
     $this->output()->writeln('');
 
-    $response = $this->io()->confirm(
-      "Would you like to apply $pending_migrations pending migrations?",
-      TRUE
-    );
-    if ($response) {
-      $success = $migrator->performTask();
-      if ($success) {
-        $this->output()->writeln(dt('<info>[Success]</info> Chado was successfully migrated to the most recent version.'));
-      } else {
-        throw new \Exception(dt(
-          'Unable to migrate chado in {schema}',
-          ['schema' => $options['schema-name']]
-        ));
+    if ($pending_migrations) {
+      $response = $this->io()->confirm(
+        "Would you like to apply $pending_migrations pending migrations?",
+        TRUE
+      );
+      if ($response) {
+        $success = $migrator->performTask();
+        if ($success) {
+          $this->output()->writeln(dt('<info>[Success]</info> Chado was successfully migrated to the most recent version.'));
+        } else {
+          throw new \Exception(dt(
+            'Unable to migrate chado in {schema}',
+            ['schema' => $options['schema-name']]
+          ));
+        }
       }
     }
-
+    else {
+      $this->output()->writeln(dt('<info>[Success]</info> Chado is already up to date. There are no migrations pending.'));
+    }
+    $this->output()->writeln('');
   }
 
   /**

--- a/tripal_chado/src/Commands/ChadoManageCommands.php
+++ b/tripal_chado/src/Commands/ChadoManageCommands.php
@@ -44,6 +44,71 @@ class ChadoManageCommands extends DrushCommands {
   }
 
   /**
+   * Apply migrations to an existing Chado schema.
+   *
+   * @command tripal-chado:migrate-chado
+   * @aliases trp-migrate-chado
+   * @options schema-name
+   *   The name of the schema to apply chado migrations to.
+   * @usage drush trp-install-chado --schema-name='teapot'
+   *   Applies all pending migrations to a schema named "teapot".
+   */
+  public function migrateChado($options = ['schema-name' => 'chado']) {
+
+    // First setup our task.
+    $migrator = \Drupal::service('tripal_chado.apply_migrations');
+    $migrator->setParameters([
+      'input_schemas' => [$options['schema-name']],
+    ]);
+
+    // Look up the install ID
+    // @todo lookup the install ID.
+
+    // Determine what work is to be done and format into a table.
+    $all_migrations = $migrator->checkMigrationStatus();
+    $header = ['Chado Version', 'Description', 'Applied On', 'Status'];
+    $rows = [];
+    $pending_migrations = 0;
+    foreach ($all_migrations as $migration) {
+      $formatted_date = '';
+      if ($migration->applied_on) {
+        $formatted_date = \Drupal::service('date.formatter')->format($migration->applied_on, 'medium');
+      }
+      $rows[] = [
+        $migration->version,
+        $migration->description,
+        $formatted_date,
+        $migration->status,
+      ];
+
+      if ($migration->status !== 'Successful') {
+        $pending_migrations++;
+      }
+    }
+
+    $this->output()->writeln("\nThe following table summarizes the migrations for the '" . $options['schema-name'] . "' schema.");
+    $this->io()->table($header, $rows);
+    $this->output()->writeln('');
+
+    $response = $this->io()->confirm(
+      "Would you like to apply $pending_migrations pending migrations?",
+      TRUE
+    );
+    if ($response) {
+      $success = $migrator->performTask();
+      if ($success) {
+        $this->output()->writeln(dt('<info>[Success]</info> Chado was successfully migrated to the most recent version.'));
+      } else {
+        throw new \Exception(dt(
+          'Unable to migrate chado in {schema}',
+          ['schema' => $options['schema-name']]
+        ));
+      }
+    }
+
+  }
+
+  /**
    * Drops the Chado schema.
    *
    * @command tripal-chado:drop-chado

--- a/tripal_chado/src/Commands/ChadoManageCommands.php
+++ b/tripal_chado/src/Commands/ChadoManageCommands.php
@@ -61,7 +61,7 @@ class ChadoManageCommands extends DrushCommands {
     $schema_exists = $tripaldbx->schemaExists($options['schema-name']);
     if (!$schema_exists) {
       throw new \Exception(dt(
-        'The \'@schema\' does not exist and therefore cannot be migrated.',
+        'The schema \'@schema\' does not exist and therefore cannot be migrated.',
         [
           '@schema' => $options['schema-name'],
         ]
@@ -114,7 +114,7 @@ class ChadoManageCommands extends DrushCommands {
           $this->output()->writeln(dt('<info>[Success]</info> Chado was successfully migrated to the most recent version.'));
         } else {
           throw new \Exception(dt(
-            'Unable to migrate chado in {schema}',
+            'Unable to migrate chado in schema \'{schema}\'',
             ['schema' => $options['schema-name']]
           ));
         }

--- a/tripal_chado/src/Task/ChadoApplyMigrations.php
+++ b/tripal_chado/src/Task/ChadoApplyMigrations.php
@@ -141,7 +141,7 @@ class ChadoApplyMigrations extends ChadoTaskBase {
    * @return int|bool
    *   The install ID of the associated installation.
    */
-  public function lookupInstallID(): bool {
+  public function lookupInstallID(): int|bool {
 
     $schema_name = $this->parameters['input_schemas'][0];
 

--- a/tripal_chado/src/Task/ChadoApplyMigrations.php
+++ b/tripal_chado/src/Task/ChadoApplyMigrations.php
@@ -136,6 +136,32 @@ class ChadoApplyMigrations extends ChadoTaskBase {
   }
 
   /**
+   * Lookup the install ID based on the input schema name.
+   *
+   * @return int|bool
+   *   The install ID of the associated installation.
+   */
+  public function lookupInstallID(): bool {
+
+    $schema_name = $this->parameters['input_schemas'][0];
+
+    $query = \Drupal::service('database')->select('chado_installations' ,'i')
+      ->fields('i', ['install_id'])
+      ->condition('i.schema_name', $schema_name, '=');
+
+    $install_id = $query->execute()
+      ->fetchField();
+
+    if (is_numeric($install_id) && ($install_id > 0)) {
+      $this->setInstallID($install_id);
+      return $install_id;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  /**
    * A callable function to provide to tripal jobs as the callback.
    *
    * Simply sets up the biotask with the details saved in the job

--- a/tripal_chado/src/Task/ChadoApplyMigrations.php
+++ b/tripal_chado/src/Task/ChadoApplyMigrations.php
@@ -98,7 +98,7 @@ class ChadoApplyMigrations extends ChadoTaskBase {
    * The unique ID of the above saved Tripal job.
    * @var int
    */
-  protected int $job_id;
+  protected int $job_id = 0;
 
   /**
    * The unique id of the Tripal-managed Chado installation.


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #2111 

## Description

With PR #1937 and PR #2109, we now have full support for a migrated Chado database. As such, it would be great to encourage people to use the newest chado versions in their sites and development.

- [x] add a drush command to apply the currently pending migrations to a given schema.
- [x] add use of this drush command to the docker

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Drush command

1. Start a fresh docker on this branch --this will start on Chado 1.3.
2. Check the definition of the project table and confirm there is no project.type_id
```
drush sql:cli
\d+ teapot.project
```
<img width="1077" alt="Screenshot 2025-02-07 at 10 28 04 AM" src="https://github.com/user-attachments/assets/147c6edb-848b-47f8-9f3b-133480cda26c" />

3. Run the drush command to get a list of the outstanding migrations and choose "No" when asked if you want to apply them. Note: you may need to replace the word teapot with the name of your chado schema if you are not using the devcontiner setup.
```
drush trp-migrate-chado --schema-name='teapot'
```
<img width="1188" alt="Screenshot 2025-02-07 at 10 26 24 AM" src="https://github.com/user-attachments/assets/64d08e10-e15c-4645-ac3d-93ee384b3aa7" />

4. Confirm that the project table still does not have a project.type_id.
5. Run the drush command again and confirm that the migrations are all still pending. This time choose "Yes" when asked if you would like to apply them.
<img width="1367" alt="Screenshot 2025-02-07 at 10 29 39 AM" src="https://github.com/user-attachments/assets/499e0ba8-746d-4749-95bd-858c1aa01c30" />

6. Confirm that the project table now DOES have the project.type_id column which is in one of the  migrations :-)
<img width="1367" alt="Screenshot 2025-02-07 at 10 30 14 AM" src="https://github.com/user-attachments/assets/b8f6adab-ac09-4ccc-a6b8-07f559abc598" />

7. Run the command again and confirm the migrations are now marked successful.
<img width="1299" alt="Screenshot 2025-02-07 at 10 31 28 AM" src="https://github.com/user-attachments/assets/78278a19-62e0-42da-8991-90eaa860dca0" />

8. Run the command with a non-existent schema name and confirm you get an error.
<img width="991" alt="Screenshot 2025-02-07 at 10 31 45 AM" src="https://github.com/user-attachments/assets/92f0653b-443a-49ab-98ba-c279f177b693" />

### Migrate during docker build

This needs to be tested without using the devcontainer but rather by manually building the docker image and container.

1. Checkout a local copy of this branch.
2. Build the docker without any arguments and ensure that the database has not been migrated.
```
docker build --tag=tripaldocker:testing-2115 ./
docker run --publish=8080:80 -tid --name=testing-2115 --volume=$(pwd):/var/www/drupal/web/modules/contrib/tripal tripaldocker:testing-2115
drush trp-migrate-chado --schema-name='teapot'
```
3. Build a docker with migratechado set to TRUE and confirm that you have a migrated chado right off the bat :-)
```
docker build --tag=tripaldocker:testing-2115 --build-arg migratechado='TRUE' ./
docker run --publish=8080:80 -tid --name=testing-2115 --volume=$(pwd):/var/www/drupal/web/modules/contrib/tripal tripaldocker:testing-2115
drush trp-migrate-chado --schema-name='teapot'
```