### PR TITLE
Fix escaped HTML tags in tripal content type listing view

### DIFF
--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -1,3 +1,4 @@
+uuid: c99e6739-ccab-4512-9a1c-de5d208686c4
 langcode: en
 status: true
 dependencies:
@@ -5,7 +6,7 @@ dependencies:
     - tripal
     - user
 _core:
-  default_config_hash: pW72ou_ok2gGi1X6U3oPn631_rvNA_Q4W_PJHDFVNTg
+  default_config_hash: Bkx9Iy16THW-fIBoCMoaUpI8M_N301WjHNLpq1ztcBQ
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -35,8 +36,8 @@ display:
           label: Title
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ title__value | raw }}'
             make_link: false
             path: ''
             absolute: false
@@ -383,7 +384,18 @@ display:
       cache:
         type: none
         options: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<p>There are no tripal content entities yet.</p>'
+          tokenize: false
       sorts:
         created:
           id: created
@@ -458,7 +470,7 @@ display:
           entity_type: tripal_entity
           entity_field: title
           plugin_id: string
-          operator: 'contains'
+          operator: contains
           value: ''
           group: 1
           exposed: true

--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -394,7 +394,7 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          content: '<p>There are no tripal content entities yet.</p>'
+          content: '<p>No Tripal content available.</p>'
           tokenize: false
       sorts:
         created:


### PR DESCRIPTION
# Bug Fix
~~### Depends on #2124~~ merged
### Closes #2122

## Description
Two changes to the Tripal Content Listing
1. I added a "No results behavior" as was implemented before, so on a brand new site you will see this
![issue2122 0records](https://github.com/user-attachments/assets/2fe3df79-e437-474a-b9a0-88ca071f7fec)

2. HTML in the entity title is now rendered instead of being escaped. This primarily affects the organism content type
![issue2122 1record](https://github.com/user-attachments/assets/b7d50437-8ee3-42a9-a2a2-f2df17b1d621)


## Testing?
1. Create a new docker
2. Look at the empty content listing, see expected message as shown above
3. Create an organism
4. Title should be rendered in italics