### PR TITLE
Clear cache for republished entities

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -666,6 +666,16 @@ class ChadoPublish extends TripalBackendPublishBase {
       }
     }
 
+    // If we are going to republish, then clear the cache for all of the
+    // existing entities because we may change titles or field values.
+    if ($this->republish) {
+      $tags = [];
+      foreach ($this->existing_published_entities as $entity_id) {
+        $tags[] = 'tripal_entity:' . $entity_id;
+      }
+      \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
+    }
+
     return $titles;
   }
 

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -671,9 +671,12 @@ class ChadoPublish extends TripalBackendPublishBase {
     if ($this->republish) {
       $tags = [];
       foreach ($this->existing_published_entities as $entity_id) {
-        $tags[] = 'tripal_entity:' . $entity_id;
+        $tags[] = 'values:tripal_entity:' . $entity_id;
       }
-      \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
+      if ($tags) {
+        \Drupal::service('cache.entity')->invalidateMultiple($tags);
+        \Drupal::service('cache_tags.invalidator')->invalidateTags(['rendered']);
+      }
     }
 
     return $titles;
@@ -797,12 +800,18 @@ class ChadoPublish extends TripalBackendPublishBase {
     $storage = \Drupal::entityTypeManager()->getStorage('tripal_entity');
     $entities = $storage->loadMultiple($entity_ids);
     $index = 0;
+    $tags = [];
     foreach ($entities as $entity_id => $entity) {
       $record_id = $added_record_ids[$index];
       $entity->setTokenValues($this->token_values[$record_id]);
       $entity->setAlias();
-      $entity->save();
+      $tags[] = 'values:tripal_entity:' . $entity_id;
       $index++;
+    }
+    // Clear cache so that fields will appear on new entities
+    if ($index) {
+      \Drupal::service('cache.entity')->invalidateMultiple($tags);
+      \Drupal::service('cache_tags.invalidator')->invalidateTags(['rendered']);
     }
   }
 


### PR DESCRIPTION
# New Feature

### Closes #2169 

## Description

When republishing content, the title may be updated if the title format was changed, fields may have been added to the content type, or field values may be updated if values in chado were updated.
This PR adds cache invalidation for new and for republished entities, because otherwise you need a full cache rebuild after publishing to see the changes for republished content.

I was able to also remove the `$entity->save()` by replacing it with a cache clear for the new entities.

My one concern is that this `\Drupal::service('cache_tags.invalidator')->invalidateTags(['rendered']);` will, I assume, invalidate all render tags, but it will still be faster than a full cache rebuild.

### Timings

I created a publication importer for all pubs with "carrot" in the title in the last 1000 days, which loaded ~~233~~ 10 publications (see bug in #2172 why only ten)

On 4.x:
Cumulative time doing `$entity->save()` = 0.059466 second

On this branch:
Initial publish clear cache new entities: 0.000350 second
Republish, clear cache existing entities: 0.011120 (no content had been viewed)
If I view ten publications, and republish a second time, the republish time actually decreased to 0.003930

None of these times are particulary long, but removing save does seem to be beneficial.

## Testing?

Example of testing on publication.
1. Create a publication importer and import at least one publication.
2. Publish - verify that fields are present and not just the title.
3. Now edit the publication title format, add another field or just some fixed text
4. Check for new fields, hopefully there will be several
5. And change a value in chado, e.g. `update pub set publisher='tripal' where pub_id=2;`
6. Publish with republish set
7. View and confirm expected changes appear without needing a cache rebuild.