### PR TITLE
Fix wrong config for PHPUnit for Drupal < 11.x

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -70,8 +70,8 @@ jobs:
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/tripal \
             tripaldocker:localdocker
           docker exec tripaldocker service postgresql restart
-          docker exec tripaldocker bash -c 'if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then
-            mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml
+          docker exec tripaldocker bash -c 'if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
+            mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
             && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; fi'
       # Runs the PHPUnit tests.
       - name: Run PHPUnit Tests

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -70,6 +70,9 @@ jobs:
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/tripal \
             tripaldocker:localdocker
           docker exec tripaldocker service postgresql restart
+          docker exec tripaldocker bash -c 'if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then
+            mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml
+            && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; fi'
       # Runs the PHPUnit tests.
       - name: Run PHPUnit Tests
         env:


### PR DESCRIPTION
# Bug Fix

### Closes #2170

## Description
When running tests, we mount the current tripal version on top of the docker tripal directory, so the PHPUnit config file in the docker image gets "reset" to always be the one for Drupal 11.x.
This happens here
https://github.com/tripal/tripal/blob/ec51eef784a7a113496e23903ef01e7f421c2b64/.github/workflows/ALL-phpunit.yml#L69-L71

This PR adds a step to update the PHPUnit config file for Drupal 10.x

## Testing?
Automated test check only, confirm that Drupal 10.x tests no longer use the wrong config file
The following text should **no longer appear** (note that this does not throw an error so it can go unnoticed!)
```
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 20:
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerErrors': The attribute 'displayDetailsOnTestsThatTriggerErrors' is not allowed.
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerWarnings': The attribute 'displayDetailsOnTestsThatTriggerWarnings' is not allowed.
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerDeprecations': The attribute 'displayDetailsOnTestsThatTriggerDeprecations' is not allowed.
  - Element 'phpunit', attribute 'cacheDirectory': The attribute 'cacheDirectory' is not allowed.

  Line 61:
  - Element 'bootstrap': This element is not expected. Expected is ( extension ).

  Line 95:
  - Element 'source': This element is not expected.

  Test results may not be as expected.
```
Expected output without the error messages:
![PR2202_1](https://github.com/user-attachments/assets/23403473-ada9-4888-8298-1e25c55b1459)
