### PR TITLE
Implement "AND" instead of "OR" for tripal content listing filter

### DIFF
--- a/tripal/config/install/views.view.tripal_content_type_listing.yml
+++ b/tripal/config/install/views.view.tripal_content_type_listing.yml
@@ -6,7 +6,7 @@ dependencies:
     - tripal
     - user
 _core:
-  default_config_hash: mP9f-XmAQWc4QPnYqqJiE6GnTFEhd9H5qcy-Q3hxzF4
+  default_config_hash: MFwmxO1-UgyEec22hL2SmulHUG_sl8LvW2_nX5MybdQ
 id: tripal_content_type_listing
 label: 'Tripal Content Type Listing'
 module: views
@@ -617,7 +617,7 @@ display:
       filter_groups:
         operator: AND
         groups:
-          1: OR
+          1: AND
       style:
         type: table
         options:


### PR DESCRIPTION
# Bug Fix

### Closes #2192

## Description
This is a very simple change to the tripal content listing, where conditions in the filter are now combined with "AND" instead of "OR"
The problem was that if you tried to filter by both a content type, and some text, the existing "OR" condition meant that you would potentially see records from a different content type than what was in the filter.

## Testing?
1. Create any two different content types with "Tripal" in the title e.g. Project and Contact
2. In the content listing first filter by "Project" - you will now only see one
3. Then type "T" in the "Title" field. The other one will again appear on 4.x, but not on this branch