### PR TITLE
pass drupalversion to docker

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -72,10 +72,10 @@ jobs:
           docker exec tripaldocker service postgresql restart
           docker exec tripaldocker bash -c 'export drupalversion="'${{ matrix.drupal-version }}'"; \
             if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
-            echo "Drupal version ${drupalversion}, copying phpunit config for 10.x" \
+            echo "Drupal version is ${drupalversion}, copying phpunit config for 10.x" \
             && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
             && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
-            else "Drupal version ${drupalversion}, using default phpunit config for 11.x"; fi'
+            else echo "Drupal version is ${drupalversion}, using default phpunit config for 11.x"; fi'
       # Runs the PHPUnit tests.
       - name: Run PHPUnit Tests
         env:

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -70,9 +70,12 @@ jobs:
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/tripal \
             tripaldocker:localdocker
           docker exec tripaldocker service postgresql restart
-          docker exec tripaldocker bash -c 'if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
-            mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
-            && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; fi'
+          docker exec tripaldocker bash -c 'export drupalversion="'${{ matrix.drupal-version }}'"; \
+            if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
+            echo "Drupal version ${drupalversion}, copying phpunit config for 10.x" \
+            && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
+            && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
+            else "Drupal version ${drupalversion}, using default phpunit config for 11.x"; fi'
       # Runs the PHPUnit tests.
       - name: Run PHPUnit Tests
         env:


### PR DESCRIPTION
# Bug Fix

### Closes #2170 

## Description
Let's try one more time, forgot to pass the drupal version to the command.
And now print a message so it is easy to tell what version of phpunit.xml is actually being used, I should have done that before!

## Testing?
Check automated tests on 10.x and 11.x to confirm correct config file is being used
For 10.x you should see
![PR2204 10 x](https://github.com/user-attachments/assets/e0c72e6f-226d-49cd-bfe3-a26d359531ca)

For 11.x you should see
![PR2204 11 x](https://github.com/user-attachments/assets/efdcc877-ed8a-4db4-8102-1615e3586ed1)

And confirm tests on 11.x are not taking double time (2 hours) to complete
