### PR TITLE
Provide correct phpunit.xml version in 10.x docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN service apache2 start \
   && rm -rf /tripal_app \
   && allmodules="${tripalmodules} ${modules}" \
   && vendor/bin/drush en ${allmodules} -y \
+  && if $(dpkg --compare-versions "${drupalversion}" "lt" "10.6"); then \
+     mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
+     && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
+  fi \
   && service apache2 stop \
   && service postgresql stop
 


### PR DESCRIPTION
# Bug Fix

### Closes #2170

## Description
This adds a step to the docker build process to set up the correct phpunit.xml version for drupal 10.x versions

## Testing?
1. Build a docker on any 10.x version, for example
```
docker build \
  --tag=tripaldocker:testing-2170 \
  --build-arg drupalversion="10.4.x-dev" \
  --build-arg postgresqlversion="16" \
  --build-arg chadoschema="chado" ./
docker run --publish=8080:80 -tid --name=2170 tripaldocker:testing-2170
```

2. Now verify correct renaming of phpunit.xml files inside the docker:
```
root@42418cc98642:/var/www/drupal# ls -l web/modules/contrib/tripal/phpunit*
-rw-r--r-- 1 root www-data 6667 Apr  2 14:18 web/modules/contrib/tripal/phpunit.10.5.xml
-rw-r--r-- 1 root www-data 6161 Apr  2 14:18 web/modules/contrib/tripal/phpunit.xml
```

3. Try running a test
```
# cd web/modules/contrib/tripal/
# phpunit --filter=ChadoCvtermBuddyTest
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

Testing 
..                                                                  2 / 2 (100%)

Time: 00:12.054, Memory: 22.00 MB

OK (2 tests, 259 assertions)
```
