### PR TITLE
Repair widget remove button

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -915,8 +915,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // Determine whether the property values are to be cached in the
           // Drupal Entity Field tables.
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
-            $prop_values[$key] = $prop_value;
-            $prop_types[$key] = $prop_type;
+            $prop_values[] = $prop_value;
+            $prop_types[] = $prop_type;
           }
         }
 

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -908,10 +908,22 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         // Load into the entity the properties that are to be stored in Drupal.
         $prop_values = [];
         $prop_types = [];
+        $store_values = [];
         foreach ($values[$tsid][$field_name][$delta] as $key => $prop_info) {
           $storage = $tripal_storages[$tsid];
           $prop_type = $storage->getPropertyType($field_name, $key);
           $prop_value = $prop_info['value'];
+
+          // Store the values of any properties with a "store" action.
+          // There will usually only be one, exceptions are dbxref, relationship.
+          $action = '';
+          if ($prop_type) {
+            $action = $prop_type->getStorageSettings()['action'] ?? '';
+          }
+          if ($action == 'store') {
+            $store_values[$key] = $prop_value->getValue();
+          }
+
           // Determine whether the property values are to be cached in the
           // Drupal Entity Field tables.
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
@@ -931,13 +943,19 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           if ($this->allNull($prop_values) && !($delta_remove[$field_name][$delta] ?? NULL)) {
             $delta_remove[$field_name][] = $delta;
           }
-          // When we choose "- Select -" in a widget, or remove the row with the
-          // "Remove" button, then we will see the entity_id here as -2 or -3.
+
+          // If there is a zero value in $store_values, this means that
+          // we choose "- Select -" in a widget, or removed the row with the
+          // "Remove" button.
           // Chado storage has already done its work, so now remove this
           // delta so that Drupal doesn't make a blank field table entry.
-          if (array_key_exists('entity_id', $prop_values)
-              && ($prop_values['entity_id']->getValue() <= -2)
-              && !($delta_remove[$field_name][$delta] ?? NULL)) {
+          $remove = FALSE;
+          foreach ($store_values as $value) {
+            if ($value === 0) {
+              $remove = TRUE;
+            }
+          }
+          if ($remove && !($delta_remove[$field_name][$delta] ?? NULL)) {
             $delta_remove[$field_name][] = $delta;
           }
         }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -835,6 +835,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // Perform the Insert or Update of the submitted values to the
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
+
       // Do an insert
       if ($this->isDefaultRevision() and $this->isNewRevision()) {
         try {
@@ -927,14 +928,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.
           // A given delta should only be present once here.
-          if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
+          if ($this->allNull($prop_values) && !($delta_remove[$field_name][$delta] ?? NULL)) {
             $delta_remove[$field_name][] = $delta;
           }
-          // When we choose -Select- in a widget, or remove the row with the
+          // When we choose "- Select -" in a widget, or remove the row with the
           // "Remove" button, then we will see the entity_id here as -2 or -3.
           // Chado storage has already done its work, so now remove this
           // delta so that Drupal doesn't make a blank field table entry.
-          if (array_key_exists('entity_id', $prop_values) and $prop_values['entity_id']->getValue() <= -2) {
+          if (array_key_exists('entity_id', $prop_values)
+              && ($prop_values['entity_id']->getValue() <= -2)
+              && !($delta_remove[$field_name][$delta] ?? NULL)) {
             $delta_remove[$field_name][] = $delta;
           }
         }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -940,7 +940,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $item->tripalLoad($item, $field_name, $prop_types, $prop_values, $this);
           // Keep track of elements that have no value.
           // A given delta should only be present once here.
-          if ($this->allNull($prop_values) && !($delta_remove[$field_name][$delta] ?? NULL)) {
+          if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
             $delta_remove[$field_name][] = $delta;
           }
 

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -813,7 +813,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *   The array to check for null values. It is expected to be a flat array.
    *
    * @return bool
-   *   True IFF all elements are null; False if even one element is not null.
+   *   True if all elements are null; False if even one element is not null.
    */
   public static function allNull(array $array_to_check) : bool {
     foreach ($array_to_check as $value) {
@@ -835,7 +835,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // Perform the Insert or Update of the submitted values to the
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
-
       // Do an insert
       if ($this->isDefaultRevision() and $this->isNewRevision()) {
         try {
@@ -911,13 +910,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         foreach ($values[$tsid][$field_name][$delta] as $key => $prop_info) {
           $storage = $tripal_storages[$tsid];
           $prop_type = $storage->getPropertyType($field_name, $key);
-
           $prop_value = $prop_info['value'];
           // Determine whether the property values are to be cached in the
           // Drupal Entity Field tables.
           if ($storage->isDrupalStoreByFieldNameKey($field_name, $key)) {
-            $prop_values[] = $prop_value;
-            $prop_types[] = $prop_type;
+            $prop_values[$key] = $prop_value;
+            $prop_types[$key] = $prop_type;
           }
         }
 
@@ -930,6 +928,13 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // Keep track of elements that have no value.
           // A given delta should only be present once here.
           if ($this->allNull($prop_values) and (!array_key_exists($field_name, $delta_remove) or !in_array($delta, $delta_remove[$field_name]))) {
+            $delta_remove[$field_name][] = $delta;
+          }
+          // When we choose -Select- in a widget, or remove the row with the
+          // "Remove" button, then we will see the entity_id here as -2 or -3.
+          // Chado storage has already done its work, so now remove this
+          // delta so that Drupal doesn't make a blank field table entry.
+          if (array_key_exists('entity_id', $prop_values) and $prop_values['entity_id']->getValue() <= -2) {
             $delta_remove[$field_name][] = $delta;
           }
         }
@@ -1183,6 +1188,5 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       }
     }
   }
-
 
 }

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
@@ -70,6 +70,9 @@ class ChadoDbxrefWidgetDefault extends ChadoWidgetBase {
       if (!preg_match('/remove_button/', $triggering_element)) {
         $storage['initial_values'][$field_name][$delta]['db_id'] = $db_id;
         $storage['initial_values'][$field_name][$delta]['db_name'] = $db_name;
+        if (!array_key_exists('linker_id', $storage['initial_values'][$field_name][$delta])) {
+          $storage['initial_values'][$field_name][$delta]['linker_id'] = $linker_id;
+        }
         $form_state->setStorage($storage);
       }
     }
@@ -150,9 +153,7 @@ class ChadoDbxrefWidgetDefault extends ChadoWidgetBase {
       }
     }
 
-    // Save some initial values to allow later handling of the "Remove" button
-    $this->saveInitialValues($delta, $field_name, $linker_id, $form_state);
-
+    // n.b. this field does not use saveInitialValues() because they were saved earlier
     return $element;
   }
 

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1440,8 +1440,13 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    *   to calculate the field's final value.
    *
    * @return int
-   *   The Drupal entity ID, or -1 if it doesn't exist.
-   *   We use -1 because Tripal preSave will flag a zero for deletion.
+   *   The Drupal entity ID, or a negative value if there is no corresponding entity.
+   *   -1 signifies that the record exists, but is not published.
+   *   -2 signifies that the record exists but has no value.
+   *      This happens during edit if the widget removes a record.
+   *   -3 signifies that the record doesn't exist.
+   *   -4 will only occur due to an incorrect field definition, fkey is missing.
+   *   Note that Tripal preSave will flag a zero for deletion.
    */
   static public function drupalEntityIdLookupCallback($context) {
 
@@ -1458,17 +1463,17 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $fkey = $prop_storage_settings['fkey'] ?? NULL;
     if (!$fkey) {
       // Maybe throw an exception here so developers know they forgot the 'fkey'
-      return -1;
+      return -4;
     }
 
     $record_id = $context['values'][$field_name][$delta][$fkey]['value'] ?? NULL;
     if (!$record_id) {
-      return -1;
+      return -3;
     }
     $record_id = $record_id->getValue('value');
 
     if (!$record_id) {
-      return -1;
+      return -2;
     }
 
     // Given the Chado record ID and bundle term, we can lookup the Drupal entity ID,

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -1440,13 +1440,8 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
    *   to calculate the field's final value.
    *
    * @return int
-   *   The Drupal entity ID, or a negative value if there is no corresponding entity.
-   *   -1 signifies that the record exists, but is not published.
-   *   -2 signifies that the record exists but has no value.
-   *      This happens during edit if the widget removes a record.
-   *   -3 signifies that the record doesn't exist.
-   *   -4 will only occur due to an incorrect field definition, fkey is missing.
-   *   Note that Tripal preSave will flag a zero for deletion.
+   *   The Drupal entity ID, or -1 if it doesn't exist.
+   *   We use -1 because Tripal preSave will flag a zero for deletion.
    */
   static public function drupalEntityIdLookupCallback($context) {
 
@@ -1463,17 +1458,17 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
     $fkey = $prop_storage_settings['fkey'] ?? NULL;
     if (!$fkey) {
       // Maybe throw an exception here so developers know they forgot the 'fkey'
-      return -4;
+      return -1;
     }
 
     $record_id = $context['values'][$field_name][$delta][$fkey]['value'] ?? NULL;
     if (!$record_id) {
-      return -3;
+      return -1;
     }
     $record_id = $record_id->getValue('value');
 
     if (!$record_id) {
-      return -2;
+      return -1;
     }
 
     // Given the Chado record ID and bundle term, we can lookup the Drupal entity ID,

--- a/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
+++ b/tripal_chado/src/Plugin/TripalStorage/ChadoStorage.php
@@ -349,7 +349,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
           $this->records->deleteRecords($base_table, $table);
         }
 
-        // Second, delete the record in the base talbe.
+        // Second, delete the record in the base table.
         $this->records->deleteRecords($base_table, $base_table);
       }
 
@@ -1192,7 +1192,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       return $ret_array;
     }
 
-    // If the path is not a join but has a period then this specifices
+    // If the path is not a join but has a period then this specifies
     // the table and the column with the value.
     else if (preg_match('/\./', $curr_path)) {
 
@@ -1204,7 +1204,7 @@ class ChadoStorage extends TripalStorageBase implements TripalStorageInterface {
       }
 
       // If the base table is not the same as the root table then
-      // we should add the field name to the colun alias. Otherwise
+      // we should add the field name to the column alias. Otherwise
       // we may have conflicts if mutiple fields use the same alias.
       $value_alias = $as ? $as : $value_column;
       if ($base_table != $root_table) {

--- a/tripal_chado/src/TripalField/ChadoWidgetBase.php
+++ b/tripal_chado/src/TripalField/ChadoWidgetBase.php
@@ -373,7 +373,8 @@ abstract class ChadoWidgetBase extends TripalWidgetBase {
         }
         else {
           // If there is no record_id, then it is the empty
-          // field at the end of the list, and can be ignored.
+          // field at the end of the list, and should be removed
+          // so that drupal does not try to save it.
           unset($values[$val_key]);
         }
       }

--- a/tripal_chado/src/TripalField/ChadoWidgetBase.php
+++ b/tripal_chado/src/TripalField/ChadoWidgetBase.php
@@ -387,7 +387,7 @@ abstract class ChadoWidgetBase extends TripalWidgetBase {
     // so that chado storage is informed to delete the linking record.
     $next_delta = $values ? array_key_last($values) + 1 : 0;
     $storage_values = $form_state->getStorage();
-    $initial_values = $storage_values['initial_values'][$field_name];
+    $initial_values = (array_key_exists($field_name, $storage_values['initial_values'])) ? $storage_values['initial_values'][$field_name] : [];
     foreach ($initial_values as $initial_value) {
       // For initial values, the key is always 'linker_id', regardless of $linker_key value.
       $linker_id = $initial_value['linker_id'] ?? 0;


### PR DESCRIPTION
# Bug Fix

### Closes  #2157
### Closes #2020

## Description
On Drupal 10.3, the widget remove button is leaving a record in the Drupal field table. Chado is updated correctly.
On Drupal 11.1 the same thing, but also setting a record back to "-Select-" also has the same problem.
I figure this is high priority because it means editing content is broken if you want to remove a link.

~~To fix this, I needed to get information from the widget into Tripal `preSave()`. The widget only returns a `$values` array, and this gets significantly processed before `preSave()` sees it, and you can't just add additional information to it and expect to see it in `preSave()`. I realized I could use the `entity_id` property to pass a value to tell `preSave()` to remove the record (using the existing mechanism) so that Drupal won't see it and try to create a field table entry.
The only problem with this is that a field not linked to a content type won't be able to use this method, and specifically I am thinking of the dbxref field. There is an existing issue for this very problem in that field #2020~~
~~So for now this PR is draft~~

To fix this, in `preSave()` I check for the properties with an action of `save` and get their values. For example where we have projects on a contact entity, the property will be for `project_id`.
This property is an integer zero when either the "Remove" button was used, or the value was removed from the form.
When this happens, then the existing mechanism (the `$delta_remove` array) is populated with this delta, and downstream Drupal will not see this delta 🙈 so won't create an empty record. YAY!

And with this now working, commit https://github.com/tripal/tripal/pull/2190/commits/86f85ba480b8d83919ae22604d54bb20c5b56e29 fixes issue #2020

## Testing?
See Issue #2157 for steps to reproduce the bug, do the same to test this PR
Also test setting an existing record to `- Select -`
![project-to-select](https://github.com/user-attachments/assets/271e4fb7-e639-47c2-8517-7c79e0cb404c)

Also test the dbxref field specifically, I did that on the project content type.
