### PR TITLE
Logging error with mixed job types

### DIFF
--- a/tripal/src/Services/TripalJob.php
+++ b/tripal/src/Services/TripalJob.php
@@ -726,13 +726,14 @@ class TripalJob {
    *   stack trace, it MUST be in a key named "exception".
    */
   public function log($message, $context=[]) {
-    // Generate a translated message.
-    $tmessage = t($message, $context);
-
+    // Generate a translated message. If $message is an object, it is already translated.
+    $tmessage = $message;
+    if (is_string($message)) {
+      $tmessage = t($message, $context);
+    }
     // For the sake of the command-line user, print the message to the
     // terminal.
     print $tmessage . "\n";
-
     // Add this message to the job's log.
     $this->job->error_msg .= "\n" . $tmessage;
   }

--- a/tripal/src/Services/TripalJob.php
+++ b/tripal/src/Services/TripalJob.php
@@ -731,9 +731,11 @@ class TripalJob {
     if (is_string($message)) {
       $tmessage = t($message, $context);
     }
+
     // For the sake of the command-line user, print the message to the
     // terminal.
     print $tmessage . "\n";
+
     // Add this message to the job's log.
     $this->job->error_msg .= "\n" . $tmessage;
   }


### PR DESCRIPTION
# Bug Fix

### Closes #2152

## Description
I must confess that I can't figure out why this only shows up when running two jobs, but the fix is simple.

To summarize, when we create tripal log messages, sometimes we pre-translate with `t()`. The guilty one for this issue is 
https://github.com/tripal/tripal/blob/a8d662dccd8c6624ecc58c21939123c7316282d0/tripal/src/Services/TripalEntityTypeCollection.php#L249-L250

The tripal logger will do the translating, so we really only need to pass a string and context, and skip the `t()` - nevertheless we can support pre-translating too since there are a number of places where this is done, and maybe other modules will call it this way.
The problem occurs when we try to apply `t()` to an already translated message object. The simple and fairly straightforward solution is to not try to translate an already translated object.

I have this as high priority because if you do encounter this error, you have broken your site for that type collection, you can't publish any of them. Nevertheless, it is an unlikely combination of jobs, which is why it hasn't been reported before.

## Testing?
1. Create a job to publish something, I used organism. It's okay if there aren't any organisms to publish. But don't run it yet!
2. Create a job to import a content type collection, I used expression.
3. Now run the jobs together. Both jobs should complete normally on this branch, see issue #2152 for error on 4.x
