### PR TITLE
Support Field group 4.0 semversion update

### DIFF
--- a/.github/workflows/MAIN-composerInstall.yml
+++ b/.github/workflows/MAIN-composerInstall.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 4.x
-      - tv4g0-2138-installIssues
+      - tv4g0-2199-composerFailing
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -51,7 +51,7 @@ jobs:
           # Exclude higher postgresql version from middle Drupal versions
           # This is done to reduce combinations; higher postgresql version
           # will be tested on merge to 4.x.
-          # Note: Drupal 11.0 is already only tested on one postgresql 
+          # Note: Drupal 11.0 is already only tested on one postgresql
           # version since it requires 16+.
           - pgsql-version: "17"
             drupal-version: "10.4.x-dev"
@@ -67,7 +67,7 @@ jobs:
       # Now download Tripal using composer and install it in the docker.
       - name: Install Tripal via docker
         env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ "$BRANCH_NAME" = "4.x" ]; then
             docker exec --workdir=/var/www/drupal drupaldocker composer require --dev tripal/tripal:4.x-dev --no-interaction --with-all-dependencies

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^8.1",
     "drupal/core": "^10.3 | ^11.0",
-    "drupal/field_group": "^3.6",
+    "drupal/field_group": "^3.6 | ^4.0",
     "drupal/field_group_table": "1.x-dev@dev"
   },
   "lock": false


### PR DESCRIPTION
# Bug Fix

### Issue #2199

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Each time 4.x-dev is updated, a set of tests checking composer install is run. Currently it is failing: https://github.com/tripal/tripal/actions/runs/14785768145/job/41513768386

```
Running composer update tripal/tripal --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires tripal/tripal 4.x-dev -> satisfiable by tripal/tripal[4.x-dev].
    - tripal/tripal 4.x-dev requires drupal/field_group ^3.6 -> found drupal/field_group[dev-3.x, 3.6.0, 3.x-dev (alias of dev-3.x)] but it conflicts with your root composer.json require (^4.0).


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
I've updated the composer test workflow to run on this branch. Confirm it is passing for all versions now.
