### PR TITLE
Revisit fix brittle tests depending on external sites

### DIFF
--- a/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
+++ b/tripal/src/Plugin/TripalPubLibrary/TripalPubLibraryPubMed.php
@@ -330,18 +330,12 @@ class TripalPubLibraryPubMed extends TripalPubLibraryBase {
     }
 
     usleep($sleep_time);  // 1/3 of a second delay, NCBI limits requests to 3 / second without API key
-    $rfh = fopen($query_url, "r");
-    if (!$rfh) {
+    $query_xml = $this->fileretriever->retrieveFileContents($query_url);
+    if (is_null($query_xml)) {
       $this->logger->error("Could not perform Pubmed query. Cannot connect to Entrez.");
       return FALSE;
     }
 
-    // retrieve the XML results
-    $query_xml = '';
-    while (!feof($rfh)) {
-      $query_xml .= fread($rfh, 255);
-    }
-    fclose($rfh);
     $xml = new \XMLReader();
     $xml->xml($query_xml);
 

--- a/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
+++ b/tripal/tests/src/Kernel/Services/TripalFileRetriever/TripalFileRetrieverTest.php
@@ -129,7 +129,8 @@ class TripalFileRetrieverTest extends TripalTestKernelBase {
       'https://github.com/vmasiufekxlkajfd.txt',
       [],
       [
-        'error_message' => 'Invalid file',
+        // Expect "Invalid file", but in rare cases when host is down can get "Invalid hostname"
+        'error_message' => 'Invalid',
         'has_content' => FALSE,
         'skip' => FALSE,
         'download_status' => FALSE,


### PR DESCRIPTION
# Bug Fix

### Closes #2143

## Description
I missed this `fopen()` which finally after a week caused an error.
Fix is to use the new file retriever service.
And this means that the publication importer doesn't have download retry capability, this PR adds that.

## Testing?
I don't know how really, with these rare intermittent errors. With code review, and if automated tests pass I think it should be good. ¯\\_(ツ)_/¯