### PR TITLE
Reduce combinations slightly for Github workflows run on each commit to a PR.

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -44,14 +44,12 @@ jobs:
           # Exclude higher postgresql version from middle Drupal versions
           # This is done to reduce combinations; higher postgresql version
           # will be tested on merge to 4.x.
+          # Note: Drupal 11.0 is already only tested on one postgresql 
+          # version since it requires 16+.
           - pgsql-version: "17"
             drupal-version: "10.4.x-dev"
           - pgsql-version: "17"
             drupal-version: "10.5.x-dev"
-          - pgsql-version: "17"
-            drupal-version: "11.0.x-dev"
-          - pgsql-version: "17"
-            drupal-version: "11.1.x-dev"
     steps:
       # Check out the repo
       - name: Checkout Repository

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -25,19 +25,32 @@ jobs:
           - "11.0.x-dev"
           - "11.1.x-dev"
         exclude:
+          # Drupal 11+ requires at least php 8.3.
           - php-version: "8.1"
             drupal-version: "11.0.x-dev"
           - php-version: "8.2"
-            drupal-version: "11.0.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "13"
             drupal-version: "11.0.x-dev"
           - php-version: "8.1"
             drupal-version: "11.1.x-dev"
           - php-version: "8.2"
             drupal-version: "11.1.x-dev"
+          # Drupal 11+ requires at least Postgresql 16.
           - php-version: "8.3"
             pgsql-version: "13"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "11.1.x-dev"
+          # Exclude higher postgresql version from middle Drupal versions
+          # This is done to reduce combinations; higher postgresql version
+          # will be tested on merge to 4.x.
+          - pgsql-version: "17"
+            drupal-version: "10.4.x-dev"
+          - pgsql-version: "17"
+            drupal-version: "10.5.x-dev"
+          - pgsql-version: "17"
+            drupal-version: "11.0.x-dev"
+          - pgsql-version: "17"
             drupal-version: "11.1.x-dev"
     steps:
       # Check out the repo


### PR DESCRIPTION
# Tripal 4 Core Dev Task 

### Issue #2134

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Currently the number of combinations in the PHPUnit Matrix workflow is high enough that Github will not start them all at once. This is resulting in it taking EVEN longer for our test suite to complete since it doesn't start some of the combinations until the first batch is done (which already takes almost as hour).

This issue proposes only testing one version of postgresql version php/drupal combo for the middle drupal versions. The oldest and newest drupal version will still be tested on both PostgreSQL 13 + 16.

We've chosen to remove one Postgresql version from the matrix because we see less backwards incompatible issues across postgresql versions (only 1 detected so far) but we see a lot of incompatibilities across PHP and Drupal versions.

Also, we will choose the lowest Postgresql version for the reduced combinations since researchers take longer to update postgresql. Additionally the main branch tests run on the highest version of postgresql so in this way after merge we will detect any issue missed by the reduced combination which is better then missing it entirely.

NOTE: We used to run 20 combinations but only 18 could run at once.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

- Ensure the automated tests run in one batch (14 combos).
- Ensure the right combinations are being tested.
    - D10.3 is tested on all 3 PHP versions and both Postgresql versions (6 combos)
    - D10.4 + D10.5 are tested on all 3 php versions but only Postgresql 13 (6 combos)
    - D11.0 is tested on PHP 8.3 + Postgresql 17
    - D11.1 is tested on PHP 8.3 + Postgresql 17