### PR TITLE
Allow field property types to know which ID Space plugin should be used if ID Space is missing.

### DIFF
--- a/tripal/src/TripalStorage/BoolStoragePropertyType.php
+++ b/tripal/src/TripalStorage/BoolStoragePropertyType.php
@@ -14,22 +14,21 @@ class BoolStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "bool", $storage_settings);
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "bool", $storage_settings, $idspace_plugin_id);
   }
 
   /**

--- a/tripal/src/TripalStorage/DateTimeStoragePropertyType.php
+++ b/tripal/src/TripalStorage/DateTimeStoragePropertyType.php
@@ -14,22 +14,21 @@ class DateTimeStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "dateTime", $storage_settings);
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "dateTime", $storage_settings, $idspace_plugin_id);
   }
 
   /**

--- a/tripal/src/TripalStorage/IntStoragePropertyType.php
+++ b/tripal/src/TripalStorage/IntStoragePropertyType.php
@@ -14,22 +14,21 @@ class IntStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "int", $storage_settings );
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "int", $storage_settings, $idspace_plugin_id);
   }
 
   /**

--- a/tripal/src/TripalStorage/RealStoragePropertyType.php
+++ b/tripal/src/TripalStorage/RealStoragePropertyType.php
@@ -15,22 +15,21 @@ class RealStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "real", $storage_settings);
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "real", $storage_settings, $idspace_plugin_id);
   }
 
   /**

--- a/tripal/src/TripalStorage/StoragePropertyBase.php
+++ b/tripal/src/TripalStorage/StoragePropertyBase.php
@@ -21,18 +21,18 @@ class StoragePropertyBase {
    *
    * @param string entityType
    *   The entity type associated with this storage property base object.
-   *
    * @param string fieldType
    *   The field type associated with this storage property base object.
-   *
    * @param string key
    *   The key associated with this storage property base object.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id) {
+  public function __construct($entityType, $fieldType, $key, $term_id, $idspace_plugin_id = '') {
     $this->entityType = $entityType;
     $this->fieldType = $fieldType;
 
@@ -66,11 +66,16 @@ class StoragePropertyBase {
       $this->termIdSpace = $matches[1];
       $this->termAccession = $matches[2];
 
-      $idspace = $this->idSpaceService->loadCollection($this->termIdSpace);
+      if ($idspace_plugin_id) {
+        $idspace = $this->idSpaceService->loadCollection($this->termIdSpace, $idspace_plugin_id);
+      }
+      else {
+        $idspace = $this->idSpaceService->loadCollection($this->termIdSpace);
+      }
       if (!$idspace) {
         throw new \Exception('Cannot create a StorageProperty object for entity type "' . $entityType
             . '", field type "' . $fieldType . '", key "' . $key
-            . '" as IdSpace for the property term is not recognized: "' . $term_id . '"');
+            . '" as IdSpace for the property term is not recognized: "' . $term_id . '" (' . $idspace_plugin_id . ')');
       }
       $term = $idspace->getTerm($this->termAccession);
       if (!$term) {

--- a/tripal/src/TripalStorage/StoragePropertyTypeBase.php
+++ b/tripal/src/TripalStorage/StoragePropertyTypeBase.php
@@ -14,25 +14,23 @@ class StoragePropertyTypeBase extends StoragePropertyBase {
    *
    * @param string entityType
    *   The entity type associated with this storage property type base.
-   *
    * @param string fieldType
    *   The field type associated with this storage property type base.
-   *
    * @param string key
    *   The key associated with this storage property type base.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param string id
    *   The id of this storage property type base.
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id);
+  public function __construct($entityType, $fieldType, $key, $term_id, $id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $idspace_plugin_id);
     $this->id = $id;
     $this->cardinality = 1;
     $this->searchability = TRUE;

--- a/tripal/src/TripalStorage/TextStoragePropertyType.php
+++ b/tripal/src/TripalStorage/TextStoragePropertyType.php
@@ -15,22 +15,21 @@ class TextStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.
+   * @param string $idspace_plugin_id
+   *   The plugin_id associated with the term. This is optional but if provided
+   *   allows a missing ID Space to be looked up in the backend storage.
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "text", $storage_settings);
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "text", $storage_settings, $idspace_plugin_id);
   }
 
   /**

--- a/tripal/src/TripalStorage/VarCharStoragePropertyType.php
+++ b/tripal/src/TripalStorage/VarCharStoragePropertyType.php
@@ -14,25 +14,20 @@ class VarCharStoragePropertyType extends StoragePropertyTypeBase {
    *
    * @param string entityType
    *   The entity type associated with this property type.
-   *
    * @param string fieldType
    *   The field type associated with this property type.
-   *
    * @param string key
    *   The key associated with this property type.
-   *
    * @param string term_id
    *   The controlled vocabulary term asssociated with this property. It must be
    *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
-   *
    * @param int size
    *   The maximum size of characters for this type.
-   *
    * @param array storage_settings
    *   An array of settings required for this property by the storage backend.*
    */
-  public function __construct($entityType, $fieldType, $key, $term_id, int $size = 255, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "varchar", $storage_settings);
+  public function __construct($entityType, $fieldType, $key, $term_id, int $size = 255, $storage_settings = [], $idspace_plugin_id = '') {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "varchar", $storage_settings, $idspace_plugin_id);
     $this->maxCharacterSize = $size;
   }
 

--- a/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
@@ -9,4 +9,22 @@ use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
  */
 class ChadoBoolStoragePropertyType extends BoolStoragePropertyType {
 
+  /**
+   * Constructs a new boolean chado storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, "bool", $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoBoolStoragePropertyType.php
@@ -25,6 +25,6 @@ class ChadoBoolStoragePropertyType extends BoolStoragePropertyType {
    *   An array of settings required for this property by the storage backend.
    */
   public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
-    parent::__construct($entityType, $fieldType, $key, $term_id, "bool", $storage_settings, 'chado_id_space');
+    parent::__construct($entityType, $fieldType, $key, $term_id, $storage_settings, 'chado_id_space');
   }
 }

--- a/tripal_chado/src/TripalStorage/ChadoBpCharStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoBpCharStoragePropertyType.php
@@ -9,4 +9,24 @@ use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
  */
 class ChadoBpCharStoragePropertyType extends VarCharStoragePropertyType {
 
+  /**
+   * Constructs a new variable character tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param int size
+   *   The maximum size of characters for this type.
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.*
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, int $size = 255, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $size, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoDateTimeStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoDateTimeStoragePropertyType.php
@@ -9,4 +9,22 @@ use Drupal\tripal\TripalStorage\DateTimeStoragePropertyType;
  */
 class ChadoDateTimeStoragePropertyType extends DateTimeStoragePropertyType {
 
+  /**
+   * Constructs a new date time tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoIntStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoIntStoragePropertyType.php
@@ -9,4 +9,22 @@ use Drupal\tripal\TripalStorage\IntStoragePropertyType;
  */
 class ChadoIntStoragePropertyType extends IntStoragePropertyType {
 
+  /**
+   * Constructs a new integer tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoRealStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoRealStoragePropertyType.php
@@ -9,4 +9,22 @@ use Drupal\tripal\TripalStorage\RealStoragePropertyType;
  */
 class ChadoRealStoragePropertyType extends RealStoragePropertyType {
 
+  /**
+   * Constructs a new real tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoTextStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoTextStoragePropertyType.php
@@ -9,4 +9,22 @@ use Drupal\tripal\TripalStorage\TextStoragePropertyType;
  */
 class ChadoTextStoragePropertyType extends TextStoragePropertyType {
 
+  /**
+   * Constructs a new text tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/src/TripalStorage/ChadoVarCharStoragePropertyType.php
+++ b/tripal_chado/src/TripalStorage/ChadoVarCharStoragePropertyType.php
@@ -9,4 +9,24 @@ use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
  */
 class ChadoVarCharStoragePropertyType extends VarCharStoragePropertyType {
 
+  /**
+   * Constructs a new variable character tripal storage property type.
+   *
+   * @param string entityType
+   *   The entity type associated with this property type.
+   * @param string fieldType
+   *   The field type associated with this property type.
+   * @param string key
+   *   The key associated with this property type.
+   * @param string term_id
+   *   The controlled vocabulary term asssociated with this property. It must be
+   *   in the form of "IdSpace:Accession" (e.g. "rdfs:label" or "OBI:0100026")
+   * @param int size
+   *   The maximum size of characters for this type.
+   * @param array storage_settings
+   *   An array of settings required for this property by the storage backend.*
+   */
+  public function __construct($entityType, $fieldType, $key, $term_id, int $size = 255, $storage_settings = []) {
+    parent::__construct($entityType, $fieldType, $key, $term_id, $size, $storage_settings, 'chado_id_space');
+  }
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeSimpleCRUDTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeSimpleCRUDTest.php
@@ -46,51 +46,6 @@ class ChadoPropertyTypeSimpleCRUDTest extends ChadoTestKernelBase {
   ];
 
   /**
-   * An array of terms that need to be created for this field to work.
-   *
-   * @var array
-   *  A list of terms keyed by the IDSPACE:ACCESSION format where the value is
-   *  and array including the parameters for createTripalTerm().
-   */
-  protected array $terms = [
-    'SIO:000729' => [
-      'vocab_name' => 'SIO',
-      'id_space_name' => 'SIO',
-      'term' => [
-        'accession' => '000729',
-      ]
-    ],
-    'NCIT:C25712' => [
-      'vocab_name' => 'ncit',
-      'id_space_name' => 'NCIT',
-      'term' => [
-        'accession' => 'C25712',
-      ],
-    ],
-    'OBCS:0000117' => [
-      'vocab_name' => 'OBCS',
-      'id_space_name' => 'OBCS',
-      'term' => [
-        'accession' => '0000117',
-      ],
-    ],
-    'schema:additionalType' => [
-      'vocab_name' => 'schema',
-      'id_space_name' => 'schema',
-      'term' => [
-        'accession' => 'additionalType',
-      ],
-    ],
-    'OBI:0100026' => [
-      'vocab_name' => 'obi',
-      'id_space_name' => 'OBI',
-      'term' => [
-        'accession' => '0100026',
-      ],
-    ],
-  ];
-
-  /**
    * A List of the expected property types for this field.
    *
    * @var array

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeSimpleCRUDTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldType/ChadoPropertyTypeSimpleCRUDTest.php
@@ -188,11 +188,6 @@ class ChadoPropertyTypeSimpleCRUDTest extends ChadoTestKernelBase {
     // Setup the field to be tested based on the data provider values.
     $this->field_name = $this->randomMachineName();
 
-    // Next create the terms for the properies this field will use.
-    foreach ($this->terms as $key => $term_deets) {
-      $this->createTripalTerm($term_deets, 'chado_id_space', 'chado_vocabulary');
-    }
-
     // Then create the Tripal Content Type.
     $bundle = $this->createTripalContentType([
       'id' => $this->bundle_name,


### PR DESCRIPTION
# Tripal 4 Core Dev Task 

### Issue #2129

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When you create a field with a property type whose term ID Space has not previously been added, on 4.x you receive an error:

```
Exception: Cannot create a StorageProperty object for entity type "tripal_entity", field type "chado_string_type_default", key "record_id" as IdSpace for the property term is not recognized: "SIO:000729"
```

This PR allows chado property types to be aware of the ID Space plugin they should use to lookup an ID Space in the backend storage if it has not yet been registered with Tripal.

This is backwards compatible since passing in the idspace plugin id when creating property types is optional. Additionally, this does not require any changes to ChadoFields since the Chado property types already know they should use the chado_id_space plugin id.

This functionality is most helpful in the automated testing environment. In the past, we have had to curate a list of all the terms used in property types for every field in an automated test in order to pre-register the ID Space with Tripal. This is no longer needed as shown in test ChadoPropertyTypeSimpleCRUDTest::testCreateEntityWithField() where I removed the pre-registering of needed terms and the test still passes.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

This is mostly going to affect automated testing. That said, since it affects field, you can simply test creating Tripal content to ensure that the property types are still created properly.
