### PR TITLE
Republish now updates already published fields

### DIFF
--- a/tripal/src/Form/TripalEntityPublishForm.php
+++ b/tripal/src/Form/TripalEntityPublishForm.php
@@ -108,9 +108,9 @@ class TripalEntityPublishForm extends FormBase {
     $form['republish'] = [
       '#type' => 'checkbox',
       '#title' => 'Republish Existing Content',
-      '#description' => 'Check this if the title format has been changed, or if'
-         . ' new fields have been added to the content type. The entity ID number'
-         . ' will not be changed.',
+      '#description' => 'Check this if the title format has been changed, if'
+         . ' new fields have been added to the content type, or if records have'
+         . ' been changed in Chado. The entity ID number will not be changed.',
     ];
 
     $form['batch_size'] = [

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1119,9 +1119,9 @@ class ChadoPublish extends TripalBackendPublishBase {
    *         data, rather just skip over them.
    *
    * @return bool
-   *   TRUE if successful, FALSE if error occurred
+   *   TRUE if successful, FALSE if an error occurred
    */
-  public function publish_init(array $options) : bool {
+  public function publish_init(array $options): bool {
     $this->logger->notice('Initializing publish');
 
     // Required options
@@ -1149,7 +1149,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       return FALSE;
     }
 
-    // Current user will be the author of newly published entitites
+    // The current user will be the author of any newly published entitites
     $this->uid = \Drupal::currentUser()->id();
 
     // Initialize class variables that may persist between consecutive jobs
@@ -1202,7 +1202,7 @@ class ChadoPublish extends TripalBackendPublishBase {
       $message .= ", checked " . number_format($stats['total_existing_entities']) . " existing entities";
     }
     // Titles will be updated only if the entity title format was changed
-    if ($total_updated_titles) {
+    if ($stats['total_updated_titles']) {
       $message .= ", updated titles for " . number_format($stats['total_updated_titles']) . " entities";
     }
     $message .= ", added " . number_format($stats['total_new_field_items']) . " new field values";
@@ -1237,10 +1237,9 @@ class ChadoPublish extends TripalBackendPublishBase {
    *   keyed by their titles, and the value being the entity_id.
    *
    */
-  public function publish($options) {
+  public function publish(array $options): array {
     // Initialization for publish
-    $success = $this->publish_init($options);
-    if (!$success) {
+    if (!$this->publish_init($options)) {
       return [];
     }
 

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -817,26 +817,25 @@ class ChadoPublish extends TripalBackendPublishBase {
     $field_table = 'tripal_entity__' . $field_name;
 
     $insert_batch_size = 1000;
-    $num_matches = $this->countFieldMatches($field_name, $matches);
+    $num_total_matches = $this->countFieldMatches($field_name, $matches);
 
-    // Generate the insert SQL and add the field-specific columns to it.
-    $init_sql = "
-      INSERT INTO {" . $field_table . "}
-        (bundle, deleted, entity_id, revision_id, langcode, delta, ";
+    // Construct a list of the columns in the field table
+    $fields = ['bundle', 'deleted', 'entity_id', 'revision_id', 'langcode', 'delta'];
     $all_types = array_merge(
       $this->required_types[$field_name] ?? [],
       $this->non_required_types[$field_name] ?? []
     );
     foreach (array_keys($all_types) as $key) {
-      $init_sql .= $field_name . '_'. $key . ', ';
+      $fields[] = $field_name . '_'. $key;
     }
-    $init_sql = rtrim($init_sql, ', ') . ") VALUES\n";
 
-    $j = 0;
-    $total = 0;
-    $sql = '';
-    $args = [];
+    // Initialize queries
+    $insert_query = $this->connection->insert($field_table)->fields($fields);
+    $insert_count = 0;
+    $num_processed_matches = 0;
     $num_inserted = 0;
+    $num_updated = 0;
+    $batch_num_values = 0;
 
     // Iterate through the matches. Each match corresponds to a single
     // entity.
@@ -848,40 +847,35 @@ class ChadoPublish extends TripalBackendPublishBase {
       // for each non-empty item.
       $num_items = count(array_keys($match[$field_name]));
       for ($delta = 0; $delta < $num_items; $delta++) {
-        // Leave these increments outside the add_record check
-        // to keep our count predictable, just note that some
-        // values of $j may not be used, however, $num_inserted
-        // will be accurate.
-        $j++;
-        $total++;
+        $num_processed_matches++;
 
         // No need to add items to those that are already published.
         $add_record = $this->checkOneFieldItem($field_name, $match, $existing, $titles, $entity_id, $delta, $record_id);
         if ($add_record) {
-          $this->insertOneFieldItem($sql, $args, $j, $match, $entity_id, $delta, $field_name);
+          $this->insertOneFieldItem($insert_query, $match, $entity_id, $delta, $field_name);
           $num_inserted++;
+          $batch_num_values++;
+        }
+        elseif ($this->republish) {
+          $this->updateOneFieldItem($match, $entity_id, $delta, $field_name, $field_table);
+          $num_updated++;
         }
 
         // If we've reached the size of the batch then let's do the insert.
-        if ($j == $insert_batch_size or $total == $num_matches) {
-          if (count($args) > 0) {
-            $sql = rtrim($sql, ",\n");
-            $sql = $init_sql . $sql;
-            $this->connection->query($sql, $args);
+        if ($batch_num_values) {
+          if (($batch_num_values == $insert_batch_size) or ($num_processed_matches == $num_total_matches)) {
+            $insert_query->execute();
+            $batch_num_values = 0;
+            $insert_query = $this->connection->insert($field_table)->fields($fields);
           }
-
-          // Now reset all of the variables for the next batch.
-          $sql = '';
-          $j = 0;
-          $args = [];
         }
       }
     }
-    return $num_inserted;
+    return [$num_inserted, $num_updated];
   }
 
   /**
-   * Determine if a particular field item needs to be published.
+   * Determine if a particular field item is new and needs to be published.
    *
    * @param string $field_name
    *   Name of the field being published
@@ -932,15 +926,11 @@ class ChadoPublish extends TripalBackendPublishBase {
   }
 
   /**
-   * Add a single field item to the sql and args.
+   * Add a single field item to the insert query.
    * This is a helper function for insertFieldItems().
    *
-   * @param string &$sql
-   *   The sql command under construction
-   * @param array &$args
-   *   Values for the placeholders
-   * @param int $j
-   *   Index for the placeholders
+   * @param &$insert_query
+   *   The query builder object under construction
    * @param array $match
    *   Contains all data to be published
    * @param int $entity_id
@@ -949,36 +939,86 @@ class ChadoPublish extends TripalBackendPublishBase {
    *   Field delta
    * @param string $field_name
    *   Name of the field being published
+   * @return void
    */
-  private function insertOneFieldItem(&$sql, &$args, $j, $match, $entity_id, $delta, $field_name) {
-    $sql .= "(:bundle_$j, :deleted_$j, :entity_id_$j, :revision_id_$j, :langcode_$j, :delta_$j, ";
-    $args[":bundle_$j"] = $this->bundle;
-    $args[":deleted_$j"] = 0;
-    $args[":entity_id_$j"] = $entity_id;
-    $args[":revision_id_$j"] = $entity_id;  // For an unversioned entity this is the same as the entity id
-    $args[":langcode_$j"] = 'und';
-    $args[":delta_$j"] = $delta;
+  private function insertOneFieldItem(&$insert_query, $match, $entity_id, $delta, $field_name): void {
+    $values = [
+      'bundle' => $this->bundle,
+      'deleted' => 0,
+      'entity_id' => $entity_id,
+      'revision_id' => $entity_id,  // For an unversioned entity this is the same as the entity id
+      'langcode' => 'und',
+      'delta' => $delta,
+    ];
     foreach ($this->required_types[$field_name] as $key => $properties) {
-      $placeholder = ':' . $field_name . '_'. $key . '_' . $j;
-      $sql .=  $placeholder . ', ';
+      $column = $field_name . '_'. $key;
       $value = $match[$field_name][$delta][$key]['value']->getValue();
       // If there is no value, use a placeholder of the correct type, string '', int 0, etc.
       if (is_null($value)) {
         $value = $properties->getDefaultValue();
       }
-      $args[$placeholder] = $match[$field_name][$delta][$key]['value']->getValue();
+      $values[$column] = $value;
     }
     // Non-required types never have a value stored, just a placeholder.
     // There might not be non_required_types for this field.
     if (isset($this->non_required_types[$field_name])) {
       foreach ($this->non_required_types[$field_name] as $key => $properties) {
-        $placeholder = ':' . $field_name . '_' . $key . '_' . $j;
-        $sql .= $placeholder . ', ';
-        $args[$placeholder] = $properties->getDefaultValue();
+        $column = $field_name . '_'. $key;
+        $values[$column] = $properties->getDefaultValue();
       }
     }
-    $sql = rtrim($sql, ", ");
-    $sql .= "),\n";
+    $insert_query->values($values);
+  }
+
+  /**
+   * Update an existing published field item.
+   * This is a helper function for insertFieldItems().
+   * Unlike insertOneFieldItem(), each update is a separate
+   * query because we need to include conditions.
+   *
+   * @param array $match
+   *   Contains all data to be published
+   * @param int $entity_id
+   *   Id of the entity for this field
+   * @param int $delta
+   *   Field delta
+   * @param string $field_name
+   *   Name of the field being published
+   * @param string $field_table
+   *   Name of the drupal field table
+   * @return void
+   */
+  private function updateOneFieldItem($match, $entity_id, $delta, $field_name, $field_table): void {
+    $values = [
+      'bundle' => $this->bundle,
+      'deleted' => 0,
+      'entity_id' => $entity_id,
+      'revision_id' => $entity_id,  // For an unversioned entity this is the same as the entity id
+      'langcode' => 'und',
+      'delta' => $delta,
+    ];
+    foreach ($this->required_types[$field_name] as $key => $properties) {
+      $column = $field_name . '_'. $key;
+      $value = $match[$field_name][$delta][$key]['value']->getValue();
+      // If there is no value, use a placeholder of the correct type, string '', int 0, etc.
+      if (is_null($value)) {
+        $value = $properties->getDefaultValue();
+      }
+      $values[$column] = $value;
+    }
+    // Non-required types never have a value stored, just a placeholder.
+    // There might not be non_required_types for this field.
+    if (isset($this->non_required_types[$field_name])) {
+      foreach ($this->non_required_types[$field_name] as $key => $properties) {
+        $column = $field_name . '_'. $key;
+        $values[$column] = $properties->getDefaultValue();
+      }
+    }
+    $update_query = $this->connection->update($field_table, [])->fields($values);
+    $update_query->condition('bundle', $this->bundle, '=');
+    $update_query->condition('entity_id', $entity_id, '=');
+    $update_query->condition('delta', $delta, '=');
+    $update_query->execute();
   }
 
   /**
@@ -1202,7 +1242,8 @@ class ChadoPublish extends TripalBackendPublishBase {
     }
     $this->logger->notice($message);
 
-    $total_items = 0;
+    $total_new_field_items = 0;
+    $total_republished_field_items = 0;
     $total_existing_entities = 0;
     $total_new_entities = 0;
     $total_updated_titles = 0;
@@ -1269,12 +1310,16 @@ class ChadoPublish extends TripalBackendPublishBase {
         foreach (array_keys($this->field_info) as $field_name) {
 
           $existing_field_items = $this->findFieldItems($field_name, $record_id_batch);
-          $num_inserted = $this->insertFieldItems($field_name, $matches, $existing_field_items, $titles);
+          [$num_inserted, $num_updated] = $this->insertFieldItems($field_name, $matches, $existing_field_items, $titles);
 
           // To reduce clutter, a log message is not shown for fields with no items added
           if ($num_inserted) {
             $this->logger->notice('  Published ' . number_format($num_inserted) . " items for field \"$field_name\"");
-            $total_items += $num_inserted;
+            $total_new_field_items += $num_inserted;
+          }
+          if ($num_updated) {
+            $this->logger->notice('  Republished ' . number_format($num_updated) . " items for field \"$field_name\"");
+            $total_republished_field_items += $num_updated;
           }
         }
       }
@@ -1298,7 +1343,11 @@ class ChadoPublish extends TripalBackendPublishBase {
     if ($total_updated_titles) {
       $message .= ", updated titles for " . number_format($total_updated_titles) . " entities";
     }
-    $message .= ", and added " . number_format($total_items) . " field values.";
+    $message .= ", added " . number_format($total_new_field_items) . " new field values";
+    if ($this->republish) {
+      $message .= ", and republished ". number_format($total_republished_field_items) . " existing field values";
+    }
+    $message .= '.';
     $this->logger->notice($message);
 
     // This return value is currently only used for unit tests, so is limited to 100 records.

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1186,6 +1186,34 @@ class ChadoPublish extends TripalBackendPublishBase {
   }
 
   /**
+   * Provides a final summary message for publish
+   *
+   * @param bool $success
+   *   TRUE if no errors encountered
+   * @param array $stats
+   *   Various statistics to display
+   * @return void
+   */
+  protected function publish_summarize(bool $success, array $stats): void {
+    $message = "Publish " . ($success?'completed.':'encountered errors.');
+    $message .= " Published " . number_format($stats['total_new_entities']) . " new entities";
+    // This summary value is displayed only when republish is specified
+    if ($this->republish) {
+      $message .= ", checked " . number_format($stats['total_existing_entities']) . " existing entities";
+    }
+    // Titles will be updated only if the entity title format was changed
+    if ($total_updated_titles) {
+      $message .= ", updated titles for " . number_format($stats['total_updated_titles']) . " entities";
+    }
+    $message .= ", added " . number_format($stats['total_new_field_items']) . " new field values";
+    if ($this->republish) {
+      $message .= ", and republished ". number_format($stats['total_republished_field_items']) . " existing field values";
+    }
+    $message .= '.';
+    $this->logger->notice($message);
+  }
+
+  /**
    * Publishes Chado content to Tripal entities.
    *
    * @param array $options
@@ -1333,22 +1361,13 @@ class ChadoPublish extends TripalBackendPublishBase {
     } // end of the batch loop
 
     // Present a final summary message, cumulative for all batches
-    $message = "Publish " . ($success?'completed.':'encountered errors.');
-    $message .= " Published " . number_format($total_new_entities) . " new entities";
-    // This summary value is displayed only when republish is specified
-    if ($this->republish) {
-      $message .= ", checked " . number_format($total_existing_entities) . " existing entities";
-    }
-    // Titles will be updated only if the entity title format was changed
-    if ($total_updated_titles) {
-      $message .= ", updated titles for " . number_format($total_updated_titles) . " entities";
-    }
-    $message .= ", added " . number_format($total_new_field_items) . " new field values";
-    if ($this->republish) {
-      $message .= ", and republished ". number_format($total_republished_field_items) . " existing field values";
-    }
-    $message .= '.';
-    $this->logger->notice($message);
+    $this->publish_summarize($success, [
+      'total_new_entities' => $total_new_entities,
+      'total_existing_entities' => $total_existing_entities,
+      'total_updated_titles' => $total_updated_titles,
+      'total_new_field_items' => $total_new_field_items,
+      'total_republished_field_items' => $total_republished_field_items,
+    ]);
 
     // This return value is currently only used for unit tests, so is limited to 100 records.
     return $this->published_or_updated_entities;


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2137

## Description

This PR updates the "Republish Existing Content" option of publish to update fields that are already published.
This allows an existing site to benefit from the changes from PR #2126 by republishing existing content, and it will now be cached in the drupal field tables.

I also took the opportunity to update `insertFieldItems()` to use query builder instead of concatenating sql code.

## Testing?
1. Create a contact in chado `INSERT INTO chado.contact (name) VALUES ('NCBI');`
2. Publish contact content type and run the job
3. Update the contact in chado `UPDATE chado.contact SET description='Where we blast stuff' WHERE name='NCBI';`
4. Publish contact specifying "Republish Existing Content"
5. Rebuild cache drush cache:rebuild
6. Go to the contact and observe the description has been added.
