### PR TITLE
Make the tripal content listing view again link to the content entities

### DIFF
--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -6,7 +6,7 @@ dependencies:
     - tripal
     - user
 _core:
-  default_config_hash: Bkx9Iy16THW-fIBoCMoaUpI8M_N301WjHNLpq1ztcBQ
+  default_config_hash: mP9f-XmAQWc4QPnYqqJiE6GnTFEhd9H5qcy-Q3hxzF4
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -23,6 +23,72 @@ display:
     display_options:
       title: 'Tripal Content Type Listing'
       fields:
+        id:
+          id: id
+          table: tripal_entity
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tripal_entity
+          entity_field: id
+          plugin_id: field
+          label: ID
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         title:
           id: title
           table: tripal_entity
@@ -38,8 +104,8 @@ display:
           alter:
             alter_text: true
             text: '{{ title__value | raw }}'
-            make_link: false
-            path: ''
+            make_link: true
+            path: '/bio_data/{{ id }}'
             absolute: false
             external: false
             replace_spaces: false
@@ -77,7 +143,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
# Bug Fix

### Closes #2131

## Description

PR #2125 allowed rendering of HTML tags in entity titles, but we did not notice that it broke the link to the corresponding entity.
Apparently using "Rewrite results" is incompatible with also using "Link to the Tripal content"

My solution is to 
1. Add a hidden column with the entity ID
![fields_with_id_added](https://github.com/user-attachments/assets/5a28da32-f5f0-4d46-a651-401ba73b87b1)
2. Turn off "Link to the Tripal content"
3. Turn on "Output this field as a custom link" using the path `/bio_data/{{ id }}`

## Testing?
1. Create any content entity, but especially organism as it has HTML in the title
2. Go to Tripal Content Type Listing at `/admin/content/bio_data`
3. HTML should be rendered, and you should be able to click and go to that entity
![now_clickable](https://github.com/user-attachments/assets/0be8cf9e-988a-4a77-815e-7605b84e3527)
