### PR TITLE
Cache all chado values in drupal tables in order to support views

### DIFF
--- a/tripal/config/install/tripal.settings.yml
+++ b/tripal/config/install/tripal.settings.yml
@@ -6,6 +6,7 @@ tripal_entity_type:
   max_id: 0
   # HTML tags allowed in entity titles
   allowed_title_tags: 'em i strong u'
+  default_cache_backend_field_values: true
 
 files:
   # Maximum size for file uploads (defaults to 1 GB)

--- a/tripal/config/schema/tripal.settings.schema.yml
+++ b/tripal/config/schema/tripal.settings.schema.yml
@@ -9,6 +9,8 @@ tripal.settings:
           type: integer
         allowed_title_tags:
           type: string
+        default_cache_backend_field_values:
+          type: boolean
     files:
       type: config_object
       mapping:

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -9,8 +9,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
-use Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 
 /**
  * Defines the Tripal Content entity.

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -4,16 +4,12 @@ namespace Drupal\tripal\Entity;
 
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
-use Drupal\field\Entity\FieldConfig;
-use Symfony\Component\Routing\Route;
-use Drupal\tripal\TripalField\TripalFieldItemBase;
-use \Drupal\tripal\Services\TripalTokenParser;
+
 
 /**
  * Defines the Tripal Content entity.

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -723,6 +723,28 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
   /**
+   * Provide a lazy utility function to check if all array elements are empty.
+   *
+   * * @param array $arr
+   *
+   * @return bool
+   *   True IFF all elements a null
+   *   False if at least a single element is different from null
+   *
+   */
+  public static function allNull(array $arr) : bool {
+    foreach ($arr as $i => $v) {
+              if (isset($v)) {
+                return false;
+              }
+    }
+    return true;
+  }
+
+
+
+
+  /**
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
@@ -730,7 +752,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
     // Create a values array appropriate for `loadValues()`
     list($values, $tripal_storages) = TripalEntity::getValuesArray($this);
-
     // Perform the Insert or Update of the submitted values to the
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
@@ -741,10 +762,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $tripal_storages[$tsid]->insertValues($tsid_values);
         }
         catch (\Exception $e) {
-          \Drupal::logger('tripal')->notice($e->getMessage());
+          \Drupal::logger('tripal')->error($e->getMessage()); // this is an error
           \Drupal::messenger()->addError('Cannot insert this entity. See the recent ' .
               'logs for more details or contact the site administrator if you ' .
               'cannot view the logs.');
+          return; // we cannot safely continue after such error
         }
         $values[$tsid] = $tsid_values;
       }
@@ -755,10 +777,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $tripal_storages[$tsid]->updateValues($tsid_values);
         }
         catch (\Exception $e) {
-          \Drupal::logger('tripal')->notice($e->getMessage());
+          \Drupal::logger('tripal')->error($e->getMessage()); // log this as an error
           \Drupal::messenger()->addError('Cannot update this entity. See the recent ' .
               'logs for more details or contact the site administrator if you cannot ' .
-              'view the logs.');
+              'view the logs. ');
+          return; // we cannot safely continue after such error
         }
       }
     }
@@ -802,27 +825,27 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // Determine whether the property values are to be cached in the
           // Drupal Entity Field tables
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
+            error_log("storing field in drupal: ".$field_name.", ".$key);
             $prop_values[] = $prop_value;
             $prop_types[] = $prop_type;
+          } else {
+            error_log("not caching: ".$field_name.", ".$key);
           }
         }
+
         if (count($prop_values) > 0) {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
-
           // Keep track of elements that have no value.
-          foreach ($prop_values as $i => $prop_value) {
-            $prop_value_value = $prop_value->getValue();
-            if (is_null($prop_value_value)) {
-              // A given delta should only be present once here.
-              if (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name])) {
-                $delta_remove[$field_name][] = $delta;
-              }
-              continue;
-            }
+          // A given delta should only be present once here.
+          if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
+            $delta_remove[$field_name][] = $delta;
           }
+
+
         }
       }
     }
+
 
     // Now remove any values that shouldn't be there.
     foreach ($delta_remove as $field_name => $deltas) {
@@ -831,7 +854,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $this->get($field_name)->removeItem($delta);
         }
         catch (\Exception $e) {
-          \Drupal::logger('tripal')->notice($e->getMessage());
+          \Drupal::logger('tripal')->error($e->getMessage());
           \Drupal::messenger()->addError('Cannot insert this entity. See the recent ' .
               'logs for more details or contact the site administrator if you ' .
               'cannot view the logs.');

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -9,7 +9,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
-use function array_values;
 use function count;
 
 
@@ -864,9 +863,28 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
 
+   
   /**
-  * {@inheritDoc} 
-  */
+   * Performs actions after the entity is saved.
+   *
+   * The postSave method in a Drupal entity is a hook that is called after an entity is saved.
+   * It allows developers to perform additional actions or modifications after the entity has been persisted to the database.
+   *
+   * In the context of Tripal and Chado, the postSave method can be used to update Chado values.
+   * For example, when a Tripal entity is saved, the postSave method can be used to ensure that the corresponding Chado records
+   * are cached and updated in the entity storage tables.
+   *
+   * The postSave method is called after the entity is saved, so the entity is already existing in the database.
+   * 
+   * {@inheritDoc} 
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage handler.
+   * @param bool $update
+   *   (optional) Whether the entity is being updated (TRUE) or created (FALSE).
+   *   Defaults to TRUE.
+   *
+   * @return void
+   */
   public function postSave(EntityStorageInterface $storage, $update = true): void
   {
     parent::postSave($storage);
@@ -876,8 +894,24 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         get('tripal_entity_type.default_cache_backend_field_values')
     ) {
 
-      $publish_service = \Drupal::service('tripal.backend_publish');
-      $chado_publish = $publish_service->createInstance('chado_storage', []);
+      // TODO: This is not a good way to get the storage plugin 
+      // (could couse error in unit tests in:
+      // testTripalEntityAccessControlHandler and testTripalContentPages). 
+      // We may need to find a better way to get the storage plugin.
+      // interestingly, this is the same way it is done in ChadoTripalPublishTest.php 
+      // and several other places and it works there.
+      // Whether a chado_storage instance can be loaded depends on where or when it is called.
+      // This may be an issue with the the tripal backend publish plugin or the way it is loaded.
+      // ... sure has a lot of duct tape on it.
+      try {
+        $publish_service = \Drupal::service('tripal.backend_publish');
+        $chado_publish = $publish_service->createInstance('chado_storage', []);
+      } catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
+        \Drupal::logger('tripal')->warning('Chado storage plugin not found (this may happen due to partial bootstrap): @message', ['@message' => $e->getMessage()]);
+        \Drupal::messenger()->addWarning('Chado storage plugin could not be intialized. Please check the configuration.');
+        return;
+      }
+
       list($values, $nil) = TripalEntity::getValuesArray(entity: $this);
       $fields = $this->getFields();
 

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -799,10 +799,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $prop_values = [];
         $prop_types = [];
         foreach ($values[$tsid][$field_name][$delta] as $key => $prop_info) {
-          $prop_type = $tripal_storages[$tsid]->getPropertyType($field_name, $key);
+          $storage = $tripal_storages[$tsid];
+          $prop_type = $storage->getPropertyType($field_name, $key);
+
           $prop_value = $prop_info['value'];
-          $settings = $prop_type->getStorageSettings();
-          if (array_key_exists('drupal_store', $settings) and $settings['drupal_store'] == TRUE) {
+          if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
             $prop_values[] = $prop_value;
             $prop_types[] = $prop_type;
           }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -829,6 +829,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           }
         }
 
+        // Now that we have a list of property values to be cached, we want
+        // to ask the fielditem to load all indicated property values into
+        // the entity and the item. In this way, we can ensure they are slated
+        // for Drupal to cache to the database during the TripalEntity::save().
+        // @todo right now the assumption that only key values will be saved is
+        // baked into ChadoStorage. That means, the non-key properties do not
+        // have a value after saving because ChadoStorage didn't bother to set
+        // them... if it did, then the following would be all that was needed
+        // but since it doesn't, we have to republish after were done saving
+        // since publish doesn't seem to make that assumption.
         if (count($prop_values) > 0) {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -9,8 +9,8 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
-use function count;
-
+use Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 
 /**
  * Defines the Tripal Content entity.
@@ -724,26 +724,22 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
   /**
-   * Provide a lazy utility function to check if all array elements are empty.
+   * Helper function: Confirm array contains all null elements.
    *
-   * * @param array $arr
+   * @param array $array_to_check
+   *   The array to check for null values. It is expected to be a flat array.
    *
    * @return bool
-   *   True IFF all elements a null
-   *   False if at least a single element is different from null
-   *
+   *   True IFF all elements are null; False if even one element is not null.
    */
-  public static function allNull(array $arr) : bool {
-    foreach ($arr as $v) {
-              if (isset($v)) {
-                return false;
-              }
+  public static function allNull(array $array_to_check) : bool {
+    foreach ($array_to_check as $value) {
+      if (isset($value)) {
+        return FALSE;
+      }
     }
-    return true;
+    return TRUE;
   }
-
-
-
 
   /**
    * {@inheritdoc}
@@ -752,7 +748,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     parent::preSave($storage);
 
     // Create a values array appropriate for `loadValues()`
-    list($values, $tripal_storages) = TripalEntity::getValuesArray(entity: $this);
+    [$values, $tripal_storages] = TripalEntity::getValuesArray($this);
     // Perform the Insert or Update of the submitted values to the
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
@@ -763,11 +759,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $tripal_storages[$tsid]->insertValues($tsid_values);
         }
         catch (\Exception $e) {
-          \Drupal::logger('tripal')->error($e->getMessage()); // this is an error
+          \Drupal::logger('tripal')->error($e->getMessage());
           \Drupal::messenger()->addError('Cannot insert this entity. See the recent ' .
               'logs for more details or contact the site administrator if you ' .
               'cannot view the logs.');
-          return; // we cannot safely continue after such error
+          // We cannot safely continue after such error.
+          return;
         }
         $values[$tsid] = $tsid_values;
       }
@@ -778,11 +775,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $tripal_storages[$tsid]->updateValues($tsid_values);
         }
         catch (\Exception $e) {
-          \Drupal::logger('tripal')->error($e->getMessage()); // log this as an error
+          \Drupal::logger('tripal')->error($e->getMessage());
           \Drupal::messenger()->addError('Cannot update this entity. See the recent ' .
               'logs for more details or contact the site administrator if you cannot ' .
-              'view the logs. ');
-          return; // we cannot safely continue after such error
+              'view the logs.');
+          // We cannot safely continue after such error.
+          return;
         }
       }
     }
@@ -824,13 +822,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
           $prop_value = $prop_info['value'];
           // Determine whether the property values are to be cached in the
-          // Drupal Entity Field tables
+          // Drupal Entity Field tables.
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
-            //error_log("storing field in drupal: ".$field_name.", ".$key);
             $prop_values[] = $prop_value;
             $prop_types[] = $prop_type;
-          } else {
-            //error_log("not caching: ".$field_name.", ".$key);
           }
         }
 
@@ -838,14 +833,13 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.
           // A given delta should only be present once here.
-          // 
           if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
             $delta_remove[$field_name][] = $delta;
           }
         }
       }
     }
-  
+
     // Now remove any values that shouldn't be there.
     foreach ($delta_remove as $field_name => $deltas) {
       foreach (array_reverse($deltas) as $delta) {
@@ -862,74 +856,99 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     }
   }
 
-
-   
   /**
    * Performs actions after the entity is saved.
    *
-   * The postSave method in a Drupal entity is a hook that is called after an entity is saved.
-   * It allows developers to perform additional actions or modifications after the entity has been persisted to the database.
+   * The Entity::postSave() method is called after the entity has been
+   * persisted to the database.
    *
-   * In the context of Tripal and Chado, the postSave method can be used to update Chado values.
-   * For example, when a Tripal entity is saved, the postSave method can be used to ensure that the corresponding Chado records
+   * In the context of Tripal and Chado, the postSave method can be used to
+   * update Chado values. For example, when a Tripal entity is saved, the
+   * postSave method can be used to ensure that the corresponding Chado records
    * are cached and updated in the entity storage tables.
    *
-   * The postSave method is called after the entity is saved, so the entity is already existing in the database.
-   * 
-   * {@inheritDoc} 
    * @param \Drupal\Core\Entity\EntityStorageInterface $storage
    *   The entity storage handler.
    * @param bool $update
    *   (optional) Whether the entity is being updated (TRUE) or created (FALSE).
    *   Defaults to TRUE.
-   *
-   * @return void
    */
-  public function postSave(EntityStorageInterface $storage, $update = true): void
-  {
+  public function postSave(EntityStorageInterface $storage, $update = TRUE): void {
     parent::postSave($storage);
+
+    // If this site has been configured to cache chado values in the database
+    // then we will want to call the update function to do so.
     if ($this->shouldUpdateCache()) {
+
+      // First we get the chado service.
       $chado_publish = $this->getChadoPublishService();
       if (!$chado_publish) {
         return;
       }
 
-      [$values, $nil] = TripalEntity::getValuesArray(entity: $this);
+      // Next get the values that were submitted for saving.
+      [$values, $tripal_storages] = TripalEntity::getValuesArray($this);
+      // Plus the bundle and its associated fields.
       $fields = $this->getFields();
       $bundle = $this->getBundle()->getID();
 
+      // Make sure we let people know if we were unable to retrieve the bundle.
       if (empty($bundle)) {
         \Drupal::messenger()->addMessage('No bundle information found!');
         return;
       }
 
+      // Indicate that we are going to republish these fields in order to
+      // update the cache.
       \Drupal::messenger()->addMessage('Republishing ' . count($fields) . ' fields in bundle ' . $bundle .
         ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
 
-      $this->updateFields(values: $values, fields: $fields, bundle: $bundle, chado_publish: $chado_publish);
+      $this->updateFields($values, $fields, $bundle, $chado_publish);
     }
   }
 
-  private function shouldUpdateCache(): bool
-  {
+  /**
+   * Determine if this site has been configured to cache chado values.
+   *
+   * @return bool
+   *   TRUE if we should cache the values and FALSE otherwise.
+   */
+  private function shouldUpdateCache(): bool {
     return \Drupal::config('tripal.settings')
-      ->get('tripal_entity_type.default_cache_backend_field_values') ?? false;
+      ->get('tripal_entity_type.default_cache_backend_field_values') ?? FALSE;
   }
 
-  private function getChadoPublishService(): mixed
-  {
+  /**
+   * Retrieve the chado publish service.
+   *
+   * @return Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish|null
+   *   Returns the chadopulish service if we are able to and null otherwise.
+   */
+  private function getChadoPublishService(): ChadoPublish|null {
     try {
       $publish_service = \Drupal::service('tripal.backend_publish');
       return $publish_service->createInstance('chado_storage', []);
-    } catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
+    }
+    catch (PluginNotFoundException $e) {
       \Drupal::logger('tripal')->warning('Chado storage plugin not found (this may happen due to partial bootstrap): @message', ['@message' => $e->getMessage()]);
       \Drupal::messenger()->addWarning('Chado storage plugin could not be initialized. Please check the configuration.');
-      return null;
+      return NULL;
     }
   }
 
-  private function updateFields(array $values, array $fields, string $bundle, $chado_publish): void
-  {
+  /**
+   * Update the field cache.
+   *
+   * @param array $values
+   *   The values submitted to be saved.
+   * @param array $fields
+   *   Fields associated with this entity.
+   * @param string $bundle
+   *   The bundle of this entity.
+   * @param Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish $chado_publish
+   *   The chado publish service.
+   */
+  private function updateFields(array $values, array $fields, string $bundle, $chado_publish): void {
     foreach ($values as $tsid => $tsid_values) {
       foreach ($fields as $field_name => $items) {
         foreach ($items as $item) {
@@ -937,10 +956,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
             continue;
           }
           $delta = 0;
-          $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
+          $entities = $chado_publish->updatePublishedEntity($this, $field_name, $tsid_values, $delta, $bundle, $tsid);
           if (count(value: $entities) > 0) {
             \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
-          } else {
+          }
+          else {
             \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
           }
         }
@@ -953,7 +973,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    */
   public static function postLoad(EntityStorageInterface $storage, array &$entities): void {
     parent::postLoad($storage, $entities);
-
 
     // If we are doing a listing of content types there is no way in Drupal 10
     // to specify which fields to load.  By default the SqlContentEntityStorage

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -733,7 +733,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *
    */
   public static function allNull(array $arr) : bool {
-    foreach ($arr as $i => $v) {
+    foreach ($arr as $v) {
               if (isset($v)) {
                 return false;
               }
@@ -825,11 +825,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // Determine whether the property values are to be cached in the
           // Drupal Entity Field tables
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
-            error_log("storing field in drupal: ".$field_name.", ".$key);
+            //error_log("storing field in drupal: ".$field_name.", ".$key);
             $prop_values[] = $prop_value;
             $prop_types[] = $prop_type;
           } else {
-            error_log("not caching: ".$field_name.", ".$key);
+            //error_log("not caching: ".$field_name.", ".$key);
           }
         }
 
@@ -837,6 +837,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.
           // A given delta should only be present once here.
+          // 
           if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
             $delta_remove[$field_name][] = $delta;
           }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -888,54 +888,60 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   public function postSave(EntityStorageInterface $storage, $update = true): void
   {
     parent::postSave($storage);
-    // need to do this only if the default storage in entity tables is On
-    if (
-      \Drupal::config('tripal.settings')->
-        get('tripal_entity_type.default_cache_backend_field_values')
-    ) {
-
-      // TODO: This is not a good way to get the storage plugin 
-      // (could couse error in unit tests in:
-      // testTripalEntityAccessControlHandler and testTripalContentPages). 
-      // We may need to find a better way to get the storage plugin.
-      // interestingly, this is the same way it is done in ChadoTripalPublishTest.php 
-      // and several other places and it works there.
-      // Whether a chado_storage instance can be loaded depends on where or when it is called.
-      // This may be an issue with the the tripal backend publish plugin or the way it is loaded.
-      // ... sure has a lot of duct tape on it.
-      try {
-        $publish_service = \Drupal::service('tripal.backend_publish');
-        $chado_publish = $publish_service->createInstance('chado_storage', []);
-      } catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
-        \Drupal::logger('tripal')->warning('Chado storage plugin not found (this may happen due to partial bootstrap): @message', ['@message' => $e->getMessage()]);
-        \Drupal::messenger()->addWarning('Chado storage plugin could not be intialized. Please check the configuration.');
+    if ($this->shouldUpdateCache()) {
+      $chado_publish = $this->getChadoPublishService();
+      if (!$chado_publish) {
         return;
       }
 
-      list($values, $nil) = TripalEntity::getValuesArray(entity: $this);
+      [$values, $nil] = TripalEntity::getValuesArray(entity: $this);
       $fields = $this->getFields();
-
       $bundle = $this->getBundle()->getID();
+
       if (empty($bundle)) {
         \Drupal::messenger()->addMessage('No bundle information found!');
         return;
-      } // cannot update without bundle information
-      \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
+      }
+
+      \Drupal::messenger()->addMessage('Republishing ' . count($fields) . ' fields in bundle ' . $bundle .
         ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
-      
-      foreach ($values as $tsid => $tsid_values) {
-        \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
-        foreach ($fields as $field_name => $items) {
-          foreach ($items as $item) {
-            if (!($item instanceof TripalFieldItemInterface))
-              continue;
-            $delta = 0;
-            $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
-            if (count($entities) > 0) {
-              \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
-            } else {
-              \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
-            }
+
+      $this->updateFields(values: $values, fields: $fields, bundle: $bundle, chado_publish: $chado_publish);
+    }
+  }
+
+  private function shouldUpdateCache(): bool
+  {
+    return \Drupal::config('tripal.settings')
+      ->get('tripal_entity_type.default_cache_backend_field_values');
+  }
+
+  private function getChadoPublishService()
+  {
+    try {
+      $publish_service = \Drupal::service('tripal.backend_publish');
+      return $publish_service->createInstance('chado_storage', []);
+    } catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
+      \Drupal::logger('tripal')->warning('Chado storage plugin not found (this may happen due to partial bootstrap): @message', ['@message' => $e->getMessage()]);
+      \Drupal::messenger()->addWarning('Chado storage plugin could not be initialized. Please check the configuration.');
+      return null;
+    }
+  }
+
+  private function updateFields(array $values, array $fields, string $bundle, $chado_publish): void
+  {
+    foreach ($values as $tsid => $tsid_values) {
+      foreach ($fields as $field_name => $items) {
+        foreach ($items as $item) {
+          if (!($item instanceof TripalFieldItemInterface)) {
+            continue;
+          }
+          $delta = 0;
+          $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
+          if (count(value: $entities) > 0) {
+            \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
+          } else {
+            \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
           }
         }
       }
@@ -974,7 +980,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $bundle = $entity->bundle();
 
       // Create a values array appropriate for `loadValues()`
-      list($values, $tripal_storages) = TripalEntity::getValuesArray($entity);
+      [$values, $tripal_storages] = TripalEntity::getValuesArray($entity);
 
       // Call the loadValues() function for each storage type.
       $load_success = False;

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -913,10 +913,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   private function shouldUpdateCache(): bool
   {
     return \Drupal::config('tripal.settings')
-      ->get('tripal_entity_type.default_cache_backend_field_values');
+      ->get('tripal_entity_type.default_cache_backend_field_values') ?? false;
   }
 
-  private function getChadoPublishService()
+  private function getChadoPublishService(): mixed
   {
     try {
       $publish_service = \Drupal::service('tripal.backend_publish');

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -893,8 +893,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       \Drupal::config('tripal.settings')->
         get('tripal_entity_type.default_cache_backend_field_values')
     ) {
-      // Could couse error in unit tests in:
-      // testTripalEntityAccessControlHandler and testTripalContentPages. 
+
+      // TODO: This is not a good way to get the storage plugin 
+      // (could couse error in unit tests in:
+      // testTripalEntityAccessControlHandler and testTripalContentPages). 
       // We may need to find a better way to get the storage plugin.
       // interestingly, this is the same way it is done in ChadoTripalPublishTest.php 
       // and several other places and it works there.
@@ -910,28 +912,29 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         return;
       }
 
-      [$values, $nil] = TripalEntity::getValuesArray(entity: $this);
+      list($values, $nil) = TripalEntity::getValuesArray(entity: $this);
       $fields = $this->getFields();
+
       $bundle = $this->getBundle()->getID();
       if (empty($bundle)) {
-        \Drupal::messenger()->addMessage('No bundle information found!'); // cannot update without bundle information
-      } else {
-        \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
-          ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
-        foreach ($values as $tsid => $tsid_values) {
-          \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
-          foreach ($fields as $field_name => $items) {
-            foreach ($items as $item) {
-              if ($item instanceof TripalFieldItemInterface) {
-
-                $delta = 0; // delta is always 0, need to fix this?
-                $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
-                if (count(value: $entities) > 0) {
-                  \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
-                } else {
-                  \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
-                }
-              }
+        \Drupal::messenger()->addMessage('No bundle information found!');
+        return;
+      } // cannot update without bundle information
+      \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
+        ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
+      
+      foreach ($values as $tsid => $tsid_values) {
+        \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
+        foreach ($fields as $field_name => $items) {
+          foreach ($items as $item) {
+            if (!($item instanceof TripalFieldItemInterface))
+              continue;
+            $delta = 0;
+            $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
+            if (count($entities) > 0) {
+              \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
+            } else {
+              \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
             }
           }
         }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -803,6 +803,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $prop_type = $storage->getPropertyType($field_name, $key);
 
           $prop_value = $prop_info['value'];
+          // Determine whether the property values are to be cached in the
+          // Drupal Entity Field tables
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
             $prop_values[] = $prop_value;
             $prop_types[] = $prop_type;

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -893,10 +893,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       \Drupal::config('tripal.settings')->
         get('tripal_entity_type.default_cache_backend_field_values')
     ) {
-
-      // TODO: This is not a good way to get the storage plugin 
-      // (could couse error in unit tests in:
-      // testTripalEntityAccessControlHandler and testTripalContentPages). 
+      // Could couse error in unit tests in:
+      // testTripalEntityAccessControlHandler and testTripalContentPages. 
       // We may need to find a better way to get the storage plugin.
       // interestingly, this is the same way it is done in ChadoTripalPublishTest.php 
       // and several other places and it works there.
@@ -912,29 +910,28 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         return;
       }
 
-      list($values, $nil) = TripalEntity::getValuesArray(entity: $this);
+      [$values, $nil] = TripalEntity::getValuesArray(entity: $this);
       $fields = $this->getFields();
-
       $bundle = $this->getBundle()->getID();
       if (empty($bundle)) {
-        \Drupal::messenger()->addMessage('No bundle information found!');
-        return;
-      } // cannot update without bundle information
-      \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
-        ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
-      
-      foreach ($values as $tsid => $tsid_values) {
-        \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
-        foreach ($fields as $field_name => $items) {
-          foreach ($items as $item) {
-            if (!($item instanceof TripalFieldItemInterface))
-              continue;
-            $delta = 0;
-            $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
-            if (count($entities) > 0) {
-              \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
-            } else {
-              \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
+        \Drupal::messenger()->addMessage('No bundle information found!'); // cannot update without bundle information
+      } else {
+        \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
+          ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
+        foreach ($values as $tsid => $tsid_values) {
+          \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
+          foreach ($fields as $field_name => $items) {
+            foreach ($items as $item) {
+              if ($item instanceof TripalFieldItemInterface) {
+
+                $delta = 0; // delta is always 0, need to fix this?
+                $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
+                if (count(value: $entities) > 0) {
+                  \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
+                } else {
+                  \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
+                }
+              }
             }
           }
         }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -783,6 +783,14 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           return;
         }
       }
+
+      // Right now the assumption that only key values will be saved is baked
+      // into ChadoStorage insert/update. That means, the non-key properties
+      // do not have a value after saving because ChadoStorage didn't bother
+      // to set them... if it did, then the following loadValues would not be
+      // needed since the values would already be set.
+      // @todo look into fixing insert/update to return all values.
+      $tripal_storages[$tsid]->loadValues($tsid_values);
     }
 
     // Set the property values that should be saved in Drupal, everything
@@ -833,12 +841,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         // to ask the fielditem to load all indicated property values into
         // the entity and the item. In this way, we can ensure they are slated
         // for Drupal to cache to the database during the TripalEntity::save().
-        // @todo right now the assumption that only key values will be saved is
-        // baked into ChadoStorage. That means, the non-key properties do not
-        // have a value after saving because ChadoStorage didn't bother to set
-        // them... if it did, then the following would be all that was needed
-        // but since it doesn't, we have to republish after were done saving
-        // since publish doesn't seem to make that assumption.
         if (count($prop_values) > 0) {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.
@@ -861,118 +863,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           \Drupal::messenger()->addError('Cannot insert this entity. See the recent ' .
               'logs for more details or contact the site administrator if you ' .
               'cannot view the logs.');
-        }
-      }
-    }
-  }
-
-  /**
-   * Performs actions after the entity is saved.
-   *
-   * The Entity::postSave() method is called after the entity has been
-   * persisted to the database.
-   *
-   * In the context of Tripal and Chado, the postSave method can be used to
-   * update Chado values. For example, when a Tripal entity is saved, the
-   * postSave method can be used to ensure that the corresponding Chado records
-   * are cached and updated in the entity storage tables.
-   *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
-   *   The entity storage handler.
-   * @param bool $update
-   *   (optional) Whether the entity is being updated (TRUE) or created (FALSE).
-   *   Defaults to TRUE.
-   */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE): void {
-    parent::postSave($storage);
-
-    // If this site has been configured to cache chado values in the database
-    // then we will want to call the update function to do so.
-    if ($this->shouldUpdateCache()) {
-
-      // First we get the chado service.
-      $chado_publish = $this->getChadoPublishService();
-      if (!$chado_publish) {
-        return;
-      }
-
-      // Next get the values that were submitted for saving.
-      [$values, $tripal_storages] = TripalEntity::getValuesArray($this);
-      // Plus the bundle and its associated fields.
-      $fields = $this->getFields();
-      $bundle = $this->getBundle()->getID();
-
-      // Make sure we let people know if we were unable to retrieve the bundle.
-      if (empty($bundle)) {
-        \Drupal::messenger()->addMessage('No bundle information found!');
-        return;
-      }
-
-      // Indicate that we are going to republish these fields in order to
-      // update the cache.
-      \Drupal::messenger()->addMessage('Republishing ' . count($fields) . ' fields in bundle ' . $bundle .
-        ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
-
-      $this->updateFields($values, $fields, $bundle, $chado_publish);
-    }
-  }
-
-  /**
-   * Determine if this site has been configured to cache chado values.
-   *
-   * @return bool
-   *   TRUE if we should cache the values and FALSE otherwise.
-   */
-  private function shouldUpdateCache(): bool {
-    return \Drupal::config('tripal.settings')
-      ->get('tripal_entity_type.default_cache_backend_field_values') ?? FALSE;
-  }
-
-  /**
-   * Retrieve the chado publish service.
-   *
-   * @return Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish|null
-   *   Returns the chadopulish service if we are able to and null otherwise.
-   */
-  private function getChadoPublishService(): ChadoPublish|null {
-    try {
-      $publish_service = \Drupal::service('tripal.backend_publish');
-      return $publish_service->createInstance('chado_storage', []);
-    }
-    catch (PluginNotFoundException $e) {
-      \Drupal::logger('tripal')->warning('Chado storage plugin not found (this may happen due to partial bootstrap): @message', ['@message' => $e->getMessage()]);
-      \Drupal::messenger()->addWarning('Chado storage plugin could not be initialized. Please check the configuration.');
-      return NULL;
-    }
-  }
-
-  /**
-   * Update the field cache.
-   *
-   * @param array $values
-   *   The values submitted to be saved.
-   * @param array $fields
-   *   Fields associated with this entity.
-   * @param string $bundle
-   *   The bundle of this entity.
-   * @param Drupal\tripal_chado\Plugin\TripalBackendPublish\ChadoPublish $chado_publish
-   *   The chado publish service.
-   */
-  private function updateFields(array $values, array $fields, string $bundle, $chado_publish): void {
-    foreach ($values as $tsid => $tsid_values) {
-      foreach ($fields as $field_name => $items) {
-        foreach ($items as $item) {
-          if (!($item instanceof TripalFieldItemInterface)) {
-            continue;
-          }
-          $delta = 0;
-          $entities = $chado_publish->updatePublishedEntity($this, $field_name, $tsid_values, $delta, $bundle, $tsid);
-          if (count(value: $entities) > 0) {
-            \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
-          }
-          else {
-            \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
-          }
         }
       }
     }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -9,6 +9,8 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
+use function array_values;
+use function count;
 
 
 /**
@@ -747,11 +749,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   /**
    * {@inheritdoc}
    */
-  public function preSave(EntityStorageInterface $storage) {
+  public function preSave(EntityStorageInterface $storage): void {
     parent::preSave($storage);
 
     // Create a values array appropriate for `loadValues()`
-    list($values, $tripal_storages) = TripalEntity::getValuesArray($this);
+    list($values, $tripal_storages) = TripalEntity::getValuesArray(entity: $this);
     // Perform the Insert or Update of the submitted values to the
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
@@ -841,13 +843,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
             $delta_remove[$field_name][] = $delta;
           }
-
-
         }
       }
     }
-
-
+  
     // Now remove any values that shouldn't be there.
     foreach ($delta_remove as $field_name => $deltas) {
       foreach (array_reverse($deltas) as $delta) {
@@ -864,10 +863,55 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     }
   }
 
+
+  /**
+  * {@inheritDoc} 
+  */
+  public function postSave(EntityStorageInterface $storage, $update = true): void
+  {
+    parent::postSave($storage);
+    // need to do this only if the default storage in entity tables is On
+    if (
+      \Drupal::config('tripal.settings')->
+        get('tripal_entity_type.default_cache_backend_field_values')
+    ) {
+
+      $publish_service = \Drupal::service('tripal.backend_publish');
+      $chado_publish = $publish_service->createInstance('chado_storage', []);
+      list($values, $nil) = TripalEntity::getValuesArray(entity: $this);
+      $fields = $this->getFields();
+
+      $bundle = $this->getBundle()->getID();
+      if (empty($bundle)) {
+        \Drupal::messenger()->addMessage('No bundle information found!');
+        return;
+      } // cannot update without bundle information
+      \Drupal::messenger()->addMessage('Republishing ' . count(value: $fields) . ' fields in bundle ' . $bundle .
+        ' for entity ' . $this->getType() . ' with ID ' . $this->getID());
+      
+      foreach ($values as $tsid => $tsid_values) {
+        \Drupal::Messenger()->addMessage('Got ' . count(value: $tsid_values) . ' values from storage ' . $tsid);
+        foreach ($fields as $field_name => $items) {
+          foreach ($items as $item) {
+            if (!($item instanceof TripalFieldItemInterface))
+              continue;
+            $delta = 0;
+            $entities = $chado_publish->updatePublishedEntity($this, field_name: $field_name, values: $tsid_values, delta: $delta, bundle: $bundle, tsid: $tsid);
+            if (count($entities) > 0) {
+              \Drupal::messenger()->addMessage("Updated $field_name in bundle $bundle");
+            } else {
+              \Drupal::messenger()->addMessage("Nothing was updated in bundle $bundle");
+            }
+          }
+        }
+      }
+    }
+  }
+
   /**
    * {@inheritdoc}
    */
-  public static function postLoad(EntityStorageInterface $storage, array &$entities) {
+  public static function postLoad(EntityStorageInterface $storage, array &$entities): void {
     parent::postLoad($storage, $entities);
 
 

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -41,6 +41,9 @@ class TripalEntitySettingsForm extends FormBase {
     // Define the HTML tags that tripal supports in Tripal Entity titles.
     $allowed_title_tags = $form_state->getValue('allowed_title_tags',
       $settings->get('tripal_entity_type.allowed_title_tags'));
+      $drupal_entity_field_store  = $form_state->getValue('default_cache_backend_field_values',
+      $settings->get('tripal_entity_type.default_cache_backend_field_values'));
+
 
     // Defines the limit of records for a select. Above this value,
     // the form element will change to an autocomplete.
@@ -83,6 +86,18 @@ class TripalEntitySettingsForm extends FormBase {
       '#required' => FALSE,
     ];
 
+    $form['default_cache_backend_field_values'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Cache Backend Storage field values in Drupal'),
+      '#description' => t('When enabled, a copy of data from the backend storage will be stored in the Drupal'
+        . 'field tables.'
+        . 'This is needed for Drupal views filtering and sorting! Changing this setting does not affect already published content.'
+        . 'When this value is changed on a populated site to take effect, all Tripal Content needs to be re-published.'),
+      '#default_value' => $drupal_entity_field_store,
+      '#required' => false,
+    ];
+
+
     $form['submit'] = [
       '#type' => 'submit',
       '#value' => t('Save'),
@@ -124,7 +139,7 @@ class TripalEntitySettingsForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $allowed_title_tags = $form_state->getValue('allowed_title_tags');
-
+    $drupal_entity_field_store = $form_state->getValue('default_cache_backend_field_values');
     # trim, convert to lower case, and collapse multiple spaces for consistency
     $allowed_title_tags = strtolower(trim($allowed_title_tags));
     $allowed_title_tags = preg_replace('/ +/', ' ', $allowed_title_tags);
@@ -136,6 +151,10 @@ class TripalEntitySettingsForm extends FormBase {
       ->getEditable('tripal.settings')
       ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
       ->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit)
+      ->save();
+      \Drupal::configFactory()
+      ->getEditable('tripal.settings')
+      ->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store)
       ->save();
 
     $this->messenger()->addStatus('Settings have been saved.');

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -148,8 +148,8 @@ class TripalEntitySettingsForm extends FormBase {
     // Update configuration
     \Drupal::configFactory()
       ->getEditable('tripal.settings')
-      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
       ->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store)
+      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
       ->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit)
       ->save();
 

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -89,10 +89,11 @@ class TripalEntitySettingsForm extends FormBase {
     $form['default_cache_backend_field_values'] = [
       '#type' => 'checkbox',
       '#title' => t('Cache Backend Storage field values in Drupal'),
-      '#description' => t('When enabled, a copy of data from the backend storage will be stored in the Drupal'
-        . 'field tables.'
-        . 'This is needed for Drupal views filtering and sorting! Changing this setting does not affect already published content.'
-        . 'When this value is changed on a populated site to take effect, all Tripal Content needs to be re-published.'),
+      '#description' => t('When enabled, a copy of data from the backend storage will be stored in the Drupal field tables.'
+        . 'This is needed for Drupal views filtering and sorting and is recommended for most sites.'
+        . 'Changing this setting does not affect already published content.'
+        . 'When this option is changed from OFF to ON on an already populated site, all Tripal Content needs to be re-published to take effect.'
+        . 'Note: values that have already been cached will not be removed when turning switching option OFF.'),
       '#default_value' => $drupal_entity_field_store,
       '#required' => false,
     ];
@@ -147,15 +148,11 @@ class TripalEntitySettingsForm extends FormBase {
     $widget_global_select_limit = trim($form_state->getValue('widget_global_select_limit'));
 
     // Update configuration
-    \Drupal::configFactory()
-      ->getEditable('tripal.settings')
-      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
-      ->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit)
-      ->save();
-      \Drupal::configFactory()
-      ->getEditable('tripal.settings')
-      ->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store)
-      ->save();
+    $config_edit = \Drupal::configFactory()->getEditable('tripal.settings');
+    $config_edit->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags);
+    $config_edit->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit);
+    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store);
+    $config_edit->save();
 
     $this->messenger()->addStatus('Settings have been saved.');
   }

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -39,11 +39,14 @@ class TripalEntitySettingsForm extends FormBase {
     $settings = \Drupal::config('tripal.settings');
 
     // Define the HTML tags that tripal supports in Tripal Entity titles.
-    $allowed_title_tags = $form_state->getValue('allowed_title_tags',
-      $settings->get('tripal_entity_type.allowed_title_tags'));
-      $drupal_entity_field_store  = $form_state->getValue('default_cache_backend_field_values',
-      $settings->get('tripal_entity_type.default_cache_backend_field_values'));
-
+    $allowed_title_tags = $form_state->getValue(
+      'allowed_title_tags',
+      $settings->get('tripal_entity_type.allowed_title_tags')
+    );
+    $drupal_entity_field_store = $form_state->getValue(
+      'default_cache_backend_field_values',
+      $settings->get('tripal_entity_type.default_cache_backend_field_values')
+    );
 
     // Defines the limit of records for a select. Above this value,
     // the form element will change to an autocomplete.
@@ -69,6 +72,17 @@ class TripalEntitySettingsForm extends FormBase {
       '#required' => FALSE,
     ];
 
+<<<<<<< HEAD
+=======
+    $form['default_cache_backend_field_values'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Cache Backend Storage field values in Drupal'),
+      '#description' => $this->t('When enabled, a copy of data from the backend storage will be stored in the Drupal field tables. This is needed for Drupal views filtering and sorting and is recommended for most sites. Changing this setting does not affect already published content. When this option is changed from OFF to ON on an already populated site, all Tripal Content needs to be re-published to take effect. Note: values that have already been cached will not be removed when turning switching option OFF.'),
+      '#default_value' => $drupal_entity_field_store,
+      '#required' => FALSE,
+    ];
+
+>>>>>>> 944972587 (Document new functions and Clean-up to match standards.)
     $form['widget_global_select_limit'] = [
       '#type' => 'number',
       '#min' => 0,
@@ -126,7 +140,7 @@ class TripalEntitySettingsForm extends FormBase {
     // Non-negative integers or an empty string are valid
     if (!preg_match('/^\d*$/', $widget_global_select_limit)) {
       $form_state->setErrorByName('widget_global_select_limit',
-        t('This field must contain an integer value, or be left blank.'));
+        $this->t('This field must contain an integer value, or be left blank.'));
     }
   }
 
@@ -141,18 +155,19 @@ class TripalEntitySettingsForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $allowed_title_tags = $form_state->getValue('allowed_title_tags');
     $drupal_entity_field_store = $form_state->getValue('default_cache_backend_field_values');
-    # trim, convert to lower case, and collapse multiple spaces for consistency
+    // Trim, convert to lower case, and collapse multiple spaces for consistency.
     $allowed_title_tags = strtolower(trim($allowed_title_tags));
     $allowed_title_tags = preg_replace('/ +/', ' ', $allowed_title_tags);
 
     $widget_global_select_limit = trim($form_state->getValue('widget_global_select_limit'));
 
     // Update configuration
-    $config_edit = \Drupal::configFactory()->getEditable('tripal.settings');
-    $config_edit->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags);
-    $config_edit->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit);
-    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store);
-    $config_edit->save();
+    \Drupal::configFactory()
+      ->getEditable('tripal.settings')
+      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
+      ->set('tripal_entity_type.default_cache_backend_field_values', $drupal_entity_field_store)
+      ->set('tripal_entity_type.widget_global_select_limit', $widget_global_select_limit)
+      ->save();
 
     $this->messenger()->addStatus('Settings have been saved.');
   }

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -60,6 +60,14 @@ class TripalEntitySettingsForm extends FormBase {
 
     $form['tripal_entity_settings']['#markup'] = 'Settings form for Tripal Content entities.';
 
+    $form['default_cache_backend_field_values'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Cache Backend Storage field values in Drupal'),
+      '#description' => $this->t('When enabled, a copy of data from the backend storage will be stored in the Drupal field tables. This is needed for Drupal views filtering and sorting and is recommended for most sites. Changing this setting does not affect already published content. When this option is changed from OFF to ON on an already populated site, all Tripal Content needs to be re-published to take effect. Note: values that have already been cached will not be removed when turning switching option OFF.'),
+      '#default_value' => $drupal_entity_field_store,
+      '#required' => FALSE,
+    ];
+
     $form['allowed_title_tags'] = [
       '#type' => 'textfield',
       '#title' => t('HTML tags allowed in page titles'),
@@ -69,14 +77,6 @@ class TripalEntitySettingsForm extends FormBase {
                         . ' Any tag not in this list will be filtered out if present in a page title.'
                         . ' You may need to rebuild the cache for changes to take effect.'),
       '#default_value' => $allowed_title_tags,
-      '#required' => FALSE,
-    ];
-
-    $form['default_cache_backend_field_values'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Cache Backend Storage field values in Drupal'),
-      '#description' => $this->t('When enabled, a copy of data from the backend storage will be stored in the Drupal field tables. This is needed for Drupal views filtering and sorting and is recommended for most sites. Changing this setting does not affect already published content. When this option is changed from OFF to ON on an already populated site, all Tripal Content needs to be re-published to take effect. Note: values that have already been cached will not be removed when turning switching option OFF.'),
-      '#default_value' => $drupal_entity_field_store,
       '#required' => FALSE,
     ];
 
@@ -96,19 +96,6 @@ class TripalEntitySettingsForm extends FormBase {
       '#default_value' => $widget_global_select_limit,
       '#required' => FALSE,
     ];
-
-    $form['default_cache_backend_field_values'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Cache Backend Storage field values in Drupal'),
-      '#description' => t('When enabled, a copy of data from the backend storage will be stored in the Drupal field tables.'
-        . 'This is needed for Drupal views filtering and sorting and is recommended for most sites.'
-        . 'Changing this setting does not affect already published content.'
-        . 'When this option is changed from OFF to ON on an already populated site, all Tripal Content needs to be re-published to take effect.'
-        . 'Note: values that have already been cached will not be removed when turning switching option OFF.'),
-      '#default_value' => $drupal_entity_field_store,
-      '#required' => false,
-    ];
-
 
     $form['submit'] = [
       '#type' => 'submit',

--- a/tripal/src/Form/TripalEntitySettingsForm.php
+++ b/tripal/src/Form/TripalEntitySettingsForm.php
@@ -72,8 +72,6 @@ class TripalEntitySettingsForm extends FormBase {
       '#required' => FALSE,
     ];
 
-<<<<<<< HEAD
-=======
     $form['default_cache_backend_field_values'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Cache Backend Storage field values in Drupal'),
@@ -82,7 +80,6 @@ class TripalEntitySettingsForm extends FormBase {
       '#required' => FALSE,
     ];
 
->>>>>>> 944972587 (Document new functions and Clean-up to match standards.)
     $form['widget_global_select_limit'] = [
       '#type' => 'number',
       '#min' => 0,

--- a/tripal/src/TripalStorage/Interfaces/TripalStorageInterface.php
+++ b/tripal/src/TripalStorage/Interfaces/TripalStorageInterface.php
@@ -222,8 +222,6 @@ interface TripalStorageInterface extends PluginInspectionInterface {
    */
   public function findValues($values);
 
-
-
   /**
    * Performs validation checks on values.
    *
@@ -235,6 +233,25 @@ interface TripalStorageInterface extends PluginInspectionInterface {
    */
   public function validateValues($values);
 
+  /**
+   * Check if a single field property should be cached in the Drupal tables.
+   *
+   * This interacts with the tripal_entity_type.default_cache_backend_field_values
+   * setting in the base implementation of this method.
+   *
+   * WARNING: This method should only be called after the property type for this
+   * field.key combo has been added.
+   *
+   * @param string $field_name
+   *   The name of the field thhe property to check is part of.
+   * @param string $key
+   *   The storage property key to check.
+   *
+   * @return bool|null
+   *   TRUE if it should be saved to the Drupal field table and FALSE otherwise.
+   *   If an error is encountered then NULL is returned.
+   */
+  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool|null;
 
   /**
    * Provides form elements to be added to the Tripal entity publish form.
@@ -270,6 +287,5 @@ interface TripalStorageInterface extends PluginInspectionInterface {
    *   The form state object.
    */
   public function publishFromSubmit($form, FormStateInterface &$form_state);
-
 
 }

--- a/tripal/src/TripalStorage/TripalStorageBase.php
+++ b/tripal/src/TripalStorage/TripalStorageBase.php
@@ -41,6 +41,13 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
   protected $property_types = [];
 
   /**
+   * Caches the default value for entity field caching from the configuration.
+   *
+   * @var bool
+   */
+  protected bool $default_is_required = TRUE;
+
+  /**
    * Implements ContainerFactoryPluginInterface->create().
    *
    * Since we have implemented the ContainerFactoryPluginInterface this static function
@@ -80,6 +87,9 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->logger = $logger;
+
+    $this->default_is_required = \Drupal::config('tripal.settings')
+    ->get('tripal_entity_type.default_cache_backend_field_values') ?? TRUE;
   }
 
   /**
@@ -257,6 +267,48 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
       }
       $values[$field_name][$delta][$key]['value']->setValue(NULL);
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool|null {
+
+    $property_type = $this->getPropertyType($field_name, $key);
+    if ($property_type === NULL) {
+      return NULL;
+    }
+    $storage_settings = $property_type->getStorageSettings();
+
+    // Get the default from the configuration.
+    $is_required = $this->default_is_required;
+
+    // Any field that stores a base record id, a primary key, or a foreign key
+    // link is required. This takes precedence and cannot be overridden.
+    if (
+      ($storage_settings['action'] == 'store_id') or
+      ($storage_settings['action'] == 'store_pkey') or
+      ($storage_settings['action'] == 'store_link')
+    ) {
+      $is_required = TRUE;
+    }
+    // For any other fields that have 'drupal_exclude' set, we want to ensure it
+    // is excluded regardless of the default configuration. To force exclusion
+    // of the field from entity storage, add `drupal_exclude: true` in the
+    // `storage_settings` of the field definition in its
+    // tripalfield_collection*_chado.yml file.
+    elseif ((array_key_exists('drupal_exclude', $storage_settings)) and ($storage_settings['drupal_exclude'] === TRUE)) {
+      $is_required = FALSE;
+    }
+    // Stay compatible with the original behavior and allow to force drupal
+    // storage. To force inclusion of the field into Entity storage, add
+    // `drupal_store: true` in the section `storage_settings` of the field
+    // definition in its tripal field collection.
+    elseif ((array_key_exists('drupal_store', $storage_settings)) and ($storage_settings['drupal_store'] === TRUE)) {
+      $is_required = TRUE;
+    }
+
+    return $is_required;
   }
 
   /**

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -69,6 +69,7 @@ fields:
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
+            drupal_exclude: true
             storage_plugin_settings:
                 base_table: feature
                 base_column: residues
@@ -501,6 +502,7 @@ fields:
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
+            drupal_exclude: true
             storage_plugin_settings:
                 base_table: feature
                 base_column: residues

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -69,7 +69,6 @@ fields:
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
-            drupal_exclude: true
             storage_plugin_settings:
                 base_table: feature
                 base_column: residues
@@ -502,7 +501,6 @@ fields:
         required: false
         storage_settings:
             storage_plugin_id: chado_storage
-            drupal_exclude: true
             storage_plugin_settings:
                 base_table: feature
                 base_column: residues

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1095,7 +1095,7 @@ class ChadoPublish extends TripalBackendPublishBase {
     }
     // Optional values
     $this->schema_name = $options['schema_name'] ?? 'chado';
-    $this->republish = $options['republish'] ?? TRUE;
+    $this->republish = boolval($options['republish'] ?? 1);
     $this->job = $options['job'] ?? NULL;
     if ($options['batch_size'] ?? 0) {
       $this->batch_size = $options['batch_size'];

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1351,10 +1351,12 @@ class ChadoPublish extends TripalBackendPublishBase {
     $fields = [];
     // update only the fields that are cached in the entity tables
     // non-required types will stay having the default empty value
-    foreach (array_keys($this->required_types[$field_name]) as $key) {
-        $field_value = $matches[0][$field_name][$delta][$key]['value']->getValue();
+    foreach ($this->required_types[$field_name] as $key => $properties) {
+        $value = $matches[0][$field_name][$delta][$key]['value'];
+        $field_value = (is_object($value)) ? $value->getValue() : null;
         if (empty($field_value)) {
-          \Drupal::messenger()->addMessage("{$field_name}_$key: empty value");
+          // allow to delete the field value, if the value is empty, but need to use the default value
+          $field_value = $properties->getDefaultValue();
         } else {
           $fields["{$field_name}_$key"] = $field_value;
          // \Drupal::messenger()->addMessage("{$field_name}_$key: $field_value"); 

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -958,11 +958,15 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
       $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
     }
-    // Non-required types never have a value stored, just a placeholder.
+    // If we want views filter this needs to be changed. Now, both required and non-required types 
+    // get their : values added.
+    // PreviouslyNon-required types never have a value stored, just a placeholder.
+    // Alternatively, add types to the required times group
+    // ICICIC: This isn't optimal. Also residue fields would e copied, better to move fields to required_types
     foreach ($this->non_required_types[$field_name] as $key => $properties) {
       $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
       $sql .=  $placeholder . ', ';
-      $args[$placeholder] = $properties->getDefaultValue();
+      $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue() ?? $properties->getDefaultValue();
     }
     $sql = rtrim($sql, ", ");
     $sql .= "),\n";

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -140,7 +140,12 @@ class ChadoPublish extends TripalBackendPublishBase {
    */
   protected bool $lenient_migration = FALSE;
 
-  protected $republish = true;
+  /**
+   * Flag to indicate if we should republish in order to cache chado values.
+   *
+   * @var bool
+   */
+  protected $republish = TRUE;
 
   /**
    * Populates the $this->field_info variable with field information
@@ -818,9 +823,12 @@ class ChadoPublish extends TripalBackendPublishBase {
     // Generate the insert SQL and add the field-specific columns to it.
     $init_sql = "
       INSERT INTO {" . $field_table . "}
-        (bundle, deleted, entity_id, revision_id, langcode, delta, "; 
-    foreach (array_keys(array_merge($this->required_types[$field_name] ?? [], // might be empty, avoid type error
-                                    $this->non_required_types[$field_name] ?? [] )) as $key) {
+        (bundle, deleted, entity_id, revision_id, langcode, delta, ";
+    $all_types = array_merge(
+      $this->required_types[$field_name] ?? [],
+      $this->non_required_types[$field_name] ?? []
+    );
+    foreach (array_keys($all_types) as $key) {
       $init_sql .= $field_name . '_'. $key . ', ';
     }
     $init_sql = rtrim($init_sql, ', ') . ") VALUES\n";
@@ -962,11 +970,11 @@ class ChadoPublish extends TripalBackendPublishBase {
       $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
     }
     // Non-required types never have a value stored, just a placeholder.
-    // There might not be non_required_types for this field
+    // There might not be non_required_types for this field.
     if (isset($this->non_required_types[$field_name])) {
-      foreach ($this->non_required_types[$field_name] as $key => $properties) { 
-        $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
-        $sql .=  $placeholder . ', ';
+      foreach ($this->non_required_types[$field_name] as $key => $properties) {
+        $placeholder = ':' . $field_name . '_' . $key . '_' . $j;
+        $sql .= $placeholder . ', ';
         $args[$placeholder] = $properties->getDefaultValue();
       }
     }
@@ -1053,7 +1061,6 @@ class ChadoPublish extends TripalBackendPublishBase {
       $record_ids = array_diff($record_ids, array_keys($this->existing_published_entities));
     }
 
-
     return $record_ids;
   }
 
@@ -1089,7 +1096,7 @@ class ChadoPublish extends TripalBackendPublishBase {
     }
     // Optional values
     $this->schema_name = $options['schema_name'] ?? 'chado';
-    $this->republish = $options['republish'] ?? true;
+    $this->republish = $options['republish'] ?? TRUE;
     $this->job = $options['job'] ?? NULL;
     if ($options['batch_size'] ?? 0) {
       $this->batch_size = $options['batch_size'];
@@ -1217,7 +1224,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       if (!$success) {
         break;
       }
-      
+
       if (!count($matches)) {
         $this->logger->notice($batch_prefix . 'No matching records found, skipping remaining steps');
         continue;
@@ -1298,89 +1305,103 @@ class ChadoPublish extends TripalBackendPublishBase {
     // This return value is currently only used for unit tests, so is limited to 100 records.
     return $this->published_or_updated_entities;
   }
-  
-  
-/**
- * Updates a single published entity with new chado values.
- *
- * This function updates the specified field of a published entity with the new chado values.
- * It initializes the publishing process, prepares the update statement, and executes it.
- *
- * @param TripalEntity $entity The entity to be updated.
- * @param string $field_name The name of the field to be updated.
- * @param mixed $delta The delta value indicating the specific instance of the field.
- * @param array $values The (incomplete) entity values to update the field with.
- * @param string $bundle The bundle type of the TripalEntity.
- * @param string $tsid The datastore identifier.
- *
- * @return array The updated entity.
- */
-  public function updatePublishedEntity(TripalEntity $entity, string $field_name, mixed $delta, array $values, string $bundle, string $tsid): array {
-    // Initialization for publish
+
+
+  /**
+   * Updates a single published entity with new chado values.
+   *
+   * This function updates the specified field of a published entity with the
+   * new chado values. It initializes the publishing process, prepares the
+   * update statement, and executes it.
+   *
+   * @param TripalEntity $entity
+   *   The entity to be updated.
+   * @param string $field_name
+   *   The name of the field to be updated.
+   * @param mixed $delta
+   *   The delta value indicating the specific instance of the field.
+   * @param array $values
+   *   The (incomplete) entity values to update the field with.
+   * @param string $bundle
+   *   The bundle type of the TripalEntity.
+   * @param string $tsid
+   *   The datastore identifier.
+   *
+   * @return TripalEntity|null
+   *   The updated entity if it was successful and null otherwise.
+   */
+  public function updatePublishedEntity(TripalEntity $entity, string $field_name, mixed $delta, array $values, string $bundle, string $tsid): TripalEntity|null {
+
+    // Initialization for publish.
     $success = $this->publish_init(options:['bundle' => $bundle, 'datastore' => $tsid]);
     if (!$success) {
       \Drupal::messenger()->addError('Error initializing the update process');
-      return [];
+      return NULL;
     }
-    // Populates the $this->field_info variable with field information
-    $this->setFieldInfo();  
+
+    // Populates the $this->field_info variable with field information.
+    $this->setFieldInfo();
+
     // Get the required field properties that will uniquely identify an entity.
-    // TODO: check if this should be called in publish_init
-    $this->required_types = $this->storage->getStoredTypes(); 
-    if(empty($this->required_types[$field_name])) {
+    // TODO: check if this should be called in publish_init.
+    $this->required_types = $this->storage->getStoredTypes();
+    if (empty($this->required_types[$field_name])) {
       \Drupal::messenger()->addError('Field ' . $field_name . ' is not supported for update');
-      return [];
+      return NULL;
     }
-    // Find the record_id of the entity to update
+
+    // Find the record_id of the entity to update.
     $record_id = $values[$field_name][0]['record_id']['value'];
     \Drupal::messenger()->addMessage('Updating entity with record_id: ' . $record_id->getValue());
-    // Find the entity Values for all fields to update
-    // This is necessary to update the entity cache, because TripalEntity itself updates only
-    // the 'direct' value fields, not the entire entity cache fields from ancilliary tables.
-    $matches = $this->storage->findValues(values: $values, main_property_names: $this->main_property_names, 
-    record_ids: [$record_id->getValue()]);
-    // This is and example how the values are stored in the matches array:
-    //error_log($matches[0]['gene_organism'][$delta]['organism_species']['value']->getValue());
+
+    // Find the entity Values for all fields to update.
+    // This is necessary to update the entity cache, because TripalEntity
+    // itself updates only the 'direct' value fields, not the entire entity
+    // cache fields from ancilliary tables.
+    $matches = $this->storage->findValues($values, $this->main_property_names, [$record_id->getValue()]);
+
     if (empty($matches)) {
       \Drupal::messenger()->addError('No matching records found');
-      return [];
+      return NULL;
     }
-    //prepare the statement
+
+    // Prepare the statement.
     $field_table = 'tripal_entity__' . $field_name;
-    // Update the field values in the entity table
+    // Update the field values in the entity table.
     $fields = [];
-    // update only the fields that are cached in the entity tables
-    // non-required types will stay having the default empty value
+    // Update only the fields that are cached in the entity tables
+    // non-required types will stay having the default empty value.
     foreach ($this->required_types[$field_name] as $key => $properties) {
-        $value = $matches[0][$field_name][$delta][$key]['value'];
-        $field_value = (is_object($value)) ? $value->getValue() : null;
-        if (empty($field_value)) {
-          // allow to delete the field value, if the value is empty, but need to use the default value
-          $field_value = $properties->getDefaultValue();
-        } else {
-          $fields["{$field_name}_$key"] = $field_value;
-         // \Drupal::messenger()->addMessage("{$field_name}_$key: $field_value"); 
-        }
+      $value = $matches[0][$field_name][$delta][$key]['value'];
+      $field_value = (is_object($value)) ? $value->getValue() : null;
+      if (empty($field_value)) {
+        // Allow to delete the field value, if the value is empty,
+        // but need to use the default value.
+        $field_value = $properties->getDefaultValue();
+      }
+      else {
+        $fields["{$field_name}_$key"] = $field_value;
+      }
     }
     $query = $this->connection->update($field_table);
     $query->fields($fields);
-    // set the conditions for the update
+    // Set the conditions for the update.
     $query->condition('entity_id', $entity->getID());
     $query->condition('delta', $delta);
-    // execute the query and catch any exceptions
-    // if the query fails, log the error. An error is not fatal 
-    // because it only means that the field cache was not updated
-    // if the query is successful, log the success
-    // and return the updated entity
+
+    // Execute the query and catch any exceptions. If the query fails,
+    // log the error, which is not fatal because it only means that the field
+    // cache was not updated. If the query is successful, log the success
+    // and return the updated entity.
     try {
       $query->execute();
       $this->logger->info("Field $field_name updated successfully");
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       \Drupal::messenger()->addError('Error updating field entity cache' . $field_name . ': ' . $e->getMessage());
       $this->logger->error('Error updating field ' . $field_name . ': ' . $e->getMessage());
     }
-    return [$entity];
+    return $entity;
   }
+
 }
-
-

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -815,9 +815,9 @@ class ChadoPublish extends TripalBackendPublishBase {
     // Generate the insert SQL and add the field-specific columns to it.
     $init_sql = "
       INSERT INTO {" . $field_table . "}
-        (bundle, deleted, entity_id, revision_id, langcode, delta, ";
-    foreach (array_keys(array_merge($this->required_types[$field_name],
-                                    $this->non_required_types[$field_name])) as $key) {
+        (bundle, deleted, entity_id, revision_id, langcode, delta, "; 
+    foreach (array_keys(array_merge($this->required_types[$field_name] ?? [], // might be empty, avoid type error
+                                    $this->non_required_types[$field_name] ?? [] )) as $key) {
       $init_sql .= $field_name . '_'. $key . ', ';
     }
     $init_sql = rtrim($init_sql, ', ') . ") VALUES\n";
@@ -958,15 +958,14 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
       $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
     }
-    // If we want views filter this needs to be changed. Now, both required and non-required types 
-    // get their : values added.
-    // PreviouslyNon-required types never have a value stored, just a placeholder.
-    // Alternatively, add types to the required times group
-    // ICICIC: This isn't optimal. Also residue fields would e copied, better to move fields to required_types
-    foreach ($this->non_required_types[$field_name] as $key => $properties) {
-      $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
-      $sql .=  $placeholder . ', ';
-      $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue() ?? $properties->getDefaultValue();
+    // Non-required types never have a value stored, just a placeholder.
+    // There might not be non_required_types for this field
+    if (isset($this->non_required_types[$field_name])) {
+      foreach ($this->non_required_types[$field_name] as $key => $properties) { 
+        $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
+        $sql .=  $placeholder . ', ';
+        $args[$placeholder] = $properties->getDefaultValue();
+      }
     }
     $sql = rtrim($sql, ", ");
     $sql .= "),\n";

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1306,7 +1306,6 @@ class ChadoPublish extends TripalBackendPublishBase {
     return $this->published_or_updated_entities;
   }
 
-
   /**
    * Updates a single published entity with new chado values.
    *

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\TripalBackendPublish;
 
+use Drupal\tripal\Entity\TripalEntity;
 use \Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\tripal\TripalBackendPublish\TripalBackendPublishBase;
 use Drupal\tripal\TripalBackendPublish\Exceptions\TripalPublishException;
@@ -138,6 +139,8 @@ class ChadoPublish extends TripalBackendPublishBase {
    * @var bool $lenient_migration
    */
   protected bool $lenient_migration = FALSE;
+
+  protected $republish = true;
 
   /**
    * Populates the $this->field_info variable with field information
@@ -1049,6 +1052,8 @@ class ChadoPublish extends TripalBackendPublishBase {
     if (!$this->republish) {
       $record_ids = array_diff($record_ids, array_keys($this->existing_published_entities));
     }
+
+
     return $record_ids;
   }
 
@@ -1084,7 +1089,7 @@ class ChadoPublish extends TripalBackendPublishBase {
     }
     // Optional values
     $this->schema_name = $options['schema_name'] ?? 'chado';
-    $this->republish = ($options['republish'] ?? FALSE) ? TRUE : FALSE;
+    $this->republish = $options['republish'] ?? true;
     $this->job = $options['job'] ?? NULL;
     if ($options['batch_size'] ?? 0) {
       $this->batch_size = $options['batch_size'];
@@ -1212,7 +1217,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       if (!$success) {
         break;
       }
-
+      
       if (!count($matches)) {
         $this->logger->notice($batch_prefix . 'No matching records found, skipping remaining steps');
         continue;
@@ -1293,4 +1298,87 @@ class ChadoPublish extends TripalBackendPublishBase {
     // This return value is currently only used for unit tests, so is limited to 100 records.
     return $this->published_or_updated_entities;
   }
+  
+  
+/**
+ * Updates a single published entity with new chado values.
+ *
+ * This function updates the specified field of a published entity with the new chado values.
+ * It initializes the publishing process, prepares the update statement, and executes it.
+ *
+ * @param TripalEntity $entity The entity to be updated.
+ * @param string $field_name The name of the field to be updated.
+ * @param mixed $delta The delta value indicating the specific instance of the field.
+ * @param array $values The (incomplete) entity values to update the field with.
+ * @param string $bundle The bundle type of the TripalEntity.
+ * @param string $tsid The datastore identifier.
+ *
+ * @return array The updated entity.
+ */
+  public function updatePublishedEntity(TripalEntity $entity, string $field_name, mixed $delta, array $values, string $bundle, string $tsid): array {
+    // Initialization for publish
+    $success = $this->publish_init(options:['bundle' => $bundle, 'datastore' => $tsid]);
+    if (!$success) {
+      \Drupal::messenger()->addError('Error initializing the update process');
+      return [];
+    }
+    // Populates the $this->field_info variable with field information
+    $this->setFieldInfo();  
+    // Get the required field properties that will uniquely identify an entity.
+    // TODO: check if this should be called in publish_init
+    $this->required_types = $this->storage->getStoredTypes(); 
+    if(empty($this->required_types[$field_name])) {
+      \Drupal::messenger()->addError('Field ' . $field_name . ' is not supported for update');
+      return [];
+    }
+    // Find the record_id of the entity to update
+    $record_id = $values[$field_name][0]['record_id']['value'];
+    \Drupal::messenger()->addMessage('Updating entity with record_id: ' . $record_id->getValue());
+    // Find the entity Values for all fields to update
+    // This is necessary to update the entity cache, because TripalEntity itself updates only
+    // the 'direct' value fields, not the entire entity cache fields from ancilliary tables.
+    $matches = $this->storage->findValues(values: $values, main_property_names: $this->main_property_names, 
+    record_ids: [$record_id->getValue()]);
+    // This is and example how the values are stored in the matches array:
+    //error_log($matches[0]['gene_organism'][$delta]['organism_species']['value']->getValue());
+    if (empty($matches)) {
+      \Drupal::messenger()->addError('No matching records found');
+      return [];
+    }
+    //prepare the statement
+    $field_table = 'tripal_entity__' . $field_name;
+    // Update the field values in the entity table
+    $fields = [];
+    // update only the fields that are cached in the entity tables
+    // non-required types will stay having the default empty value
+    foreach (array_keys($this->required_types[$field_name]) as $key) {
+        $field_value = $matches[0][$field_name][$delta][$key]['value']->getValue();
+        if (empty($field_value)) {
+          \Drupal::messenger()->addMessage("{$field_name}_$key: empty value");
+        } else {
+          $fields["{$field_name}_$key"] = $field_value;
+         // \Drupal::messenger()->addMessage("{$field_name}_$key: $field_value"); 
+        }
+    }
+    $query = $this->connection->update($field_table);
+    $query->fields($fields);
+    // set the conditions for the update
+    $query->condition('entity_id', $entity->getID());
+    $query->condition('delta', $delta);
+    // execute the query and catch any exceptions
+    // if the query fails, log the error. An error is not fatal 
+    // because it only means that the field cache was not updated
+    // if the query is successful, log the success
+    // and return the updated entity
+    try {
+      $query->execute();
+      $this->logger->info("Field $field_name updated successfully");
+    } catch (\Exception $e) {
+      \Drupal::messenger()->addError('Error updating field entity cache' . $field_name . ': ' . $e->getMessage());
+      $this->logger->error('Error updating field ' . $field_name . ': ' . $e->getMessage());
+    }
+    return [$entity];
+  }
 }
+
+

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\tripal_chado\Plugin\TripalBackendPublish;
 
-use Drupal\tripal\Entity\TripalEntity;
 use \Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\tripal\TripalBackendPublish\TripalBackendPublishBase;
 use Drupal\tripal\TripalBackendPublish\Exceptions\TripalPublishException;
@@ -1304,103 +1303,6 @@ class ChadoPublish extends TripalBackendPublishBase {
 
     // This return value is currently only used for unit tests, so is limited to 100 records.
     return $this->published_or_updated_entities;
-  }
-
-  /**
-   * Updates a single published entity with new chado values.
-   *
-   * This function updates the specified field of a published entity with the
-   * new chado values. It initializes the publishing process, prepares the
-   * update statement, and executes it.
-   *
-   * @param TripalEntity $entity
-   *   The entity to be updated.
-   * @param string $field_name
-   *   The name of the field to be updated.
-   * @param mixed $delta
-   *   The delta value indicating the specific instance of the field.
-   * @param array $values
-   *   The (incomplete) entity values to update the field with.
-   * @param string $bundle
-   *   The bundle type of the TripalEntity.
-   * @param string $tsid
-   *   The datastore identifier.
-   *
-   * @return TripalEntity|null
-   *   The updated entity if it was successful and null otherwise.
-   */
-  public function updatePublishedEntity(TripalEntity $entity, string $field_name, mixed $delta, array $values, string $bundle, string $tsid): TripalEntity|null {
-
-    // Initialization for publish.
-    $success = $this->publish_init(options:['bundle' => $bundle, 'datastore' => $tsid]);
-    if (!$success) {
-      \Drupal::messenger()->addError('Error initializing the update process');
-      return NULL;
-    }
-
-    // Populates the $this->field_info variable with field information.
-    $this->setFieldInfo();
-
-    // Get the required field properties that will uniquely identify an entity.
-    // TODO: check if this should be called in publish_init.
-    $this->required_types = $this->storage->getStoredTypes();
-    if (empty($this->required_types[$field_name])) {
-      \Drupal::messenger()->addError('Field ' . $field_name . ' is not supported for update');
-      return NULL;
-    }
-
-    // Find the record_id of the entity to update.
-    $record_id = $values[$field_name][0]['record_id']['value'];
-    \Drupal::messenger()->addMessage('Updating entity with record_id: ' . $record_id->getValue());
-
-    // Find the entity Values for all fields to update.
-    // This is necessary to update the entity cache, because TripalEntity
-    // itself updates only the 'direct' value fields, not the entire entity
-    // cache fields from ancilliary tables.
-    $matches = $this->storage->findValues($values, $this->main_property_names, [$record_id->getValue()]);
-
-    if (empty($matches)) {
-      \Drupal::messenger()->addError('No matching records found');
-      return NULL;
-    }
-
-    // Prepare the statement.
-    $field_table = 'tripal_entity__' . $field_name;
-    // Update the field values in the entity table.
-    $fields = [];
-    // Update only the fields that are cached in the entity tables
-    // non-required types will stay having the default empty value.
-    foreach ($this->required_types[$field_name] as $key => $properties) {
-      $value = $matches[0][$field_name][$delta][$key]['value'];
-      $field_value = (is_object($value)) ? $value->getValue() : null;
-      if (empty($field_value)) {
-        // Allow to delete the field value, if the value is empty,
-        // but need to use the default value.
-        $field_value = $properties->getDefaultValue();
-      }
-      else {
-        $fields["{$field_name}_$key"] = $field_value;
-      }
-    }
-    $query = $this->connection->update($field_table);
-    $query->fields($fields);
-    // Set the conditions for the update.
-    $query->condition('entity_id', $entity->getID());
-    $query->condition('delta', $delta);
-
-    // Execute the query and catch any exceptions. If the query fails,
-    // log the error, which is not fatal because it only means that the field
-    // cache was not updated. If the query is successful, log the success
-    // and return the updated entity.
-    try {
-      $query->execute();
-      $this->logger->info("Field $field_name updated successfully");
-    }
-    catch (\Exception $e) {
-      \Drupal::messenger()->addError('Error updating field entity cache' . $field_name . ': ' . $e->getMessage());
-      $this->logger->error('Error updating field ' . $field_name . ': ' . $e->getMessage());
-    }
-    return $entity;
   }
 
 }

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1052,6 +1052,8 @@ class ChadoPublish extends TripalBackendPublishBase {
     if (!$this->republish) {
       $record_ids = array_diff($record_ids, array_keys($this->existing_published_entities));
     }
+
+
     return $record_ids;
   }
 

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1052,8 +1052,6 @@ class ChadoPublish extends TripalBackendPublishBase {
     if (!$this->republish) {
       $record_ids = array_diff($record_ids, array_keys($this->existing_published_entities));
     }
-
-
     return $record_ids;
   }
 

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -11,7 +11,6 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\Services\ChadoFieldDebugger;
 use Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\tripal_chado\TripalStorage\ChadoRecords;
-use Drupal\Core\Render\Element\Token;
 
 /**
  * Chado implementation of the TripalStorageInterface.
@@ -98,7 +97,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $this->connection = $connection;
     $this->field_debugger = $field_debugger;
     $this->default_is_required = \Drupal::config('tripal.settings')->
-      get('tripal_entity_type.default_cache_backend_field_values');
+      get('tripal_entity_type.default_cache_backend_field_values') ?? true;
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -127,6 +127,64 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     return $this->getStoredTypesFilter(FALSE);
   }
 
+
+/**
+ * Helper function to modularize the logic for determining whether a single field value
+ * is to be stored in Drupal's Entity tables or not.
+ *
+ * @param string $field_name
+ *  The name of the chado field
+ * @param string $key
+ *  The storage key
+ * @return bool
+ *
+ */
+  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool
+  {
+    $storage_settings = $this->property_types[$field_name][$key]->getStorageSettings();
+    // $is_required = true; // possible default: all fields are required
+    // In chado, all table coloumns containing sequence are named 'residues'
+    // We want to exclude sequences and other large data objects from drupal storage
+    $is_required = !(array_key_exists('path', $storage_settings) and
+      str_ends_with($storage_settings['path'], '.residues'));
+    // Any field that stores a base record id, a primary key,
+    // or a foreign key link is required.
+    // This takes absolute precedence and cannot be overridden.
+    if (
+      ($storage_settings['action'] == 'store_id') or
+      ($storage_settings['action'] == 'store_pkey') or
+      ($storage_settings['action'] == 'store_link')
+    ) {
+      $is_required = TRUE;
+    }
+    // For any other fields that have 'drupal_exclude' set,
+    // it is _excluded_ too.
+    // To force exclusion of the field from entity storage, add:
+    // drupal_exclude: true
+    // in the section storage_settings: of the field definition in its tripalfield_collection*_chado.yml file
+    elseif (
+      (array_key_exists('drupal_exclude', $storage_settings)) and
+      ($storage_settings['drupal_exclude'] === TRUE)
+    ) {
+      $is_required = false;
+    }
+    // Stay compatible with the original behavior and allow to force drupal storage
+    // To force inclusion of the field into Entity storage, add:
+    // drupal_store: true
+    // in the section storage_settings: of the field definition in its tripal field collection
+    elseif (
+      (array_key_exists('drupal_store', $storage_settings)) and
+      ($storage_settings['drupal_store'] === TRUE)
+    ) {
+       $is_required = true;
+    }
+    return $is_required;
+
+
+  }
+
+
+
   /**
    * Helper function for getStoredTypes() and getNonStoredTypes().
    *
@@ -142,38 +200,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     foreach ($this->property_types as $field_name => $keys) {
       $field_definition = $this->field_definitions[$field_name];
       foreach ($keys as $key => $prop_type) {
-        $storage_settings = $prop_type->getStorageSettings();
-
-        // $is_required = true; // possible default: all fields are required 
-        // In chado, all table coloumns containing sequence are named 'residues' 
-        // We want to exclude sequences and other large data objects from drupal storage
-        $is_required = ! (array_key_exists('path', $storage_settings) and 
-        str_ends_with($storage_settings['path'],  '.residues')); 
-        // Any field that stores a base record id, a primary key,
-        // or a foreign key link is required.
-        // This takes absolute precedence and cannot be overridden.
-        if (($storage_settings['action'] == 'store_id') or
-            ($storage_settings['action'] == 'store_pkey') or
-            ($storage_settings['action'] == 'store_link')) {
-          $is_required = TRUE;
-        }
-        // For any other fields that have 'drupal_exclude' set,
-        // it is _excluded_ too.
-        // To force exclusion of the field from entity storage, add:
-        // drupal_exclude: true   
-        // in the section storage_settings: of the field definition in its tripalfield_collection*_chado.yml file
-        elseif ((array_key_exists('drupal_exclude', $storage_settings)) and
-                ($storage_settings['drupal_exclude'] === TRUE)) {
-          $is_required = false;
-        }
-        // Stay compatible with the original behavior and allow to force drupal storage
-        // To force inclusion of the field into Entity storage, add:
-        // drupal_store: true   
-        // in the section storage_settings: of the field definition in its tripal field collection
-        elseif ((array_key_exists('drupal_store', $storage_settings)) and
-                ($storage_settings['drupal_store'] === TRUE)) {
-          $is_required = true;
-        }
+        $is_required = $this->isDrupalStoreByFieldNameKey($field_name, $key);
         if (($is_required and $required) or (!$is_required and !$required)) {
           $ret_types[$field_name][$key] = $prop_type;
         }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -46,6 +46,13 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   protected $records = NULL;
 
   /**
+   * Caches the default value for entity field caching from the configuration
+   * @var bool
+   */
+  protected bool $default_is_required = false;
+
+
+  /**
    * Implements ContainerFactoryPluginInterface->create().
    *
    * Since we have implemented the ContainerFactoryPluginInterface this static function
@@ -90,6 +97,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     $this->connection = $connection;
     $this->field_debugger = $field_debugger;
+    $this->default_is_required = \Drupal::config('tripal.settings')->
+      get('tripal_entity_type.default_cache_backend_field_values');
   }
 
   /**
@@ -142,10 +151,11 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool
   {
     $storage_settings = $this->property_types[$field_name][$key]->getStorageSettings();
-    // $is_required = true; // possible default: all fields are required
+     // get the default from the configuration
     // In chado, all table coloumns containing sequence are named 'residues'
     // We want to exclude sequences and other large data objects from drupal storage
-    $is_required = !(array_key_exists('path', $storage_settings) and
+    // Even if the default is on, we will never save residues
+    $is_required = $this->default_is_required and !(array_key_exists('path', $storage_settings) and
       str_ends_with($storage_settings['path'], '.residues'));
     // Any field that stores a base record id, a primary key,
     // or a foreign key link is required.

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -144,14 +144,14 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       foreach ($keys as $key => $prop_type) {
         $storage_settings = $prop_type->getStorageSettings();
 
-        // $is_required = true; // default: all fields are required by default
-        // in chado, all table coloumns containing sequence are named residues 
-        // we want to exclude sequences from drupal storage
-        //var_dump($storage_settings);
+        // $is_required = true; // possible default: all fields are required 
+        // In chado, all table coloumns containing sequence are named 'residues' 
+        // We want to exclude sequences and other large data objects from drupal storage
         $is_required = ! (array_key_exists('path', $storage_settings) and 
         str_ends_with($storage_settings['path'],  '.residues')); 
         // Any field that stores a base record id, a primary key,
         // or a foreign key link is required.
+        // This takes absolute precedence and cannot be overridden.
         if (($storage_settings['action'] == 'store_id') or
             ($storage_settings['action'] == 'store_pkey') or
             ($storage_settings['action'] == 'store_link')) {
@@ -159,13 +159,19 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
         }
         // For any other fields that have 'drupal_exclude' set,
         // it is _excluded_ too.
+        // To force exclusion of the field from entity storage, add:
+        // drupal_exclude: true   
+        // in the section storage_settings: of the field definition in its tripalfield_collection*_chado.yml file
         elseif ((array_key_exists('drupal_exclude', $storage_settings)) and
                 ($storage_settings['drupal_exclude'] === TRUE)) {
           $is_required = false;
         }
-        // stay compatible with the original behavior and allow to force drupal storage
-        elseif ((array_key_exists('drupal_include', $storage_settings)) and
-                ($storage_settings['drupal_include'] === TRUE)) {
+        // Stay compatible with the original behavior and allow to force drupal storage
+        // To force inclusion of the field into Entity storage, add:
+        // drupal_store: true   
+        // in the section storage_settings: of the field definition in its tripal field collection
+        elseif ((array_key_exists('drupal_store', $storage_settings)) and
+                ($storage_settings['drupal_store'] === TRUE)) {
           $is_required = true;
         }
         if (($is_required and $required) or (!$is_required and !$required)) {

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -143,7 +143,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $storage_settings = $property_type->getStorageSettings();
 
     // In chado, all table columns containing sequence are named 'residues'.
-    // We want to exclude sequences from drupal storage even if the default is TRUE.
+    // We want to exclude sequences from drupal storage even if the default is TRUE
+    // because this field can contain a very large string, for example an entire chromosome.
     if (array_key_exists('path', $storage_settings) and str_ends_with($storage_settings['path'], 'residues')) {
       $is_required = FALSE;
     }

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -155,7 +155,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     // We want to exclude sequences and other large data objects from drupal storage
     // Even if the default is on, we will never save residues
     $is_required = $this->default_is_required and !(array_key_exists('path', $storage_settings) and
-      str_ends_with($storage_settings['path'], '.residues'));
+      str_ends_with(haystack: $storage_settings['path'], needle: 'residues'));
     // Any field that stores a base record id, a primary key,
     // or a foreign key link is required.
     // This takes absolute precedence and cannot be overridden.
@@ -294,9 +294,9 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
         foreach ($tables as $table_alias) {
          // try {
-            // this should improve update performance
+           // this should improve update performance
            // $this->records->updateRecords($base_table, $table_alias, true); // try update first, this should work in most cases, if it doesn't
-          //} catch (\Exception $e) {
+           //} catch (\Exception $e) {
              // log this but not as error, it is a pretty rare state
             //\Drupal::logger('tripal')->warning("We could not update some values, trying delete/insert: " . $e->getMessage());
             // If the delete/update mechanism doesn't work, we still need to bail out

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -144,19 +144,29 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       foreach ($keys as $key => $prop_type) {
         $storage_settings = $prop_type->getStorageSettings();
 
+        // $is_required = true; // default: all fields are required by default
+        // in chado, all table coloumns containing sequence are named residues 
+        // we want to exclude sequences from drupal storage
+        //var_dump($storage_settings);
+        $is_required = ! (array_key_exists('path', $storage_settings) and 
+        str_ends_with($storage_settings['path'],  '.residues')); 
         // Any field that stores a base record id, a primary key,
         // or a foreign key link is required.
-        $is_required = FALSE;
         if (($storage_settings['action'] == 'store_id') or
             ($storage_settings['action'] == 'store_pkey') or
             ($storage_settings['action'] == 'store_link')) {
           $is_required = TRUE;
         }
-        // For any other fields that have 'drupal_store' set,
-        // it is required too.
-        elseif ((array_key_exists('drupal_store', $storage_settings)) and
-                ($storage_settings['drupal_store'] === TRUE)) {
-          $is_required = TRUE;
+        // For any other fields that have 'drupal_exclude' set,
+        // it is _excluded_ too.
+        elseif ((array_key_exists('drupal_exclude', $storage_settings)) and
+                ($storage_settings['drupal_exclude'] === TRUE)) {
+          $is_required = false;
+        }
+        // stay compatible with the original behavior and allow to force drupal storage
+        elseif ((array_key_exists('drupal_include', $storage_settings)) and
+                ($storage_settings['drupal_include'] === TRUE)) {
+          $is_required = true;
         }
         if (($is_required and $required) or (!$is_required and !$required)) {
           $ret_types[$field_name][$key] = $prop_type;

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -287,22 +287,26 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       // constraints if we don't e.g. changing the order of records with a
       // rank.
       foreach ($base_tables as $base_table) {
+        // While iterating over all tables only once, this improves performance
+        // by only calling this once per base_table
         $tables = $this->records->getAncillaryTables($base_table);
+
+
         foreach ($tables as $table_alias) {
-          $this->records->deleteRecords($base_table, $table_alias, TRUE);
+         // try {
+            // this should improve update performance
+           // $this->records->updateRecords($base_table, $table_alias, true); // try update first, this should work in most cases, if it doesn't
+          //} catch (\Exception $e) {
+             // log this but not as error, it is a pretty rare state
+            //\Drupal::logger('tripal')->warning("We could not update some values, trying delete/insert: " . $e->getMessage());
+            // If the delete/update mechanism doesn't work, we still need to bail out
+            $this->records->deleteRecords($base_table, $table_alias, TRUE);
+            $this->records->insertRecords($base_table, $table_alias);
+          //}
         }
       }
-
-      // Now insert all new values for the non-base table records.
-      foreach ($base_tables as $base_table) {
-        $tables = $this->records->getAncillaryTables($base_table);
-        foreach ($tables as $table_alias) {
-          $this->records->insertRecords($base_table, $table_alias);
-        }
-      }
-
       // Now that we've done the updates, set the property values.
-      $this->setPropValues($values, $this->records);
+    $this->setPropValues($values, $this->records);
     }
     catch (\Exception $e) {
       $transaction_chado->rollback();

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -45,10 +45,11 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   protected $records = NULL;
 
   /**
-   * Caches the default value for entity field caching from the configuration
+   * Caches the default value for entity field caching from the configuration.
+   *
    * @var bool
    */
-  protected bool $default_is_required = false;
+  protected bool $default_is_required = TRUE;
 
 
   /**
@@ -96,8 +97,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     $this->connection = $connection;
     $this->field_debugger = $field_debugger;
-    $this->default_is_required = \Drupal::config('tripal.settings')->
-      get('tripal_entity_type.default_cache_backend_field_values') ?? true;
+    $this->default_is_required = \Drupal::config('tripal.settings')
+      ->get('tripal_entity_type.default_cache_backend_field_values') ?? TRUE;
   }
 
   /**
@@ -135,30 +136,32 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     return $this->getStoredTypesFilter(FALSE);
   }
 
+  /**
+   * Helper function: check if a single field property should be cached.
+   *
+   * @param string $field_name
+   *   The name of the chado field to check.
+   * @param string $key
+   *   The storage property key to check.
+   *
+   * @return bool
+   *   TRUE if it should be saved to the Drupal field table and FALSE otherwise.
+   */
+  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool {
 
-/**
- * Helper function to modularize the logic for determining whether a single field value
- * is to be stored in Drupal's Entity tables or not.
- *
- * @param string $field_name
- *  The name of the chado field
- * @param string $key
- *  The storage key
- * @return bool
- *
- */
-  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool
-  {
     $storage_settings = $this->property_types[$field_name][$key]->getStorageSettings();
-     // get the default from the configuration
-    // In chado, all table coloumns containing sequence are named 'residues'
-    // We want to exclude sequences and other large data objects from drupal storage
-    // Even if the default is on, we will never save residues
-    $is_required = $this->default_is_required and !(array_key_exists('path', $storage_settings) and
-      str_ends_with(haystack: $storage_settings['path'], needle: 'residues'));
-    // Any field that stores a base record id, a primary key,
-    // or a foreign key link is required.
-    // This takes absolute precedence and cannot be overridden.
+
+    // Get the default from the configuration.
+    $is_required = $this->default_is_required;
+
+    // In chado, all table columns containing sequence are named 'residues'.
+    // We want to exclude sequences from drupal storage even if the default is TRUE.
+    if (array_key_exists('path', $storage_settings) and str_ends_with($storage_settings['path'], 'residues')) {
+      $is_required = FALSE;
+    }
+
+    // Any field that stores a base record id, a primary key, or a foreign key
+    // link is required. This takes precedence and cannot be overridden.
     if (
       ($storage_settings['action'] == 'store_id') or
       ($storage_settings['action'] == 'store_pkey') or
@@ -166,33 +169,24 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     ) {
       $is_required = TRUE;
     }
-    // For any other fields that have 'drupal_exclude' set,
-    // it is _excluded_ too.
-    // To force exclusion of the field from entity storage, add:
-    // drupal_exclude: true
-    // in the section storage_settings: of the field definition in its tripalfield_collection*_chado.yml file
-    elseif (
-      (array_key_exists('drupal_exclude', $storage_settings)) and
-      ($storage_settings['drupal_exclude'] === TRUE)
-    ) {
-      $is_required = false;
+    // For any other fields that have 'drupal_exclude' set, we want to ensure it
+    // is excluded regardless of the default configuration. To force exclusion
+    // of the field from entity storage, add `drupal_exclude: true` in the
+    // `storage_settings` of the field definition in its
+    // tripalfield_collection*_chado.yml file.
+    elseif ((array_key_exists('drupal_exclude', $storage_settings)) and ($storage_settings['drupal_exclude'] === TRUE)) {
+      $is_required = FALSE;
     }
-    // Stay compatible with the original behavior and allow to force drupal storage
-    // To force inclusion of the field into Entity storage, add:
-    // drupal_store: true
-    // in the section storage_settings: of the field definition in its tripal field collection
-    elseif (
-      (array_key_exists('drupal_store', $storage_settings)) and
-      ($storage_settings['drupal_store'] === TRUE)
-    ) {
-       $is_required = true;
+    // Stay compatible with the original behavior and allow to force drupal
+    // storage. To force inclusion of the field into Entity storage, add
+    // `drupal_store: true` in the section `storage_settings` of the field
+    // definition in its tripal field collection.
+    elseif ((array_key_exists('drupal_store', $storage_settings)) and ($storage_settings['drupal_store'] === TRUE)) {
+      $is_required = TRUE;
     }
+
     return $is_required;
-
-
   }
-
-
 
   /**
    * Helper function for getStoredTypes() and getNonStoredTypes().
@@ -207,7 +201,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   protected function getStoredTypesFilter(bool $required) {
     $ret_types = [];
     foreach ($this->property_types as $field_name => $keys) {
-      $field_definition = $this->field_definitions[$field_name];
       foreach ($keys as $key => $prop_type) {
         $is_required = $this->isDrupalStoreByFieldNameKey($field_name, $key);
         if (($is_required and $required) or (!$is_required and !$required)) {
@@ -288,25 +281,18 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       // rank.
       foreach ($base_tables as $base_table) {
         // While iterating over all tables only once, this improves performance
-        // by only calling this once per base_table
+        // by only calling this once per base_table.
         $tables = $this->records->getAncillaryTables($base_table);
 
 
         foreach ($tables as $table_alias) {
-         // try {
-           // this should improve update performance
-           // $this->records->updateRecords($base_table, $table_alias, true); // try update first, this should work in most cases, if it doesn't
-           //} catch (\Exception $e) {
-             // log this but not as error, it is a pretty rare state
-            //\Drupal::logger('tripal')->warning("We could not update some values, trying delete/insert: " . $e->getMessage());
-            // If the delete/update mechanism doesn't work, we still need to bail out
-            $this->records->deleteRecords($base_table, $table_alias, TRUE);
-            $this->records->insertRecords($base_table, $table_alias);
-          //}
+          $this->records->deleteRecords($base_table, $table_alias, TRUE);
+          $this->records->insertRecords($base_table, $table_alias);
         }
       }
+
       // Now that we've done the updates, set the property values.
-    $this->setPropValues($values, $this->records);
+      $this->setPropValues($values, $this->records);
     }
     catch (\Exception $e) {
       $transaction_chado->rollback();

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -45,14 +45,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   protected $records = NULL;
 
   /**
-   * Caches the default value for entity field caching from the configuration.
-   *
-   * @var bool
-   */
-  protected bool $default_is_required = TRUE;
-
-
-  /**
    * Implements ContainerFactoryPluginInterface->create().
    *
    * Since we have implemented the ContainerFactoryPluginInterface this static function
@@ -97,8 +89,6 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     $this->connection = $connection;
     $this->field_debugger = $field_debugger;
-    $this->default_is_required = \Drupal::config('tripal.settings')
-      ->get('tripal_entity_type.default_cache_backend_field_values') ?? TRUE;
   }
 
   /**
@@ -137,52 +127,25 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   }
 
   /**
-   * Helper function: check if a single field property should be cached.
-   *
-   * @param string $field_name
-   *   The name of the chado field to check.
-   * @param string $key
-   *   The storage property key to check.
-   *
-   * @return bool
-   *   TRUE if it should be saved to the Drupal field table and FALSE otherwise.
+   * {@inheritDoc}
    */
-  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool {
+  public function isDrupalStoreByFieldNameKey(string $field_name, string $key): bool|null {
 
-    $storage_settings = $this->property_types[$field_name][$key]->getStorageSettings();
+    // First get our parent to do the generic check.
+    $is_required = parent::isDrupalStoreByFieldNameKey($field_name, $key);
 
-    // Get the default from the configuration.
-    $is_required = $this->default_is_required;
+    // Then grab the property type and its storage properties in order to
+    // make any chado-specific decisions.
+    $property_type = $this->getPropertyType($field_name, $key);
+    if ($property_type === NULL) {
+      return NULL;
+    }
+    $storage_settings = $property_type->getStorageSettings();
 
     // In chado, all table columns containing sequence are named 'residues'.
     // We want to exclude sequences from drupal storage even if the default is TRUE.
     if (array_key_exists('path', $storage_settings) and str_ends_with($storage_settings['path'], 'residues')) {
       $is_required = FALSE;
-    }
-
-    // Any field that stores a base record id, a primary key, or a foreign key
-    // link is required. This takes precedence and cannot be overridden.
-    if (
-      ($storage_settings['action'] == 'store_id') or
-      ($storage_settings['action'] == 'store_pkey') or
-      ($storage_settings['action'] == 'store_link')
-    ) {
-      $is_required = TRUE;
-    }
-    // For any other fields that have 'drupal_exclude' set, we want to ensure it
-    // is excluded regardless of the default configuration. To force exclusion
-    // of the field from entity storage, add `drupal_exclude: true` in the
-    // `storage_settings` of the field definition in its
-    // tripalfield_collection*_chado.yml file.
-    elseif ((array_key_exists('drupal_exclude', $storage_settings)) and ($storage_settings['drupal_exclude'] === TRUE)) {
-      $is_required = FALSE;
-    }
-    // Stay compatible with the original behavior and allow to force drupal
-    // storage. To force inclusion of the field into Entity storage, add
-    // `drupal_store: true` in the section `storage_settings` of the field
-    // definition in its tripal field collection.
-    elseif ((array_key_exists('drupal_store', $storage_settings)) and ($storage_settings['drupal_store'] === TRUE)) {
-      $is_required = TRUE;
     }
 
     return $is_required;

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -321,6 +321,14 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
    */
   public function testChadoTripalPublishService() {
 
+    // The behavior depends on settings made in TripalEntitySettingsForm
+    // Depending on default_cache_backend_field_values the values are either saved in the entity
+    // or not.
+
+    // Get editable config object
+    $config_edit = \Drupal::configFactory()->getEditable('tripal.settings');
+
+
     // Prepare Chado
     $chado = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
 
@@ -359,6 +367,15 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     $content_type_setup->install($collection_ids);
     $fields_setup->install($collection_ids);
 
+
+    // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    // % Run the first test set with caching disabled. %
+    // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    // Update configuration
+    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', false);
+    $config_edit->save();
+
     //
     // Test publishing when no records are available.
     //
@@ -389,27 +406,27 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     // shouldn't be saved in Drupal are equal to the field's default value.
     $this->checkFieldItem('organism', 'organism_genus', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Oryza']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_species', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'species']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_abbreviation', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'O. sativa']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_infraspecific_name', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Japonica']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_infraspecific_type', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'type_id' => $subspecies_term_id]);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'type_id' => 0]);
 
     $this->checkFieldItem('organism', 'organism_comment', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'rice is nice']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     // Test that the title via token replacement is working.
     $this->assertTrue($entities[$entity_id] == '<em>Oryza species</em> subspecies <em>Japonica</em>',
@@ -434,19 +451,19 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
 
     $this->checkFieldItem('organism', 'organism_genus', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Gorilla']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_species', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'gorilla']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_abbreviation', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'G. gorilla']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     $this->checkFieldItem('organism', 'organism_comment', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Gorilla']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
 
     // We expect no infraspecies here, so expected count is zero
     $this->checkFieldItem('organism', 'organism_infraspecific_name', 0,
@@ -508,10 +525,6 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
 
     // Check that the property values got published. The type_id should be
     // 0 in the drupal field table, the default for an integer.
-
-    // With the new scheme the value of type_id isn't predictable any more
-    // Also, it does make little sense to check for a value NOT being stored
-    /*
     $this->checkFieldItem('organism', 'field_note', 1,
         ['record_id' => $organism_id, 'prop_id' => 1],
         ['type_id' => 0, 'linker_id' => $organism_id,
@@ -536,7 +549,7 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         ['record_id' => $organism_id, 'prop_id' => 5],
         ['type_id' => 0, 'linker_id' => $organism_id,
          'bundle' => 'organism', 'entity_id' => 1]);
-    */
+
     // Check that only the exact number of properties were published.
     $this->checkFieldItem('organism', 'field_note', 3, ['entity_id' => 1], []);
     $this->checkFieldItem('organism', 'field_comment', 2, ['entity_id' => 1], []);
@@ -618,11 +631,222 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         'Failed to publish 1 array design entitity.');
     $this->checkFieldItem('array_design', 'array_design_num_of_elements', 1,
         ['record_id' => $array_design_id1],
-        ['bundle' => 'array_design', 'entity_id' => 8, 'value' => 1]);
+        ['bundle' => 'array_design', 'entity_id' => 8, 'value' => 0]);
     // We do not expect a NULL integer item to be published
     $this->checkFieldItem('array_design', 'array_design_num_array_columns', 0,
         ['record_id' => $array_design_id1],
         []);
+
+    // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    // %     Run tests set with caching enabled.       %
+    // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    // Update configuration
+    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', true);
+    $config_edit->save();
+    //
+    // Test publishing a single record: Organism 3
+    //
+    $taxrank_db = $idsmanager->loadCollection('TAXRANK', "chado_id_space");
+    $subspecies_term_id = $taxrank_db->getTerm('0000023')->getInternalId();
+
+    $organism_id3 = $this->addChadoOrganism($chado, [
+      'genus' => 'Oryza',
+      'species' => 'sativa',
+      'abbreviation' => 'O. sativa',
+      'type_id' => $subspecies_term_id,
+      'infraspecific_name' => 'Japonica',
+      'comment' => 'rice is nice, too'
+    ]);
+    $entities = $chado_publish->publish(['bundle' => 'organism', 'datastore' => 'chado_storage']);
+    $this->assertCount(1, $entities,
+      'The TripalPublish service should have published 1 organism.');
+    $entity_id = array_key_first($entities);
+
+    // Test that entries were added for all field items and that fields that
+    // shouldn't be saved in Drupal are equal to the field's default value.
+    $this->checkFieldItem('organism', 'organism_genus', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Oryza']);
+
+    $this->checkFieldItem('organism', 'organism_species', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'sativa']);
+
+    $this->checkFieldItem('organism', 'organism_abbreviation', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'O. sativa']);
+
+    $this->checkFieldItem('organism', 'organism_infraspecific_name', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Japonica']);
+
+    $this->checkFieldItem('organism', 'organism_infraspecific_type', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'type_id' => $subspecies_term_id]);
+
+    $this->checkFieldItem('organism', 'organism_comment', 1,
+        ['record_id' => $organism_id3],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'rice is nice, too']);
+
+    // Test that the title via token replacement is working.
+    $this->assertTrue($entities[$entity_id] == '<em>Oryza sativa</em> subspecies <em>Japonica</em>',
+        'The title of a Chado organism is incorrect after publishing: ' . array_values($entities)[0] . '!=' . '<em>Oryza sativa</em> subspecies <em>Japonica</em>');
+
+    // Because we added properties for the first organism we should get its
+    // entity in those returned, but not the gorilla organism.
+    $this->assertEquals(
+      '<em>Oryza sativa</em> subspecies <em>Japonica</em>',
+      array_values($entities)[0],
+      'The Oryza species subspecies Japonica organism should appear in the published list because it has new properties.'
+    );
+
+    //
+    // Test publishing properties.
+    //
+    $comment_type_id = $schema_db->getTerm('comment')->getInternalId();
+    $note_type_id = $local_db->getTerm('Note')->getInternalId();
+    $this->attachOrganismPropertyFields();
+    $this->addProperty($chado, 'organism', [
+      'organism_id' => $organism_id3,
+      'type_id' => $note_type_id,
+      'value' => 'Note 1',
+      'rank' => 1,
+    ]);
+    $this->addProperty($chado, 'organism', [
+      'organism_id' => $organism_id3,
+      'type_id' => $note_type_id,
+      'value' => 'Note 0',
+      'rank' => 0,
+    ]);
+    $this->addProperty($chado, 'organism', [
+      'organism_id' => $organism_id3,
+      'type_id' => $note_type_id,
+      'value' => 'Note 2',
+      'rank' => 2,
+    ]);
+
+    $this->addProperty($chado, 'organism', [
+      'organism_id' => $organism_id3,
+      'type_id' => $comment_type_id,
+      'value' => 'Comment 0',
+      'rank' => 0,
+    ]);
+    $this->addProperty($chado, 'organism', [
+      'organism_id' => $organism_id3,
+      'type_id' => $comment_type_id,
+      'value' => 'Comment 1',
+      'rank' => 1,
+    ]);
+
+    // Now publish the organism content type again.
+    $entities = $chado_publish->publish(['bundle' => 'organism', 'datastore' => 'chado_storage', 'republish' => true]);
+    $entity_id = array_key_first($entities);
+    // Because we added properties for the first organism we should get its
+    // entity in those returned, but not the gorilla organism.
+    $this->assertEquals('<em>Oryza sativa</em> subspecies <em>Japonica</em>', array_values($entities)[0],
+    'The Oryza species subspecies Japonica organism should appear in the published list because it has new properties.');
+    $this->assertCount(1, array_values($entities),
+    'There should only be one published entity for a single organism with new properties.');
+
+
+    // Check that the property values got published. The type_id should be
+    // be the $note_type_id in the drupal field table, not the default for an integer.
+    $this->checkFieldItem('organism', 'field_note', 1,
+      ['record_id' => $organism_id3, 'prop_id' => 6],
+      ['type_id' => $note_type_id, 'linker_id' => $organism_id3,
+      'bundle' => 'organism', 'entity_id' => $entity_id]);
+
+    $this->checkFieldItem('organism', 'field_note', 1,
+      ['record_id' => $organism_id3, 'prop_id' => 7],
+      ['type_id' => $note_type_id, 'linker_id' => $organism_id3,
+      'bundle' => 'organism', 'entity_id' => $entity_id]);
+
+    $this->checkFieldItem('organism', 'field_note', 1,
+    ['record_id' => $organism_id3, 'prop_id' => 8],
+    ['type_id' => $note_type_id, 'linker_id' => $organism_id3,
+     'bundle' => 'organism', 'entity_id' => $entity_id]);
+
+    $this->checkFieldItem('organism', 'field_comment', 1,
+    ['record_id' => $organism_id3, 'prop_id' => 9],
+    ['type_id' => $comment_type_id, 'linker_id' => $organism_id3,
+     'bundle' => 'organism', 'entity_id' => $entity_id]);
+
+    $this->checkFieldItem('organism', 'field_comment', 1,
+    ['record_id' => $organism_id3, 'prop_id' => 10],
+    ['type_id' => $comment_type_id, 'linker_id' => $organism_id3,
+     'bundle' => 'organism', 'entity_id' => $entity_id]);
+
+    // Check that only the exact number of properties were published.
+    $this->checkFieldItem('organism', 'field_note', 3, ['entity_id' => 1], []);
+    $this->checkFieldItem('organism', 'field_comment', 2, ['entity_id' => 1], []);
+
+    //
+    // Test a single entity: Organism 4. Also use a title without all tokens
+    //
+    $organism_id4 = $this->addChadoOrganism($chado, [
+      'genus' => 'Lepeophtheirus',
+      'species' => 'salmonis',
+      'common_name' => 'salmon louse',
+      'abbreviation' => 'L. salmonis',
+      'comment' => 'The salmon louse is a major ectoparasite of salmonids.'
+    ]);
+    $entities = $chado_publish->publish(['bundle' => 'organism', 'datastore' => 'chado_storage']);
+    $this->assertCount(1, $entities,
+      'The TripalPublish service should have published 1 organism.');
+    $entity_id = array_key_first($entities);
+    // Token parser will also remove a token if it is empty, e.g. infraspecific nomenclature absent.
+    $this->assertEquals('<em>Lepeophtheirus salmonis</em>', $entities[$entity_id],
+        'The title of Chado organism with missing tokens is incorrect after publishing');
+
+    $this->checkFieldItem('organism', 'organism_genus', 1,
+        ['record_id' => $organism_id4],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Lepeophtheirus']);
+
+    $this->checkFieldItem('organism', 'organism_species', 1,
+        ['record_id' => $organism_id4],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'salmonis']);
+
+    $this->checkFieldItem('organism', 'organism_abbreviation', 1,
+        ['record_id' => $organism_id4],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'L. salmonis']);
+
+    $this->checkFieldItem('organism', 'organism_common_name', 1,
+        ['record_id' => $organism_id4],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'salmon louse']);
+
+    $this->checkFieldItem('organism', 'organism_comment', 1,
+        ['record_id' => $organism_id4],
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'The salmon louse is a major ectoparasite of salmonids.']);
+
+    // We expect no infraspecies here, so expected count is zero
+    $this->checkFieldItem('organism', 'organism_infraspecific_name', 0,
+        ['record_id' => $organism_id4],
+        []);
+
+    $this->checkFieldItem('organism', 'organism_infraspecific_type', 0,
+        ['record_id' => $organism_id4],
+        []);
+
+
+// Test publishing of integer fields
+$array_design_id2 = $this->addChadoArrayDesign($chado, [
+  'name' => 'AD2',
+  'num_of_elements' => 12,
+]);
+$entities = $chado_publish->publish(['bundle' => 'array_design', 'datastore' => 'chado_storage']);
+$entity_id = array_key_first($entities);
+$this->assertCount(1, $entities,
+    'Failed to publish 1 array design entitity.');
+$this->checkFieldItem('array_design', 'array_design_num_of_elements', 1,
+    ['record_id' => $array_design_id2],
+    ['bundle' => 'array_design', 'entity_id' => $entity_id, 'value' => 12]);
+// We do not expect a NULL integer item to be published
+$this->checkFieldItem('array_design', 'array_design_num_array_columns', 0,
+    ['record_id' => $array_design_id2],
+    []);
+
+
 
   }
 }

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -434,19 +434,19 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
 
     $this->checkFieldItem('organism', 'organism_genus', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Gorilla']);
 
     $this->checkFieldItem('organism', 'organism_species', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'gorilla']);
 
     $this->checkFieldItem('organism', 'organism_abbreviation', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'G. gorilla']);
 
     $this->checkFieldItem('organism', 'organism_comment', 1,
         ['record_id' => $organism_id2],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Gorilla']);
 
     // We expect no infraspecies here, so expected count is zero
     $this->checkFieldItem('organism', 'organism_infraspecific_name', 0,

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -389,27 +389,27 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     // shouldn't be saved in Drupal are equal to the field's default value.
     $this->checkFieldItem('organism', 'organism_genus', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Oryza']);
 
     $this->checkFieldItem('organism', 'organism_species', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'species']);
 
     $this->checkFieldItem('organism', 'organism_abbreviation', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'O. sativa']);
 
     $this->checkFieldItem('organism', 'organism_infraspecific_name', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'Japonica']);
 
     $this->checkFieldItem('organism', 'organism_infraspecific_type', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'type_id' => 0]);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'type_id' => $subspecies_term_id]);
 
     $this->checkFieldItem('organism', 'organism_comment', 1,
         ['record_id' => $organism_id],
-        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => '']);
+        ['bundle' => 'organism', 'entity_id' => $entity_id, 'value' => 'rice is nice']);
 
     // Test that the title via token replacement is working.
     $this->assertTrue($entities[$entity_id] == '<em>Oryza species</em> subspecies <em>Japonica</em>',

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -322,12 +322,9 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
   public function testChadoTripalPublishService() {
 
     // The behavior depends on settings made in TripalEntitySettingsForm
-    // Depending on default_cache_backend_field_values the values are either saved in the entity
-    // or not.
-
-    // Get editable config object
+    // Depending on default_cache_backend_field_values the values are either
+    // saved in the entity or not.
     $config_edit = \Drupal::configFactory()->getEditable('tripal.settings');
-
 
     // Prepare Chado
     $chado = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
@@ -367,13 +364,12 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     $content_type_setup->install($collection_ids);
     $fields_setup->install($collection_ids);
 
-
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     // % Run the first test set with caching disabled. %
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-    // Update configuration
-    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', false);
+    // Update configuration.
+    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', FALSE);
     $config_edit->save();
 
     //
@@ -642,7 +638,7 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     // Update configuration
-    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', true);
+    $config_edit->set('tripal_entity_type.default_cache_backend_field_values', TRUE);
     $config_edit->save();
     //
     // Test publishing a single record: Organism 3
@@ -748,7 +744,6 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     $this->assertCount(1, array_values($entities),
     'There should only be one published entity for a single organism with new properties.');
 
-
     // Check that the property values got published. The type_id should be
     // be the $note_type_id in the drupal field table, not the default for an integer.
     $this->checkFieldItem('organism', 'field_note', 1,
@@ -827,25 +822,22 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         ['record_id' => $organism_id4],
         []);
 
-
-// Test publishing of integer fields
-$array_design_id2 = $this->addChadoArrayDesign($chado, [
-  'name' => 'AD2',
-  'num_of_elements' => 12,
-]);
-$entities = $chado_publish->publish(['bundle' => 'array_design', 'datastore' => 'chado_storage']);
-$entity_id = array_key_first($entities);
-$this->assertCount(1, $entities,
-    'Failed to publish 1 array design entitity.');
-$this->checkFieldItem('array_design', 'array_design_num_of_elements', 1,
-    ['record_id' => $array_design_id2],
-    ['bundle' => 'array_design', 'entity_id' => $entity_id, 'value' => 12]);
-// We do not expect a NULL integer item to be published
-$this->checkFieldItem('array_design', 'array_design_num_array_columns', 0,
-    ['record_id' => $array_design_id2],
-    []);
-
-
-
+    // Test publishing of integer fields
+    $array_design_id2 = $this->addChadoArrayDesign($chado, [
+      'name' => 'AD2',
+      'num_of_elements' => 12,
+    ]);
+    $entities = $chado_publish->publish(['bundle' => 'array_design', 'datastore' => 'chado_storage']);
+    $entity_id = array_key_first($entities);
+    $this->assertCount(1, $entities,
+      'Failed to publish 1 array design entitity.');
+    $this->checkFieldItem('array_design', 'array_design_num_of_elements', 1,
+      ['record_id' => $array_design_id2],
+      ['bundle' => 'array_design', 'entity_id' => $entity_id, 'value' => 12]);
+    // We do not expect a NULL integer item to be published
+    $this->checkFieldItem('array_design', 'array_design_num_array_columns', 0,
+      ['record_id' => $array_design_id2],
+      []);
   }
+
 }

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -618,7 +618,7 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         'Failed to publish 1 array design entitity.');
     $this->checkFieldItem('array_design', 'array_design_num_of_elements', 1,
         ['record_id' => $array_design_id1],
-        ['bundle' => 'array_design', 'entity_id' => 8, 'value' => 0]);
+        ['bundle' => 'array_design', 'entity_id' => 8, 'value' => 1]);
     // We do not expect a NULL integer item to be published
     $this->checkFieldItem('array_design', 'array_design_num_array_columns', 0,
         ['record_id' => $array_design_id1],

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -706,7 +706,6 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
     //
     $comment_type_id = $schema_db->getTerm('comment')->getInternalId();
     $note_type_id = $local_db->getTerm('Note')->getInternalId();
-    $this->attachOrganismPropertyFields();
     $this->addProperty($chado, 'organism', [
       'organism_id' => $organism_id3,
       'type_id' => $note_type_id,

--- a/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoTripalPublishTest.php
@@ -508,6 +508,10 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
 
     // Check that the property values got published. The type_id should be
     // 0 in the drupal field table, the default for an integer.
+
+    // With the new scheme the value of type_id isn't predictable any more
+    // Also, it does make little sense to check for a value NOT being stored
+    /*
     $this->checkFieldItem('organism', 'field_note', 1,
         ['record_id' => $organism_id, 'prop_id' => 1],
         ['type_id' => 0, 'linker_id' => $organism_id,
@@ -532,7 +536,7 @@ class ChadoTripalPublishTest extends ChadoTestBrowserBase {
         ['record_id' => $organism_id, 'prop_id' => 5],
         ['type_id' => 0, 'linker_id' => $organism_id,
          'bundle' => 'organism', 'entity_id' => 1]);
-
+    */
     // Check that only the exact number of properties were published.
     $this->checkFieldItem('organism', 'field_note', 3, ['entity_id' => 1], []);
     $this->checkFieldItem('organism', 'field_comment', 2, ['entity_id' => 1], []);


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# New Feature

### Issue #1828 

### PR #2083 

This PR is a remake of the one linked above because that one had a number of commits made by root/Debian. While @mdondrup tried to fix this using rebase, it was not successful. As such, I cherry picked all his commits and ammended the authorship to point to him instead of root/debian. I also had to fix a few merge conflicts along the way --specifically in the TripalEntitySettings form. The downside of this approach is that now it mentions me as the committer and him as the author, which is not ideal.

## Description
<!--- Describe your changes in detail -->
This PR fundamentally affects the way chado data is published.

The logic determining which field data will be copied into Drupal Entity tables from the Chado base tables have been changed by modifying the function `getStoredTypesFilter` in `ChadoStorage.php`. Now, by default, most data is copied.

Fields with storage paths ending in ".residues" are now automatically exempt from redundant storage. While there was already an option to add a storage parameter "drupal_store" to annotate a field to cause it to be copied, this wasn't used anywhere and would have required extensive editing of the Yaml files containing field type collections. 

Note that the behavior is now the opposite of the original behavior, and most field values will now be stored redundantly.
The behavior of not storing entity values during Chado publishing was covered by unit testing in `ChadoTripalPublishTest.php`.
The tests have been adapted to reflect the new behavior.

<!--- Why is this change required? What problem does it solve? -->
These changes address #1828 to allow proper filtering and sorting of chado-derived data in Views, according to Solution 1 described [here](https://github.com/tripal/tripal/issues/1828#issuecomment-2541585273): 

> The first approach involves ensuring that while publishing Tripal content, fields like organism_common_name_value are populated with meaningful values rather than left empty. This would allow the Views filter to function correctly without modifying its logic. However, this approach could introduce redundancy and might conflict with the current design, where these fields are likely left empty intentionally.

## Testing?
<!--- Please describe in detail how to test these changes. -->
### Unit testing:

- Publishing of Chado data is covered by phpunit test`testChadoTripalPublishService` in `ChadoTripalPublishTest.php`

### Manual testing:

1. Create an organism and an analysis --fill in all the fields.
2. Go to the GFF3 importer and add `/var/www/drupal/web/modules/contrib/tripal/tripal_chado/tests/fixtures/gff3_loader/TripalusDatabasicaChr1Genes.gff3` under Server Path. Select the organism and analysis you chose above and enter "chromosome (SO:0000340)" as the default landmark type. Run the submitted Tripal Job.
3. Go to Page Structure and import the Genomic content type collection. Run the submitted job.
4. Go to Tripal > Content > Publish and choose "Gene" as the content type. Run the submitted publish job and confirm it runs without error.
```
2025-02-20 01:21:24
Tripal Job Launcher
Running as user 'drupaladmin'
-------------------
2025-02-20 01:21:24: Job ID 3.
2025-02-20 01:21:24: Calling: Drupal\tripal\TripalBackendPublish\PluginManager\TripalBackendPublishManager::runTripalJob(gene, chado_storage, Array)
 [notice] Initializing publish
Finding all candidate records in the "feature" chado table
 [notice] Finding all candidate records in the "feature" chado table
Preparing to publish 50 "gene" records
 [notice] Preparing to publish 50 "gene" records
Step 1 of 6: Find matching records
 [notice] Step 1 of 6: Find matching records
Step 2 of 6: Generate page titles
 [notice] Step 2 of 6: Generate page titles
Step 3 of 6: Find existing published entity titles
 [notice] Step 3 of 6: Find existing published entity titles
Step 4 of 6: Updating existing page titles
 [notice] Step 4 of 6: Updating existing page titles
Step 5 of 6: Publishing 50 new entities
 [notice] Step 5 of 6: Publishing 50 new entities
Step 6 of 6: Adding field items to published entities
 [notice] Step 6 of 6: Adding field items to published entities
  Published 50 items for field "gene_dbxref_ann"
 [notice]   Published 50 items for field "gene_dbxref_ann"
  Published 50 items for field "gene_is_analysis"
 [notice]   Published 50 items for field "gene_is_analysis"
  Published 50 items for field "gene_is_obsolete"
 [notice]   Published 50 items for field "gene_is_obsolete"
  Published 50 items for field "gene_length"
 [notice]   Published 50 items for field "gene_length"
  Published 50 items for field "gene_name"
 [notice]   Published 50 items for field "gene_name"
  Published 50 items for field "gene_organism"
 [notice]   Published 50 items for field "gene_organism"
  Published 50 items for field "gene_sequence"
 [notice]   Published 50 items for field "gene_sequence"
  Published 50 items for field "gene_sequence_coordinates"
 [notice]   Published 50 items for field "gene_sequence_coordinates"
  Published 50 items for field "gene_sequence_md5_checksum"
 [notice]   Published 50 items for field "gene_sequence_md5_checksum"
  Published 50 items for field "gene_type"
 [notice]   Published 50 items for field "gene_type"
  Published 50 items for field "gene_uniquename"
 [notice]   Published 50 items for field "gene_uniquename"
Publish completed. Published 50 new entities, and added 550 field values.
 [notice] Publish completed. Published 50 new entities, and added 550 field values.
```
5. Take a look at some of those pages and make sure they look right. Also check the Drupal tables and make sure the chado information is there.
```
sitedb=# SELECT * FROM tripal_entity__gene_organism LIMIT 5;
 bundle | deleted | entity_id | revision_id | langcode | delta | gene_organism_record_id | gene_organism_entity_id | gen
e_organism_organism_id | gene_organism_organism_genus | gene_organism_organism_species | gene_organism_organism_infraspe
cific_type | gene_organism_organism_infraspecific_name |    gene_organism_organism_scientific_name     | gene_organism_o
rganism_abbreviation | gene_organism_organism_common_name |      gene_organism_organism_comment      
--------+---------+-----------+-------------+----------+-------+-------------------------+-------------------------+----
-----------------------+------------------------------+--------------------------------+--------------------------------
-----------+-------------------------------------------+-----------------------------------------------+----------------
---------------------+------------------------------------+------------------------------------------
 gene   |       0 |         3 |           3 | und      |     0 |                       2 |                       1 |    
                     1 | Tripalus                     | databasica                     | subspecies                     
           | postgresquelus                            | Tripalus databasica subspecies postgresquelus | T.databasica sp
. postgresquelus     | Tripal: PostgreSQL                 | <p>This is some sort of description.</p>
 gene   |       0 |         4 |           4 | und      |     0 |                      12 |                       1 |    
                     1 | Tripalus                     | databasica                     | subspecies                     
           | postgresquelus                            | Tripalus databasica subspecies postgresquelus | T.databasica sp
. postgresquelus     | Tripal: PostgreSQL                 | <p>This is some sort of description.</p>
 gene   |       0 |         5 |           5 | und      |     0 |                      37 |                       1 |    
                     1 | Tripalus                     | databasica                     | subspecies                     
           | postgresquelus                            | Tripalus databasica subspecies postgresquelus | T.databasica sp
. postgresquelus     | Tripal: PostgreSQL                 | <p>This is some sort of description.</p>
 gene   |       0 |         6 |           6 | und      |     0 |                      43 |                       1 |    
                     1 | Tripalus                     | databasica                     | subspecies                     
           | postgresquelus                            | Tripalus databasica subspecies postgresquelus | T.databasica sp
. postgresquelus     | Tripal: PostgreSQL                 | <p>This is some sort of description.</p>
 gene   |       0 |         7 |           7 | und      |     0 |                      90 |                       1 |    
                     1 | Tripalus                     | databasica                     | subspecies                     
           | postgresquelus                            | Tripalus databasica subspecies postgresquelus | T.databasica sp
. postgresquelus     | Tripal: PostgreSQL                 | <p>This is some sort of description.</p>
(5 rows)
```
6. Go to one of the gene pages and edit it. Add some sequence to the "Sequence Residues" field and add an additional "Database Reference Annotations". Now check the Drupal table associated with the field you made a change in and confirm the change is reflected there. Note: For the sequence residues field, all the other chado info should be there but not the actual sequence (see below).
```
sitedb=# SELECT * FROM tripal_entity__gene_sequence WHERE entity_id=3;
 bundle | deleted | entity_id | revision_id | langcode | delta | gene_sequence_record_id | gene_sequence_residues | gene
_sequence_seqlen |    gene_sequence_md5checksum     
--------+---------+-----------+-------------+----------+-------+-------------------------+------------------------+-----
-----------------+----------------------------------
 gene   |       0 |         3 |           3 | und      |     0 |                       2 |                        |     
              12 | fc0f4f09fb9849dbdd8031f13732165e
(1 row)
sitedb=# SELECT * FROM tripal_entity__gene_dbxref_ann WHERE entity_id=3;
 bundle | deleted | entity_id | revision_id | langcode | delta | gene_dbxref_ann_record_id | gene_dbxref_ann_linker_id |
 gene_dbxref_ann_link | gene_dbxref_ann_dbxref_id | gene_dbxref_ann_linker_is_current | gene_dbxref_ann_dbxref_db_id | g
ene_dbxref_ann_dbxref_accession | gene_dbxref_ann_dbxref_version | gene_dbxref_ann_dbxref_description | gene_dbxref_ann_
dbxref_db_name |                                                                                       gene_dbxref_ann_d
bxref_db_description                                                                                        |       gene
_dbxref_ann_dbxref_db_urlprefix       |      gene_dbxref_ann_dbxref_db_url      
--------+---------+-----------+-------------+----------+-------+---------------------------+---------------------------+
----------------------+---------------------------+-----------------------------------+------------------------------+--
--------------------------------+--------------------------------+------------------------------------+-----------------
---------------+--------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------+-----------
--------------------------------------+-----------------------------------------
 gene   |       0 |         3 |           3 | und      |     0 |                         2 |                      1281 |
                    2 |                      3526 |                                 1 |                           45 | t
ripalTest                       |                                |                                    | GFF_source      
               | Added automatically by the Tripal GFF loader.                                                          
                                                                                                            |           
                                      | 
 gene   |       0 |         3 |           3 | und      |     1 |                         2 |                      1282 |
                    2 |                       180 |                                 1 |                           20 | C
164386                          |                                |                                    | NCIT            
               | The NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer
 related diseases, findings and abnormalities. NCIt OBO Edition releases should be considered experimental. | http://pur
l.obolibrary.org/obo/{db}_{accession} | http://purl.obolibrary.org/obo/ncit.owl
(2 rows)
```
7. Create 3 contacts through the UI and fill in all the fields.
8. Create a project through the UI and add all 3 contacts in the "Contacts" field.
9. Now check the fields associated with the project --especially the contact field-- to confirm they were correctly populated.
```
sitedb=# SELECT * FROM tripal_entity__project_contact;
 bundle  | deleted | entity_id | revision_id | langcode | delta | project_contact_record_id | project_contact_entity_id 
| project_contact_linker_id | project_contact_link | project_contact_contact_id | project_contact_contact_name | project
_contact_contact_description | project_contact_contact_type 
---------+---------+-----------+-------------+----------+-------+---------------------------+---------------------------
+---------------------------+----------------------+----------------------------+------------------------------+--------
-----------------------------+------------------------------
 project |       0 |        56 |          56 | und      |     0 |                         1 |                        53 
|                         4 |                    1 |                          2 | Contact A                    | A descr
iption for contact a.        | Person
 project |       0 |        56 |          56 | und      |     1 |                         1 |                        54 
|                         5 |                    1 |                          3 | Contact B                    | A descr
iption for contact b.        | Journal
 project |       0 |        56 |          56 | und      |     2 |                         1 |                        55 
|                         6 |                    1 |                          4 | Contact C                    | A descr
iption for contact c.        | Organization
(3 rows)
```

It is also a good idea to start a fresh site and turn off the cache in the Tripal Entity Settings before doing the above steps. In this case, only the keys from chado should be populated.