### PR TITLE
Fix brittle tests depending on external sites

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnSkippedTests="true"
          cacheResult="false"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache">

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -431,18 +431,8 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
       }
     }
     usleep($sleep_time);  // 1/3 or 1/10 of a second delay, NCBI limits requests to 3 / second without API key
-    $rfh = fopen($fetch_url, "r");
-    if (!$rfh) {
-      $this->logger->error("Could not perform PubMed query: $fetch_url.");
-      return NULL;
-    }
-    $results = '';
-    if ($rfh) {
-      while (!feof($rfh)) {
-        $results .= fread($rfh, 255);
-      }
-      fclose($rfh);
-    }
+
+    $results = $this->fileretriever->retrieveFile($fetch_url);
 
     return $results;
   }

--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -432,7 +432,7 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     }
     usleep($sleep_time);  // 1/3 or 1/10 of a second delay, NCBI limits requests to 3 / second without API key
 
-    $results = $this->fileretriever->retrieveFile($fetch_url);
+    $results = $this->fileretriever->retrieveFileContents($fetch_url);
 
     return $results;
   }

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -74,7 +74,6 @@ class TripalFileRetriever {
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
-$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
           sleep($options['delay'] ?? 1);
@@ -140,7 +139,6 @@ $fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retri
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
-$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $status = FALSE; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error 10% of the time
         $retries--;
         if (!$status && ($retries > 0)) {
           sleep($options['delay'] ?? 1);

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -74,7 +74,9 @@ class TripalFileRetriever {
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
-$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
+//$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
+// Simulate lots of errors for testing
+$fail = (rand(0,9) <= 5); if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
           sleep($options['delay'] ?? 1);

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -72,6 +72,7 @@ class TripalFileRetriever {
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
+$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
           sleep(1);
@@ -135,6 +136,7 @@ class TripalFileRetriever {
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
+$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $status = FALSE; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error 10% of the time
         $retries--;
         if (!$status && ($retries > 0)) {
           sleep(1);

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -74,9 +74,7 @@ class TripalFileRetriever {
         catch (\Exception $e) {
           $this->handleURLExceptions($retries, $e, $url);
         }
-//$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
-// Simulate lots of errors for testing
-$fail = (rand(0,9) <= 5); if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
+$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
           sleep($options['delay'] ?? 1);

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -1,0 +1,116 @@
+<?php
+namespace Drupal\tripal\Services;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ClientException;
+
+/**
+ * The TripalFileLoader class handles copying files from both
+ * remote URLs or local file paths, with resiliance against
+ * errors.
+ */
+class TripalFileRetriever {
+
+  /**
+   * The Drupal HTTP service (i.e. guzzle)
+   *
+   * @var object \GuzzleHttp\ClientInterface $httpClient
+   */
+  protected $httpClient = NULL;
+
+  /**
+   * A logger object.
+   *
+   * @var TripalLogger $logger
+   */
+  protected $logger;
+
+  /**
+   * Constructor
+   */
+  public function __construct(\GuzzleHttp\ClientInterface $httpClient, TripalLogger $logger) {
+    $this->httpClient = $httpClient;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static (
+      $container->get('http_client'),
+      $container->get('tripal.logger')
+    );
+  }
+
+  /**
+   * Download the contents of a remote or local file from a specified URL,
+   * and returns it in a string variable.
+   *
+   * @param string $url
+   *   The address of the file to download
+   * @param int $retries
+   *   The number of times to retry the remote download if an error occurs
+   * @param array $options
+   *   Any options to pass to the HTTP request
+   * @return string
+   *   The data obtained from the specified url, or NULL if it could not be downloaded
+   */
+  public function retrieveFile(string $url, int $retries = 3, array $options = []): string|null {
+#print "CP01 retrieveRemoteFile \"$url\" retries=$retries options=";var_dump($options); //@@@
+    // Distinguish between local and remote files
+    $parsed_url = parse_url($url);
+    if ($parsed_url['host'] ?? NULL) {
+      while ($retries > 0) {
+        try {
+          $response = $this->httpClient->get($url, $options);
+          $response_body = (string) $response->getBody();
+          return $response_body;
+        }
+        catch (ConnectException $e) {
+          $this->logger->error('Invalid hostname in URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return NULL;
+        }
+        catch (ClientException $e) {
+          $this->logger->error('Invalid file in URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return NULL;
+        }
+        catch (RequestException $e) {
+          if ($retries > 1) {
+            $this->logger->error('Unable to get response from @url: @exception. Will retry',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+          }
+          else {
+            $this->logger->error('Unable to get response from @url: @exception',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+            return NULL;
+          }
+        }
+        $retries--;
+        sleep(1);
+      }
+    }
+    // If there was no host in the url, then it is considered a local file
+    else {
+      $contents = FALSE;
+      if (!file_exists($url)) {
+        $this->logger->error('Local file @url does not exist',
+            ['@url' => $url]);
+      }
+      else {
+        $contents = file_get_contents($url);
+      }
+      if ($contents === FALSE) {
+        return NULL;
+      }
+      else {
+        return $contents;
+      }
+    }
+  }
+
+}

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -58,8 +58,7 @@ class TripalFileRetriever {
    * @return string
    *   The data obtained from the specified url, or NULL if it could not be downloaded
    */
-  public function retrieveFile(string $url, int $retries = 3, array $options = []): string|null {
-#print "CP01 retrieveRemoteFile \"$url\" retries=$retries options=";var_dump($options); //@@@
+  public function retrieveFileContents(string $url, int $retries = 3, array $options = []): string|null {
     // Distinguish between local and remote files
     $parsed_url = parse_url($url);
     if ($parsed_url['host'] ?? NULL) {
@@ -90,9 +89,15 @@ class TripalFileRetriever {
             return NULL;
           }
         }
+        catch (Exception $e) {
+          $this->logger->error('Unhandled exception downloading URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return NULL;
+        }
         $retries--;
         sleep(1);
       }
+      return NULL;
     }
     // If there was no host in the url, then it is considered a local file
     else {
@@ -113,4 +118,77 @@ class TripalFileRetriever {
     }
   }
 
+  /**
+   * Download the contents of a remote or local file from a specified URL,
+   * and saves it to a file in the local filesystem.
+   *
+   * @param string $url
+   *   The address of the file to download
+   * @param string $localfile
+   *   The path to a local file where data is saed
+   * @param int $retries
+   *   The number of times to retry the remote download if an error occurs
+   * @param array $options
+   *   Any options to pass to the HTTP request
+   * @return bool
+   *   Returns TRUE if successful, FALSE if error.
+   */
+  public function downloadFile(string $url, string $localfile, int $retries = 3, array $options = []): bool {
+    // Distinguish between local and remote files
+    $parsed_url = parse_url($url);
+    if ($parsed_url['host'] ?? NULL) {
+
+      $options['sink'] = $localfile;
+      $options['stream'] = FALSE;
+
+      while ($retries > 0) {
+        try {
+          /** @var GuzzleHttp\Psr7\Response **/
+          $response = $this->httpClient->get($url, $options);
+          return TRUE;
+        }
+        catch (ConnectException $e) {
+          $this->logger->error('Invalid hostname in URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return FALSE;
+        }
+        catch (ClientException $e) {
+          $this->logger->error('Invalid file in URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return FALSE;
+        }
+        catch (RequestException $e) {
+          if ($retries > 1) {
+            $this->logger->error('Unable to get response from @url: @exception. Will retry',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+          }
+          else {
+            $this->logger->error('Unable to get response from @url: @exception',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+            return FALSE;
+          }
+        }
+        catch (Exception $e) {
+          $this->logger->error('Unhandled exception downloading URL @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+          return FALSE;
+        }
+        $retries--;
+        sleep(1);
+      }
+      return NULL;
+    }
+    // If there was no host in the url, then it is considered a local file
+    else {
+      if (!file_exists($url)) {
+        $this->logger->error('Local file @url does not exist',
+            ['@url' => $url]);
+        return FALSE;
+      }
+      else {
+        copy($url, $localfile);
+        return TRUE;
+      }
+    }
+  }
 }

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -69,31 +69,8 @@ class TripalFileRetriever {
           $response = $this->httpClient->get($url, $options);
           $contents = (string) $response->getBody();
         }
-        catch (ConnectException $e) {
-          $this->logger->error('Invalid hostname in URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
-        }
-        catch (ClientException $e) {
-          $this->logger->error('Invalid file in URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
-        }
-        catch (RequestException $e) {
-          if ($retries > 1) {
-            $this->logger->error('Unable to get response from @url: @exception. Will retry',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-          }
-          else {
-            $this->logger->error('Unable to get response from @url: @exception',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-            $retries = 0;
-          }
-        }
         catch (\Exception $e) {
-          $this->logger->error('Unhandled exception downloading URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
+          $this->handleURLExceptions($retries, $e, $url);
         }
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
@@ -155,31 +132,8 @@ class TripalFileRetriever {
           $response = $this->httpClient->get($url, $options);
           $status = TRUE;
         }
-        catch (ConnectException $e) {
-          $this->logger->error('Invalid hostname in URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
-        }
-        catch (ClientException $e) {
-          $this->logger->error('Invalid file in URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
-        }
-        catch (RequestException $e) {
-          if ($retries > 1) {
-            $this->logger->error('Unable to get response from @url: @exception. Will retry',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-          }
-          else {
-            $this->logger->error('Unable to get response from @url: @exception',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-            $retries = 0;
-          }
-        }
         catch (\Exception $e) {
-          $this->logger->error('Unhandled exception downloading URL @url: @exception',
-              ['@url' => $url, '@exception' => $e->getMessage()]);
-          $retries = 0;
+          $this->handleURLExceptions($retries, $e, $url);
         }
         $retries--;
         if (!$status && ($retries > 0)) {
@@ -205,5 +159,45 @@ class TripalFileRetriever {
       }
     }
     return $status;
+  }
+
+  /**
+   * Logs various types of exceptions that may occur when downloading
+   *
+   * @param int &$retries
+   *   The number of times to retry the remote download if an error occurs
+   * @param \Exception $e
+   *   An exception to be handled
+   * @param string $url
+   *   The URL that caused the exception
+   * @return void
+   *   Any problems are sent to the logger
+   */
+  private function handleURLExceptions (int &$retries, \Exception $e, string $url): void {
+    if ($e instanceof ConnectException) {
+      $this->logger->error('Invalid hostname in URL @url: @exception',
+          ['@url' => $url, '@exception' => $e->getMessage()]);
+      $retries = 0;
+    }
+    elseif ($e instanceof ClientException) {
+      $this->logger->error('Invalid file in URL @url: @exception',
+          ['@url' => $url, '@exception' => $e->getMessage()]);
+      $retries = 0;
+    }
+    elseif ($e instanceof RequestException) {
+      if ($retries > 1) {
+        $this->logger->error('Unable to get response from @url: @exception. Will retry',
+            ['@url' => $url, '@exception' => $e->getMessage()]);
+      }
+      else {
+        $this->logger->error('Unable to get response from @url: @exception',
+            ['@url' => $url, '@exception' => $e->getMessage()]);
+      }
+    }
+    else {
+      $this->logger->error('Unhandled exception downloading URL @url: @exception',
+          ['@url' => $url, '@exception' => $e->getMessage()]);
+      $retries = 0;
+    }
   }
 }

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -59,24 +59,25 @@ class TripalFileRetriever {
    *   The data obtained from the specified url, or NULL if it could not be downloaded
    */
   public function retrieveFileContents(string $url, int $retries = 3, array $options = []): string|null {
+    $contents = NULL;
+
     // Distinguish between local and remote files
     $parsed_url = parse_url($url);
     if ($parsed_url['host'] ?? NULL) {
-      while ($retries > 0) {
+      while (is_null($contents) && ($retries > 0)) {
         try {
           $response = $this->httpClient->get($url, $options);
-          $response_body = (string) $response->getBody();
-          return $response_body;
+          $contents = (string) $response->getBody();
         }
         catch (ConnectException $e) {
           $this->logger->error('Invalid hostname in URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return NULL;
+          $retries = 0;
         }
         catch (ClientException $e) {
           $this->logger->error('Invalid file in URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return NULL;
+          $retries = 0;
         }
         catch (RequestException $e) {
           if ($retries > 1) {
@@ -86,36 +87,41 @@ class TripalFileRetriever {
           else {
             $this->logger->error('Unable to get response from @url: @exception',
                 ['@url' => $url, '@exception' => $e->getMessage()]);
-            return NULL;
+            $retries = 0;
           }
         }
-        catch (Exception $e) {
+        catch (\Exception $e) {
           $this->logger->error('Unhandled exception downloading URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return NULL;
+          $retries = 0;
         }
         $retries--;
-        sleep(1);
+        if (is_null($contents) && ($retries > 0)) {
+          sleep(1);
+        }
       }
-      return NULL;
     }
     // If there was no host in the url, then it is considered a local file
     else {
-      $contents = FALSE;
       if (!file_exists($url)) {
         $this->logger->error('Local file @url does not exist',
             ['@url' => $url]);
       }
       else {
-        $contents = file_get_contents($url);
+        try {
+          $contents = file_get_contents($url);
+        }
+        catch (\Exception $e) {
+          $this->logger->error('Error reading from local file @url: @exception',
+              ['@url' => $url, '@exception' => $e->getMessage()]);
+        }
       }
+      // file_get_contents() should return FALSE for error, convert to NULL here
       if ($contents === FALSE) {
-        return NULL;
-      }
-      else {
-        return $contents;
+        $contents = NULL;
       }
     }
+    $return $contents;
   }
 
   /**
@@ -134,6 +140,8 @@ class TripalFileRetriever {
    *   Returns TRUE if successful, FALSE if error.
    */
   public function downloadFile(string $url, string $localfile, int $retries = 3, array $options = []): bool {
+    $status = FALSE;
+
     // Distinguish between local and remote files
     $parsed_url = parse_url($url);
     if ($parsed_url['host'] ?? NULL) {
@@ -141,21 +149,21 @@ class TripalFileRetriever {
       $options['sink'] = $localfile;
       $options['stream'] = FALSE;
 
-      while ($retries > 0) {
+      while (!$status && ($retries > 0)) {
         try {
           /** @var GuzzleHttp\Psr7\Response **/
           $response = $this->httpClient->get($url, $options);
-          return TRUE;
+          $status = TRUE;
         }
         catch (ConnectException $e) {
           $this->logger->error('Invalid hostname in URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return FALSE;
+          $retries = 0;
         }
         catch (ClientException $e) {
           $this->logger->error('Invalid file in URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return FALSE;
+          $retries = 0;
         }
         catch (RequestException $e) {
           if ($retries > 1) {
@@ -165,30 +173,37 @@ class TripalFileRetriever {
           else {
             $this->logger->error('Unable to get response from @url: @exception',
                 ['@url' => $url, '@exception' => $e->getMessage()]);
-            return FALSE;
+            $retries = 0;
           }
         }
-        catch (Exception $e) {
+        catch (\Exception $e) {
           $this->logger->error('Unhandled exception downloading URL @url: @exception',
               ['@url' => $url, '@exception' => $e->getMessage()]);
-          return FALSE;
+          $retries = 0;
         }
         $retries--;
-        sleep(1);
+        if (!$status && ($retries > 0)) {
+          sleep(1);
+        }
       }
-      return NULL;
     }
     // If there was no host in the url, then it is considered a local file
     else {
       if (!file_exists($url)) {
         $this->logger->error('Local file @url does not exist',
             ['@url' => $url]);
-        return FALSE;
       }
       else {
-        copy($url, $localfile);
-        return TRUE;
+        try {
+          copy($url, $localfile);
+          $status = TRUE;
+        }
+        catch (\Exception $e) {
+          $this->logger->error('Error copying @url to @local: @exception',
+              ['@url' => $url, '@local' => $localfile, '@exception' => $e->getMessage()]);
+        }
       }
     }
+    return $status;
   }
 }

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -51,22 +51,24 @@ class TripalFileRetriever {
    *
    * @param string $url
    *   The address of the file to download
-   * @param int $retries
-   *   The number of times to retry the remote download if an error occurs
    * @param array $options
-   *   Any options to pass to the HTTP request
+   *   Valid keys:
+   *     retries - int: how many times to retry a download, default = 3
+   *     delay - int: number of seconds between retries, default = 1
+   *     client_options - array: any options to pass to the http client
    * @return string
    *   The data obtained from the specified url, or NULL if it could not be downloaded
    */
-  public function retrieveFileContents(string $url, int $retries = 3, array $options = []): string|null {
+  public function retrieveFileContents(string $url, array $options = []): string|null {
     $contents = NULL;
+    $retries = $options['retries'] ?? 3;
 
     // Distinguish between local and remote files
     $parsed_url = parse_url($url);
     if ($parsed_url['host'] ?? NULL) {
       while (is_null($contents) && ($retries > 0)) {
         try {
-          $response = $this->httpClient->get($url, $options);
+          $response = $this->httpClient->get($url, $options['client_options'] ?? []);
           $contents = (string) $response->getBody();
         }
         catch (\Exception $e) {
@@ -75,7 +77,7 @@ class TripalFileRetriever {
 $fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error
         $retries--;
         if (is_null($contents) && ($retries > 0)) {
-          sleep(1);
+          sleep($options['delay'] ?? 1);
         }
       }
     }
@@ -110,27 +112,29 @@ $fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retri
    *   The address of the file to download
    * @param string $localfile
    *   The path to a local file where data is saed
-   * @param int $retries
-   *   The number of times to retry the remote download if an error occurs
    * @param array $options
-   *   Any options to pass to the HTTP request
+   *   Valid keys:
+   *     retries - int: how many times to retry a download, default = 3
+   *     delay - int: number of seconds between retries, default = 1
+   *     client_options - array: any options to pass to the http client
    * @return bool
    *   Returns TRUE if successful, FALSE if error.
    */
-  public function downloadFile(string $url, string $localfile, int $retries = 3, array $options = []): bool {
+  public function downloadFile(string $url, string $localfile, array $options = []): bool {
     $status = FALSE;
+    $retries = $options['retries'] ?? 3;
 
     // Distinguish between local and remote files
     $parsed_url = parse_url($url);
     if ($parsed_url['host'] ?? NULL) {
 
-      $options['sink'] = $localfile;
-      $options['stream'] = FALSE;
+      $options['client_options']['sink'] = $localfile;
+      $options['client_options']['stream'] = FALSE;
 
       while (!$status && ($retries > 0)) {
         try {
           /** @var GuzzleHttp\Psr7\Response **/
-          $response = $this->httpClient->get($url, $options);
+          $response = $this->httpClient->get($url, $options['client_options']);
           $status = TRUE;
         }
         catch (\Exception $e) {
@@ -139,7 +143,7 @@ $fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retri
 $fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $status = FALSE; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); } //@@@ simulate error 10% of the time
         $retries--;
         if (!$status && ($retries > 0)) {
-          sleep(1);
+          sleep($options['delay'] ?? 1);
         }
       }
     }

--- a/tripal/src/Services/TripalFileRetriever.php
+++ b/tripal/src/Services/TripalFileRetriever.php
@@ -121,7 +121,7 @@ class TripalFileRetriever {
         $contents = NULL;
       }
     }
-    $return $contents;
+    return $contents;
   }
 
   /**

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -423,7 +423,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
           // Download the remote file contents.
-          $content = $this->fileretriever->retreiveFile($file_remote);
+          $content = $this->fileretriever->retrieveFile($file_remote);
           if (is_null($content)) {
             $this->is_prepared = FALSE;
             return;
@@ -431,7 +431,6 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
 
           // Write the contents from the remote file to the local temp file.
           $saved = file_put_contents($temp, $content);
-print "CP05 saved to temp file \"$temp\" ";var_dump($saved); //@@@
           if (!$saved) {
             $this->logger->error('Unable to save to local temporary file @file',
                 ['@file' => $temp]);
@@ -446,7 +445,6 @@ print "CP05 saved to temp file \"$temp\" ";var_dump($saved); //@@@
         // Is this file compressed? If so, then uncompress it.
         $matches = [];
         if (preg_match('/^(.*?)\.gz$/', $this->arguments['files'][$i]['file_path'], $matches)) {
-print "CP06 uncompressing\n";//@@@
           $this->logger->notice('Uncompressing: %file', ['%file' => $this->arguments['files'][$i]['file_path']]);
           $buffer_size = 4096;
           $new_file_path = $matches[1];

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -156,7 +156,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
     // Initialize messenger
     $this->messenger = \Drupal::messenger();
 
-    // Initialize http client
+    // Initialize file retrieval service.
     $this->fileretriever = \Drupal::service('tripal.fileretriever');
   }
 
@@ -423,7 +423,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
           // Download the remote file contents.
-          $content = $this->fileretriever($file_remote);
+          $content = $this->fileretriever->retreiveFile($file_remote);
           if (is_null($content)) {
             $this->is_prepared = FALSE;
             return;

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -422,18 +422,9 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $temp = \Drupal::service('file_system')->tempnam("temporary://", 'import_') . $ext;
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
-          // Download the remote file contents.
-          $content = $this->fileretriever->retrieveFile($file_remote);
-          if (is_null($content)) {
-            $this->is_prepared = FALSE;
-            return;
-          }
-
-          // Write the contents from the remote file to the local temp file.
-          $saved = file_put_contents($temp, $content);
-          if (!$saved) {
-            $this->logger->error('Unable to save to local temporary file @file',
-                ['@file' => $temp]);
+          // Download the remote file contents to a local temporary file
+          $status = $this->fileretriever->downloadFile($file_remote, $temp);
+          if (!$status) {
             $this->is_prepared = FALSE;
             return;
           }

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -419,7 +419,9 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
             $ext = '.gz';
           }
           // Create a temporary file.
-          $temp = \Drupal::service('file_system')->tempnam("temporary://", 'import_') . $ext;
+          $fs_service = \Drupal::service('file_system');
+          $temp = $fs_service->tempnam("temporary://", 'import_') . $ext;
+          $temp = $fs_service->realpath($temp);
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
           // Download the remote file contents to a local temporary file

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -104,11 +104,11 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
   protected $messenger = NULL;
 
   /**
-   * An instance of the Drupal HTTP client, i.e. Guzzle
+   * An instance of the Tripal file retriever service
    *
-   * @var object \GuzzleHttp\ClientInterface
+   * @var object \Drupal\tripal\Services\TripalFileRetriever
    */
-  protected $httpClient = NULL;
+  protected $fileretriever = NULL;
 
   /**
    * Stores the last percentage that progress was reported.
@@ -157,8 +157,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
     $this->messenger = \Drupal::messenger();
 
     // Initialize http client
-    $this->httpClient = \Drupal::httpClient();
-
+    $this->fileretriever = \Drupal::service('tripal.fileretriever');
   }
 
   /**
@@ -399,55 +398,6 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
   }
 
   /**
-   * Download the contents of a remote or local file from a specified URL
-   *
-   * @param string $url
-   *   The address of the file to download
-   * @param int $retries
-   *   The number of times to retry the remote download if an error occurs
-   * @param array $options
-   *   Any options to pass to the HTTP request
-   * @return string
-   *   The data obtained from the specified url, or NULL if it could not be downloaded
-   */
-  public function retrieveFile(string $url, int $retries = 3, array $options = []): string|null {
-    // Distinguish between local and remote files
-    $parsed_url = parse_url($url);
-    if ($parsed_url['host'] ?? NULL) {
-      while ($retries > 0) {
-        try {
-          $response = $this->httpClient->get($url, $options);
-          $response_body = (string) $response->getBody();
-          return $response_body;
-        }
-        catch (RequestException $e) {
-          if ($retries > 1) {
-            $this->logger->error('Unable to get response from @url: @exception. Will retry',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-          }
-          else {
-            $this->logger->error('Unable to get response from @url: @exception',
-                ['@url' => $url, '@exception' => $e->getMessage()]);
-            return NULL;
-          }
-        }
-        $retries--;
-        sleep(1);
-      }
-    }
-    // If there was no host in the url, then it is considered a local file
-    else {
-      $contents = file_get_contents($url);
-      if ($contents === FALSE) {
-        return NULL;
-      }
-      else {
-        return $contents;
-      }
-    }
-  }
-
-  /**
    * Prepares the importer files for execution.
    *
    * This function must be run prior to the run() function to ensure that
@@ -473,7 +423,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
           // Download the remote file contents.
-          $content = $this->retrieveFile($file_remote);
+          $content = $this->fileretriever($file_remote);
           if (is_null($content)) {
             $this->is_prepared = FALSE;
             return;
@@ -481,6 +431,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
 
           // Write the contents from the remote file to the local temp file.
           $saved = file_put_contents($temp, $content);
+print "CP05 saved to temp file \"$temp\" ";var_dump($saved); //@@@
           if (!$saved) {
             $this->logger->error('Unable to save to local temporary file @file',
                 ['@file' => $temp]);
@@ -495,6 +446,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
         // Is this file compressed? If so, then uncompress it.
         $matches = [];
         if (preg_match('/^(.*?)\.gz$/', $this->arguments['files'][$i]['file_path'], $matches)) {
+print "CP06 uncompressing\n";//@@@
           $this->logger->notice('Uncompressing: %file', ['%file' => $this->arguments['files'][$i]['file_path']]);
           $buffer_size = 4096;
           $new_file_path = $matches[1];

--- a/tripal/src/TripalImporter/TripalImporterBase.php
+++ b/tripal/src/TripalImporter/TripalImporterBase.php
@@ -92,7 +92,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
    * Prior to running an importer it must be prepared to make sure the file
    * is available.  Preparing the importer will download all the necessary
    * files.  This value is set to TRUE after the importer is prepared for
-   * funning.
+   * running.
    */
   protected $is_prepared;
 
@@ -102,6 +102,13 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
    * @var object \Drupal\Core\Messenger\Messenger
    */
   protected $messenger = NULL;
+
+  /**
+   * An instance of the Drupal HTTP client, i.e. Guzzle
+   *
+   * @var object \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient = NULL;
 
   /**
    * Stores the last percentage that progress was reported.
@@ -148,6 +155,9 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
 
     // Initialize messenger
     $this->messenger = \Drupal::messenger();
+
+    // Initialize http client
+    $this->httpClient = \Drupal::httpClient();
 
   }
 
@@ -389,10 +399,60 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
   }
 
   /**
+   * Download the contents of a remote or local file from a specified URL
+   *
+   * @param string $url
+   *   The address of the file to download
+   * @param int $retries
+   *   The number of times to retry the remote download if an error occurs
+   * @param array $options
+   *   Any options to pass to the HTTP request
+   * @return string
+   *   The data obtained from the specified url, or NULL if it could not be downloaded
+   */
+  public function retrieveFile(string $url, int $retries = 3, array $options = []): string|null {
+    // Distinguish between local and remote files
+    $parsed_url = parse_url($url);
+    if ($parsed_url['host'] ?? NULL) {
+      while ($retries > 0) {
+        try {
+          $response = $this->httpClient->get($url, $options);
+          $response_body = (string) $response->getBody();
+          return $response_body;
+        }
+        catch (RequestException $e) {
+          if ($retries > 1) {
+            $this->logger->error('Unable to get response from @url: @exception. Will retry',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+          }
+          else {
+            $this->logger->error('Unable to get response from @url: @exception',
+                ['@url' => $url, '@exception' => $e->getMessage()]);
+            return NULL;
+          }
+        }
+        $retries--;
+        sleep(1);
+      }
+    }
+    // If there was no host in the url, then it is considered a local file
+    else {
+      $contents = file_get_contents($url);
+      if ($contents === FALSE) {
+        return NULL;
+      }
+      else {
+        return $contents;
+      }
+    }
+  }
+
+  /**
    * Prepares the importer files for execution.
    *
    * This function must be run prior to the run() function to ensure that
-   * the import file is ready to go.
+   * the import file is ready to go, i.e. it is downloaded and if necessary
+   * it has been uncompressed.
    */
   public function prepareFiles() {
 
@@ -403,7 +463,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $this->logger->notice('Download file: %file_remote...', ['%file_remote' => $file_remote]);
 
           // If this file is compressed then keep the .gz extension so we can
-          // uncompress it.
+          // uncompress it later.
           $ext = '';
           if (preg_match('/^(.*?)\.gz$/', $file_remote)) {
             $ext = '.gz';
@@ -412,23 +472,27 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           $temp = \Drupal::service('file_system')->tempnam("temporary://", 'import_') . $ext;
           $this->logger->notice('Saving as: %file', ['%file' => $temp]);
 
-          $url_fh = fopen($file_remote, "r");
-          $tmp_fh = fopen($temp, "w");
-          if (!$url_fh) {
-            throw new \Exception(t("Unable to download the remote file at %url. Could a firewall be blocking outgoing connections?",
-              ['%url', $file_remote]));
+          // Download the remote file contents.
+          $content = $this->retrieveFile($file_remote);
+          if (is_null($content)) {
+            $this->is_prepared = FALSE;
+            return;
           }
 
-          // Write the contents of the remote file to the temp file.
-          while (!feof($url_fh)) {
-            fwrite($tmp_fh, fread($url_fh, 255), 255);
+          // Write the contents from the remote file to the local temp file.
+          $saved = file_put_contents($temp, $content);
+          if (!$saved) {
+            $this->logger->error('Unable to save to local temporary file @file',
+                ['@file' => $temp]);
+            $this->is_prepared = FALSE;
+            return;
           }
-          // Set the path to the file for the importer to use.
+
+          // Set the path to the local temporary file for the importer to use.
           $this->arguments['files'][$i]['file_path'] = $temp;
-          $this->is_prepared = TRUE;
         }
 
-        // Is this file compressed?  If so, then uncompress it
+        // Is this file compressed? If so, then uncompress it.
         $matches = [];
         if (preg_match('/^(.*?)\.gz$/', $this->arguments['files'][$i]['file_path'], $matches)) {
           $this->logger->notice('Uncompressing: %file', ['%file' => $this->arguments['files'][$i]['file_path']]);
@@ -443,7 +507,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
           // Keep repeating until the end of the input file
           while (!gzeof($gzfile)) {
             // Read buffer-size bytes
-            // Both fwrite and gzread and binary-safe
+            // Both fwrite and gzread are binary-safe
             fwrite($out_file, gzread($gzfile, $buffer_size));
           }
 
@@ -462,8 +526,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
       throw new \Exception('Cannot prepare the importer: ' . $e->getMessage());
     }
 
-
-    // If we get here and no exception has been thrown then either
+    // If we get here and no exception has been thrown then either:
     // 1) files were added but none needed to be prepared.
     // 2) files were not added (check for files being required happens elsewhere).
     $this->is_prepared = TRUE;
@@ -489,7 +552,7 @@ abstract class TripalImporterBase extends PluginBase implements TripalImporterIn
       }
     }
     catch (\Exception $e) {
-      throw new \Exception('Cannot prepare the importer: ' . $e->getMessage());
+      throw new \Exception('Cannot remove importer temporary file: ' . $e->getMessage());
     }
   }
 

--- a/tripal/src/TripalPubLibrary/TripalPubLibraryBase.php
+++ b/tripal/src/TripalPubLibrary/TripalPubLibraryBase.php
@@ -6,6 +6,8 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\tripal\Services\TripalFileRetriever;
+
 /**
  * Defines the base class for the tripal pub parser plugins.
  */
@@ -22,6 +24,13 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
    * @var \Drupal\tripal\Services\TripalLogger
    */
   protected $logger;
+
+  /**
+   * An instance of the Tripal file retriever service
+   *
+   * @var object \Drupal\tripal\Services\TripalFileRetriever
+   */
+  protected $fileretriever = NULL;
 
   /**
    * The Tripal Citation generation service.
@@ -66,6 +75,7 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
       $container->get('database'),
       $container->get('tripal.logger'),
       $container->get('tripal.citation'),
+      $container->get('tripal.fileretriever'),
     );
   }
 
@@ -75,14 +85,16 @@ abstract class TripalPubLibraryBase extends PluginBase implements TripalPubLibra
   public function __construct(array $configuration, $plugin_id, $plugin_definition,
                               Connection $public,
                               \Drupal\tripal\Services\TripalLogger $logger,
-                              \Drupal\tripal\Services\TripalCitationManager $citation_manager) {
+                              \Drupal\tripal\Services\TripalCitationManager $citation_manager,
+                              TripalFileRetriever $fileretriever) {
 
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    // Dependency injection for public schema, tripal logger, and citation generator
+    // Dependency injection for public schema, tripal logger, citation generator, and file retriever
     $this->public = $public;
     $this->logger = $logger;
     $this->citation_manager = $citation_manager;
+    $this->fileretriever = $fileretriever;
   }
 
 }

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -62,7 +62,6 @@ protected string $mock_error = '';
     // Remove the local temporary file if a test failed
     if ($this->tempfile and file_exists($this->tempfile)) {
       unlink($this->tempfile);
-print "CP24 unlinked \"".$this->tempfile."\"";system('ls -ltr /tmp');//@@@
     }
   }
 
@@ -74,6 +73,23 @@ print "CP24 unlinked \"".$this->tempfile."\"";system('ls -ltr /tmp');//@@@
     $retrieval_service = \Drupal::service('tripal.fileretriever');
 
     // Tests retrieveFileContents()
+
+    // Test retrieval of non-existant local file
+    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
+    $this->mock_error = '';
+    $content = $retrieval_service->retrieveFileContents($url);
+    $this->assertStringContainsString('Local file', $this->mock_error,
+      'Did not generate an error for an invalid local file');
+    $this->assertNull($content,
+      'Did not receive NULL for invalid local file');
+
+    // Test retrieval of valid local file
+    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
+    $content = $retrieval_service->retrieveFileContents($url);
+    $this->assertNotNull($content,
+      'Received NULL for valid local file');
+    $this->assertGreaterThan(100, strlen($content),
+      'Received truncated content for valid local file');
 
     // Test retrieval of non-existent URL (invalid host)
     $url = 'https://vmasiufekxlkajfd.org/fail.txt';
@@ -96,29 +112,35 @@ print "CP24 unlinked \"".$this->tempfile."\"";system('ls -ltr /tmp');//@@@
     // Test retrieval of existing URL
     $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
     $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertNotNull($content,
-      'Received NULL for valid URL');
+    // Because this test accesses an external site, and it could be unavailable,
+    // do not throw an error for this test
+    if (is_null($content)) {
+      $this->markTestSkipped('Received NULL for valid URL. Remote host might be down, so skipping this test');
+    }
     $this->assertGreaterThan(100, strlen($content),
       'Received truncated content for valid URL');
 
-    // Test retrieval of non-existant local file
+    // Tests downloadFile()
+
+    // Test copy to local file from non-existant local file
     $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
     $this->mock_error = '';
-    $content = $retrieval_service->retrieveFileContents($url);
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertFalse($status,
+      'Local file was incorrectly created, status not FALSE');
     $this->assertStringContainsString('Local file', $this->mock_error,
       'Did not generate an error for an invalid local file');
-    $this->assertNull($content,
-      'Did not receive NULL for invalid local file');
 
-    // Test retrieval of valid local file
+    // Test copy to local file from another local file
     $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
-    $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertNotNull($content,
-      'Received NULL for valid local file');
-    $this->assertGreaterThan(100, strlen($content),
-      'Received truncated content for valid local file');
-
-    // Tests downloadFile()
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertTrue($status,
+      'Local file not created, status not TRUE');
+    $this->assertTrue(file_exists($this->tempfile),
+      'Local file not created, file not created');
+    $this->assertGreaterThan(100, filesize($this->tempfile),
+      'Local file is too small');
+    unlink($this->tempfile);
 
     // Test copy to local file of non-existent URL (invalid host)
     $url = 'https://vmasiufekxlkajfd.org/fail.txt';
@@ -141,28 +163,11 @@ print "CP24 unlinked \"".$this->tempfile."\"";system('ls -ltr /tmp');//@@@
     // Test copy to local file for valid URL
     $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
     $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertTrue($status,
-      'Local file not created, status not TRUE');
-    $this->assertTrue(file_exists($this->tempfile),
-      'Local file not created, file not created');
-    $this->assertGreaterThan(100, filesize($this->tempfile),
-      'Local file is too small');
-    unlink($this->tempfile);
-
-    // Test copy to local file from non-existant local file
-    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
-    $this->mock_error = '';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertFalse($status,
-      'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('Local file', $this->mock_error,
-      'Did not generate an error for an invalid local file');
-
-    // Test copy to local file from another local file
-    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertTrue($status,
-      'Local file not created, status not TRUE');
+    // Because this test accesses an external site, and it could be unavailable,
+    // do not throw an error for this test
+    if ($status === FALSE) {
+      $this->markTestSkipped('Received FALSE for valid URL. Remote host might be down, so skipping this test');
+    }
     $this->assertTrue(file_exists($this->tempfile),
       'Local file not created, file not created');
     $this->assertGreaterThan(100, filesize($this->tempfile),

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -21,7 +21,11 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
 
   private string $tempfile;
 
-protected string $mock_error = '';
+  /**
+   * @var string $mock_error
+   *   The most recent error message from the mocked tripal logger
+   */
+  protected string $mock_error = '';
 
   /**
    * {@inheritdoc}
@@ -32,11 +36,7 @@ protected string $mock_error = '';
     // Grab the container.
     $container = \Drupal::getContainer();
 
-    // Some of our tests will check logged messages that would normally go to
-    // php error_log. PHPUnit will throw an exception if anything is added to
-    // error_log so we want to mock TripalLogger to ensure all errors saved and
-    // not printed to the screen.
-    // We only need to mock the error method. Other methods will not be mocked.
+    // Create a mocked logger so we can access error messages from the Tripal logger
     $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
       ->onlyMethods(['error'])
       ->getMock();

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -19,6 +19,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
    */
   protected static $modules = ['user', 'tripal'];
 
+  private string $tempfile;
+
 protected string $mock_error = '';
 
   /**
@@ -44,6 +46,24 @@ protected string $mock_error = '';
           return NULL;
         });
     $container->set('tripal.logger', $mock_logger);
+
+    // Create a path to a temporary local file
+    $fs_service = \Drupal::service('file_system');
+    $this->tempfile = $fs_service->tempnam("temporary://", 'file_retriever_test_');
+    $this->tempfile = $fs_service->realpath($this->tempfile);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    parent::tearDown();
+
+    // Remove the local temporary file if a test failed
+    if ($this->tempfile and file_exists($this->tempfile)) {
+      unlink($this->tempfile);
+print "CP24 unlinked \"".$this->tempfile."\"";system('ls -ltr /tmp');//@@@
+    }
   }
 
   /**
@@ -53,10 +73,12 @@ protected string $mock_error = '';
     // Get the service to be tested
     $retrieval_service = \Drupal::service('tripal.fileretriever');
 
+    // Tests retrieveFileContents()
+
     // Test retrieval of non-existent URL (invalid host)
     $url = 'https://vmasiufekxlkajfd.org/fail.txt';
     $this->mock_error = '';
-    $content = $retrieval_service->retrieveFile($url);
+    $content = $retrieval_service->retrieveFileContents($url);
     $this->assertStringContainsString('ERROR: Invalid hostname', $this->mock_error,
       'Did not generate an error for an invalid host name');
     $this->assertNull($content,
@@ -65,7 +87,7 @@ protected string $mock_error = '';
     // Test retrieval of non-existent URL (valid host, invalid file)
     $url = 'https://github.com/vmasiufekxlkajfd.txt';
     $this->mock_error = '';
-    $content = $retrieval_service->retrieveFile($url);
+    $content = $retrieval_service->retrieveFileContents($url);
     $this->assertStringContainsString('ERROR: Invalid file', $this->mock_error,
       'Did not generate an error for a valid host with invalid file name');
     $this->assertNull($content,
@@ -73,7 +95,7 @@ protected string $mock_error = '';
 
     // Test retrieval of existing URL
     $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
-    $content = $retrieval_service->retrieveFile($url);
+    $content = $retrieval_service->retrieveFileContents($url);
     $this->assertNotNull($content,
       'Received NULL for valid URL');
     $this->assertGreaterThan(100, strlen($content),
@@ -82,7 +104,7 @@ protected string $mock_error = '';
     // Test retrieval of non-existant local file
     $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
     $this->mock_error = '';
-    $content = $retrieval_service->retrieveFile($url);
+    $content = $retrieval_service->retrieveFileContents($url);
     $this->assertStringContainsString('Local file', $this->mock_error,
       'Did not generate an error for an invalid local file');
     $this->assertNull($content,
@@ -90,11 +112,62 @@ protected string $mock_error = '';
 
     // Test retrieval of valid local file
     $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
-    $content = $retrieval_service->retrieveFile($url);
+    $content = $retrieval_service->retrieveFileContents($url);
     $this->assertNotNull($content,
       'Received NULL for valid local file');
     $this->assertGreaterThan(100, strlen($content),
       'Received truncated content for valid local file');
+
+    // Tests downloadFile()
+
+    // Test copy to local file of non-existent URL (invalid host)
+    $url = 'https://vmasiufekxlkajfd.org/fail.txt';
+    $this->mock_error = '';
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertFalse($status,
+      'Local file was incorrectly created, status not FALSE');
+    $this->assertStringContainsString('ERROR: Invalid hostname', $this->mock_error,
+      'Did not generate an error for an invalid host name');
+
+    // Test copy to local file of non-existent URL (valid host, invalid file)
+    $url = 'https://github.com/vmasiufekxlkajfd.txt';
+    $this->mock_error = '';
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertFalse($status,
+      'Local file was incorrectly created, status not FALSE');
+    $this->assertStringContainsString('ERROR: Invalid file', $this->mock_error,
+      'Did not generate an error for a valid host with invalid file name');
+
+    // Test copy to local file for valid URL
+    $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertTrue($status,
+      'Local file not created, status not TRUE');
+    $this->assertTrue(file_exists($this->tempfile),
+      'Local file not created, file not created');
+    $this->assertGreaterThan(100, filesize($this->tempfile),
+      'Local file is too small');
+    unlink($this->tempfile);
+
+    // Test copy to local file from non-existant local file
+    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
+    $this->mock_error = '';
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertFalse($status,
+      'Local file was incorrectly created, status not FALSE');
+    $this->assertStringContainsString('Local file', $this->mock_error,
+      'Did not generate an error for an invalid local file');
+
+    // Test copy to local file from another local file
+    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
+    $status = $retrieval_service->downloadFile($url, $this->tempfile);
+    $this->assertTrue($status,
+      'Local file not created, status not TRUE');
+    $this->assertTrue(file_exists($this->tempfile),
+      'Local file not created, file not created');
+    $this->assertGreaterThan(100, filesize($this->tempfile),
+      'Local file is too small');
+    unlink($this->tempfile);
   }
 
 }

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -104,7 +104,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     $url = 'https://github.com/vmasiufekxlkajfd.txt';
     $this->mock_error = '';
     $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertStringContainsString('ERROR: Invalid file', $this->mock_error,
+    $this->assertStringContainsString('Invalid file', $this->mock_error,
       'Did not generate an error for a valid host with invalid file name');
     $this->assertNull($content,
       'Did not receive NULL for nonexistent URL');
@@ -157,7 +157,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     $status = $retrieval_service->downloadFile($url, $this->tempfile);
     $this->assertFalse($status,
       'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('ERROR: Invalid file', $this->mock_error,
+    $this->assertStringContainsString('Invalid file', $this->mock_error,
       'Did not generate an error for a valid host with invalid file name');
 
     // Test copy to local file for valid URL

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -76,7 +76,6 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
 
     // Test retrieval of non-existant local file
     $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
-\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $this->mock_error = '';
     $content = $retrieval_service->retrieveFileContents($url);
     $this->assertStringContainsString('Local file', $this->mock_error,

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -76,6 +76,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
 
     // Test retrieval of non-existant local file
     $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
+\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $this->mock_error = '';
     $content = $retrieval_service->retrieveFileContents($url);
     $this->assertStringContainsString('Local file', $this->mock_error,

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -42,7 +42,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
       ->getMock();
     $mock_logger->method('error')
       ->willReturnCallback(function($message, $context, $options) {
-          $this->mock_error = 'ERROR: ' . str_replace(array_keys($context), $context, $message);
+          $this->mock_error .= str_replace(array_keys($context), $context, $message);
           return NULL;
         });
     $container->set('tripal.logger', $mock_logger);

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -78,6 +78,9 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
    *       content where FALSE means we expect NULL and TRUE means > 100 size.
    *     - skip: indicates if we should be more lenient when checking content.
    *       When TRUE we will skip the test when we would otherwise fail.
+   *     - download_status: the expected return value for downloadFile().
+   *     - file_exists: TRUE if we expect a local file to have been created by
+   *       downloadFile() and FALSE if we don't expect one.
    */
   public static function provideFiles2Retrieve(): array {
     $scenarios = [];
@@ -90,6 +93,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'error_message' => 'Local file',
         'has_content' => FALSE,
         'skip' => FALSE,
+        'download_status' => FALSE,
+        'file_exists' => FALSE,
       ]
     ];
 
@@ -101,6 +106,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'error_message' => FALSE,
         'has_content' => TRUE,
         'skip' => FALSE,
+        'download_status' => TRUE,
+        'file_exists' => TRUE,
       ]
     ];
 
@@ -112,6 +119,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'error_message' => 'Invalid hostname',
         'has_content' => FALSE,
         'skip' => FALSE,
+        'download_status' => FALSE,
+        'file_exists' => FALSE,
       ]
     ];
 
@@ -123,6 +132,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'error_message' => 'Invalid file',
         'has_content' => FALSE,
         'skip' => FALSE,
+        'download_status' => FALSE,
+        'file_exists' => FALSE,
       ]
     ];
 
@@ -134,6 +145,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'error_message' => FALSE,
         'has_content' => TRUE,
         'skip' => TRUE,
+        'download_status' => TRUE,
+        'file_exists' => TRUE,
       ]
     ];
 
@@ -142,6 +155,22 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
 
   /**
    * Tests the Tripal File Retrieval service.
+   *
+   * @param string $url
+   *  The URL to be passed to retrieveFileContents() + downloadFile().
+   * @param array $options
+   *   Any options to be passed to retrieveFileContents().
+   * @param array $expectations
+   *   An array of expectations where the following keys are expected:
+   *   - error_message: part of the expected error message to be logged.
+   *     Use FALSE if there should not be an error message.
+   *   - has_content: indicates if we expect retrieveFileContents() to return
+   *     content where FALSE means we expect NULL and TRUE means > 100 size.
+   *   - skip: indicates if we should be more lenient when checking content.
+   *     When TRUE we will skip the test when we would otherwise fail.
+   *   - download_status: the expected return value for downloadFile().
+   *   - file_exists: TRUE if we expect a local file to have been created by
+   *     downloadFile() and FALSE if we don't expect one.
    *
    * @dataProvider provideFiles2Retrieve
    */
@@ -181,61 +210,37 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
         'Did not receive NULL when we expect file retrieval to have failed.');
     }
 
-      /*
     // Tests downloadFile()
-
-    // Test copy to local file from non-existant local file
-    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
     $this->mock_error = '';
     $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertFalse($status,
-      'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('Local file', $this->mock_error,
-      'Did not generate an error for an invalid local file');
-
-    // Test copy to local file from another local file
-    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertTrue($status,
-      'Local file not created, status not TRUE');
-    $this->assertTrue(file_exists($this->tempfile),
-      'Local file not created, file not created');
-    $this->assertGreaterThan(100, filesize($this->tempfile),
-      'Local file is too small');
-    unlink($this->tempfile);
-
-    // Test copy to local file of non-existent URL (invalid host)
-    $url = 'https://vmasiufekxlkajfd.org/fail.txt';
-    $this->mock_error = '';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertFalse($status,
-      'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('Invalid hostname', $this->mock_error,
-      'Did not generate an error for an invalid host name');
-
-    // Test copy to local file of non-existent URL (valid host, invalid file)
-    $url = 'https://github.com/vmasiufekxlkajfd.txt';
-    $this->mock_error = '';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    $this->assertFalse($status,
-      'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('Invalid file', $this->mock_error,
-      'Did not generate an error for a valid host with invalid file name');
-
-    // Test copy to local file for valid URL
-    $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
-    $status = $retrieval_service->downloadFile($url, $this->tempfile);
-    // Because this test accesses an external site, and it could be unavailable,
-    // do not throw an error for this test
-    if ($status === FALSE) {
-      $this->markTestSkipped('Received FALSE for valid URL. Remote host might be down, so skipping this test');
+    // -- Check the error message.
+    if ($expectations['error_message'] !== FALSE) {
+      $this->assertStringContainsString(
+        $expectations['error_message'],
+        $this->mock_error,
+        'Did not log an error for this scenario when we expected one.'
+      );
+    } else {
+      $this->assertEquals(
+        '',
+        $this->mock_error,
+        "We logged an error when we did not expect one."
+      );
     }
-    $this->assertTrue(file_exists($this->tempfile),
-      'Local file not created, file not created');
-    $this->assertGreaterThan(100, filesize($this->tempfile),
-      'Local file is too small');
-    unlink($this->tempfile);
+    // -- Check download status.
+    $this->assertEquals($expectations['download_status'], $status,
+      'downloadFile() did not return the status we expected for this scenario.');
+    // -- Check temp file exists or not as expected.
+    /** @todo checking for the temp file when we don't expect one has found a bug
+    $this->assertEquals($expectations['file_exists'], file_exists($this->tempfile),
+      'downloadFile() did not perform as expected with creating the local file.');
+    if ($expectations['file_exists']) {
+      $this->assertGreaterThan(100, filesize($this->tempfile),
+        'Local file created by downloadFile() is too small');
+      unlink($this->tempfile);
+    }
     */
+
   }
 
 }

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\tripal\Kernel\Services\TripalFileRetriever;
+
+use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+
+
+/**
+ * Tests retrieval of remote or local files.
+ *
+ * @group Tripal
+ * @group Tripal FileRetriever
+ */
+class TripalFileRetrieverTest extends TripalTestKernelBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['user', 'tripal'];
+
+protected string $mock_error = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() :void {
+    parent::setUp();
+
+    // Grab the container.
+    $container = \Drupal::getContainer();
+
+    // Some of our tests will check logged messages that would normally go to
+    // php error_log. PHPUnit will throw an exception if anything is added to
+    // error_log so we want to mock TripalLogger to ensure all errors saved and
+    // not printed to the screen.
+    // We only need to mock the error method. Other methods will not be mocked.
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['error'])
+      ->getMock();
+    $mock_logger->method('error')
+      ->willReturnCallback(function($message, $context, $options) {
+          $this->mock_error = 'ERROR: ' . str_replace(array_keys($context), $context, $message);
+          return NULL;
+        });
+    $container->set('tripal.logger', $mock_logger);
+  }
+
+  /**
+   * Tests the Tripal File Retrieval service.
+   */
+  public function testTripalFileRetriever() {
+    // Get the service to be tested
+    $retrieval_service = \Drupal::service('tripal.fileretriever');
+
+    // Test retrieval of non-existent URL (invalid host)
+    $url = 'https://vmasiufekxlkajfd.org/fail.txt';
+    $this->mock_error = '';
+    $content = $retrieval_service->retrieveFile($url);
+    $this->assertStringContainsString('ERROR: Invalid hostname', $this->mock_error,
+      'Did not generate an error for an invalid host name');
+    $this->assertNull($content,
+      'Did not receive NULL for nonexistent URL');
+
+    // Test retrieval of non-existent URL (valid host, invalid file)
+    $url = 'https://github.com/vmasiufekxlkajfd.txt';
+    $this->mock_error = '';
+    $content = $retrieval_service->retrieveFile($url);
+    $this->assertStringContainsString('ERROR: Invalid file', $this->mock_error,
+      'Did not generate an error for a valid host with invalid file name');
+    $this->assertNull($content,
+      'Did not receive NULL for nonexistent URL');
+
+    // Test retrieval of existing URL
+    $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
+    $content = $retrieval_service->retrieveFile($url);
+    $this->assertNotNull($content,
+      'Received NULL for valid URL');
+    $this->assertGreaterThan(100, strlen($content),
+      'Received truncated content for valid URL');
+
+    // Test retrieval of non-existant local file
+    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
+    $this->mock_error = '';
+    $content = $retrieval_service->retrieveFile($url);
+    $this->assertStringContainsString('Local file', $this->mock_error,
+      'Did not generate an error for an invalid local file');
+    $this->assertNull($content,
+      'Did not receive NULL for invalid local file');
+
+    // Test retrieval of valid local file
+    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
+    $content = $retrieval_service->retrieveFile($url);
+    $this->assertNotNull($content,
+      'Received NULL for valid local file');
+    $this->assertGreaterThan(100, strlen($content),
+      'Received truncated content for valid local file');
+  }
+
+}

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -95,7 +95,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     $url = 'https://vmasiufekxlkajfd.org/fail.txt';
     $this->mock_error = '';
     $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertStringContainsString('ERROR: Invalid hostname', $this->mock_error,
+    $this->assertStringContainsString('Invalid hostname', $this->mock_error,
       'Did not generate an error for an invalid host name');
     $this->assertNull($content,
       'Did not receive NULL for nonexistent URL');
@@ -148,7 +148,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     $status = $retrieval_service->downloadFile($url, $this->tempfile);
     $this->assertFalse($status,
       'Local file was incorrectly created, status not FALSE');
-    $this->assertStringContainsString('ERROR: Invalid hostname', $this->mock_error,
+    $this->assertStringContainsString('Invalid hostname', $this->mock_error,
       'Did not generate an error for an invalid host name');
 
     // Test copy to local file of non-existent URL (valid host, invalid file)

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -230,17 +230,14 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     // -- Check download status.
     $this->assertEquals($expectations['download_status'], $status,
       'downloadFile() did not return the status we expected for this scenario.');
-    // -- Check temp file exists or not as expected.
-    /** @todo checking for the temp file when we don't expect one has found a bug
-    $this->assertEquals($expectations['file_exists'], file_exists($this->tempfile),
-      'downloadFile() did not perform as expected with creating the local file.');
+    // -- Check temp file has content if we expect it to have been populated.
     if ($expectations['file_exists']) {
       $this->assertGreaterThan(100, filesize($this->tempfile),
-        'Local file created by downloadFile() is too small');
-      unlink($this->tempfile);
+        'Local file created by downloadFile() is too small to have been properly populated by download.');
     }
-    */
 
+    // Remove the temporary file.
+    unlink($this->tempfile);
   }
 
 }

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -13,7 +13,6 @@ use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
  */
 class TripalFileRetrieverTest extends TripalTestKernelBase {
 
-
   /**
    * {@inheritdoc}
    */
@@ -66,60 +65,123 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
   }
 
   /**
-   * Tests the Tripal File Retrieval service.
+   * Provide scenarios for testing retrieveFileContents().
+   *
+   * @return array
+   *   A list of scenarios to be tested. Each scenario has the following:
+   *   - a URL to be passed to retrieveFileContents().
+   *   - an array of options taken by retrieveFileContents().
+   *   - an array of expectations where the following keys are expected:
+   *     - error_message: part of the expected error message to be logged.
+   *       Use FALSE if there should not be an error message.
+   *     - has_content: indicates if we expect retrieveFileContents() to return
+   *       content where FALSE means we expect NULL and TRUE means > 100 size.
+   *     - skip: indicates if we should be more lenient when checking content.
+   *       When TRUE we will skip the test when we would otherwise fail.
    */
-  public function testTripalFileRetriever() {
+  public static function provideFiles2Retrieve(): array {
+    $scenarios = [];
+
+    // Test retrieval of non-existant local file.
+    $scenarios[] = [
+      DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt',
+      [],
+      [
+        'error_message' => 'Local file',
+        'has_content' => FALSE,
+        'skip' => FALSE,
+      ]
+    ];
+
+    // Test retrieval of valid local file.
+    $scenarios[] = [
+      DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt',
+      [],
+      [
+        'error_message' => FALSE,
+        'has_content' => TRUE,
+        'skip' => FALSE,
+      ]
+    ];
+
+    // Test retrieval of non-existent URL (invalid host).
+    $scenarios[] = [
+      'https://vmasiufekxlkajfd.org/fail.txt',
+      [],
+      [
+        'error_message' => 'Invalid hostname',
+        'has_content' => FALSE,
+        'skip' => FALSE,
+      ]
+    ];
+
+    // Test retrieval of non-existent URL (valid host, invalid file)
+    $scenarios[] = [
+      'https://github.com/vmasiufekxlkajfd.txt',
+      [],
+      [
+        'error_message' => 'Invalid file',
+        'has_content' => FALSE,
+        'skip' => FALSE,
+      ]
+    ];
+
+    // Test retrieval of existing URL.
+    $scenarios[] = [
+      'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt',
+      [],
+      [
+        'error_message' => FALSE,
+        'has_content' => TRUE,
+        'skip' => TRUE,
+      ]
+    ];
+
+    return $scenarios;
+  }
+
+  /**
+   * Tests the Tripal File Retrieval service.
+   *
+   * @dataProvider provideFiles2Retrieve
+   */
+  public function testTripalFileRetriever(string $url, array $options, array $expectations) {
     // Get the service to be tested
     $retrieval_service = \Drupal::service('tripal.fileretriever');
 
     // Tests retrieveFileContents()
-
-    // Test retrieval of non-existant local file
-    $url = DRUPAL_ROOT . 'modules/contrib/bogus/NOLICENSE.txt';
     $this->mock_error = '';
     $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertStringContainsString('Local file', $this->mock_error,
-      'Did not generate an error for an invalid local file');
-    $this->assertNull($content,
-      'Did not receive NULL for invalid local file');
-
-    // Test retrieval of valid local file
-    $url = DRUPAL_ROOT . '/modules/contrib/tripal/LICENSE.txt';
-    $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertNotNull($content,
-      'Received NULL for valid local file');
-    $this->assertGreaterThan(100, strlen($content),
-      'Received truncated content for valid local file');
-
-    // Test retrieval of non-existent URL (invalid host)
-    $url = 'https://vmasiufekxlkajfd.org/fail.txt';
-    $this->mock_error = '';
-    $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertStringContainsString('Invalid hostname', $this->mock_error,
-      'Did not generate an error for an invalid host name');
-    $this->assertNull($content,
-      'Did not receive NULL for nonexistent URL');
-
-    // Test retrieval of non-existent URL (valid host, invalid file)
-    $url = 'https://github.com/vmasiufekxlkajfd.txt';
-    $this->mock_error = '';
-    $content = $retrieval_service->retrieveFileContents($url);
-    $this->assertStringContainsString('Invalid file', $this->mock_error,
-      'Did not generate an error for a valid host with invalid file name');
-    $this->assertNull($content,
-      'Did not receive NULL for nonexistent URL');
-
-    // Test retrieval of existing URL
-    $url = 'https://raw.githubusercontent.com/tripal/tripal/4.x/LICENSE.txt';
-    $content = $retrieval_service->retrieveFileContents($url);
-    // Because this test accesses an external site, and it could be unavailable,
-    // do not throw an error for this test
-    if (is_null($content)) {
-      $this->markTestSkipped('Received NULL for valid URL. Remote host might be down, so skipping this test');
+    // -- Check the error message.
+    if ($expectations['error_message'] !== FALSE) {
+      $this->assertStringContainsString(
+        $expectations['error_message'],
+        $this->mock_error,
+        'Did not log an error for this scenario when we expected one.'
+      );
     }
-    $this->assertGreaterThan(100, strlen($content),
-      'Received truncated content for valid URL');
+    else {
+      $this->assertEquals('', $this->mock_error,
+        "We logged an error when we did not expect one.");
+    }
+    // -- Skip instead of fail for certain scenarios.
+    if (is_null($content) AND $expectations['skip']) {
+      $this->markTestSkipped("Received NULL for valid URL. Remote host might be down, so skipping this test.");
+    }
+    // -- Check the contents.
+    if ($expectations['has_content'] == TRUE) {
+      $this->assertNotNull($content,
+        "Recieved NULL when we expected file retrieval to be successful.");
+      $this->assertGreaterThan(100, strlen($content),
+        'Received truncated content when retrieving a valid file.'
+      );
+    }
+    else {
+      $this->assertNull($content,
+        'Did not receive NULL when we expect file retrieval to have failed.');
+    }
 
+      /*
     // Tests downloadFile()
 
     // Test copy to local file from non-existant local file
@@ -173,6 +235,7 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
     $this->assertGreaterThan(100, filesize($this->tempfile),
       'Local file is too small');
     unlink($this->tempfile);
+    */
   }
 
 }

--- a/tripal/tripal.services.yml
+++ b/tripal/tripal.services.yml
@@ -8,6 +8,10 @@ services:
     class: Drupal\tripal\Services\bulkPgSchemaInstaller
   tripal.job:
     class: Drupal\tripal\Services\TripalJob
+  tripal.fileretriever:
+    class: Drupal\tripal\Services\TripalFileRetriever
+    arguments: ['@http_client',
+                '@tripal.logger']
   tripal.logger:
     class: Drupal\tripal\Services\TripalLogger
   tripal.token_parser:

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -990,7 +990,7 @@ class OBOImporter extends ChadoImporterBase {
     // first download the OBO
     $temp = tempnam(sys_get_temp_dir(), 'obo_');
     $this->logger->notice("Downloading URL $url, saving to $temp");
-    $status = $this->fileimporter->downloadFile($url, $temp);
+    $status = $this->fileretriever->downloadFile($url, $temp);
     if (!$status) {
       throw new \Exception("Unable to download the remote OBO file at $url. " .
         "Could a firewall be blocking outgoing connections? If you are unable " .
@@ -2872,7 +2872,6 @@ class OBOImporter extends ChadoImporterBase {
    * @ingroup tripal_obo_loader
    */
   private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL, $found_ontology = NULL) {
-#@@@    $client = \Drupal::httpClient();
 
     // Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
@@ -2918,7 +2917,7 @@ class OBOImporter extends ChadoImporterBase {
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
     }
 
-    $content = $this->fileloader->getFileContents($full_url, $options);
+    $content = $this->fileretriever->retrieveFileContents($full_url);
     if ($content) {
       $response = Json::decode($content);
       return $response;

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -990,19 +990,13 @@ class OBOImporter extends ChadoImporterBase {
     // first download the OBO
     $temp = tempnam(sys_get_temp_dir(), 'obo_');
     $this->logger->notice("Downloading URL $url, saving to $temp");
-    $url_fh = fopen($url, "r");
-    $obo_fh = fopen($temp, "w");
-    if (!$url_fh) {
+    $status = $this->fileimporter->downloadFile($url, $temp);
+    if (!$status) {
       throw new \Exception("Unable to download the remote OBO file at $url. " .
         "Could a firewall be blocking outgoing connections? If you are unable " .
         "to download the file you may manually download the OBO file and use " .
         "the web interface to specify the location of the file on your server.");
     }
-    while (!feof($url_fh)) {
-      fwrite($obo_fh, fread($url_fh, 255), 255);
-    }
-    fclose($url_fh);
-    fclose($obo_fh);
 
     if ($is_new) {
       tripal_insert_obo($obo_name, $url);
@@ -2878,7 +2872,7 @@ class OBOImporter extends ChadoImporterBase {
    * @ingroup tripal_obo_loader
    */
   private function oboEbiLookup($accession, $type_of_search, $found_iri = NULL, $found_ontology = NULL) {
-    $client = \Drupal::httpClient();
+#@@@    $client = \Drupal::httpClient();
 
     // Grab just the ontology from the $accession.
     $parts = explode(':', $accession);
@@ -2924,15 +2918,14 @@ class OBOImporter extends ChadoImporterBase {
       $full_url = 'http://www.ebi.ac.uk/ols/api/search?q=' . $accession . '&queryFields=obo_id';
     }
 
-    try {
-      $response = $client->get($full_url, $options);
-      $response = $response->getBody();
-      $response = Json::decode($response);
+    $content = $this->fileloader->getFileContents($full_url, $options);
+    if ($content) {
+      $response = Json::decode($content);
       return $response;
     }
-    catch (RequestException $e) {
-      $this->logger->error('Unable to get response from @url when trying to retrieve data for @accession. @exception',
-          ['@url' => $full_url, '@accession' => $accession, '@exception' => $e->getMessage()]);
+    else {
+      $this->logger->error('Unable to get response from @url when trying to retrieve data for @accession.',
+          ['@url' => $full_url, '@accession' => $accession]);
     }
 
     return FALSE;

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -307,7 +307,7 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
         if (!empty($api_key)) {
           $search_url .= "&api_key=" . $api_key;
         }
-        $xml_text = $this->fileretriever->retrieveFile($search_url);
+        $xml_text = $this->fileretriever->retrieveFileContents($search_url);
         if (is_null($xml_text)) {
           $this->logger->warning("Could not look up @sci_name",
             ['@sci_name' => $sci_name_escaped]
@@ -526,7 +526,7 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
     }
 
     // Query NCBI
-    $xml_text = $this->fileretriever->retrieveFile($fetch_url);
+    $xml_text = $this->fileretriever->retrieveFileContents($fetch_url);
     if (!is_null($xml_text)) {
       $xml = new \SimpleXMLElement($xml_text);
       $taxon = $xml->Taxon;

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -307,37 +307,13 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
         if (!empty($api_key)) {
           $search_url .= "&api_key=" . $api_key;
         }
-        $rfh = NULL;
-        // Query NCBI. To accomodate occasional glitches, retry up to three times.
-        $retries = 3;
-        while (($retries > 0) and (!$rfh)) {
-          $start = microtime(TRUE);
-          // Get the search response from NCBI.
-          $rfh = @fopen($search_url, "r");
-          // If error, delay then retry
-          if ((!$rfh) and ($retries)) {
-            $this->logger->warning("Error contacting NCBI to look up @sci_name, will retry",
-              ['@sci_name' => $sci_name_escaped]
-            );
-          }
-          $retries--;
-          $remaining_sleep = $sleep_time - ((int) (1e6 * (microtime(TRUE) - $start)));
-          if ($remaining_sleep > 0) {
-            usleep($remaining_sleep);
-          }
-        }
-
-        if (!$rfh) {
+        $xml_text = $this->fileretriever->retrieveFile($search_url);
+        if (is_null($xml_text)) {
           $this->logger->warning("Could not look up @sci_name",
             ['@sci_name' => $sci_name_escaped]
           );
           continue;
         }
-        $xml_text = '';
-        while (!feof($rfh)) {
-          $xml_text .= fread($rfh, 255);
-        }
-        fclose($rfh);
 
         // Parse the XML to get the taxonomy ID
         $result = FALSE;
@@ -549,35 +525,10 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
       $fetch_url .= "&api_key=" . $api_key;
     }
 
-    // Query NCBI. To accomodate occasional glitches, retry up to three times.
-    $xml = FALSE;
-    $rfh = NULL;
-    $retries = 3;
-    while (($retries > 0) and (!$rfh)) {
-      $start = microtime(TRUE);
-      $rfh = @fopen($fetch_url, "r");
-      if ($rfh) {
-        $xml_text = '';
-        while (!feof($rfh)) {
-          $xml_text .= fread($rfh, 255);
-        }
-        fclose($rfh);
-
-        $xml = new \SimpleXMLElement($xml_text);
-      }
-      else {
-        $this->logger->warning("Error contacting NCBI to look up @taxid, will retry",
-          ['@taxid' => $taxid]
-        );
-      }
-      $retries--;
-      $remaining_sleep = $sleep_time - ((int) (1e6 * (microtime(TRUE) - $start)));
-      if ($remaining_sleep > 0) {
-        usleep($remaining_sleep);
-      }
-    }
-
-    if ($xml) {
+    // Query NCBI
+    $xml_text = $this->fileretriever->retrieveFile($fetch_url);
+    if (!is_null($xml_text)) {
+      $xml = new \SimpleXMLElement($xml_text);
       $taxon = $xml->Taxon;
 
       // Get the genus and species from the xml.

--- a/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
@@ -78,7 +78,6 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     $plugin = $pub_library_manager->createInstance($plugin_id, []);
 
     $this->mock_error = '';
-\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $results = $plugin->retrieve($criteria, 1, 0);
     // We will have an error message in the logger if there was an intermittent download problem
     if ($this->mock_error) {

--- a/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
@@ -14,13 +14,36 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
 {
 
   /**
+   * @var string $mock_error
+   *   The most recent error message from the mocked tripal logger
+   */
+  protected string $mock_error = '';
+
+  protected function setUp() :void {
+    parent::setUp();
+
+    // Grab the container.
+    $container = \Drupal::getContainer();
+
+    // Create a mocked logger so we can access error messages from the Tripal logger
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['error'])
+      ->getMock();
+    $mock_logger->method('error')
+      ->willReturnCallback(function($message, $context, $options) {
+          $this->mock_error .= str_replace(array_keys($context), $context, $message);
+          return NULL;
+        });
+    $container->set('tripal.logger', $mock_logger);
+  }
+
+  /**
    * Confirm basic Publications importer functionality.
    *
    * @group pub
    */
   public function testPubSearchQueryImporterSimpleTest()
   {
-    $this->assertNotEquals(1, 0);
     // Public schema connection
     $public = \Drupal::database();
 
@@ -53,10 +76,18 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     $plugin_id = $criteria['form_state_user_input']['plugin_id'];
 
     $plugin = $pub_library_manager->createInstance($plugin_id, []);
+
+    $this->mock_error = '';
     $results = $plugin->retrieve($criteria, 1, 0);
-    // This should return a single pub since we used the limit 1 in the retrieve function
-    $pub_count = count($results['pubs']);
-    $this->assertEquals($pub_count, 1, 'One publication should have been retrieved but was not');
+    // We will have an error message in the logger if there was an intermittent download problem
+    if ($this->mock_error) {
+      $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
+    }
+    else {
+      // This should return a single pub since we used the limit 1 in the retrieve function
+      $pub_count = count($results['pubs']);
+      $this->assertEquals($pub_count, 1, 'One publication should have been retrieved but was not');
+    }
 
 
     // Specific PMID
@@ -79,19 +110,23 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     $pub_record = $pub_library_manager->getSearchQuery(intval($query_id));
     $criteria = unserialize($pub_record->criteria);
     // Perform a lookup for the PMID:39125884
+    $this->mock_error = '';
     $results = $plugin->retrieve($criteria, 1, 0);
-
-    // This should return a single pub since we used the limit 1 in the retrieve function
-    $pub_count = count($results['pubs']);
-    $this->assertEquals(1, $pub_count, 'One publication should have been retrieved but was not');
-    $this->assertEquals('39125884', $results['pubs'][0]['Publication Dbxref'], 'Publication Dbxref should have been 39125884 but it is not');
-    $this->assertEquals('10.3390/ijms25158314', $results['pubs'][0]['DOI'], 'DOI should have been 10.3390/ijms25158314 but it is not - parsing issue?');
-    $this->assertEquals('2024', $results['pubs'][0]['Year'], 'Year should have been 2024 but it is not - parsing issue?');
-    $this->assertEquals('Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus.', $results['pubs'][0]['Title'], 'Title should have been Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus. but it is not - parsing issue?');
-    $this->assertEquals('Yang X, Zhu P, Gui J. Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus. International journal of molecular sciences. 2024 Jul 30; 25(15).', $results['pubs'][0]['Citation'], 'Citation does not look correct, review test for details');
-    $this->assertGreaterThan(2, count($results['pubs'][0]['Author List']), 'Author List should have more than 2 elements but does not');
-
-
+    // We will have an error message in the logger if there was an intermittent download problem
+    if ($this->mock_error) {
+      $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
+    }
+    else {
+      // This should return a single pub since we used the limit 1 in the retrieve function
+      $pub_count = count($results['pubs']);
+      $this->assertEquals(1, $pub_count, 'One publication should have been retrieved but was not');
+      $this->assertEquals('39125884', $results['pubs'][0]['Publication Dbxref'], 'Publication Dbxref should have been 39125884 but it is not');
+      $this->assertEquals('10.3390/ijms25158314', $results['pubs'][0]['DOI'], 'DOI should have been 10.3390/ijms25158314 but it is not - parsing issue?');
+      $this->assertEquals('2024', $results['pubs'][0]['Year'], 'Year should have been 2024 but it is not - parsing issue?');
+      $this->assertEquals('Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus.', $results['pubs'][0]['Title'], 'Title should have been Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus. but it is not - parsing issue?');
+      $this->assertEquals('Yang X, Zhu P, Gui J. Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus. International journal of molecular sciences. 2024 Jul 30; 25(15).', $results['pubs'][0]['Citation'], 'Citation does not look correct, review test for details');
+      $this->assertGreaterThan(2, count($results['pubs'][0]['Author List']), 'Author List should have more than 2 elements but does not');
+    }
     // Perform an actual import with the importer (on our second query - the one above to see if props get imported in)
     $importer_manager = \Drupal::service('tripal.importer');
     $pub_search_query_loader_importer = $importer_manager->createInstance('pub_search_query_loader');
@@ -101,9 +136,10 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
       'query_id' => 2,
     ];
     $pub_search_query_loader_importer->createImportJob($run_args);
+    $this->mock_error = '';
     $able_to_run = $pub_search_query_loader_importer->run();
-    if ($able_to_run === FALSE) {
-      $this->markTestSkipped('Unable to access NCBI to test publication importer.');
+    if ($this->mock_error) {
+      $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
     }
     $pub_records = $chado->query("SELECT * FROM {1:pub}",[]);
     $pub_record = NULL;
@@ -116,9 +152,9 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     even though an import was executed');
 
 
-    $this->assertEquals($pub_record->title, 'Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus.', 'Publication title is different');
-    $this->assertEquals($pub_record->series_name, 'International journal of molecular sciences', 'Series name is different');
-    $this->assertEquals($pub_record->pyear, '2024', 'Publication year is different');
+    $this->assertEquals('Advancements of CRISPR-Mediated Base Editing in Crops and Potential Applications in Populus.', $pub_record->title, 'Publication title is different');
+    $this->assertEquals('International journal of molecular sciences', $pub_record->series_name, 'Series name is different');
+    $this->assertEquals('2024', $pub_record->pyear, 'Publication year is different');
 
     $pub_id = $pub_record->pub_id;
     $pub_props = $chado->query("SELECT count(*) as c1 FROM {1:pubprop} WHERE pub_id = :pub_id",[
@@ -214,7 +250,11 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     // We need a clean instance for the test
     $pub_search_query_loader_importer = $importer_manager->createInstance('pub_search_query_loader');
     $pub_search_query_loader_importer->setArguments($arguments);
+    $this->mock_error = '';
     $result = $pub_search_query_loader_importer->run();
+    if ($this->mock_error) {
+      $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
+    }
     $pub = $chado->select('1:pub', 'p')
       ->fields('p')
       ->condition('p.title', $title)

--- a/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/PubSearchQueryImporterTest.php
@@ -78,6 +78,7 @@ class PubSearchQueryImporterTest extends ChadoTestBrowserBase
     $plugin = $pub_library_manager->createInstance($plugin_id, []);
 
     $this->mock_error = '';
+\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $results = $plugin->retrieve($criteria, 1, 0);
     // We will have an error message in the logger if there was an intermittent download problem
     if ($this->mock_error) {

--- a/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
@@ -13,6 +13,30 @@ namespace Drupal\Tests\tripal_chado\Functional;
 class TaxonomyImporterTest extends ChadoTestBrowserBase {
 
   /**
+   * @var string $mock_error
+   *   The most recent error message from the mocked tripal logger
+   */
+  protected string $mock_error = '';
+
+  protected function setUp() :void {
+    parent::setUp();
+
+    // Grab the container.
+    $container = \Drupal::getContainer();
+
+    // Create a mocked logger so we can access error messages from the Tripal logger
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['error'])
+      ->getMock();
+    $mock_logger->method('error')
+      ->willReturnCallback(function($message, $context, $options) {
+          $this->mock_error .= str_replace(array_keys($context), $context, $message);
+          return NULL;
+        });
+    $container->set('tripal.logger', $mock_logger);
+  }
+
+  /**
    * Confirm basic Taxonomy importer functionality.
    *
    * @group taxonomy
@@ -49,10 +73,14 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
     $file_details = [
     ];
 
+    $this->mock_error = '';
     $taxonomy_importer->createImportJob($run_args, $file_details);
     $taxonomy_importer->prepareFiles();
     $taxonomy_importer->run();
     $taxonomy_importer->postRun();
+    if ($this->mock_error) {
+      $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
+    }
 
     // Check if Arabidopsis thaliana retrieved by tax_id 3702 from NCBI and organism created
     $results = $chado->query("SELECT count(*) as c1 FROM {1:organism}

--- a/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
@@ -74,7 +74,6 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
     ];
 
     $this->mock_error = '';
-\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $taxonomy_importer->createImportJob($run_args, $file_details);
     $taxonomy_importer->prepareFiles();
     $taxonomy_importer->run();

--- a/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TaxonomyImporterTest.php
@@ -74,6 +74,7 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
     ];
 
     $this->mock_error = '';
+\Drupal::state()->set('FAIL', 1); //@@@ Temporary!
     $taxonomy_importer->createImportJob($run_args, $file_details);
     $taxonomy_importer->prepareFiles();
     $taxonomy_importer->run();


### PR DESCRIPTION
# Bug Fix

### Closes #2143

## Description
1. A number of tests fail infrequently due to intermittent download problems performed by unit tests.
Frequently just retrying the download again is enough to get past this.
**Since this can also occur during actual site administration**, it will be helpful to create a service using the Drupal HTTPClient that will automatically retry downloads a limited number of times, and replace relevant `fopen()` + `fread()` with this service.

2. If the download still fails, the test should fail gracefully (`markTestSkipped()`)

## Testing?
Failures are relatively rare, so to simulate them during development, I had some temporary code in `tripal/src/Services/TripalFileRetriever.php`
`$fail = \Drupal::state()->get('FAIL', '0');if ($fail) { $contents = NULL; $retries = 0; $this->logger->error('Unable to get response from @url: mocked_error', ['@url' => $url]); }`
then temporarily add this:
`\Drupal::state()->set('FAIL', 1);`
in an appropriate spot in the unit test to trigger the mocked download failure.

I ran tests with forced failure (commit https://github.com/tripal/tripal/pull/2201/commits/1fd62597dc2313c4043485f57e4302d9f8aa67fa) and the failed tests were skipped instead of causing failure 
![PR2201 2](https://github.com/user-attachments/assets/70db2705-a4cf-4be0-ae95-6a1b319ba03b)

