### PR TITLE
Eliminate double logging for publish

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1082,6 +1082,7 @@ class ChadoPublish extends TripalBackendPublishBase {
    *   TRUE if successful, FALSE if error occurred
    */
   public function publish_init(array $options) : bool {
+    $this->logger->setGlobalOption('logger', FALSE);
     $this->logger->notice('Initializing publish');
 
     // Required options


### PR DESCRIPTION
# Bug Fix

### Issue #2116

## Description
Eliminates double logging for publish as described in this comment https://github.com/tripal/tripal/issues/2116#issuecomment-2676294689

## Testing?
Publish any content type, and confirm that messages only appear once
