### PR TITLE
Import pubs in batches

### DIFF
--- a/tripal/src/Form/PubSearchQueryForm.php
+++ b/tripal/src/Form/PubSearchQueryForm.php
@@ -837,6 +837,17 @@ class PubSearchQueryForm extends FormBase {
           }
         }
       }
+
+      // Call plugin-specific form validation
+      $plugin_id = $user_input['plugin_id'] ?? NULL;
+      if ($plugin_id) {
+        // Instantiate the selected plugin
+        // Pub Library Manager is found in tripal module:
+        // tripal/tripal/src/TripalPubLibrary/PluginManagers/TripalPubLibraryManager.php
+        $pub_library_manager = \Drupal::service('tripal.pub_library');
+        $plugin = $pub_library_manager->createInstance($plugin_id, []);
+        $plugin->formValidate($form, $form_state);
+      }
     }
   }
 

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -158,16 +158,14 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * @ingroup tripal_pub
    */
   public function remoteSearchPMID($search_array, $num_to_retrieve, $page, $row_mode = 1): ?array {
+    $api_key = $search_array['ncbi_api_key'] ?? $search_array['form_state_user_input']['ncbi_api_key'] ?? '';
     // Only initialize for page zero, subsequent pages use the established query
     if ($page == 0) {
+      $days = $search_array['days'] ?? '';
+
       // convert the terms list provided by the caller into a string with words
       // separated by a '+' symbol.
       $num_criteria = $search_array['num_criteria'];
-      $days = NULL;
-      if (isset($search_array['days'])) {
-        $days = $search_array['days'];
-      }
-
       $search_str = '';
 
       for ($i = 1; $i <= $num_criteria; $i++) {
@@ -235,7 +233,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       }
 
       // Initialize the remote query
-      if (!$this->pmidSearchInit($search_str, $num_to_retrieve)) {
+      if (!$this->pmidSearchInit($search_str, $num_to_retrieve, $api_key)) {
         return NULL;
       }
     }
@@ -255,7 +253,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     }
 
     // Get the list of PMIDs from the initialized search
-    $pmids_txt = $this->pmidFetch('uilist', 'text', $start, $num_to_retrieve);
+    $pmids_txt = $this->pmidFetch('uilist', 'text', $start, $num_to_retrieve, $api_key, []);
     if (is_null($pmids_txt)) {
       return NULL;
     }
@@ -266,7 +264,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     $n_skipped = 0;
     foreach ($pmids as $pmid) {
       // Retrieve and parse each record.
-      $pub_xml = $this->pmidFetch('null', 'xml', 0, 1, ['id' => $pmid]);
+      $pub_xml = $this->pmidFetch('null', 'xml', 0, 1, $api_key, ['id' => $pmid]);
       if (is_null($pub_xml)) {
         // Skip over any individual publication that had a download error
         $n_skipped++;
@@ -294,17 +292,19 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * containing the Count, WebEnv and QueryKey as returned
    * by PubMed's esearch utility.
    *
-   * @param $search_str
+   * @param string $search_str
    *   The PubMed Search string
-   * @param $retmax
+   * @param int $retmax
    *   The maximum number of records to return
+   * @param string $api_key
+   *   The optional NCBI API key
    *
    * @return bool
    *   TRUE for success, FALSE for error.
    *
    * @ingroup tripal_pub
    */
-  private function pmidSearchInit($search_str, $retmax): bool {
+  private function pmidSearchInit(string $search_str, int $retmax, string $api_key = ''): bool {
 
     // do a search for a single result so that we can establish a history, and get
     // the number of records. Once we have the number of records we can retrieve
@@ -315,9 +315,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       "&usehistory=y" .
       "&term=" . urlencode($search_str);
 
-    $api_key = \Drupal::state()->get('tripal_pub_importer_ncbi_api_key', NULL);
     $sleep_time = 333334;
-    if (!empty($api_key)) {
+    if ($api_key) {
       $query_url .= "&api_key=" . $api_key;
       $sleep_time = 100000;
     }
@@ -373,15 +372,17 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * Retrieves from PubMed a set of publications from the
    * previously initiated query.
    *
-   * @param $rettype
+   * @param string $rettype
    *   The efetch return type
-   * @param $retmod
+   * @param string $retmod
    *   The efetch return mode
-   * @param $start
+   * @param int $start
    *   The start of the range to retrieve
-   * @param $limit
+   * @param int $limit
    *   The number of publications to retrieve
-   * @param $args
+   * @param string $api_key
+   *   The optional NCBI API key
+   * @param array $args
    *   Any additional arguments to add the efetch query URL
    *
    * @return string|NULL
@@ -389,7 +390,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *
    * @ingroup tripal_pub
    */
-  private function pmidFetch($rettype = 'null', $retmod = 'null', $start = 0, $limit = 10, $args = []): ?string {
+  private function pmidFetch(string $rettype, string $retmod, int $start,
+                             int $limit, string $api_key, array $args): ?string {
 
     // repeat the search performed previously (using WebEnv & QueryKey) to retrieve
     // the PMID's within the range specied.  The PMIDs will be returned as a text list
@@ -402,9 +404,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       "&query_key=" . $this->webquery['QueryKey'] .
       "&WebEnv=" . $this->webquery['WebEnv'];
 
-    $api_key = \Drupal::state()->get('tripal_pub_importer_ncbi_api_key', NULL);
     $sleep_time = 333334;
-    if (!empty($api_key)) {
+    if ($api_key) {
       $fetch_url .= "&api_key=" . $api_key;
       $sleep_time = 100000;
     }
@@ -421,7 +422,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
         $fetch_url .= "&$key=$value";
       }
     }
-    usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
+    usleep($sleep_time);  // 1/3 or 1/10 of a second delay, NCBI limits requests to 3 / second without API key
     $rfh = fopen($fetch_url, "r");
     if (!$rfh) {
       $this->logger->error("Could not perform PubMed query: $fetch_url.");

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -42,12 +42,20 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
   public function form_submit(array $form, \Drupal\Core\Form\FormStateInterface $form_state, array &$criteria): void {
     $user_input = $form_state->getUserInput();
     $criteria['days'] = $user_input['days'];
+    $criteria['ncbi_api_key'] = $user_input['ncbi_api_key'];
+
+    // If an NCBI API key was entered, store it as the default for new queries
+    if ($criteria['ncbi_api_key']) {
+      \Drupal::state()->set('tripal_pub_importer_ncbi_api_key', $criteria['ncbi_api_key']);
+    }
   }
 
   /**
    * Adds plugin specific form items and returns the $form array
    */
   public function form(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): array {
+    $default_api_key = \Drupal::state()->get('tripal_pub_importer_ncbi_api_key', '');
+
     // Add form elements specific to this parser.
     $api_key_description = t('Tripal imports publications using NCBI\'s ')
       . Link::fromTextAndUrl('EUtils API',
@@ -71,7 +79,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       '#type' => 'textfield',
       '#description' => $api_key_description,
       '#required' => FALSE,
-      //to-do add ajax callback to populate?
+      '#default_value' => $default_api_key,
       '#size' => 20,
     ];
 

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -257,7 +257,6 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     $pubs = [];
     foreach ($pmids as $pmid) {
       // Retrieve and parse each record.
-print "CPP1 downloading $pmid\n";//@@@
       $pub_xml = $this->pmidFetch('null', 'xml', 0, 1, ['id' => $pmid]);
       $pub = $this->parse_xml($pub_xml);
       $pubs[] = $pub;

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -481,52 +481,52 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
           case 'BookDocument':
             $this->pmidParseBookDocument($xml, $pub);
             break;
-          case 'ChemicalList':
+          // case 'ChemicalList':
             // TODO: handle this
-            break;
-          case 'CitationSubset':
+            // break;
+          // case 'CitationSubset':
             // TODO: not sure this is needed.
-            break;
-          case 'CommentsCorrections':
+            // break;
+          // case 'CommentsCorrections':
             // TODO: handle this
-            break;
-          case 'DeleteCitation':
+            // break;
+          // case 'DeleteCitation':
             // TODO: need to know how to handle this
-            break;
+            // break;
           case 'ERROR':
             $xml->read(); // get the value for this element
             $this->logger->error('XML Internal Error: @err', ['@err' => $xml->value]);
             break;
-          case 'GeneralNote':
+          // case 'GeneralNote':
             // TODO: handle this
-            break;
-          case 'GeneSymbolList':
+            // break;
+          // case 'GeneSymbolList':
             // TODO: handle this
-            break;
-          case 'InvestigatorList':
+            // break;
+          // case 'InvestigatorList':
             // TODO: personal names of individuals who are not authors (can be used with collection)
-            break;
-          case 'KeywordList':
+            // break;
+          // case 'KeywordList':
             // TODO: handle this
-            break;
+            // break;
           case 'MedlineJournalInfo':
             $this->pmidParseMedlineJournalInfo($xml, $pub);
             break;
-          case 'MeshHeadingList':
+          // case 'MeshHeadingList':
             // TODO: Medical subject headings
-            break;
-          case 'NumberOfReferences':
+            // break;
+          // case 'NumberOfReferences':
             // TODO: not sure we should keep this as it changes frequently.
-            break;
-          case 'OtherAbstract':
+            // break;
+          // case 'OtherAbstract':
             // TODO: when the journal does not contain an abstract for the publication.
-            break;
-          case 'OtherID':
+            // break;
+          // case 'OtherID':
             // TODO: ID's from another NLM partner.
-            break;
-          case 'PersonalNameSubjectList':
+            // break;
+          // case 'PersonalNameSubjectList':
             // TODO: for works about an individual or with biographical note/obituary.
-            break;
+            // break;
           case 'PMID':
             // There are multiple places where a PMID is present in the XML and
             // since this code does not descend into every branch of the XML tree,
@@ -539,9 +539,9 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
               $pub['Publication Dbxref'] = $xml->value;
             }
             break;
-          case 'SupplMeshList':
+          // case 'SupplMeshList':
             // TODO: meant for protocol list
-            break;
+            // break;
           default:
             break;
         }

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -131,7 +131,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       $results = $this->remoteSearchPMID($query, $limit, $page);
     }
     catch (\Exception $e) {
-      \Drupal::service('tripal.logger')->error($e->getMessage());
+      $this->logger->error($e->getMessage());
     }
     return $results;
   }
@@ -270,7 +270,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       if (is_null($pub_xml)) {
         // Skip over any individual publication that had a download error
         $n_skipped++;
-        \Drupal::service('tripal.logger')->error('Skipping publication @acc due to download error.',
+        $this->logger->error('Skipping publication @acc due to download error.',
           ['@acc' => $pmid]);
       }
       else {
@@ -325,7 +325,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
     $rfh = fopen($query_url, "r");
     if (!$rfh) {
-      \Drupal::service('tripal.logger')->error("Could not perform Pubmed query. Cannot connect to Entrez.");
+      $this->logger->error("Could not perform Pubmed query. Cannot connect to Entrez.");
       return FALSE;
     }
 
@@ -424,7 +424,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
     $rfh = fopen($fetch_url, "r");
     if (!$rfh) {
-      \Drupal::service('tripal.logger')->error("Could not perform PubMed query: $fetch_url.");
+      $this->logger->error("Could not perform PubMed query: $fetch_url.");
       return NULL;
     }
     $results = '';
@@ -495,7 +495,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
             break;
           case 'ERROR':
             $xml->read(); // get the value for this element
-            \Drupal::service('tripal.logger')->error('XML Internal Error: @err', ['@err' => $xml->value]);
+            $this->logger->error('XML Internal Error: @err', ['@err' => $xml->value]);
             break;
           case 'GeneralNote':
             // TODO: handle this

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -19,18 +19,27 @@ use Drupal\Core\Url;
  */
 class TripalPubLibraryPubMed extends TripalPubLibraryBase {
 
-  public function formSubmit($form, &$form_state) {
+  /**
+   * Stores information of an initialized search.
+   * Array keys are 'Count', 'WebEnv', and 'QueryKey'
+   * with values as returned by PubMed's esearch utility
+   *
+   * @var array $webquery
+   */
+  protected array $webquery = [];
+
+  public function formSubmit(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): void {
     // DUMMY function from inheritance so it had to be kept.
     // The form_submit function which is called by TripalPubLibrary
     // is needed to receive and process the criteria data. See below.
   }
 
   /**
-   * Plugin specific form submit to add form values for example to criteria array
+   * Plugin specific form submit to add form values to the criteria array.
    * The criteria array eventually gets serialized and stored in the tripal_pub_import
    * database table. (This code gets called from ChadoNewPublicationForm)
    */
-  public function form_submit($form, $form_state, &$criteria) {
+  public function form_submit(array $form, \Drupal\Core\Form\FormStateInterface $form_state, array &$criteria): void {
     $user_input = $form_state->getUserInput();
     $criteria['days'] = $user_input['days'];
   }
@@ -38,7 +47,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
   /**
    * Adds plugin specific form items and returns the $form array
    */
-  public function form($form, &$form_state) {
+  public function form(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): array {
     // Add form elements specific to this parser.
     $api_key_description = t('Tripal imports publications using NCBI\'s ')
       . Link::fromTextAndUrl('EUtils API',
@@ -77,8 +86,16 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     return $form;
   }
 
-  public function formValidate($form, &$form_state) {
+  /**
+   * @see TripalImporter::formValidate()
+   */
+  public function formValidate(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): void {
     // Perform any form validations necessary with the form data
+    $form_state_values = $form_state->getValues();
+    $days = $form_state_values['days'] ?? '';
+    if (preg_match('/\D/', $days)) {
+      $form_state->setErrorByName('days', t('"Days since record modified" must be a non-negative integer, or blank'));
+    }
   }
 
 
@@ -90,34 +107,33 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *   specifying the database and query parameters for
    *   a particular publication repository.
    *
-   * @return array
-   *   The uniform publication information array.
+   * @return array|NULL
+   *   - 'total_records' = The number of records available for retrieval
+   *   - 'search_str' = The query string used for the search
+   *   - 'pubs' = The uniform publication information array.
+   *   or NULL if query failed and an exception was caught
    */
-  public function run(array $query) {
-    // Go through all results until pubs is empty
-    $page_results = $this->retrieve($query);
-    $publications = [];
-    if (is_array($page_results) && array_key_exists('pubs', $page_results)) {
-      if (count($page_results['pubs']) != 0) {
-        $publications = array_merge($publications, $page_results['pubs']);
-      }
-    }
-    else {
-      return NULL;
-    }
-    return $publications;
+  public function run(array $query): ?array {
+    $page = $query['page'];
+    $num_to_retrieve = $query['count'];
+
+    $page_results = $this->retrieve($query, $num_to_retrieve, $page);
+    return $page_results;
   }
 
   /**
    * More documentation can be found in TripalPubLibraryInterface
    */
-  public function retrieve(array $query, int $limit = 10, int $page = 0) {
+  public function retrieve(array $query, int $limit = 10, int $page = 0): ?array {
     $results = NULL;
     try {
       $results = $this->remoteSearchPMID($query, $limit, $page);
     }
-    catch (\Exception $ex) {
-
+    catch (\Exception $e) {
+      $msg = $e->getMessage();
+      \Drupal::messenger()->addMessage('ERROR: ' . $msg, 'error');
+      \Drupal::service('tripal.logger')->error($msg);
+      return NULL;
     }
     return $results;
   }
@@ -140,112 +156,117 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * @ingroup tripal_pub
    */
   public function remoteSearchPMID($search_array, $num_to_retrieve, $page, $row_mode = 1) {
-    // convert the terms list provided by the caller into a string with words
-    // separated by a '+' symbol.
-    $num_criteria = $search_array['num_criteria'];
-    $days = NULL;
-    if (isset($search_array['days'])) {
-      $days = $search_array['days'];
-    }
-
-    $search_str = '';
-
-    for ($i = 1; $i <= $num_criteria; $i++) {
-      $search_terms = trim($search_array['criteria'][$i]['search_terms']);
-      $scope = $search_array['criteria'][$i]['scope'];
-      $is_phrase = $search_array['criteria'][$i]['is_phrase'];
-      $op = $search_array['criteria'][$i]['operation'];
-
-      if ($op) {
-        $search_str .= "$op ";
+    // Only initialize for page zero, subsequent pages use the established query
+    if ($page == 0) {
+      // convert the terms list provided by the caller into a string with words
+      // separated by a '+' symbol.
+      $num_criteria = $search_array['num_criteria'];
+      $days = NULL;
+      if (isset($search_array['days'])) {
+        $days = $search_array['days'];
       }
 
-      // if this is phrase make sure the search terms are surrounded by quotes
-      if ($is_phrase) {
-        $search_str .= "(\"$search_terms\" |SCOPE|)";
-      }
-      // if this is not a phase then we want to separate each 'OR or 'AND' into a unique criteria
-      else {
-        $search_str .= "(";
-        if (preg_match('/\s+and+\s/i', $search_terms)) {
-          $elements = preg_split('/\s+and+\s/i', $search_terms);
-          foreach ($elements as $element) {
-            $search_str .= "($element |SCOPE|) AND ";
-          }
-          $search_str = substr($search_str, 0, -5); // remove trailing 'AND '
+      $search_str = '';
+
+      for ($i = 1; $i <= $num_criteria; $i++) {
+        $search_terms = trim($search_array['criteria'][$i]['search_terms']);
+        $scope = $search_array['criteria'][$i]['scope'];
+        $is_phrase = $search_array['criteria'][$i]['is_phrase'];
+        $op = $search_array['criteria'][$i]['operation'];
+
+        if ($op) {
+          $search_str .= "$op ";
         }
-        elseif (preg_match('/\s+or+\s/i', $search_terms)) {
-          $elements = preg_split('/\s+or+\s/i', $search_terms);
-          foreach ($elements as $element) {
-            $search_str .= "($element |SCOPE|) OR ";
+
+        // if this is phrase make sure the search terms are surrounded by quotes
+        if ($is_phrase) {
+          $search_str .= "(\"$search_terms\" |SCOPE|)";
+        }
+        // if this is not a phase then we want to separate each 'OR or 'AND' into a unique criteria
+        else {
+          $search_str .= "(";
+          if (preg_match('/\s+and+\s/i', $search_terms)) {
+            $elements = preg_split('/\s+and+\s/i', $search_terms);
+            foreach ($elements as $element) {
+              $search_str .= "($element |SCOPE|) AND ";
+            }
+            $search_str = substr($search_str, 0, -5); // remove trailing 'AND '
           }
-          $search_str = substr($search_str, 0, -4); // remove trailing 'OR '
+          elseif (preg_match('/\s+or+\s/i', $search_terms)) {
+            $elements = preg_split('/\s+or+\s/i', $search_terms);
+            foreach ($elements as $element) {
+              $search_str .= "($element |SCOPE|) OR ";
+            }
+            $search_str = substr($search_str, 0, -4); // remove trailing 'OR '
+          }
+          else {
+            $search_str .= "($search_terms |SCOPE|)";
+          }
+          $search_str .= ')';
+        }
+
+        if ($scope == 'title') {
+          $search_str = preg_replace('/\|SCOPE\|/', '[Title]', $search_str);
+        }
+        elseif ($scope == 'author') {
+          $search_str = preg_replace('/\|SCOPE\|/', '[Author]', $search_str);
+        }
+        elseif ($scope == 'abstract') {
+          $search_str = preg_replace('/\|SCOPE\|/', '[Title/Abstract]', $search_str);
+        }
+        elseif ($scope == 'journal') {
+          $search_str = preg_replace('/\|SCOPE\|/', '[Journal]', $search_str);
+        }
+        elseif ($scope == 'id') {
+          $search_str = preg_replace('/PMID:([^\s]*)/', '$1', $search_str);
+          $search_str = preg_replace('/\|SCOPE\|/', '[Uid]', $search_str);
         }
         else {
-          $search_str .= "($search_terms |SCOPE|)";
+          $search_str = preg_replace('/\|SCOPE\|/', '', $search_str);
         }
-        $search_str .= ')';
+      }
+      if ($days) {
+        // get the date of the day suggested
+        $past_timestamp = time() - ($days * 86400);
+        $past_date = getdate($past_timestamp);
+        $search_str .= " AND (\"" . sprintf("%04d/%02d/%02d", $past_date['year'], $past_date['mon'], $past_date['mday']) . "\"[Date - Create] : \"3000\"[Date - Create]))";
       }
 
-      if ($scope == 'title') {
-        $search_str = preg_replace('/\|SCOPE\|/', '[Title]', $search_str);
-      }
-      elseif ($scope == 'author') {
-        $search_str = preg_replace('/\|SCOPE\|/', '[Author]', $search_str);
-      }
-      elseif ($scope == 'abstract') {
-        $search_str = preg_replace('/\|SCOPE\|/', '[Title/Abstract]', $search_str);
-      }
-      elseif ($scope == 'journal') {
-        $search_str = preg_replace('/\|SCOPE\|/', '[Journal]', $search_str);
-      }
-      elseif ($scope == 'id') {
-        $search_str = preg_replace('/PMID:([^\s]*)/', '$1', $search_str);
-        $search_str = preg_replace('/\|SCOPE\|/', '[Uid]', $search_str);
-      }
-      else {
-        $search_str = preg_replace('/\|SCOPE\|/', '', $search_str);
-      }
-    }
-    if ($days) {
-      // get the date of the day suggested
-      $past_timestamp = time() - ($days * 86400);
-      $past_date = getdate($past_timestamp);
-      $search_str .= " AND (\"" . sprintf("%04d/%02d/%02d", $past_date['year'], $past_date['mon'], $past_date['mday']) . "\"[Date - Create] : \"3000\"[Date - Create]))";
+      // Initialize the remote query
+      $this->pmidSearchInit($search_str, $num_to_retrieve);
     }
 
-    // now initialize the query
-    $results = $this->pmidSearchInit($search_str, $num_to_retrieve);
-    $total_records = $results['Count'];
-    $query_key = $results['QueryKey'];
-    $web_env = $results['WebEnv'];
-
-    // initialize the pager
+    // initialize the retrieval loop
+    $total_records = $this->webquery['Count'];
     $start = $page * $num_to_retrieve;
 
     // if we have no records then return an empty array
-    if ($total_records == 0) {
+    if (($total_records == 0) or ($start > $total_records)) {
       return [
         'total_records' => $total_records,
-        'search_str' => $search_str,
+        'search_str' => '',
         'pubs' => [],
       ];
     }
-    // now get the list of PMIDs from the initialized search
-    $pmids_txt = $this->pmidFetch($query_key, $web_env, 'uilist', 'text', $start, $num_to_retrieve);
 
-    // iterate through each PMID and get the publication record. This requires a new search and new fetch
+    // Get the list of PMIDs from the initialized search
+    $pmids_txt = $this->pmidFetch('uilist', 'text', $start, $num_to_retrieve);
+
+    // Iterate through each PMID and download and parse its publication record.
     $pmids = explode("\n", trim($pmids_txt));
     $pubs = [];
     foreach ($pmids as $pmid) {
-      // now retrieve the individual record
-      $pub_xml = $this->pmidFetch($query_key, $web_env, 'null', 'xml', 0, 1, ['id' => $pmid]);
-      $pub = $this->parse($pub_xml);
+      // Retrieve and parse each record.
+print "CPP1 downloading $pmid\n";//@@@
+      $pub_xml = $this->pmidFetch('null', 'xml', 0, 1, ['id' => $pmid]);
+      $pub = $this->parse_xml($pub_xml);
       $pubs[] = $pub;
     }
+
+    // Note that search_str is only returned for the first page
     return [
       'total_records' => $total_records,
-      'search_str' => $search_str,
+      'search_str' => $search_str ?? '',
       'pubs' => $pubs,
     ];
   }
@@ -258,8 +279,9 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * @param $retmax
    *   The maximum number of records to return
    *
-   * @return
-   *   An array containing the Count, WebEnv and QueryKey as return
+   * @return void
+   *   Values are stored in $this->webquery, which is an array
+   *   containing the Count, WebEnv and QueryKey as returned
    *   by PubMed's esearch utility
    *
    * @ingroup tripal_pub
@@ -300,7 +322,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     $xml->xml($query_xml);
 
     // iterate though the child nodes of the <eSearchResult> tag and get the count, history and query_id
-    $result = [];
+    $this->webquery = [];
     while ($xml->read()) {
       $element = $xml->name;
 
@@ -314,30 +336,25 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
         switch ($element) {
           case 'Count':
             $xml->read();
-            $result['Count'] = $xml->value;
+            $this->webquery['Count'] = $xml->value;
             break;
           case 'WebEnv':
             $xml->read();
-            $result['WebEnv'] = $xml->value;
+            $this->webquery['WebEnv'] = $xml->value;
             break;
           case 'QueryKey':
             $xml->read();
-            $result['QueryKey'] = $xml->value;
+            $this->webquery['QueryKey'] = $xml->value;
             break;
         }
       }
     }
-    return $result;
   }
 
   /**
    * Retrieves from PubMed a set of publications from the
    * previously initiated query.
    *
-   * @param $query_key
-   *   The esearch QueryKey
-   * @param $web_env
-   *   The esearch WebEnv
    * @param $rettype
    *   The efetch return type
    * @param $retmod
@@ -355,8 +372,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *
    * @ingroup tripal_pub
    */
-  private function pmidFetch($query_key, $web_env, $rettype = 'null',
-                                 $retmod = 'null', $start = 0, $limit = 10, $args = []) {
+  private function pmidFetch($rettype = 'null', $retmod = 'null', $start = 0, $limit = 10, $args = []) {
 
     // repeat the search performed previously (using WebEnv & QueryKey) to retrieve
     // the PMID's within the range specied.  The PMIDs will be returned as a text list
@@ -366,8 +382,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       "&retstart=$start" .
       "&retmax=$limit" .
       "&db=Pubmed" .
-      "&query_key=$query_key" .
-      "&WebEnv=$web_env";
+      "&query_key=" . $this->webquery['QueryKey'] .
+      "&WebEnv=" . $this->webquery['WebEnv'];
 
     $api_key = \Drupal::state()->get('tripal_pub_importer_ncbi_api_key', NULL);
     $sleep_time = 333334;
@@ -426,7 +442,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *
    * @ingroup tripal_pub
    */
-  public function parse(string $pub_xml): array {
+  public function parse_xml(string $pub_xml): array {
     $pub = [];
 
     if (!$pub_xml) {
@@ -463,7 +479,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
             break;
           case 'ERROR':
             $xml->read(); // get the value for this element
-            \Drupal::service('tripal.logger')->error("Error: " . $xml->value);
+            \Drupal::service('tripal.logger')->error('XML Internal Error: @err', ['@err' => $xml->value]);
             break;
           case 'GeneralNote':
             // TODO: handle this
@@ -516,7 +532,9 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       }
     }
 
-    $pub['Citation'] = $this->pmid_generate_citation($pub);
+    if ($pub) {
+      $pub['Citation'] = $this->pmid_generate_citation($pub);
+    }
 
     return $pub;
   }
@@ -576,40 +594,42 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    */
   private function pmid_get_pub_type($pub): string {
     $pub_type = '';
-    $known_types = [
-      'Journal Article',
-      'Conference Proceedings',
-      'Review',
-      'Book',
-      'Letter',
-      'Book Chapter',
-    ];
+    if (array_key_exists('Publication Type', $pub)) {
+      $known_types = [
+        'Journal Article',
+        'Conference Proceedings',
+        'Review',
+        'Book',
+        'Letter',
+        'Book Chapter',
+      ];
 
-    // An article may have more than one publication type. For example,
-    // a publication type can be 'Journal Article' but also a 'Clinical Trial'.
-    // Therefore, we need to select the type that makes most sense for
-    // construction of the citation. Here we'll iterate through them all
-    // and select the one that matches best.
-    if (is_array($pub['Publication Type'])) {
-      foreach ($pub['Publication Type'] as $ptype) {
-        if (in_array($ptype, $known_types)) {
-          $pub_type = $ptype;
-          break;
+      // An article may have more than one publication type. For example,
+      // a publication type can be 'Journal Article' but also a 'Clinical Trial'.
+      // Therefore, we need to select the type that makes most sense for
+      // construction of the citation. Here we'll iterate through them all
+      // and select the one that matches best.
+      if (is_array($pub['Publication Type'])) {
+        foreach ($pub['Publication Type'] as $ptype) {
+          if (in_array($ptype, $known_types)) {
+            $pub_type = $ptype;
+            break;
+          }
+          elseif ($ptype == "Research Support, Non-U.S. Gov't") {
+            $pub_type = $ptype;
+            // We don't break because if the article is also a Journal Article
+            // we prefer that type.
+          }
         }
-        elseif ($ptype == "Research Support, Non-U.S. Gov't") {
-          $pub_type = $ptype;
-          // We don't break because if the article is also a Journal Article
-          // we prefer that type.
+        // If we don't have a recognized publication type, then just use the
+        // first one in the list.
+        if (!$pub_type) {
+          $pub_type = $pub['Publication Type'][0];
         }
       }
-      // If we don't have a recognized publication type, then just use the
-      // first one in the list.
-      if (!$pub_type) {
-        $pub_type = $pub['Publication Type'][0];
+      else {
+        $pub_type = $pub['Publication Type'];
       }
-    }
-    else {
-      $pub_type = $pub['Publication Type'];
     }
     return $pub_type;
   }
@@ -917,35 +937,12 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * @ingroup tripal_pub
    */
   private function pmidParsePublicationType($xml, &$pub) {
-    $chado = \Drupal::service('tripal_chado.database');
     $xml->read();
     $value = $xml->value;
-
-    $identifiers = [
-      'name' => $value,
-      'cv_id' => [
-        'name' => 'tripal_pub',
-      ],
-    ];
-    $options = ['case_insensitive_columns' => ['name']];
-    $pub_cvterm = chado_get_cvterm($identifiers, $options, $chado->getSchemaName());
-    if (!$pub_cvterm) {
-      // see if this we can find the name using a synonym
-      $identifiers = [
-        'synonym' => [
-          'name' => $value,
-          'cv_name' => 'tripal_pub',
-        ],
-      ];
-      $pub_cvterm = chado_get_cvterm($identifiers, $options, $chado->getSchemaName());
-      if (!$pub_cvterm) {
-        \Drupal::service('tripal.logger')->error('Cannot find a valid vocabulary term for the publication type: "' .
-          $value . '"');
-      }
+    if ($value) {
+      $pub['Publication Type'][] = $value;
     }
-    else {
-      $pub['Publication Type'][] = $pub_cvterm->name;
-    }
+    return;
   }
 
   /**

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -109,6 +109,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *
    * @return array|NULL
    *   - 'total_records' = The number of records available for retrieval
+   *   - 'skipped_records' = The number of records where download failed
    *   - 'search_str' = The query string used for the search
    *   - 'pubs' = The uniform publication information array.
    *   or NULL if query failed and an exception was caught
@@ -130,10 +131,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       $results = $this->remoteSearchPMID($query, $limit, $page);
     }
     catch (\Exception $e) {
-      $msg = $e->getMessage();
-      \Drupal::messenger()->addMessage('ERROR: ' . $msg, 'error');
-      \Drupal::service('tripal.logger')->error($msg);
-      return NULL;
+      \Drupal::service('tripal.logger')->error($e->getMessage());
     }
     return $results;
   }
@@ -150,12 +148,16 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    *   Indicates the page to retrieve.  This corresponds to a paged table, where
    *   each page has $num_to_retrieve publications.
    *
-   * @return
-   *  An array of publications.
+   * @return array|NULL
+   *   - 'total_records' = The number of records available for retrieval
+   *   - 'skipped_records' = The number of records where download failed
+   *   - 'search_str' = The query string used for the search
+   *   - 'pubs' = The uniform publication information array.
+   *   or NULL if query failed and an exception was caught
    *
    * @ingroup tripal_pub
    */
-  public function remoteSearchPMID($search_array, $num_to_retrieve, $page, $row_mode = 1) {
+  public function remoteSearchPMID($search_array, $num_to_retrieve, $page, $row_mode = 1): ?array {
     // Only initialize for page zero, subsequent pages use the established query
     if ($page == 0) {
       // convert the terms list provided by the caller into a string with words
@@ -233,7 +235,9 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       }
 
       // Initialize the remote query
-      $this->pmidSearchInit($search_str, $num_to_retrieve);
+      if (!$this->pmidSearchInit($search_str, $num_to_retrieve)) {
+        return NULL;
+      }
     }
 
     // initialize the retrieval loop
@@ -244,6 +248,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     if (($total_records == 0) or ($start > $total_records)) {
       return [
         'total_records' => $total_records,
+        'skipped_records' => 0,
         'search_str' => '',
         'pubs' => [],
       ];
@@ -251,41 +256,55 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
 
     // Get the list of PMIDs from the initialized search
     $pmids_txt = $this->pmidFetch('uilist', 'text', $start, $num_to_retrieve);
+    if (is_null($pmids_txt)) {
+      return NULL;
+    }
 
     // Iterate through each PMID and download and parse its publication record.
     $pmids = explode("\n", trim($pmids_txt));
     $pubs = [];
+    $n_skipped = 0;
     foreach ($pmids as $pmid) {
       // Retrieve and parse each record.
       $pub_xml = $this->pmidFetch('null', 'xml', 0, 1, ['id' => $pmid]);
-      $pub = $this->parse_xml($pub_xml);
-      $pubs[] = $pub;
+      if (is_null($pub_xml)) {
+        // Skip over any individual publication that had a download error
+        $n_skipped++;
+        \Drupal::service('tripal.logger')->error('Skipping publication @acc due to download error.',
+          ['@acc' => $pmid]);
+      }
+      else {
+        $pub = $this->parse_xml($pub_xml);
+        $pubs[] = $pub;
+      }
     }
 
     // Note that search_str is only returned for the first page
     return [
       'total_records' => $total_records,
+      'skipped_records' => $n_skipped,
       'search_str' => $search_str ?? '',
       'pubs' => $pubs,
     ];
   }
 
   /**
-   * Initailizes a PubMed Search using a given search string
+   * Initailizes a PubMed Search using a given search string.
+   * Values are stored in $this->webquery, which is an array
+   * containing the Count, WebEnv and QueryKey as returned
+   * by PubMed's esearch utility.
    *
    * @param $search_str
    *   The PubMed Search string
    * @param $retmax
    *   The maximum number of records to return
    *
-   * @return void
-   *   Values are stored in $this->webquery, which is an array
-   *   containing the Count, WebEnv and QueryKey as returned
-   *   by PubMed's esearch utility
+   * @return bool
+   *   TRUE for success, FALSE for error.
    *
    * @ingroup tripal_pub
    */
-  private function pmidSearchInit($search_str, $retmax) {
+  private function pmidSearchInit($search_str, $retmax): bool {
 
     // do a search for a single result so that we can establish a history, and get
     // the number of records. Once we have the number of records we can retrieve
@@ -306,9 +325,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
     $rfh = fopen($query_url, "r");
     if (!$rfh) {
-      \Drupal::messenger()->addMessage('Could not perform Pubmed query. Cannot connect to Entrez.', 'error');
       \Drupal::service('tripal.logger')->error("Could not perform Pubmed query. Cannot connect to Entrez.");
-      return 0;
+      return FALSE;
     }
 
     // retrieve the XML results
@@ -348,6 +366,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
         }
       }
     }
+    return TRUE;
   }
 
   /**
@@ -365,13 +384,12 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
    * @param $args
    *   Any additional arguments to add the efetch query URL
    *
-   * @return
-   *  An array containing the total_records in the dataset, the search string
-   *  and an array of the publications that were retrieved.
+   * @return string|NULL
+   *   XML as returned from NCBI. Returns NULL if a download error occurred.
    *
    * @ingroup tripal_pub
    */
-  private function pmidFetch($rettype = 'null', $retmod = 'null', $start = 0, $limit = 10, $args = []) {
+  private function pmidFetch($rettype = 'null', $retmod = 'null', $start = 0, $limit = 10, $args = []): ?string {
 
     // repeat the search performed previously (using WebEnv & QueryKey) to retrieve
     // the PMID's within the range specied.  The PMIDs will be returned as a text list
@@ -406,9 +424,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
     $rfh = fopen($fetch_url, "r");
     if (!$rfh) {
-      \Drupal::messenger()->addMessage('ERROR: Could not perform PubMed query.', 'error');
       \Drupal::service('tripal.logger')->error("Could not perform PubMed query: $fetch_url.");
-      return '';
+      return NULL;
     }
     $results = '';
     if ($rfh) {
@@ -539,12 +556,11 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
   }
 
   /**
-   * Creates Citation
+   * Creates a citation for a publication.
    *
    * This function generates a citation for a publication. It requires
    * an array structure with keys being the terms in the Tripal
-   * publication ontology.  This function is intended to be used
-   * for any function that needs to generate a citation.
+   * publication ontology.
    *
    * @param $pub
    *   An array structure containing publication details where the keys
@@ -595,12 +611,12 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     $pub_type = '';
     if (array_key_exists('Publication Type', $pub)) {
       $known_types = [
-        'Journal Article',
-        'Conference Proceedings',
-        'Review',
         'Book',
-        'Letter',
         'Book Chapter',
+        'Conference Proceedings',
+        'Journal Article',
+        'Letter',
+        'Review',
       ];
 
       // An article may have more than one publication type. For example,

--- a/tripal/src/TripalPubLibrary/Interfaces/TripalPubLibraryInterface.php
+++ b/tripal/src/TripalPubLibrary/Interfaces/TripalPubLibraryInterface.php
@@ -24,7 +24,7 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    * @return array
    *   A new form array definition.
    */
-  public function form($form, &$form_state);
+  public function form(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): array;
 
   /**
    * Handles submission of the form elements.
@@ -37,7 +37,7 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state object.
    */
-  public function formSubmit($form, &$form_state);
+  public function formSubmit(array $form, \Drupal\Core\Form\FormStateInterface &$form_state);
 
   /**
    * Handles validation of the form elements.
@@ -49,8 +49,10 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    *   The form array definition.*
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state object.
+   *
+   * @return void
    */
-  public function formValidate($form, &$form_state);
+  public function formValidate(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): void;
 
   /**
    * Performs the import.
@@ -60,10 +62,14 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    *   specifying the database and query parameters for
    *   a particular publication repository.
    *
-   * @return array
-   *   The uniform publication information array.
+   * @return array|NULL
+   *   Array with the following keys:
+   *    - 'total_records' = The number of records available for retrieval
+   *    - 'search_str' = The query string used for the search
+   *    - 'pubs' = The uniform publication information array.
+   *   or returns NULL if the query failed and an exception was caught
    */
-  public function run(array $query);
+  public function run(array $query): ?array;
 
   /**
    * Returns publications from remote publication library.
@@ -73,33 +79,37 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    * prepared.
    *
    * @param array $query
-   * The criteria used by the parser to retreive and parse results.
+   *   The criteria used by the parser to retreive and parse results.
    *
    * @param int $limit
-   * The number of publication records to return.
+   *   The number of publication records to return.
    *
    * @param int $page
-   * The specific page to retrieve publication results
-   * Page values start at 0.
+   *   The specific page of publication results to retrieve
+   *   Page values start at 0.
    *
-   * @return array
-   * Return an array with keys total_records, search_str, pubs(array)
+   * @return array|NULL
+   *   Array with the following keys:
+   *    - 'total_records' = The number of records available for retrieval
+   *    - 'search_str' = The query string used for the search
+   *    - 'pubs' = The uniform publication information array.
+   *   or returns NULL if the query failed and an exception was caught
    */
-  public function retrieve(array $query, int $limit = 10, int $page = 0);
+  public function retrieve(array $query, int $limit = 10, int $page = 0): ?array;
 
   /**
-   * Parses raw data and structures it
+   * Parses raw xml data and structures it
    *
    * Receive the raw publication data and formats it into an
-   * array / object that PHP can utilize.
+   * array that PHP can utilize.
    *
    * @param string $raw
-   * Raw data input example xml data which may be received
+   *   Raw data in xml format
    *
-   * @return array/object $results
-   * Results are the processed/structured array/object created by extracting
-   * from the raw data input
+   * @return array $results
+   *   An array describing the publication created by extracting
+   *   from the raw data input
    */
-  public function parse(string $raw);
+  public function parse_xml(string $raw): array;
 
 }

--- a/tripal/src/TripalPubLibrary/Interfaces/TripalPubLibraryInterface.php
+++ b/tripal/src/TripalPubLibrary/Interfaces/TripalPubLibraryInterface.php
@@ -36,8 +36,10 @@ interface TripalPubLibraryInterface extends PluginInspectionInterface {
    *   The form array definition.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state object.
+   *
+   * @return void
    */
-  public function formSubmit(array $form, \Drupal\Core\Form\FormStateInterface &$form_state);
+  public function formSubmit(array $form, \Drupal\Core\Form\FormStateInterface &$form_state): void;
 
   /**
    * Handles validation of the form elements.

--- a/tripal/src/TripalPubLibrary/TripalPubLibraryBase.php
+++ b/tripal/src/TripalPubLibrary/TripalPubLibraryBase.php
@@ -17,6 +17,13 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
   protected $public;
 
   /**
+   * The logger for reporting progress, warnings and errors to admin.
+   *
+   * @var \Drupal\tripal\Services\TripalLogger
+   */
+  protected $logger;
+
+  /**
    * The Tripal Citation generation service.
    *
    * @var \Drupal\tripal\Services\TripalCitationManager $citation_manager
@@ -57,6 +64,7 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
       $plugin_id,
       $plugin_definition,
       $container->get('database'),
+      $container->get('tripal.logger'),
       $container->get('tripal.citation'),
     );
   }
@@ -65,11 +73,15 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition,
-                              Connection $public, \Drupal\tripal\Services\TripalCitationManager $citation_manager) {
+                              Connection $public,
+                              \Drupal\tripal\Services\TripalLogger $logger,
+                              \Drupal\tripal\Services\TripalCitationManager $citation_manager) {
+
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    // Dependency injection for public schema
+    // Dependency injection for public schema, tripal logger, and citation generator
     $this->public = $public;
+    $this->logger = $logger;
     $this->citation_manager = $citation_manager;
   }
 

--- a/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
+++ b/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
@@ -47,6 +47,7 @@ class TripalPubParserManager extends DefaultPluginManager {
   // All elements need to be under the 'pub_parser' array index since
   // a placeholder exists for this to be updated by the Ajax callback.
   public function form($form, $form_state) {
+dpm("Calling form in class TripalPubParserManager extends DefaultPluginManager");//@@@
     //@todo get these values
     $disabled = '';
     $do_contact = '';

--- a/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
+++ b/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
@@ -204,9 +204,10 @@ class TripalPubParserManager extends DefaultPluginManager {
       ];
       $row["search_terms-$i"] = [
         '#type' => 'textfield',
-        '#description' => t('<span style="white-space: normal">Please provide a list of words for searching. You may use
-          conjunctions such as "AND" or "OR" to separate words if they are expected in
-          the same scope, but do not mix ANDs and ORs. Check the "Is Phrase" checkbox to use conjunctions as part of the text to search</span>'),
+        '#description' => t('<span style="white-space: normal">Please provide a list of words
+          for searching. You may use conjunctions such as "AND" or "OR" to separate words if
+          they are expected in the same scope, but do not mix ANDs and ORs. Check the
+          "Is Phrase" checkbox to use conjunctions as part of the text to search</span>'),
         '#description_display' => 'after',
         '#default_value' => $search_terms,
         '#required' => TRUE,
@@ -227,52 +228,12 @@ class TripalPubParserManager extends DefaultPluginManager {
             '#type' => 'button',
             '#name' => 'remove',
             '#value' => t('Remove'),
-            '#ajax' => [
-              'callback' => 'tripal_pub_setup_form_ajax_update',
-              'wrapper' => 'tripal-pub-importer-setup',
-              'effect' => 'fade',
-              'method' => 'replace',
-              'prevent' => 'click',
-            ],
-            // When this button is clicked, the form will be validated and submitted.
-            // Therefore, we set custom submit and validate functions to override the
-            // default form submit. In the validate function we set the form_state to
-            // rebuild the form so that the submit function never actually gets called,
-            // but we need it or Drupal will run the default validate anyway.
-            // We also set #limit_validation_errors to empty so fields that are
-            // required that don't have values won't generate warnings.
-
-            // RISH REMOVED FOR TESTING (9/23/2023)
-            // '#submit' => ['tripal_pub_setup_form_ajax_button_submit'],
-            // '#validate' => ['tripal_pub_setup_form_ajax_button_validate'], 
-            // '#limit_validation_errors' => [],
           ];
         }
         $row["add-$i"] = [
           '#type' => 'button',
           '#name' => 'add',
           '#value' => t('Add'),
-          '#ajax' => [
-            'callback' => 'tripal_pub_setup_form_ajax_update',
-            'wrapper' => 'tripal-pub-importer-setup',
-            'effect' => 'fade',
-            'method' => 'replace',
-            'prevent' => 'click',
-          ],
-          // When this button is clicked, the form will be validated and submitted.
-          // Therefore, we set custom submit and validate functions to override the
-          // default form submit. In the validate function we set the form_state to
-          // rebuild the form so that the submit function never actually gets called,
-          // but we need it or Drupal will run the default validate anyway.
-          // we also set #limit_validation_errors to empty so fields that
-          // are required that don't have values won't generate warnings.
-
-          //@to-do this submit function is not being called - why?
-
-          // RISH REMOVED FOR TESTING (9/23/2023)
-          // '#submit' => ['tripal_pub_setup_form_ajax_button_submit'],
-          // '#validate' => ['tripal_pub_setup_form_ajax_button_validate'],
-          // '#limit_validation_errors' => [],
         ];
       }
       $form['pub_parser']['table'][$i] = $row;
@@ -281,40 +242,4 @@ class TripalPubParserManager extends DefaultPluginManager {
     return $form;
   }
 
-  /**
-   * This function is used to rebuild the form if an ajax call is made via a
-   * button. The button causes the form to be submitted. We don't want this so we
-   * override the validate and submit routines on the form button. Therefore,
-   * this function only needs to tell Drupal to rebuild the form
-   *
-   * @ingroup tripal_pub
-   */
-  public function tripal_pub_setup_form_ajax_button_validate($form, &$form_state) {
-    $trigger = $form_state->getTriggeringElement()['#name'];
-    dpm($trigger, "tripal_pub_setup_form_ajax_button_validate() called, not yet implemented");
-    $form_state->setRebuild(TRUE);
-  }
-
-  /**
-   * This function is just a dummy to override the default form submit on ajax
-   * calls for buttons
-   *
-   * @ingroup tripal_pub
-   */
-  public function tripal_pub_setup_form_ajax_button_submit($form, &$form_state) {
-    $trigger = $form_state->getTriggeringElement()['#name'];
-    dpm($trigger, "tripal_pub_setup_form_ajax_button_submit() called, not yet implemented");
-    // do nothing
-  }
-
-  /**
-   * This function received ajax calls from the add button in the criteria table
-   */
-  public function tripal_pub_setup_form_ajax_update($form, &$form_state) {
-    // dpm('hmmm');
-    $response = new AjaxResponse();
-    // $response->addCommand(new ReplaceCommand('#tripal-pub-importer-setup', $form['pub_parser']['table']));
-
-    return $response;
-  }
 }

--- a/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
+++ b/tripal/src/TripalPubParser/PluginManagers/TripalPubParserManager.php
@@ -47,7 +47,6 @@ class TripalPubParserManager extends DefaultPluginManager {
   // All elements need to be under the 'pub_parser' array index since
   // a placeholder exists for this to be updated by the Ajax callback.
   public function form($form, $form_state) {
-dpm("Calling form in class TripalPubParserManager extends DefaultPluginManager");//@@@
     //@todo get these values
     $disabled = '';
     $do_contact = '';

--- a/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
@@ -36,6 +36,12 @@ class PubSearchQueryImporter extends ChadoImporterBase {
   protected $chado = NULL;
 
   /**
+   * Publication library manager service
+   * @var Drupal\tripal_chado\Plugin\TripalImporter\PubSearchQueryImporter $pub_library_manager
+   */
+  protected $pub_library_manager = NULL;
+
+  /**
    * db_id value from the chado.db table for the external database
    * @var ?int $db_id
    */
@@ -158,8 +164,10 @@ class PubSearchQueryImporter extends ChadoImporterBase {
    */
   protected function formQueryIdNotSet(&$form, $form_state) {
     // Get list of database/libraries
-    $pub_library_manager = \Drupal::service('tripal.pub_library');
-    $plugins = $pub_library_manager->getLibraryOptions();
+    if (is_null($this->pub_library_manager)) {
+      $this->pub_library_manager = \Drupal::service('tripal.pub_library');
+    }
+    $plugins = $this->pub_library_manager->getLibraryOptions();
     $form_state_values = $form_state->getValues();
 
     $form['database'] = [
@@ -321,8 +329,10 @@ class PubSearchQueryImporter extends ChadoImporterBase {
           t('The query name must include its ID value in parentheses'));
     }
     else {
-      $pub_library_manager = \Drupal::service('tripal.pub_library');
-      $pub_record = $pub_library_manager->getSearchQuery($query_id);
+      if (is_null($this->pub_library_manager)) {
+        $this->pub_library_manager = \Drupal::service('tripal.pub_library');
+      }
+      $pub_record = $this->pub_library_manager->getSearchQuery($query_id);
       if (!$pub_record) {
         $form_state->setErrorByName('search_query_name',
             t('There is no query with an ID value of @id', ['@id' => $query_id]));
@@ -856,19 +866,23 @@ class PubSearchQueryImporter extends ChadoImporterBase {
   }
 
   /**
-   * @see TripalImporter::run()
+   * Handles initialization for the run() function
    *
-   * n.b. the calling function will wrap this in a database transaction
+   * @return array|NULL
+   *   The criteria array, or NULL if an error occurred
    */
-  public function run() {
+  protected function run_init(): ?array {
+
     $this->logger->notice('Initializing publication importer');
 
-    $arguments = $this->arguments['run_args'];
-    $pub_library_manager = \Drupal::service('tripal.pub_library');
+    // Initialize services
+    $this->chado = $this->getChadoConnection();
+    $this->pub_library_manager = \Drupal::service('tripal.pub_library');
 
-    // We can pass either a query_id value, in which case we retrieve a criteria
-    // array from the public.tripal_pub_library_query table. Alternatively we can
-    // pass a criteria array directly.
+    // We can pass a query_id value, in which case we retrieve a criteria
+    // array from the public.tripal_pub_library_query table. Alternatively we
+    // can pass a criteria array directly.
+    $arguments = $this->arguments['run_args'];
     $criteria = [];
     if ($arguments['criteria'] ?? NULL) {
       $criteria = $arguments['criteria'];
@@ -884,31 +898,29 @@ class PubSearchQueryImporter extends ChadoImporterBase {
       }
       if (!$query_id) {
         $this->logger->error('A query ID was not supplied, cannot continue');
-        return FALSE;
+        return NULL;
       }
 
       // Use the query_id to retrieve the query information from the database
-      $pub_record = $pub_library_manager->getSearchQuery($query_id);
+      $pub_record = $this->pub_library_manager->getSearchQuery($query_id);
       if (!$pub_record) {
         $this->logger->error('There is no search query defined for the supplied identifier "'. $query_id . '"');
-        return FALSE;
+        return NULL;
       }
       $criteria = unserialize($pub_record->criteria);
     }
-    $plugin_id = $criteria['form_state_user_input']['plugin_id'] ?? NULL;
-    if (is_null($plugin_id)) {
-      $this->logger->error('Could not find the plugin_id, could not find adequate query information');
-      return FALSE;
+    if (!($criteria['plugin_id'] ?? NULL)) {
+      $plugin_id = $criteria['form_state_user_input']['plugin_id'] ?? NULL;
+      if (is_null($plugin_id)) {
+        $this->logger->error('Could not find the plugin_id, could not find adequate query information');
+        return NULL;
+      }
+      $criteria['plugin_id'] = $plugin_id;
     }
     if (($criteria['disabled'] ?? 0) > 0) {
       $this->logger->error('This query cannot be executed because it is marked as "Disabled"');
-      return FALSE;
+      return NULL;
     }
-    // This is stored as an integer in the database table, this converts it to a boolean
-    $do_contact = (($criteria['do_contact'] ?? 0) > 0);
-
-    // Initialize chado connection (used in other helper functions within this class)
-    $this->chado = $this->getChadoConnection();
 
     // Lookup the db_id for the external database for the plugin
     $this->getRemoteDbId($criteria['remote_db']);
@@ -916,8 +928,27 @@ class PubSearchQueryImporter extends ChadoImporterBase {
     // Preload all tripal_pub ontology terms to $this->cvterm_lookups
     $this->cachePublicationCvterms();
 
+    return $criteria;
+  }
+
+  /**
+   * @see TripalImporter::run()
+   *
+   * n.b. the calling function will wrap this in a database transaction
+   */
+  public function run() {
+
+    $criteria = $this->run_init();
+    if (is_null($criteria)) {
+      return;
+    }
+
+    // This is stored as an integer in the database table, this converts it to a boolean
+    $do_contact = (($criteria['do_contact'] ?? 0) > 0);
+
     // Set up a loop to load publications in batches
-    $plugin = $pub_library_manager->createInstance($plugin_id, []);
+    $plugin_id = $criteria['plugin_id'];
+    $plugin = $this->pub_library_manager->createInstance($plugin_id, []);
     $page = 0;
     $n_groups = '?';
     $completed = FALSE;
@@ -947,8 +978,8 @@ class PubSearchQueryImporter extends ChadoImporterBase {
         if ($n_groups > 1) {
           $prefix = 'Group ' . ($page+1) . ' of ' . $n_groups . ', ';
           if ($page == 0) {
-            $this->logger->notice('  🗸 Publications will be imported in @group groups of @size publications each',
-              ['@group' => $n_groups, '@size' => $this->batch_size]);
+            $this->logger->notice('  🗸 @total publications will be imported in @group groups of @size publications each',
+              ['@total' => number_format($total_records), '@group' => $n_groups, '@size' => $this->batch_size]);
           }
         }
         $this->logger->notice('  🗸 Importing @count publications', ['@count' => count($publications)]);

--- a/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
@@ -524,10 +524,9 @@ class PubSearchQueryImporter extends ChadoImporterBase {
           $this->addBundleTypeProperty('pub_id', $pub_id, 'pubprop', 'TPUB', '0000002', 'publication');
         }
         else {
-          // If there is no type_id, we cannot process this publication further
+          // If there is no type_id, we cannot process this publication further. This was logged earlier
           unset($publications[$index]);
           unset($this->pub_index[$accession]);
-          $this->logger->warning('Publication accession @acc is missing a type, so will not be imported', ['@acc' => $accession]);
         }
       }
     }
@@ -558,8 +557,8 @@ class PubSearchQueryImporter extends ChadoImporterBase {
       }
       $type_id = $this->cvterm_lookups[$type] ?? 0;
       if (!$type_id) {
-        $this->logger->warning('Publication with accession @acc has a type "@type" which is not present in the tripal_pub vocabulary',
-          ['@acc' => $accession, '@type', $type]);
+        $this->logger->warning('Publication with accession @acc has a type "@type" which is not present in the tripal_pub vocabulary, so will not be imported',
+          ['@acc' => $accession, '@type' => $type]);
       }
     }
     return $type_id;
@@ -922,7 +921,6 @@ class PubSearchQueryImporter extends ChadoImporterBase {
     $n_groups = '?';
     $completed = FALSE;
     $prefix = '';
-$this->batch_size = 5;//@@@
 
     while (!$completed) {
 

--- a/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
@@ -557,7 +557,8 @@ class PubSearchQueryImporter extends ChadoImporterBase {
       }
       $type_id = $this->cvterm_lookups[$type] ?? 0;
       if (!$type_id) {
-        $this->logger->warning('Publication with accession @acc has a type "@type" which is not present in the tripal_pub vocabulary, so will not be imported',
+        $this->logger->warning('Publication with accession @acc has a type "@type" which is not present'
+          . ' in the tripal_pub vocabulary, so will not be imported. Consider adding a term for this type.',
           ['@acc' => $accession, '@type' => $type]);
       }
     }
@@ -943,7 +944,7 @@ class PubSearchQueryImporter extends ChadoImporterBase {
         $publications = $page_results['pubs'];
         $total_records = $page_results['total_records'];
         $n_groups = intval(($total_records - 1) / $this->batch_size) + 1;
-        if (count($publications) >= $this->batch_size) {
+        if ($n_groups > 1) {
           $prefix = 'Group ' . ($page+1) . ' of ' . $n_groups . ', ';
           if ($page == 0) {
             $this->logger->notice('  🗸 Publications will be imported in @group groups of @size publications each',
@@ -986,10 +987,13 @@ class PubSearchQueryImporter extends ChadoImporterBase {
           $this->logger->notice('  🗸 Inserted: ' . $n_added);
         }
       }
+      // n.b. $page starts at 0 so last page is $n_groups-1
       $page++;
-      $prefix = 'Group ' . ($page+1) . ', ';
       if ($page == $n_groups) {
         $completed = TRUE;
+      }
+      else {
+        $prefix = 'Group ' . ($page+1) . ' of ' . $n_groups . ', ';
       }
     }
     return;

--- a/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/PubSearchQueryImporter.php
@@ -390,6 +390,7 @@ class PubSearchQueryImporter extends ChadoImporterBase {
 
     // Get all publication accessions
     $all_publications_dbxref = [];
+    $this->pub_index = [];
     foreach ($publications as $index => $publication) {
       $accession = $publication['Publication Dbxref'];
       $all_publications_dbxref[] = $accession;
@@ -473,6 +474,7 @@ class PubSearchQueryImporter extends ChadoImporterBase {
    *   The list is stored at $this->new_accessions
    */
   protected function getNewPublicationAccessions(array $publications): void {
+    $this->new_accessions = [];
     // Create the list of new accessions to be imported
     foreach ($this->pub_index as $accession => $info) {
       if ($info['is_new']) {
@@ -497,10 +499,10 @@ class PubSearchQueryImporter extends ChadoImporterBase {
 
         // Assemble the values for the pub table columns
         $title = $publication['Title'];
-        $series_name = trim(explode('(', $publication['Journal Name'])[0]);
+        $series_name = trim(explode('(', $publication['Journal Name'] ?? '')[0]);
         $pyear = $publication['Year'];
         // Here for the uniquename field in the pub table we use the citation,
-        // which should be unique, and we should have already generated it for
+        // which should be unique, and we should have already generated it
         // for all importers, but a simple default is provided as a fallback.
         $uniquename = $publication['Citation']
           ?? trim(str_replace(',', ';', $publication['Authors'] ?? '') . ' ' . $title . ' ' . $series_name . '; ' . $pyear);
@@ -524,6 +526,8 @@ class PubSearchQueryImporter extends ChadoImporterBase {
         else {
           // If there is no type_id, we cannot process this publication further
           unset($publications[$index]);
+          unset($this->pub_index[$accession]);
+          $this->logger->warning('Publication accession @acc is missing a type, so will not be imported', ['@acc' => $accession]);
         }
       }
     }
@@ -542,7 +546,10 @@ class PubSearchQueryImporter extends ChadoImporterBase {
    */
   protected function getPublicationTypeId(array $publication): int {
     $type_id = 0;
-    $type = $publication['Publication Type'] ?? NULL;
+    // In the event that the publication has no type, e.g. 39755038,
+    // then assign a generic 'Publication' type.
+    $type = $publication['Publication Type'] ?? 'Publication';
+    $accession = $publication['Publication Dbxref'] ?? 'accession_unknown';
     if ($type) {
       if (is_array($type)) {
         // A publication can have more than one type. We can't support
@@ -550,13 +557,10 @@ class PubSearchQueryImporter extends ChadoImporterBase {
         $type = $type[array_key_first($type)];
       }
       $type_id = $this->cvterm_lookups[$type] ?? 0;
-      // @todo change to just issue warning so we can skip over this publication
       if (!$type_id) {
-        $this->logger->warning('Type ID for Publication Type: ' . $type . ' is not present in the tripal_pub vocabulary');
+        $this->logger->warning('Publication with accession @acc has a type "@type" which is not present in the tripal_pub vocabulary',
+          ['@acc' => $accession, '@type', $type]);
       }
-    }
-    else {
-      $this->logger->warning('Publication is missing a type: ' . print_r($publication, TRUE));
     }
     return $type_id;
   }
@@ -857,6 +861,8 @@ class PubSearchQueryImporter extends ChadoImporterBase {
    * n.b. the calling function will wrap this in a database transaction
    */
   public function run() {
+    $this->logger->notice('Initializing publication importer');
+
     $arguments = $this->arguments['run_args'];
     $pub_library_manager = \Drupal::service('tripal.pub_library');
 
@@ -898,68 +904,96 @@ class PubSearchQueryImporter extends ChadoImporterBase {
       $this->logger->error('This query cannot be executed because it is marked as "Disabled"');
       return FALSE;
     }
-    // This is stored as an integer in the database table, convert to boolean
+    // This is stored as an integer in the database table, this converts it to a boolean
     $do_contact = (($criteria['do_contact'] ?? 0) > 0);
 
-    // Initialize chado variable (used in other helper functions within this class)
+    // Initialize chado connection (used in other helper functions within this class)
     $this->chado = $this->getChadoConnection();
 
-    // Lookup the db_id for the external database
-    $this->logger->notice('Step 1 of 9: Find db_id for remote database (table: db) ...');
+    // Lookup the db_id for the external database for the plugin
     $this->getRemoteDbId($criteria['remote_db']);
-    $this->logger->notice('  🗸 Found db_id: ' . $this->db_id);
 
-    // Preload all tripal_pub ontology terms
-    $this->logger->notice('Step 2 of 9: CVTERMs lookup and caching ...');
+    // Preload all tripal_pub ontology terms to $this->cvterm_lookups
     $this->cachePublicationCvterms();
-    $this->logger->notice('  🗸 Cached cvterms: ' . count($this->cvterm_lookups));
 
-    // Use the appropriate plugin to run the query and process the results
-    $this->logger->notice('Step 3 of 9: Retrieving publication data from remote database ...');
+    // Set up a loop to load publications in batches
     $plugin = $pub_library_manager->createInstance($plugin_id, []);
-    $publications = $plugin->run($criteria);
+    $page = 0;
+    $n_groups = '?';
+    $completed = FALSE;
+    $prefix = '';
+$this->batch_size = 5;//@@@
 
-    if (!is_array($publications)) {
-      $this->logger->error('  ✗ ERROR: Unable to connect to external database to lookup publications');
-    }
-    else {
-      $this->logger->notice('  🗸 Found publications: ' . count($publications));
+    while (!$completed) {
 
-      // Determine the number of new publications to be inserted
-      $n_to_insert = 0;
-      if (count($publications)) {
-        $this->logger->notice('Step 4 of 9: Check for already imported publications ...');
-        $n_to_insert = $this->findExistingPublications($publications);
-        $this->logger->notice('  🗸 New publications to be inserted: ' . $n_to_insert);
+      // Use the appropriate plugin to run the query and process the results, in groups of 100
+      $this->logger->notice($prefix . 'Step 1 of 7: Retrieving publication data from remote database ' . $plugin_id);
+      $criteria['page'] = $page;
+      $criteria['count'] = $this->batch_size;
+      $page_results = $plugin->run($criteria);
+
+      // NULL indicates exception caught
+      if (!is_array($page_results)) {
+        $this->logger->error('  ✗ ERROR: Unable to connect to external database to lookup publications');
+        $completed = TRUE;
       }
-
-      // If no new publications, then nothing to do
-      if (!$n_to_insert) {
-        $this->logger->notice('  ✗ No new publications were found, there is nothing to import');
+      elseif ($page_results['total_records'] == 0) {
+        $this->logger->notice('  🗸 No records matched the search criteria');
+        $completed = TRUE;
       }
       else {
-        $this->logger->notice('Step 5 of 9: Insert database crossreferences ...');
-        $n_inserted = $this->insertMissingPublicationsDbxref($publications);
-        $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+        $publications = $page_results['pubs'];
+        $total_records = $page_results['total_records'];
+        $n_groups = intval(($total_records - 1) / $this->batch_size) + 1;
+        if (count($publications) >= $this->batch_size) {
+          $prefix = 'Group ' . ($page+1) . ' of ' . $n_groups . ', ';
+          if ($page == 0) {
+            $this->logger->notice('  🗸 Publications will be imported in @group groups of @size publications each',
+              ['@group' => $n_groups, '@size' => $this->batch_size]);
+          }
+        }
+        $this->logger->notice('  🗸 Importing @count publications', ['@count' => count($publications)]);
 
-        $this->logger->notice('Step 6 of 9: Insert new publications ...');
-        $n_inserted = $this->insertPublications($publications);
-        $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+        // Determine the number of new publications to be inserted
+        $n_to_insert = 0;
+        if (count($publications)) {
+          $this->logger->notice($prefix . 'Step 2 of 7: Check for already imported publications');
+          $n_to_insert = $this->findExistingPublications($publications);
+          $this->logger->notice('  🗸 New publications to be inserted: ' . $n_to_insert);
+        }
 
-        $this->logger->notice('Step 7 of 9: Link publications to database crossreferences ...');
-        $n_inserted = $this->insertPubDbxrefs();
-        $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+        // If no new publications, then nothing to do
+        if (!$n_to_insert) {
+          $this->logger->notice('  ✗ No new publications were found, there is nothing to import');
+        }
+        else {
+          $this->logger->notice($prefix . 'Step 3 of 7: Insert new publications');
+          $n_inserted = $this->insertPublications($publications);
+          $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
 
-        $this->logger->notice('Step 8 of 9: Insert publication properties ...');
-        $n_inserted = $this->insertPubProps($publications);
-        $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+          $this->logger->notice($prefix . 'Step 4 of 7: Insert database crossreferences');
+          $n_inserted = $this->insertMissingPublicationsDbxref($publications);
+          $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
 
-        $this->logger->notice('Step 9 of 9: Insert authors ...');
-        $n_added = $this->insertContacts($publications, $do_contact);
-        $this->logger->notice('  🗸 Inserted: ' . $n_added);
+          $this->logger->notice($prefix . 'Step 5 of 7: Link publications to database crossreferences');
+          $n_inserted = $this->insertPubDbxrefs();
+          $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+
+          $this->logger->notice($prefix . 'Step 6 of 7: Insert publication properties');
+          $n_inserted = $this->insertPubProps($publications);
+          $this->logger->notice('  🗸 Inserted: ' . $n_inserted);
+
+          $this->logger->notice($prefix . 'Step 7 of 7: Insert authors');
+          $n_added = $this->insertContacts($publications, $do_contact);
+          $this->logger->notice('  🗸 Inserted: ' . $n_added);
+        }
+      }
+      $page++;
+      $prefix = 'Group ' . ($page+1) . ', ';
+      if ($page == $n_groups) {
+        $completed = TRUE;
       }
     }
-
     return;
   }
 


### PR DESCRIPTION
# Bug Fix + New Feature

### Closes #2172
### Closes #2173

## Description
The bug fixed here is that the publication importer only imports the first ten publications. This is the justification for "High" priority.
The new feature is to load publications in batches of 100 to match the batch size used for remote queries, and to minimize memory usage.
Added injection of tripal logger service.
Fix issue #2173 as it was a very small change and too hard for me not to just fix that too.

## Testing?
1. Create a query that will match just a few publications and import. e.g. "tripal" in title or in abstract
```
Initializing publication importer
Step 1 of 7: Retrieving publication data from remote database tripal_pub_library_PMID
  🗸 Importing 23 publications
Step 2 of 7: Check for already imported publications
  🗸 New publications to be inserted: 22
Step 3 of 7: Insert new publications
  🗸 Inserted: 22
Step 4 of 7: Insert database crossreferences
  🗸 Inserted: 22
Step 5 of 7: Link publications to database crossreferences
  🗸 Inserted: 22
Step 6 of 7: Insert publication properties
  🗸 Inserted: 520
Step 7 of 7: Insert authors
  🗸 Inserted: 230
Done.
``` 
2. Create a query that will import more than 100 publications and import. A prefix is added to the log messages when there is more than one batch
```
Step 1 of 7: Retrieving publication data from remote database tripal_pub_library_PMID
  🗸 277 publications will be imported in 3 groups of 100 publications each
  🗸 Importing 100 publications
Group 1 of 3, Step 2 of 7: Check for already imported publications
...
```
3. Create a query that will match no publications and import.
```
Initializing publication importer
Step 1 of 7: Retrieving publication data from remote database tripal_pub_library_PMID
  🗸 No records matched the search criteria
Done.
```
4. Import this pubmed accession 38234546, which is a retracted publication, and its type is not present in the tripal_pub vocabulary. It will be skipped.
`WARNING: Publication with accession 38234546 has a type "Retraction Notice" which is not present in the tripal_pub vocabulary, so will not be imported. Consider adding a term for this type.`
