### PR TITLE
Resolve high memory consumption during publish

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -810,10 +810,14 @@ class ChadoPublish extends TripalBackendPublishBase {
       $tags[] = 'values:tripal_entity:' . $entity_id;
       $index++;
     }
-    // Clear cache so that fields will appear on new entities
     if ($index) {
+      // Clear cache so that fields will appear on new entities
       \Drupal::service('cache.entity')->invalidateMultiple($tags);
       \Drupal::service('cache_tags.invalidator')->invalidateTags(['rendered']);
+
+      // The Drupal memory cache can get quite large with large
+      // publish jobs. Clear it since we are done with these entities.
+      \Drupal::service('entity.memory_cache')->deleteAll();
     }
   }
 


### PR DESCRIPTION
# Bug Fix

### Closes #2179

## Description
When publishing a large number of entities, e.g. genes, you may run out of memory eventually.
This is because Drupal caches every new entity in memory.
The resolution is to clear the memory cache after each batch during publish, after we are done with the entity objects.

## Testing?
Either migrate a Tripal 3 site, or import a lot of genes, but try to publish them.
A good diagnostic is to put a memory usage message in
`tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php`
such as
```
$memory = number_format(memory_get_usage());
$this->logger->notice("Batch $batch_num memory: $memory");
```
before line 1443 on this branch


Example with publications, more memory-intensive because there are lots of fields
```
root@8f6bd6f2910f:/var/www/drupal# drush trp-chado-publish pub     
 [notice] Initial memory: 31,141,600
...
 [notice] Preparing to publish 39,242 "pub" records in 40 batches
...
 [notice] Batch 0 memory: 149,249,328
...
 [notice] Batch 1 memory: 196,258,784
...
 [notice] Batch 2 memory: 194,211,928
...
 [notice] Batch 3 memory: 137,605,048
...
```
and so on. There may be a slow average increase but nothing like it was before. In the graph you can see where we ran out of memory on 4.x
![memoryusage](https://github.com/user-attachments/assets/a2ebcfb9-2943-48cb-9758-4aef0576d647)

