### PR TITLE
Improve the performance of TripalEntity::load() by using the Drupal cache

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -860,7 +860,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       // to set them... if it did, then the following loadValues would not be
       // needed since the values would already be set.
       // @todo look into fixing insert/update to return all values.
-      $tripal_storages[$tsid]->loadValues($tsid_values);
+      // NOTE: We use FALSE here so that the values are loaded from the database.
+      $tripal_storages[$tsid]->loadValues($tsid_values, FALSE);
     }
 
     // Set the property values that should be saved in Drupal, everything
@@ -1041,6 +1042,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $load_success = False;
       foreach ($values as $tsid => $tsid_values) {
         try {
+          // If this storage backend is cache-aware then only the values for
+          // fields which have un-cached properties will be loaded here.
           $load_success = $tripal_storages[$tsid]->loadValues($tsid_values);
           if ($load_success) {
             $values[$tsid] = $tsid_values;

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -716,7 +716,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *   The returned array has two elements: an array of values as described
    *   above, and an array of TripalStorage objects,
    */
-  public static function getValuesArray($entity) {
+  public static function getValuesArray($entity, $ignore_cached_fields = FALSE) {
     $values = [];
     $tripal_storages = [];
     $fields = $entity->getFields();
@@ -754,39 +754,46 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $tripal_storages[$tsid] = $tripal_storage;
         }
 
-        // Add the field definition to the storage for this field.
-        $tripal_storages[$tsid]->addFieldDefinition($field_name, $item->getFieldDefinition());
-
         // Get the empty property values for this field item and the
         // property type objects.
         $prop_values = $item->tripalValuesTemplate($item->getFieldDefinition());
         $prop_types = get_class($item)::tripalTypes($item->getFieldDefinition());
 
-        // Sets the values from the entity on both the property and in entity.
-        // Despite the function name, no values are saved to the database.
-        $item->tripalSave($item, $field_name, $prop_types, $prop_values, $entity);
-
         // Ensure that only the properties that should be are cleared.
-        $tripal_storage->markPropertiesForCaching($field_name, $prop_types);
+        // Note: is_cached will only be true for this field if all properties
+        // for this field are cached in the drupal field tables.
+        $is_cached = $tripal_storage->markPropertiesForCaching($field_name, $prop_types);
 
-        // Clears the values from the entity (does not clear them from the
-        // property).
-        $item->tripalClear($item, $field_name, $prop_types, $prop_values, $entity);
+        // Only setup TripalStorage for this field if it is not cached
+        // or if we are not ignoring cached fields right now.
+        if (!$is_cached OR ($ignore_cached_fields == FALSE)) {
 
-        // Add the property types to the storage plugin.
-        $tripal_storages[$tsid]->addTypes($field_name, $prop_types);
+          // Add the field definition to the storage for this field.
+          $tripal_storages[$tsid]->addFieldDefinition($field_name, $item->getFieldDefinition());
 
-        // Prepare the property values for the storage plugin.
-        // Note: We are assuming the key for the value is the
-        // same as the key for the type here... This is a temporary assumption
-        // as soon the values array will not contain types ;-)
-        foreach ($prop_types as $prop_type) {
-          $key = $prop_type->getKey();
-          $values[$tsid][$field_name][$delta][$key] = [];
-        }
-        foreach ($prop_values as $prop_value) {
-          $key = $prop_value->getKey();
-          $values[$tsid][$field_name][$delta][$key]['value'] = $prop_value;
+          // Sets the values from the entity on both the property and in entity.
+          // Despite the function name, no values are saved to the database.
+          $item->tripalSave($item, $field_name, $prop_types, $prop_values, $entity);
+
+          // Clears the values from the entity (does not clear them from the
+          // property).
+          $item->tripalClear($item, $field_name, $prop_types, $prop_values, $entity);
+
+          // Add the property types to the storage plugin.
+          $tripal_storages[$tsid]->addTypes($field_name, $prop_types);
+
+          // Prepare the property values for the storage plugin.
+          // Note: We are assuming the key for the value is the
+          // same as the key for the type here... This is a temporary assumption
+          // as soon the values array will not contain types ;-)
+          foreach ($prop_types as $prop_type) {
+            $key = $prop_type->getKey();
+            $values[$tsid][$field_name][$delta][$key] = [];
+          }
+          foreach ($prop_values as $prop_value) {
+            $key = $prop_value->getKey();
+            $values[$tsid][$field_name][$delta][$key]['value'] = $prop_value;
+          }
         }
       }
     }
@@ -1035,66 +1042,72 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     foreach ($entities as $entity) {
       $bundle = $entity->bundle();
 
+      // @todo it would be great to skip the entity entirely if it is
+      // fully cached.
+
       // Create a values array appropriate for `loadValues()`
-      [$values, $tripal_storages] = TripalEntity::getValuesArray($entity);
+      [$values, $tripal_storages] = TripalEntity::getValuesArray($entity, TRUE);
 
-      // Call the loadValues() function for each storage type.
-      $load_success = False;
-      foreach ($values as $tsid => $tsid_values) {
-        try {
-          // If this storage backend is cache-aware then only the values for
-          // fields which have un-cached properties will be loaded here.
-          $load_success = $tripal_storages[$tsid]->loadValues($tsid_values);
-          if ($load_success) {
-            $values[$tsid] = $tsid_values;
+      // Only do the following if there are any values to load.
+      if (!empty($values)) {
+        // Call the loadValues() function for each storage type.
+        $load_success = FALSE;
+        foreach ($values as $tsid => $tsid_values) {
+          try {
+            // If this storage backend is cache-aware then only the values for
+            // fields which have un-cached properties will be loaded here.
+            $load_success = $tripal_storages[$tsid]->loadValues($tsid_values);
+            if ($load_success) {
+              $values[$tsid] = $tsid_values;
+            }
+          }
+          catch (\Exception $e) {
+            \Drupal::logger('tripal')->notice($e->getMessage());
+            \Drupal::messenger()->addError('Cannot load the entity. See the recent ' .
+                'logs for more details or contact the site administrator if you cannot ' .
+                'view the logs.');
           }
         }
-        catch (\Exception $e) {
-          \Drupal::logger('tripal')->notice($e->getMessage());
-          \Drupal::messenger()->addError('Cannot load the entity. See the recent ' .
-              'logs for more details or contact the site administrator if you cannot ' .
-              'view the logs.');
-        }
-      }
 
-      // Update the entity values with the values returned by loadValues().
-      $field_defs = $field_manager->getFieldDefinitions($entity_type_id, $bundle);
-      foreach ($field_defs as $field_name => $field_def) {
+        // Update the entity values with the values returned by loadValues().
+        $field_defs = $field_manager->getFieldDefinitions($entity_type_id, $bundle);
+        foreach ($field_defs as $field_name => $field_def) {
 
-        // Create a fieldItemlist and iterate through it.
-        $items = $field_type_manager->createFieldItemList($entity, $field_name, $entity->get($field_name)->getValue());
-        foreach($items as $item) {
+          // Create a fieldItemlist and iterate through it.
+          $items = $field_type_manager->createFieldItemList($entity, $field_name, $entity->get($field_name)->getValue());
+          foreach($items as $item) {
 
-          // If it is not a TripalField then skip it.
-          if (! $item instanceof TripalFieldItemInterface) {
-            continue;
+            // If it is not a TripalField then skip it.
+            if (! $item instanceof TripalFieldItemInterface) {
+              continue;
+            }
+            $delta = $item->getName();
+            $tsid = $item->tripalStorageId();
+
+            // If the Tripal Storage Backend is not set on a Tripal-based field,
+            // we will log an error and not support the field. If developers want
+            // to use Drupal storage for a Tripal-based field then they need to
+            // indicate that by using our Drupal SQL Storage option OR by not
+            // creating a Tripal-based field at all depending on their needs.
+            if (empty($tsid)) {
+              \Drupal::logger('tripal')->error('The Tripal-based field :field on
+                this content type must indicate a TripalStorage backend and currently does not.',
+                [':field' => $field_name]
+              );
+              continue;
+            }
+
+            // Create a new properties array for this field item.
+            $prop_values = [];
+            $prop_types = [];
+            foreach ($values[$tsid][$field_name][$delta] as $key => $info) {
+              $prop_values[] = $info['value'];
+              $prop_types[] = $tripal_storages[$tsid]->getPropertyType($bundle, $field_name, $key);
+            }
+
+            // Now set the entity values for this field.
+            $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $entity);
           }
-          $delta = $item->getName();
-          $tsid = $item->tripalStorageId();
-
-          // If the Tripal Storage Backend is not set on a Tripal-based field,
-          // we will log an error and not support the field. If developers want
-          // to use Drupal storage for a Tripal-based field then they need to
-          // indicate that by using our Drupal SQL Storage option OR by not
-          // creating a Tripal-based field at all depending on their needs.
-          if (empty($tsid)) {
-            \Drupal::logger('tripal')->error('The Tripal-based field :field on
-              this content type must indicate a TripalStorage backend and currently does not.',
-              [':field' => $field_name]
-            );
-            continue;
-          }
-
-          // Create a new properties array for this field item.
-          $prop_values = [];
-          $prop_types = [];
-          foreach ($values[$tsid][$field_name][$delta] as $key => $info) {
-            $prop_values[] = $info['value'];
-            $prop_types[] = $tripal_storages[$tsid]->getPropertyType($bundle, $field_name, $key);
-          }
-
-          // Now set the entity values for this field.
-          $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $entity);
         }
       }
     }

--- a/tripal/src/Plugin/TripalStorage/DrupalSqlStorage.php
+++ b/tripal/src/Plugin/TripalStorage/DrupalSqlStorage.php
@@ -78,7 +78,7 @@ class DrupalSqlStorage extends TripalStorageBase implements TripalStorageInterfa
   /**
    * {@inheritDoc}
    */
-  public function loadValues(&$values): bool {
+  public function loadValues(&$values, bool $ignore_cached_fields = TRUE): bool {
     // No need to do anything here.  This is handled by the
     // default SQL storage provided by Drupal
     return TRUE;

--- a/tripal/src/TripalStorage/Interfaces/TripalStorageInterface.php
+++ b/tripal/src/TripalStorage/Interfaces/TripalStorageInterface.php
@@ -182,11 +182,14 @@ interface TripalStorageInterface extends PluginInspectionInterface {
    *   - "value": a \Drupal\tripal\TripalStorage\StoragePropertyValue object
    *   - "type": a\Drupal\tripal\TripalStorage\StoragePropertyType object
    *   - "definition": a \Drupal\Field\Entity\FieldConfig object
+   * @param bool $ignore_cached_fields
+   *   If TRUE then values from fully cached fields should be ignored as they
+   *   will be loaded by Drupal; if FALSE then load them from the storage backend.
    *
    * @return bool
    *   True if successful. False otherwise.
    */
-  public function loadValues(&$values) : bool;
+  public function loadValues(&$values, bool $ignore_cached_fields = TRUE) : bool;
 
   /**
    * Deletes the given array of property values from this tripal storage plugin.

--- a/tripal/src/TripalStorage/TripalStorageBase.php
+++ b/tripal/src/TripalStorage/TripalStorageBase.php
@@ -32,13 +32,26 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
 
   /**
    * An associative array that contains all of the property types that
-   * have been added to this object. It is indexed by entityType ->
-   * fieldName -> key and the value is the
-   * Drupal\tripal\TripalStorage\StoragePropertyValue object.
+   * have been added to this object. It is indexed by fieldName -> key and the
+   * value is the Drupal\tripal\TripalStorage\StoragePropertyValue object.
    *
    * @var array
    */
   protected $property_types = [];
+
+  /**
+   * Keeps track of which fields are fully cached by Drupal and which are not.
+   *
+   * This should be used by the specific storage backend during loadValues()
+   * to improve performance by not looking up the values of fields which do
+   * not need it.
+   *
+   * @var array
+   *   This array will contain an entry (key) for each field where the value
+   *   is either TRUE to indicate that all properties for this field are cached
+   *   or FALSE if at least one property in the field is not cached.
+   */
+  protected $cached_fields = [];
 
   /**
    * Caches the default value for entity field caching from the configuration.
@@ -124,7 +137,7 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
    */
   public function addTypes(string $field_name, array $types) {
 
-    // Index the types by their entity type, field type and key.
+    // Index the types by their field name and key.
     foreach ($types as $index => $type) {
       if (!is_object($type)) {
         $this->logger->error('Type provided must be an object but instead index @index was a @type',
@@ -274,6 +287,9 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
    */
   public function markPropertiesForCaching(string $field_name, array &$prop_types) {
 
+    // We want to keep track of whether all the properties are cached (TRUE).
+    $all_cached = TRUE;
+
     // For each of the property types, we want to check if they should be cached.
     foreach ($prop_types as $k => $prop_type) {
       $key = $prop_type->getKey();
@@ -282,7 +298,13 @@ abstract class TripalStorageBase extends PluginBase implements TripalStorageInte
       $is_required = $this->isDrupalStoreByFieldNameKey($field_name, $key, $prop_type);
       // And set it on the property type.
       $prop_types[$k]->setCacheStatus($is_required);
+
+      if (!$is_required) {
+        $all_cached = FALSE;
+      }
     }
+
+    $this->cached_fields[$field_name] = $all_cached;
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -278,7 +278,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
 
     // We can actually skip this entire process if all the fields are 100% cached.
     // The cached_fields indicates for each field (key) if it is fully cached (TRUE)
-    // or not (FALSE). Thus is not fields in this variable are false then
+    // or not (FALSE). Thus if no fields in this variable are false then
     // all the fields are cached!
     if ($ignore_cached_fields AND (array_search(FALSE, $this->cached_fields, TRUE) === FALSE)) {
       return TRUE;

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -270,7 +270,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
   /**
    * @{inheritdoc}
    */
-  public function loadValues(&$values) : bool {
+  public function loadValues(&$values, bool $ignore_cached_fields = TRUE) : bool {
 
     // Setup field debugging.
     $this->field_debugger->printHeader('Load');
@@ -280,16 +280,21 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     // The cached_fields indicates for each field (key) if it is fully cached (TRUE)
     // or not (FALSE). Thus is not fields in this variable are false then
     // all the fields are cached!
-    if (array_search(FALSE, $this->cached_fields, TRUE) === FALSE) {
+    if ($ignore_cached_fields AND (array_search(FALSE, $this->cached_fields, TRUE) === FALSE)) {
       return TRUE;
     }
 
     // Build the ChadoRecords object.
     $this->records = new ChadoRecords($this->field_debugger, $this->logger, $this->connection);
 
-    // Parameters indicate this is not a find action and that we should not add
-    // any properties for fields which are 100% cached in drupal to ChadoRecords.
-    $this->buildChadoRecords($values, FALSE, TRUE);
+    if ($ignore_cached_fields) {
+      // Parameters indicate this is not a find action and that we should not add
+      // any properties for fields which are 100% cached in drupal to ChadoRecords.
+      $this->buildChadoRecords($values, FALSE, TRUE);
+    }
+    else {
+      $this->buildChadoRecords($values);
+    }
 
     $transaction_chado = $this->connection->startTransaction();
     try {

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -276,9 +276,20 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $this->field_debugger->printHeader('Load');
     $this->field_debugger->summarizeChadoStorage($this, 'At the beginning of ChadoStorage::loadValues');
 
+    // We can actually skip this entire process if all the fields are 100% cached.
+    // The cached_fields indicates for each field (key) if it is fully cached (TRUE)
+    // or not (FALSE). Thus is not fields in this variable are false then
+    // all the fields are cached!
+    if (array_search(FALSE, $this->cached_fields, TRUE) === FALSE) {
+      return TRUE;
+    }
+
     // Build the ChadoRecords object.
     $this->records = new ChadoRecords($this->field_debugger, $this->logger, $this->connection);
-    $this->buildChadoRecords($values);
+
+    // Parameters indicate this is not a find action and that we should not add
+    // any properties for fields which are 100% cached in drupal to ChadoRecords.
+    $this->buildChadoRecords($values, FALSE, TRUE);
 
     $transaction_chado = $this->connection->startTransaction();
     try {
@@ -661,13 +672,25 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    *   will be set in the StoragePropertyValue object.
    * @param bool $is_find
    *   Set to TRUE if we are building the record array for finding records.
+   * @param bool $ignore_cached
+   *   If this is set to TRUE then any values that are part of a field where
+   *   all properties are cached in Drupal are not added to ChadoRecords.
    */
-  protected function buildChadoRecords($values, bool $is_find = FALSE) {
+  protected function buildChadoRecords($values, bool $is_find = FALSE, bool $ignore_cached = FALSE) {
 
     $this->field_debugger->reportValues($values, 'The values submitted to ChadoStorage');
 
     // Iterate through the value objects.
     foreach ($values as $field_name => $deltas) {
+
+      // Check if this field is 100% cached in drupal.
+      $field_cached = (array_key_exists($field_name, $this->cached_fields)) ? $this->cached_fields[$field_name] : FALSE;
+
+      // If we are supposed to ignore cached fields and the current field is
+      // 100% cached, then we can skip this field.
+      if ($ignore_cached AND $field_cached) {
+        continue;
+      }
 
       // Retrieve the field configuration.
       $definition = $this->getFieldDefinition($field_name);

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -290,10 +290,10 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     if ($ignore_cached_fields) {
       // Parameters indicate this is not a find action and that we should not add
       // any properties for fields which are 100% cached in drupal to ChadoRecords.
-      $this->buildChadoRecords($values, FALSE, TRUE);
+      $this->buildChadoRecords($values, TRUE, TRUE);
     }
     else {
-      $this->buildChadoRecords($values);
+      $this->buildChadoRecords($values, TRUE);
     }
 
     $transaction_chado = $this->connection->startTransaction();

--- a/tripal_chado/tests/src/Traits/ChadoStorageTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoStorageTestTrait.php
@@ -247,6 +247,8 @@ trait ChadoStorageTestTrait {
 
     $success = $this->chadoStorage->insertValues($this->dataStoreValues);
     $this->assertTrue($success, 'We were not able to insert the data.');
+
+    $this->chadoStorage->loadValues($this->dataStoreValues, FALSE);
   }
 
   /**
@@ -333,7 +335,7 @@ trait ChadoStorageTestTrait {
     // Set the values in the propertyValue objects.
     $this->setExpectedValues($field_names, $values);
 
-    $success = $this->chadoStorage->loadValues($this->dataStoreValues);
+    $success = $this->chadoStorage->loadValues($this->dataStoreValues, FALSE);
     $this->assertTrue($success, 'We were not able to load the data.');
 
     return $this->dataStoreValues;
@@ -427,6 +429,8 @@ trait ChadoStorageTestTrait {
 
     $success = $this->chadoStorage->updateValues($this->dataStoreValues);
     $this->assertTrue($success, 'We were not able to update the data.');
+
+    $this->chadoStorage->loadValues($this->dataStoreValues, FALSE);
 
     return $this->dataStoreValues;
   }
@@ -609,6 +613,7 @@ trait ChadoStorageTestTrait {
   public function addPropertyTypes2ChadoStorage($field_names, $expected_property_counts) {
 
     foreach ($this->propertyTypes as $field_name => $properties) {
+      $this->chadoStorage->markPropertiesForCaching($field_name, $properties);
       $this->chadoStorage->addTypes($field_name, $properties);
     }
     $retrieved_types = $this->chadoStorage->getTypes();


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #2158 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR allows the TripalEntity::postLoad() and ChadoStorage::loadValues() to ingnore loading TripalFields where all properties are cached in Drupal. This provides an insane speed boost 😍 especially when loading many entities like in a search or view.

How does it work?
1. A previous PR (#2126) ensured that by default almost all TripalFields cache their chado values in the drupal field table. This was done for views integration but will also be used here. As such, during save:
    1. The values submitted by the fields are inserted into Chado
    2. These values are then loaded from Chado into the Drupal fields using ChadoStorage::loadValues with $ignore_cached_fields set to FALSE.
    3. Drupal then saves the loaded values into the drupal field tables.
2. Drupal then uses the SqlContentEntityStorage to load all the field values that were cached in Drupal during TripalEntity::load().
3. During TripalEntity::postLoad() we used to look up the values in chado for all fields and replace the ones set by Drupal but now we only do that for fields which contain some properties that are not cached (i.e. ChadoSequenceTypeDefault). We simply leave any fields are fully cached in Drupal alone. Additionally, we don't even setup the TripalStorage object for fields that are fully cached and all entities with only fully cached fields are essentially skipped during the postLoad().

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

## Automated testing

This change is fully tested by the tests added in PR #2147 which confirms that all the values are being saved to chado and drupal as expected and being loaded as expected.

## Manual testing

1. Create a new docker on this branch.
2. Go to Top admin bar > Tripal > Page Structure > Import type collections and import the genomic collection.
3. Go to Top admin bar > Tripal > Content > "Add Tripal Content"
4. Add a few contacts, then add an project making sure to relate the contacts you created.
5. Confirm that creating and editing the project and contacts works as expected by looking at the underlying chado and drupal field tables. This checks the cases where all fields are 100% cached and checks a variety of different fields including linker fields. This should all function the same as on 4.x but with a small speed increase. The main speed increase is in loading.
6. Next create an organism (fill in the infraspecific type) and a gene (fill in the sequence residues).
7. Confirm that creating and editing works as expected -especially the sequence residues! This tests the case where a field is not 100% cached since the residues should not be saved in the drupal field table but should still appear on the page during view and prefilled in the form on edit. Also confirm the computed style fields for the checksum and length also work.
8. Finally lets test the publish. For this we want to publish the contacts. This should populate the project link which was added to chado by the project. Run the job and then view the contact fields to ensure the project is now listed and is a link.
9. For extra completeness, feel free to import a GFF3 and fasta for the genes and publish them. This job should complete without error and the sequence should be viewable through the gene pages.

