### PR TITLE
Setup a Tripal Content Type Listing View

### DIFF
--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -281,7 +281,7 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
-              description: ''
+              description: 'time difference'
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -1,14 +1,11 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - user.role.administrator
-    - user.role.authenticated
   module:
     - tripal
     - user
 _core:
-  default_config_hash: D7URjeFAspIGq91Zp4pyy03_ET6SDH_UMcKVKDG70cg
+  default_config_hash: pW72ou_ok2gGi1X6U3oPn631_rvNA_Q4W_PJHDFVNTg
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -381,11 +378,8 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: role
-        options:
-          role:
-            authenticated: authenticated
-            administrator: administrator
+        type: none
+        options: {  }
       cache:
         type: none
         options: {  }
@@ -601,7 +595,6 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
-        - user.roles
       tags: {  }
   page_1:
     id: page_1
@@ -621,5 +614,4 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
-        - user.roles
       tags: {  }

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -4,6 +4,8 @@ dependencies:
   module:
     - tripal
     - user
+_core:
+  default_config_hash: vXHzj7L1fF2AOk6gkFs-68KBr0y9W0NEDHqsBJQe0xE
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -379,7 +381,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer tripal, access tripal content overview, view tripal content entities'
+          perm: 'access tripal content overview'
       cache:
         type: none
         options: {  }
@@ -606,6 +608,25 @@ display:
       display_extenders: {  }
       path: admin/content/bio_data
       use_admin_theme: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - user.permissions
+      tags: {  }
+  page_2:
+    id: page_2
+    display_title: 'Page 2'
+    display_plugin: page
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: admin/content/bio_data
     cache_metadata:
       max-age: -1
       contexts:

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -1,0 +1,635 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - tripal.content_type.analysis
+    - tripal.content_type.contact
+    - tripal.content_type.organism
+    - tripal.content_type.project
+    - tripal.content_type.protocol
+    - tripal.content_type.pub
+    - tripal.content_type.study
+  module:
+    - tripal
+    - user
+id: tripal_content_type_listing
+label: 'Tripal Content Type Listing'
+module: views
+description: ''
+tag: ''
+base_table: tripal_entity
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Tripal Content Type Listing'
+      fields:
+        title:
+          id: title
+          table: tripal_entity
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: tripal_entity
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: type
+          plugin_id: field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uid:
+          id: uid
+          table: tripal_entity
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: uid
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: tripal_entity
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: created
+          plugin_id: field
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        operations:
+          id: operations
+          table: tripal_entity
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: entity_operations
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer tripal'
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: tripal_entity
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: Created
+            field_identifier: created
+          exposed: true
+          granularity: second
+        title:
+          id: title
+          table: tripal_entity
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: Title
+            field_identifier: title
+          exposed: true
+        type:
+          id: type
+          table: tripal_entity
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: type
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: Type
+            field_identifier: type
+          exposed: true
+        uid:
+          id: uid
+          table: tripal_entity
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: uid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: Authors
+            field_identifier: uid
+          exposed: true
+      arguments: {  }
+      filters:
+        title:
+          id: title
+          table: tripal_entity
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: title
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+            placeholder: Title
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: tripal_entity
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            all: all
+            analysis: analysis
+            contact: contact
+            organism: organism
+            project: project
+            protocol: protocol
+            pub: pub
+            study: study
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: OR
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            operations: operations
+          default: '-1'
+          info:
+            operations:
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        uid:
+          id: uid
+          table: tripal_entity
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          entity_type: tripal_entity
+          entity_field: uid
+          plugin_id: standard
+          required: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: tripal-content-type-listing
+      use_admin_theme: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - user.permissions
+      tags: {  }

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -379,7 +379,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer tripal'
+          perm: 'administer tripal, access tripal content overview'
       cache:
         type: none
         options: {  }

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -381,7 +381,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access tripal content overview'
+          perm: 'administer tripal content'
       cache:
         type: none
         options: {  }
@@ -605,6 +605,12 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access tripal content overview'
+      defaults:
+        access: false
       display_extenders: {  }
       path: admin/content/bio_data
       use_admin_theme: true
@@ -625,6 +631,8 @@ display:
     display_plugin: page
     position: 2
     display_options:
+      defaults:
+        access: true
       display_extenders: {  }
       path: admin/content/bio_data
     cache_metadata:

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -1,14 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - tripal.content_type.analysis
-    - tripal.content_type.contact
-    - tripal.content_type.organism
-    - tripal.content_type.project
-    - tripal.content_type.protocol
-    - tripal.content_type.pub
-    - tripal.content_type.study
   module:
     - tripal
     - user
@@ -511,15 +503,7 @@ display:
           entity_field: type
           plugin_id: bundle
           operator: in
-          value:
-            all: all
-            analysis: analysis
-            contact: contact
-            organism: organism
-            project: project
-            protocol: protocol
-            pub: pub
-            study: study
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -620,7 +604,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: tripal-content-type-listing
+      path: admin/content/bio_data
       use_admin_theme: true
     cache_metadata:
       max-age: -1

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -458,7 +458,7 @@ display:
           entity_type: tripal_entity
           entity_field: title
           plugin_id: string
-          operator: '='
+          operator: 'contains'
           value: ''
           group: 1
           exposed: true

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -379,7 +379,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer tripal, access tripal content overview'
+          perm: 'administer tripal, access tripal content overview, view tripal content entities'
       cache:
         type: none
         options: {  }

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -1,11 +1,14 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - user.role.administrator
+    - user.role.authenticated
   module:
     - tripal
     - user
 _core:
-  default_config_hash: vXHzj7L1fF2AOk6gkFs-68KBr0y9W0NEDHqsBJQe0xE
+  default_config_hash: D7URjeFAspIGq91Zp4pyy03_ET6SDH_UMcKVKDG70cg
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -283,7 +286,6 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
-              # description: 'time difference'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -379,9 +381,11 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: role
         options:
-          perm: 'administer tripal content'
+          role:
+            authenticated: authenticated
+            administrator: administrator
       cache:
         type: none
         options: {  }
@@ -597,7 +601,7 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
-        - user.permissions
+        - user.roles
       tags: {  }
   page_1:
     id: page_1
@@ -605,12 +609,6 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access tripal content overview'
-      defaults:
-        access: false
       display_extenders: {  }
       path: admin/content/bio_data
       use_admin_theme: true
@@ -623,26 +621,5 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
-        - user.permissions
-      tags: {  }
-  page_2:
-    id: page_2
-    display_title: 'Page 2'
-    display_plugin: page
-    position: 2
-    display_options:
-      defaults:
-        access: true
-      display_extenders: {  }
-      path: admin/content/bio_data
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
-        - user.permissions
+        - user.roles
       tags: {  }

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -281,7 +281,7 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
-              description: 'time difference'
+              # description: 'time difference'
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -15,6 +15,7 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\Xss;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
+use Drupal\views\ViewExecutable;
 
 require_once 'src/api/tripal.api.php';
 require_once 'src/api/tripal.entities.api.php';
@@ -675,4 +676,33 @@ function tripal_gin_content_form_routes() {
   $route_names[] = 'entity.tripal_entity.edit_form';
 
   return $route_names;
+}
+
+/**
+ * Implements hook_views_pre_view().
+ */
+function tripal_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
+  if ($view->id() == 'tripal_content_type_listing') {
+    // List of permission user must have to access Tripal Content Type listings.
+    $perm = [
+      'access tripal content overview',
+      'administer tripal content',
+    ];
+
+    // Check if current user has either permissions when attempting to view listing.
+    $user = \Drupal::currentUser();
+
+    $has_permission = FALSE;
+    foreach ($perm as $permission) {
+      if ($user->hasPermission($permission)) {
+        $has_permission = TRUE;
+        break;
+      }
+    }
+
+    // Deny access if user does not have necessary permission.
+    if (!$has_permission) {
+      throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException();
+    }
+  }
 }

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -682,8 +682,13 @@ function tripal_gin_content_form_routes() {
  * Implements hook_views_pre_view().
  */
 function tripal_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
+  // Override permission of Tripal Content Type listing (admin/content/bio_data)
+  // in order to support OR when evaluating permissions since views UI does
+  // not support this. 
+  // WARNING: requires you to have NO Permissions on this view through the UI!
   if ($view->id() == 'tripal_content_type_listing') {
-    // List of permission user must have to access Tripal Content Type listings.
+    // The user must have 1+ of the following permissions to access the
+    // Tripal Content Type listing (admin/content/bio_data).
     $perm = [
       'access tripal content overview',
       'administer tripal content',


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

#

### Issue #1976 Tripal Content Type Listing not Filterable

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This Draft PR sets up a view that will display Tripal Content Type listing with filter and sort options.

**This view needs a route/menu path to become accessible in the same way as Tripal Job Listing view and replace the current non-filterable ListBuilder version.**

![image](https://github.com/user-attachments/assets/ebd808af-30cf-4dbd-84f3-bb25dacab145)


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

Load the Content Listing View:

View is setup upon Tripal Docker site creation and can be accessed at my tripal site/admin/content/bio_data

<img width="720" alt="image" src="https://github.com/user-attachments/assets/aa1217e4-2113-4f1c-abbc-bb9c03d715aa" />


Manual Test:
1. Setup an account
2. In permission, set the permission to View Tripal Content Listing
3. Sign out drupaladmin and login as the user created in step 1.
4. Access my tripal site/admin/content/bio_data
5. Content Type listing should be accessible to the user.
6. Repeat steps 1-5 except in step 2 set the permission to Administer Tripal Content.
7. Test Anonymous user - this user will get access denied to the page.


