### PR TITLE
Enforce allowed title tags for publish and in tripal entity

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -7,6 +7,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Component\Utility\Xss;
 use Drupal\user\UserInterface;
 use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
 
@@ -206,6 +207,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $token_values = $this->getBundleEntityTokenValues($title_format, $bundle);
       $title = $token_parser->replaceTokens($title_format, $token_values);
     }
+
+    // HTML token filtering for titles
+    $tag_string = \Drupal::config('tripal.settings')->get('tripal_entity_type.allowed_title_tags') ?? '';
+    $allowed_title_tags = explode(' ', $tag_string);
+    $title = Xss::filter($title, $allowed_title_tags);
 
     $this->title = $title;
     return $title;

--- a/tripal/src/TripalBackendPublish/TripalBackendPublishBase.php
+++ b/tripal/src/TripalBackendPublish/TripalBackendPublishBase.php
@@ -117,6 +117,14 @@ abstract class TripalBackendPublishBase extends PluginBase implements TripalBack
   protected $republish = FALSE;
 
   /**
+   * Valid HTML tags for titles.
+   * This is configurable through entity settings at /admin/tripal/config/entity_settings
+   *
+   * @var array $allowed_title_tags
+   */
+  protected array $allowed_title_tags = [];
+
+  /**
    * Implements ContainerFactoryPluginInterface->create().
    *
    * Since we have implemented the ContainerFactoryPluginInterface this static function

--- a/tripal/tests/src/Kernel/Entity/TripalEntityFieldTest-TestInfo.yml
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityFieldTest-TestInfo.yml
@@ -57,6 +57,34 @@ scenarios:
         - value: "Amazonite"
         metaphysical_props:
         - value: "Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work."
+  - label: "Use format for title + URL with HTML included"
+    description: "Create a page where every field has one value and the title/path are left empty."
+    create:
+      title: 'TEST Gemstones <em>amazonite</em> Entity #1'
+      url: '/test/test_gemstone/amazonite/1'
+      user_input:
+        common_name:
+        - value: "<p>amazonite</p>"
+        metaphysical_props:
+        - value: "soothing, calming, healing from grief"
+      expected:
+        common_name:
+        - value: "<p>amazonite</p>"
+        metaphysical_props:
+        - value: "soothing, calming, healing from grief"
+    edit:
+      title: 'TEST Gemstones <em><i>Amazo</i>nite</em> Entity #1'
+      url: '/test/test_gemstone/amazonite/1'
+      user_input:
+        common_name:
+        - value: "<p><i>Amazo</i>nite</p>"
+        metaphysical_props:
+        - value: "Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work."
+      expected:
+        common_name:
+        - value: "<p><i>Amazo</i>nite</p>"
+        metaphysical_props:
+        - value: "Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work."
   - label: "User submitted alias when creating"
     description: "Create a page where every field has one value, the title sets a value (should be ignored) and the path is set (should be respected)."
     create:

--- a/tripal/tests/src/Kernel/Entity/TripalEntityFieldTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityFieldTest.php
@@ -114,6 +114,11 @@ class TripalEntityFieldTest extends TripalTestKernelBase {
 
     $scenarios[] = [
       1,
+      "Use format for title + URL with HTML included"
+    ];
+
+    $scenarios[] = [
+      2,
       "User submitted alias when creating",
     ];
 

--- a/tripal/tests/src/Traits/TripalEntityFieldTestTrait.php
+++ b/tripal/tests/src/Traits/TripalEntityFieldTestTrait.php
@@ -223,6 +223,13 @@ trait TripalEntityFieldTestTrait {
         ->save();
     }
 
+    // Update entity settings to match tripal/config/install/tripal.settings.yml
+    $allowed_title_tags = 'em i strong u';
+    \Drupal::configFactory()
+      ->getEditable('tripal.settings')
+      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
+      ->save();
+
     // If information about the environment to be setup was provided, then we
     // will set it up for them :-).
     if (!empty($system_under_test)) {

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\TripalBackendPublish;
 
+use Drupal\Component\Utility\Xss;
 use \Drupal\tripal\TripalStorage\StoragePropertyValue;
 use Drupal\tripal\TripalBackendPublish\TripalBackendPublishBase;
 use Drupal\tripal\TripalBackendPublish\Exceptions\TripalPublishException;
@@ -516,7 +517,8 @@ class ChadoPublish extends TripalBackendPublishBase {
       // Now that we've gotten the values out of the property value objects,
       // we can use the token parser to get the title!
       $entity_title = $this->token_parser->replaceTokens($title_format, $token_values);
-      $titles[$record_id] = $entity_title;
+      $sanitized_title = Xss::filter($entity_title, $this->allowed_title_tags);
+      $titles[$record_id] = $sanitized_title;
       // Save the token values, we will need them again when we generate the URL Alias
       $this->token_values[$record_id] = $token_values;
     }
@@ -1212,6 +1214,10 @@ class ChadoPublish extends TripalBackendPublishBase {
 
     // The current user will be the author of any newly published entitites
     $this->uid = \Drupal::currentUser()->id();
+
+    // List of allowed HTML tags in entity titles
+    $tag_string = \Drupal::config('tripal.settings')->get('tripal_entity_type.allowed_title_tags');
+    $this->allowed_title_tags = explode(' ', $tag_string ?? '');
 
     // Initialize class variables that may persist between consecutive jobs
     $this->field_info = [];

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -40,6 +40,13 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     // Get Chado in place
     $this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
+    // Update configuration to match tripal/config/install/tripal.settings.yml
+    $allowed_title_tags = 'em i strong u';
+    \Drupal::configFactory()
+      ->getEditable('tripal.settings')
+      ->set('tripal_entity_type.allowed_title_tags', $allowed_title_tags)
+      ->save();
+
     // Create three organisms in chado to be published.
     for ($i=1; $i <= 3; $i++) {
       $this->connection->insert('1:organism')

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -48,10 +48,12 @@ class ChadoPublishTest extends ChadoTestKernelBase {
       ->save();
 
     // Create three organisms in chado to be published.
+    // Note: We added HTML to the genus (not approved tag) to confirm that
+    // unallowed tags are being filtered and allowed ones are being kept.
     for ($i=1; $i <= 3; $i++) {
       $this->connection->insert('1:organism')
         ->fields([
-          'genus' => 'Tripalus',
+          'genus' => '<p>Tripalus</p>',
           'species' => 'databasica ' . $i,
           'comment' => "Entry $i: we are adding a comment to ensure that we do have working fields that are not required.",
         ])->execute();

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -40,7 +40,7 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     // Get Chado in place
     $this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
-    // Update configuration to match tripal/config/install/tripal.settings.yml
+    // Update entity settings to match tripal/config/install/tripal.settings.yml
     $allowed_title_tags = 'em i strong u';
     \Drupal::configFactory()
       ->getEditable('tripal.settings')


### PR DESCRIPTION
# Bug Fix

### Closes #2164 

## Description

We have configuration to control what HTML tags are allowed in a title. This is not being enforced when you enter a title through the UI, paragraph tags are being saved (and any other tag too).
The same applies to publish, tags are getting through.

In the past, the config value of valid tags was not used for data entry or publish, but was only used in the entity list builder tripal/src/ListBuilders/TripalEntityListBuilder.php, however that is no longer used, because with https://github.com/tripal/tripal/pull/2117 we now use a Drupal view for the entity list.

This PR uses the configuration setting when setting the title in tripal entity, and during publish.

## Testing?

The easiest content type to test is publication, enter a title with various tags, including some non-allowed ones. You need to set the title field to "Source" and you can enter any tag.

Save and confirm entity title only has allowed tags `select * from tripal_entity;`
Check the chado table and all the tags should be there `select * from pub;`

Unpublish and then publish the publication.
Results should be the same.
