### PR TITLE
Remove final keyword from classes to allow extension and testing

### DIFF
--- a/tripal/src/Form/ImportTripalEntityTypeCollection.php
+++ b/tripal/src/Form/ImportTripalEntityTypeCollection.php
@@ -8,7 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Provides a Tripal form.
  */
-final class ImportTripalEntityTypeCollection extends FormBase {
+class ImportTripalEntityTypeCollection extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/tripal_chado/src/ChadoBuddy/Annotation/ChadoBuddy.php
+++ b/tripal_chado/src/ChadoBuddy/Annotation/ChadoBuddy.php
@@ -9,7 +9,7 @@ use Drupal\Component\Annotation\Plugin;
  *
  * @Annotation
  */
-final class ChadoBuddy extends Plugin {
+class ChadoBuddy extends Plugin {
 
   /**
    * The plugin ID.

--- a/tripal_chado/src/ChadoBuddy/PluginManagers/ChadoBuddyPluginManager.php
+++ b/tripal_chado/src/ChadoBuddy/PluginManagers/ChadoBuddyPluginManager.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 /**
  * ChadoBuddy plugin manager.
  */
-final class ChadoBuddyPluginManager extends DefaultPluginManager {
+class ChadoBuddyPluginManager extends DefaultPluginManager {
 
   /**
    * Provides the TripalDBX connection to chado that ChadoBuddies created by


### PR DESCRIPTION


<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Task

### Issue #2213 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
`ChadoBuddyPluginManager`, `ChadoBuddy` and `ImportTripalEntityTypeCollection` classes are currently declared as final, which prevents them from being extended or mocked in unit tests. This restricts test coverage for any service or class that depends on it. Removing the final keyword improves flexibility and make it easier to write isolated tests that simulate plugin behavior.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
None
