### PR TITLE
Create tripal_entity_type canonical path to fix WSOD

### DIFF
--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -20,6 +20,7 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
  *   ),
  *   handlers = {
  *     "list_builder" = "Drupal\tripal\ListBuilders\TripalEntityTypeListBuilder",
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "form" = {
  *       "add" = "Drupal\tripal\Form\TripalEntityTypeForm",
  *       "edit" = "Drupal\tripal\Form\TripalEntityTypeForm",

--- a/tripal/templates/tripal_entity_type.html.twig
+++ b/tripal/templates/tripal_entity_type.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file tripal_entity_type.html.twig
+ * Default theme implementation to present Tripal Entity Type (bundle) data.
+ *
+ * This template is used when viewing Tripal Entity Type pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_tripal_entity()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass('tripal_entity_type') }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>

--- a/tripal/templates/tripal_entity_type.page.php
+++ b/tripal/templates/tripal_entity_type.page.php
@@ -23,7 +23,7 @@ use Drupal\Core\Url;
  */
 function template_preprocess_tripal_entity_type(array &$variables) {
 
-  // Fetch TripalEntity Entity Object.
+  // Fetch TripalEntityType Object.
   $tripal_entity_type = $variables['elements']['#tripal_entity_type'];
 
   // Take information from the entity and add it to the content.

--- a/tripal/templates/tripal_entity_type.page.php
+++ b/tripal/templates/tripal_entity_type.page.php
@@ -26,13 +26,41 @@ function template_preprocess_tripal_entity_type(array &$variables) {
   // Fetch TripalEntity Entity Object.
   $tripal_entity_type = $variables['elements']['#tripal_entity_type'];
 
+  // Take information from the entity and add it to the content.
+  $variables['content']['label'] = [
+    '#type' => 'item',
+    '#title' => 'Label',
+    '#markup' => $tripal_entity_type->getLabel(),
+    '#wrapper_attributes' => [
+      'class' => ['container-inline'],
+    ],
+  ];
+  $variables['content']['term'] = [
+    '#type' => 'item',
+    '#title' => 'Term',
+    '#markup' => $tripal_entity_type->getTermIdSpace() . ':' . $tripal_entity_type->getTermAccession(),
+    '#wrapper_attributes' => [
+      'class' => ['container-inline'],
+    ],
+  ];
+  $variables['content']['category'] = [
+    '#type' => 'item',
+    '#title' => 'Category',
+    '#markup' => $tripal_entity_type->getCategory(),
+    '#wrapper_attributes' => [
+      'class' => ['container-inline'],
+    ],
+  ];
+  $variables['content']['description'] = [
+    '#type' => 'item',
+    '#title' => 'Help Text for Curators',
+    '#markup' => $tripal_entity_type->getHelpText(),
+  ];
+
   // Helpful $content variable for templates.
+  // Only adds fields which TripalEntityType may not have.
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
 
-  // See issue #2123 for the history of this
-  $variables['content']['warning'] = [
-    '#markup' => t('This tripal entity type page is a placeholder and is not currently implemented'),
-  ];
 }

--- a/tripal/templates/tripal_entity_type.page.php
+++ b/tripal/templates/tripal_entity_type.page.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Contains tripal_entity_type.page.php.
+ *
+ * Page callback for Tripal Entity Types (bundles).
+ */
+
+use Drupal\Core\Render\Element;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+
+/**
+ * Prepares variables for Tripal Entity Type templates.
+ *
+ * Default template: tripal_entity_type.html.twig.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An associative array containing the user information and any
+ *   - attributes: HTML attributes for the containing element.
+ */
+function template_preprocess_tripal_entity_type(array &$variables) {
+
+  // Fetch TripalEntity Entity Object.
+  $tripal_entity_type = $variables['elements']['#tripal_entity_type'];
+
+  // Helpful $content variable for templates.
+  foreach (Element::children($variables['elements']) as $key) {
+    $variables['content'][$key] = $variables['elements'][$key];
+  }
+
+  // See issue #2123 for the history of this
+  $variables['content']['warning'] = [
+    '#markup' => t('This tripal entity type page is a placeholder and is not currently implemented'),
+  ];
+}

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -51,6 +51,12 @@ function tripal_help($route_name, RouteMatchInterface $route_match) {
 function tripal_theme() {
   $theme = [];
 
+  $theme['tripal_entity_type'] = [
+    'render element' => 'elements',
+    'file' => 'templates/tripal_entity_type.page.php',
+    'template' => 'tripal_entity_type',
+  ];
+
   $theme['tripal_entity'] = array(
     'render element' => 'elements',
     'file' => 'templates/tripal_entity.page.php',


### PR DESCRIPTION
# Bug Fix

### Closes #2123

## Description
This creates a canonical path for tripal_entity_type. This resolves a WSOD under Drupal 10.x when viewing the Tripal Content Listing view.

This implements the canonical path that was missing and causing the WSOD. It is still just a placeholder, but with at least an informative message.

Thanks to @laceysanderson for telling me what to do 😵‍💫

## Testing?
Testing is easy. 
1. Build on Drupal 10.x
2. Create a tripal entity
3. View the listing without WSOD
4. Try viewing the canonical path directly. This is not a page that will normally be visited. For example, for contact, it is `/admin/structure/bio_data/contact` and there is a simple message displayed
![issue2123 1](https://github.com/user-attachments/assets/d14ddeab-ce13-4b35-a0a1-0122b114b0ea)
