### PR TITLE
Set the max length for field autocomplete to a much larger number to take into account long publication titles.

### DIFF
--- a/tripal_chado/src/TripalField/ChadoWidgetBase.php
+++ b/tripal_chado/src/TripalField/ChadoWidgetBase.php
@@ -174,6 +174,7 @@ abstract class ChadoWidgetBase extends TripalWidgetBase {
         '#default_value' => $default_value,
         '#autocomplete_route_name' => 'tripal_chado.generic_autocomplete',
         '#size' => $options['size'],
+        '#maxlength' => 1000,
         '#placeholder' => $options['placeholder'],
       ];
       unset($options['size']);


### PR DESCRIPTION

# Bug Fix


### Issue #2197 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Scientific publications often have long titles. When linking a publication with a long title to any other content (e.g. Project), you can select it through the autocomplete but when you try to save the page, an error is thrown and the page is not saved.

<img width="1292" alt="Image" src="https://github.com/user-attachments/assets/2e483e4b-1051-4325-be86-3db5b8491ada" />

This is solved by setting the maximum length of the autocomplete used for linking fields to a safely high number. There is no concerns doing this since the info in the textfield is not saved but rather "massaged" into the pub_id and that is saved.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
1. Create a publication with a title greater then 128 characters by going to Top Admin Bar > Tripal > Content > Add Tripal Content > Publication. These are the values I used:
  - Title: Genomic rearrangements have consequences for introgression breeding as revealed by genome assemblies of wild and cultivated lentil species.
  - Type: Journal Article
  - Unique Local Identifier: Ramsay L, Koh CS, Kagale S, Gao D, Kaur S, Haile T, Gela TS, Chen LA, Cao Z, Konkin DJ, Toegelová H, Doležel J, Rosen BD, Stonehouse R, Humann JL, Main D, Coyne CJ, McGee RJ, Cook DR, Penmetsa RV, Vandenberg A, Chan C, Banniza S, Edwards D, Bayer PE, Batley J, Udupa SM, Bett KE. Genomic rearrangements have consequences for introgression breeding as revealed by genome assemblies of wild and cultivated lentil species. bioRxiv. 2021 Jul 24. 
2. Set the project - publication linker field to always use an autocomplete. This error does not happen with the select box. This is done by 
  - going to Top Admin Bar > Tripal > Page Structure > Project > Manage Form Display.
  - Clicking on the settings gear/cog to the right side of the publication field. ![Image](https://github.com/user-attachments/assets/aefb1168-7cb4-4cf1-8a97-f0eb323e953f)
  - Entering `0` into the "Maximum records for a select" and clicking "Update" followed by "Save" at the bottom of the page. ![Image](https://github.com/user-attachments/assets/efc9a26a-b16a-44b3-8a95-2b545c8bc23a)
3. Create a project linking to the publication created above. This is done by 
  - going to Top Admin Bar > Tripal > Content > Add Tripal Content > Project
  - enter a name (it doesn't matter what it is)
  - In the publication field, start typing the long publication name and select it from the autocomplete once it is listed.
  - Attempt to save the project.

On this branch the last step with complete successfully as expected but on 4.x this would have resulting in an error as shown in screenshot in the description.