### PR TITLE
Remove unused browsertest configurations from phpunit config

### DIFF
--- a/phpunit.9.6.xml
+++ b/phpunit.9.6.xml
@@ -19,19 +19,6 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
-    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value=""/>
-    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/database_name#table_prefix -->
-    <env name="SIMPLETEST_DB" value=""/>
-    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
-    <!-- By default, browser tests will output links that use the base URL set
-     in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal
-     path (such as may be the case in a virtual or Docker-based environment),
-     you can set the base URL used in the browser test output links to something
-     reachable from your host machine here. This will allow you to follow them
-     directly and view the output. -->
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
 
     <!-- Deprecation testing is managed through Symfony's PHPUnit Bridge.
       The environment variable SYMFONY_DEPRECATIONS_HELPER is used to configure

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,22 +25,6 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value=""/>
-    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/database_name#table_prefix -->
-    <env name="SIMPLETEST_DB" value=""/>
-    <!-- By default, browser tests will output links that use the base URL set
-     in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal
-     path (such as may be the case in a virtual or Docker-based environment),
-     you can set the base URL used in the browser test output links to something
-     reachable from your host machine here. This will allow you to follow them
-     directly and view the output. -->
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
-    <!-- The environment variable SYMFONY_DEPRECATIONS_HELPER is used to configure
-      the behavior of the deprecation tests.
-      Drupal core's testing framework is setting this variable to its defaults.
-      Projects with their own requirements need to manage this variable
-      explicitly.
-    -->
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Deprecation errors can be selectively ignored by specifying a file of
@@ -58,23 +42,6 @@
     <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
   </php>
   <extensions>
-    <!-- Functional tests HTML output logging. -->
-    <bootstrap class="Drupal\TestTools\Extension\HtmlLogging\HtmlOutputLogger">
-      <!-- The directory where the browser output will be stored. If a relative
-        path is specified, it will be relative to the current working directory
-        of the process running the PHPUnit CLI. In CI environments, this can be
-        overridden by the value set for the "BROWSERTEST_OUTPUT_DIRECTORY"
-        environment variable.
-      -->
-      <parameter name="outputDirectory" value="sites/simpletest/browser_output"/>
-      <!-- By default browser tests print the individual links in the test run
-        report. To avoid overcrowding the output in CI environments, you can
-        set the "verbose" parameter or the "BROWSERTEST_OUTPUT_VERBOSE"
-        environment variable to "false". In GitLabCI, the output is saved
-        anyway as an artifact that can be browsed or downloaded from Gitlab.
-      -->
-      <parameter name="verbose" value="true"/>
-    </bootstrap>
   </extensions>
   <testsuites>
     <testsuite name="unit">


### PR DESCRIPTION
# Bug Fix

### Closes #2210 

## Description
The error this fixes is the following message is printed on PHPUnit tests on Drupal versions 11.x

`HTML output directory /var/www/drupal/web/sites/simpletest/browser_output is not a writable directory.`

## Testing?
Check automated tests to see that the indicated message no longer appears.
You can also run tests locally as well to confirm this, you only need to run one test, e.g. `--filter=PubSearchQueryNameAutocompleteControllerTest`
