### PR TITLE
Fix discovery on unit type field

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -119,7 +119,8 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
     // Specific settings for this field
     $options += [
       'id' => self::$id,
-      'table' => 'cvterm',
+      'base_table' => 'featuremap',
+      'base_column' => 'unittype_id',
       'label' => 'Unit Type',
       'termIdSpace' => 'UO',
       'termAccession' => '0000000',

--- a/tripal_chado/tests/src/Functional/Services/ChadoDiscoverTest.php
+++ b/tripal_chado/tests/src/Functional/Services/ChadoDiscoverTest.php
@@ -239,7 +239,7 @@ class ChadoDiscoverTest extends ChadoTestBrowserBase {
 
     // Test of the unit field on a generic map (featuremap table)
     $discovered_fields = $fields_service->discover($content_types['map']);
-    $this->assertArrayHasKey('map_cvterm', $discovered_fields['new'], 'The unit type field was not discovered for featuremap');
+    $this->assertArrayHasKey('map_unittype_id', $discovered_fields['new'], 'The unit type field was not discovered for featuremap');
 
     // Test discovery of a field using a column in the base table
     $discovered_fields = $fields_service->discover($content_types['gene']);


### PR DESCRIPTION
# Bug Fix

### Closes #2177 

## Description
I am sorry, I messed up the ChadoUnitTypeDefault field's `discover()` function. It should only be discovered for content types based on the `featuremap` table. Currently it is getting discovered for any table with a fkey to cvterm_id 😱

The fix is simple

## Testing?
1. On this branch, import the genetic and genomic content types
2. Remove the Unit Type field from Genetic Map
3. Confirm that "Check for new fields" discovers it and adds it*
4. Do the same for the Physical Map content type
5. Discover for the Publication content type. The field should NOT be discovered

* Note that the original field machine name is `genetic_map_unit_type` and after removal and discovery it is `genetic_map_unittype_id` because the discovered machine name is based on the table column name `unittype_id`, and the original machine name is from the yaml.
