### PR TITLE
Drupal coding standards for tripal_biodb module

### DIFF
--- a/tripal_biodb/src/Lock/PersistentDatabaseSharedLockBackend.php
+++ b/tripal_biodb/src/Lock/PersistentDatabaseSharedLockBackend.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\tripal_biodb\Lock;
 
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Lock\PersistentDatabaseLockBackend;
 
 /**
@@ -53,7 +56,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
   /**
    * Default timeout for both exclusive and shared locks.
    *
-   * 43200 seconds = 2 hours
+   * 43200 seconds = 2 hours.
    */
   const DEFAULT_LOCK_TIMEOUT = 43200.;
 
@@ -91,9 +94,9 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
    *   Drupal state service.
    */
   public function __construct(
-    \Drupal\Core\Database\Connection $database,
-    ?\Drupal\Core\Lock\LockBackendInterface $locker = NULL,
-    ?\Drupal\Core\State\StateInterface $state = NULL
+    Connection $database,
+    ?LockBackendInterface $locker = NULL,
+    ?StateInterface $state = NULL,
   ) {
     parent::__construct($database);
     $this->lockId = static::LOCK_ID;
@@ -116,7 +119,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
     $name,
     $timeout = self::DEFAULT_LOCK_TIMEOUT,
     string $owner = '',
-    ?int $pid = NULL
+    ?int $pid = NULL,
   ) {
     // Make sure it is not shared.
     $shared_locks = $this->state->get(static::STATE_KEY_SHARED, []);
@@ -163,9 +166,9 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
    *
    * Shared locks relies on a regular lock as defined in the
    * \Drupal\Core\Lock\PersistentDatabaseLockBackend class plus a list of lock
-   * share owners stored by the Drupal State API key static::STATE_KEY_SHARED. In order
-   * to avoid race conditions on the state key value modification, a lock
-   * backend provided to the constructor is used to manage modifications.
+   * share owners stored by the Drupal State API key static::STATE_KEY_SHARED.
+   * In order to avoid race conditions on the state key value modification, a
+   * lock backend provided to the constructor is used to manage modifications.
    *
    * @param string $name
    *   Shared lock name. Limit of name's length is 255 characters.
@@ -187,7 +190,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
     string $name,
     float $timeout = self::DEFAULT_LOCK_TIMEOUT,
     string $owner = '',
-    ?int $pid = NULL
+    ?int $pid = NULL,
   ) {
     // Acquire a state modification lock.
     if (!$this->modLocker->acquire(static::STATE_KEY_SHARED)) {
@@ -233,8 +236,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
         ->fields('s', ['expire'])
         ->execute()
         ->fetch()
-        ->expire
-      ;
+        ->expire;
       // Keep the largest one.
       if ($expire > $current_expire) {
         $success = (bool) $this->database->update(static::TABLE_NAME)
@@ -272,7 +274,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
 
     // Release the state modification lock.
     $this->modLocker->release(static::STATE_KEY_SHARED);
-    
+
     return $success ? $owner : FALSE;
   }
 
@@ -290,7 +292,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
     if (!empty($shared_locks[$name])) {
       return;
     }
-      
+
     // Lock status for modifications.
     if ($this->modLocker->acquire(static::STATE_KEY_EXCLUSIVE)) {
       // Get exclusive lock status.
@@ -345,7 +347,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
 
     // Try cleaning shared locks.
     $this->cleanUnusedSharedLocks();
-    
+
     if (!$available) {
       // Retry.
       $available = parent::lockMayBeAvailable($name);
@@ -407,7 +409,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
               // Share expired.
               $expired = TRUE;
             }
-            
+
             // Remove lock share.
             if ($expired) {
               unset($new_shared_locks[$name][$owner]);
@@ -479,15 +481,14 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
           ->condition('s.value', $this->getLockId())
           ->fields('s', ['name'])
           ->execute()
-          ->fetchCol()
-        ;
+          ->fetchCol();
         foreach ($names as $name) {
           if (empty($new_exclusive_locks[$name])) {
             $this->locks[$name] = TRUE;
             $this->release($name);
           }
         }
-        
+
         // Release state modification lock.
         $this->modLocker->release(static::STATE_KEY_EXCLUSIVE);
       }
@@ -560,8 +561,7 @@ class PersistentDatabaseSharedLockBackend extends PersistentDatabaseLockBackend 
       ->fields('s', ['expire'])
       ->execute()
       ->fetch()
-      ->expire
-    ;
+      ->expire;
     return $current_expire ?? 0;
   }
 

--- a/tripal_biodb/src/Lock/SharedLockBackendInterface.php
+++ b/tripal_biodb/src/Lock/SharedLockBackendInterface.php
@@ -49,7 +49,7 @@ interface SharedLockBackendInterface extends LockBackendInterface, LockInfoInter
     $name,
     $timeout = 30.0,
     string $owner = '',
-    ?int $pid = NULL
+    ?int $pid = NULL,
   );
 
   /**
@@ -74,7 +74,7 @@ interface SharedLockBackendInterface extends LockBackendInterface, LockInfoInter
     string $name,
     float $timeout = 30.0,
     string $owner = '',
-    ?int $pid = NULL
+    ?int $pid = NULL,
   );
 
   /**
@@ -131,4 +131,5 @@ interface SharedLockBackendInterface extends LockBackendInterface, LockInfoInter
    *   The system process identifier using this lock or 0 if not available.
    */
   public function getOwnerPid(string $name, ?string $owner = NULL) :int;
+
 }

--- a/tripal_biodb/src/Task/BioTaskBase.php
+++ b/tripal_biodb/src/Task/BioTaskBase.php
@@ -2,6 +2,11 @@
 
 namespace Drupal\tripal_biodb\Task;
 
+use Drupal\Core\State\StateInterface;
+use Drupal\tripal_biodb\Lock\SharedLockBackendInterface;
+use Psr\Log\LoggerInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\tripal_biodb\Exception\TaskException;
 use Drupal\tripal_biodb\Exception\ParameterException;
 use Drupal\tripal_biodb\Exception\LockException;
@@ -11,6 +16,8 @@ use Drupal\tripal\TripalDBX\TripalDbxConnection;
  * Defines the base class for tasks on one or more biological schemas.
  */
 abstract class BioTaskBase implements BioTaskInterface {
+
+  use StringTranslationTrait;
 
   /**
    * Name of the task.
@@ -64,7 +71,7 @@ abstract class BioTaskBase implements BioTaskInterface {
    *
    * @var array
    */
-  protected $parameters = ['input_schemas' => [], 'output_schemas' => [], ];
+  protected $parameters = ['input_schemas' => [], 'output_schemas' => []];
 
   /**
    * Input schemas as an array of \Drupal\tripal\TripalDBX\TripalDbxConnection.
@@ -83,7 +90,7 @@ abstract class BioTaskBase implements BioTaskInterface {
   /**
    * Creates a BioTaskBase object.
    *
-   * @param ?\Drupal\Core\Database\Connection $connection
+   * @param ?\Drupal\Core\Database\Connection $database
    *   The main database connection.
    * @param ?\Psr\Log\LoggerInterface $logger
    *   The logger.
@@ -96,10 +103,10 @@ abstract class BioTaskBase implements BioTaskInterface {
    * @see https://www.drupal.org/docs/8/api/database-api/database-configuration
    */
   public function __construct(
-    ?\Drupal\Core\Database\Connection $database = NULL,
-    ?\Psr\Log\LoggerInterface $logger = NULL,
-    ?\Drupal\tripal_biodb\Lock\SharedLockBackendInterface $locker = NULL,
-    ?\Drupal\Core\State\StateInterface $state = NULL
+    ?Connection $database = NULL,
+    ?LoggerInterface $logger = NULL,
+    ?SharedLockBackendInterface $locker = NULL,
+    ?StateInterface $state = NULL,
   ) {
     // Database.
     if (!isset($database)) {
@@ -133,8 +140,7 @@ abstract class BioTaskBase implements BioTaskInterface {
     // Task parameters.
     $this->parameters =
       $parameters
-      + ['input_schemas' => [], 'output_schemas' => [], ]
-    ;
+      + ['input_schemas' => [], 'output_schemas' => []];
 
     // Initializes schema data.
     $this->inputSchemas = $this->prepareSchemas(
@@ -229,7 +235,7 @@ abstract class BioTaskBase implements BioTaskInterface {
    *   The lock name.
    */
   protected function getSchemaLockName(
-    \Drupal\tripal\TripalDBX\TripalDbxConnection $db
+    TripalDbxConnection $db,
   ) :string {
     return $db->getDatabaseName() . '.' . $db->getSchemaName();
   }
@@ -241,8 +247,7 @@ abstract class BioTaskBase implements BioTaskInterface {
     $raw_id =
       static::TASK_NAME
       . '-'
-      . $this->connection->getConnectionOptions()['database']
-    ;
+      . $this->connection->getConnectionOptions()['database'];
     if (!empty($this->inputSchemas)) {
       $raw_id .= '-' . count($this->inputSchemas) . 'i';
     }
@@ -254,8 +259,7 @@ abstract class BioTaskBase implements BioTaskInterface {
           '-'
           . $schema->getDatabaseName()
           . '.'
-          . $schema->getSchemaName()
-        ;
+          . $schema->getSchemaName();
       }
       else {
         $raw_id .= '-' . $schema->getSchemaName();
@@ -272,8 +276,7 @@ abstract class BioTaskBase implements BioTaskInterface {
           '-'
           . $schema->getDatabaseName()
           . '.'
-          . $schema->getSchemaName()
-        ;
+          . $schema->getSchemaName();
       }
       else {
         $raw_id .= '-' . $schema->getSchemaName();
@@ -384,8 +387,8 @@ abstract class BioTaskBase implements BioTaskInterface {
     $this->validateParameters();
 
     // Acquire locks.
-    $success = $this->acquireTaskLocks();
-    if (!$success) {
+    $task_success = $this->acquireTaskLocks();
+    if (!$task_success) {
       throw new LockException(
         "Unable to acquire all locks for task. See logs for details."
       );
@@ -426,16 +429,16 @@ abstract class BioTaskBase implements BioTaskInterface {
   public function getStatus() :string {
     $progress = $this->getProgress();
     if (0 == $progress) {
-      $status = t('Not started yet.');
+      $status = $this->t('Not started yet.');
     }
     elseif (1 <= $progress) {
-      $status = t('Done.');
+      $status = $this->t('Done.');
     }
     elseif (0 > $progress) {
-      $status = t('An error occurred.');
+      $status = $this->t('An error occurred.');
     }
     else {
-      $status = t('In progress');
+      $status = $this->t('In progress');
     }
     return $status;
   }
@@ -443,7 +446,7 @@ abstract class BioTaskBase implements BioTaskInterface {
   /**
    * {@inheritdoc}
    */
-  public function getLogger() :\Psr\Log\LoggerInterface {
+  public function getLogger() :LoggerInterface {
     return $this->logger;
   }
 

--- a/tripal_biodb/src/Task/BioTaskInterface.php
+++ b/tripal_biodb/src/Task/BioTaskInterface.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\tripal_biodb\Task;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Provides an interface to manage a task on one or more biological schemas.
  */
@@ -47,7 +49,7 @@ interface BioTaskInterface {
    * Parameters are validate at runtime by ::performTask, just before the actual
    * task is started.
    *
-   * @param $parameters
+   * @param array $parameters
    *   A associative array of parameters used to configure the task. The
    *   array should include the keys 'input_schemas' and 'output_schemas', both
    *   containing an array of ordered schema names (or an empty array).
@@ -126,6 +128,6 @@ interface BioTaskInterface {
    * @return \Psr\Log\LoggerInterface
    *   The task logger.
    */
-  public function getLogger() :\Psr\Log\LoggerInterface;
+  public function getLogger() :LoggerInterface;
 
 }

--- a/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
+++ b/tripal_biodb/tests/src/Kernel/Task/BioTaskBaseTest.php
@@ -2,7 +2,10 @@
 
 namespace Drupal\Tests\tripal_biodb\Kernel\Task;
 
+use Drupal\tripal\TripalDBX\TripalDbxConnection;
+use Drupal\tripal_biodb\Task\BioTaskBase;
 use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * Tests for tasks.
@@ -16,15 +19,35 @@ use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
 class BioTaskBaseTest extends TripalTestKernelBase {
 
   /**
-   * Test members.
+   * Prophesize config factory object.
    *
-   * "pro*" members are prophesize objects while their "non-pro*" equivqlent are
-   * the revealed objects.
+   * "pro*" members are prophesize objects while their "non-pro*" equivalent
+   * are the revealed objects.
+   *
+   * @var Prophecy\Prophecy\ObjectProphecy
    */
-  protected $proConfigFactory;
-  protected $configFactory;
-  protected $proConfig;
-  protected $config;
+  protected ObjectProphecy $proConfigFactory;
+
+  /**
+   * Revealed config factory object.
+   *
+   * @var object
+   */
+  protected object $configFactory;
+
+  /**
+   * Prophesize config object.
+   *
+   * @var Prophecy\Prophecy\ObjectProphecy
+   */
+  protected ObjectProphecy $proConfig;
+
+  /**
+   * Revealed config object.
+   *
+   * @var object
+   */
+  protected object $config;
 
   /**
    * {@inheritdoc}
@@ -37,16 +60,17 @@ class BioTaskBaseTest extends TripalTestKernelBase {
   }
 
   /**
-   * Setup a mock version of the abstract Bi9oTaskBase for testing.
+   * Setup a mock version of the abstract BioTaskBase for testing.
    */
   public function getMock() {
 
-    // Create a mock for the abstract class
-    // but specify not to run the contructor + mention this is an abstract class.
-    $tmock = $this->getMockBuilder(\Drupal\tripal_biodb\Task\BioTaskBase::class)
+    // Create a mock for the abstract class, but specify not to run the
+    // constructor + mention this is an abstract class.
+    $tmock = $this->getMockBuilder(BioTaskBase::class)
       ->onlyMethods(['getTripalDbxClass'])
       ->getMockForAbstractClass();
-    // Ensure when getTripalDbxClass() is asked for the connection class, it returns our fake class.
+    // Ensure when getTripalDbxClass() is asked for the connection class,
+    // it returns our fake class.
     $tmock
       ->expects($this->any())
       ->method('getTripalDbxClass')
@@ -73,12 +97,16 @@ class BioTaskBaseTest extends TripalTestKernelBase {
     // Since the variables set by the constructor are protected properties,
     // we cannot test them directly. As such, we will use PHP closures to
     // access these properties for testing.
-    //  -- Create a variable to store a copy of this test object for use within the closure.
+    // -- Create a variable to store a copy of this test object for use within
+    // the closure.
     $that = $this;
-    //  -- Create a closure (i.e. a function tied to a variable) that does not need any parameters.
-    //     Within this function we will want all of the assertions we will use to test the private methods.
-    //     Also, $this within the function will actually be the plugin object that you bind later (mind blown).
-    $assertConstructorClosure = function ()  use ($that){
+    // -- Create a closure (i.e. a function tied to a variable) that does not
+    // need any parameters.
+    // Within this function we will want all of the assertions we will use
+    // to test the private methods.
+    // Also, $this within the function will actually be the plugin object
+    // that you bind later (mind blown).
+    $assertConstructorClosure = function () use ($that) {
       $that->assertIsObject($this->connection,
         "The connection object was not set properly by our constructor.");
       $that->assertIsObject($this->logger,
@@ -95,10 +123,11 @@ class BioTaskBaseTest extends TripalTestKernelBase {
       $that->assertEquals($this->logger, $this->getLogger(),
         "Retrieving the logger did not return the logger set in the object.");
     };
-    //  -- Now, bind our assertion closure to the $plugin object. This is what makes the plugin available
-    //     inside the function.
+    // -- Now, bind our assertion closure to the $plugin object. This is what
+    // makes the plugin available inside the function.
     $doAssertConstructorClosure = $assertConstructorClosure->bindTo($tmock, get_class($tmock));
-    //  -- Finally, call our bound closure function to run the assertions on our plugin.
+    // -- Finally, call our bound closure function to run the assertions on
+    // our plugin.
     $doAssertConstructorClosure();
   }
 
@@ -119,7 +148,7 @@ class BioTaskBaseTest extends TripalTestKernelBase {
     ];
     $tmock->setParameters($parameters);
     $that = $this;
-    $assertParametersClosure = function ()  use ($that, $parameters){
+    $assertParametersClosure = function () use ($that, $parameters) {
       $that->assertIsArray($this->parameters, "Parameters should be an array.");
       $that->assertArrayHasKey('input_schemas', $this->parameters,
         "Input schema key not set in parameters array.");
@@ -133,14 +162,14 @@ class BioTaskBaseTest extends TripalTestKernelBase {
       $that->assertCount(1, $this->inputSchemas,
         "We expect there should be one input schema based on the parameters passed in.");
       $that->assertContainsOnlyInstancesOf(
-        \Drupal\tripal\TripalDBX\TripalDbxConnection::class,
+        TripalDbxConnection::class,
         $this->inputSchemas,
         "All input schema should be prepared as TripalDBXConnection objects but are not."
       );
       $that->assertCount(1, $this->outputSchemas,
         "We expect there should be one output schema based on the parameters passed in.");
       $that->assertContainsOnlyInstancesOf(
-        \Drupal\tripal\TripalDBX\TripalDbxConnection::class,
+        TripalDbxConnection::class,
         $this->outputSchemas,
         "All output schema should be prepared as TripalDBXConnection objects but are not."
       );
@@ -148,4 +177,5 @@ class BioTaskBaseTest extends TripalTestKernelBase {
     $doAssertParametersClosure = $assertParametersClosure->bindTo($tmock, get_class($tmock));
     $doAssertParametersClosure();
   }
+
 }

--- a/tripal_biodb/tests/src/Unit/Lock/PersistentDatabaseSharedLockBackendTest.php
+++ b/tripal_biodb/tests/src/Unit/Lock/PersistentDatabaseSharedLockBackendTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\tripal_biodb\Unit\Lock;
 
+use Drupal\Core\Lock\DatabaseLockBackend;
 use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
 use Drupal\Core\Lock\PersistentDatabaseLockBackend;
 use Drupal\tripal_biodb\Lock\PersistentDatabaseSharedLockBackend;
@@ -54,10 +55,10 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
   protected $state;
 
   /**
-   * A variable set by our custom error handler when an E_USER_WARNING is thrown.
+   * A variable set by our custom error handler when E_USER_WARNING is thrown.
    *
    * If it's TRUE it means a warning was thrown.
-   * Remember to reset this variable back to false after a warning is asserted.
+   * Remember to reset this variable back to FALSE after a warning is asserted.
    *
    * @var bool
    */
@@ -77,7 +78,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->internalLocker = new \Drupal\Core\Lock\DatabaseLockBackend(
+    $this->internalLocker = new DatabaseLockBackend(
       $this->container->get('database')
     );
     $this->state = $this->container->get('state');
@@ -102,6 +103,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
    * Tears down the test environment.
    *
    * @return void
+   *   No return value.
    */
   protected function tearDown(): void {
     // Restore the original error handler now that we are done our tests.
@@ -143,7 +145,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
       $this->warning_message,
       "We did not get the warning we expected."
     );
-    // Reset warning handler
+    // Reset warning handler.
     $this->warning_thrown = FALSE;
     $this->warning_message = '';
 
@@ -301,8 +303,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
   }
 
   /**
-   * Tests acquire will continue even if it could not use state API to store
-   * infos.
+   * Tests acquire will continue even if it could not use state API for storage.
    *
    * @covers ::acquire
    */
@@ -331,10 +332,9 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
       $this->warning_message,
       "We did not get the warning we expected."
     );
-    // Reset warning handler
+    // Reset warning handler.
     $this->warning_thrown = FALSE;
     $this->warning_message = '';
-
 
     // Make sure state lock was not released.
     $this->assertFalse($other_locker->lockMayBeAvailable(PersistentDatabaseSharedLockBackend::STATE_KEY_EXCLUSIVE), 'States still locked.');
@@ -374,7 +374,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
       $this->warning_message,
       "We did not get the warning we expected."
     );
-    // Reset warning handler
+    // Reset warning handler.
     $this->warning_thrown = FALSE;
     $this->warning_message = '';
 
@@ -553,8 +553,7 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
     $this->sharedLocker->release($lock_name);
     $is_free =
       $this->sharedLocker->lockMayBeAvailable($lock_name)
-      || $other_locker->lockMayBeAvailable($lock_name)
-    ;
+      || $other_locker->lockMayBeAvailable($lock_name);
     $this->assertFalse($is_free, 'Other lock not released.');
 
     $other_locker->release($lock_name);
@@ -724,4 +723,5 @@ class PersistentDatabaseSharedLockBackendTest extends TripalTestKernelBase {
     // Release shared lock.
     $this->sharedLocker->releaseShared($lock_name, $owner);
   }
+
 }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #2215 

### Depends on PR #2216

## Description
This brings the `tripal_biodb` module into compliance with Drupal coding standards.
The procedure is described in issue #2215
The full list of issues reported by phpcs: [phpcs.tripal_biodb.txt](https://github.com/user-attachments/files/20853527/phpcs.tripal_biodb.txt)
I think this should be easy to review, but that remains to be seen...

The few warnings that I have not fixed:
```
FILE: /var/www/drupal/web/modules/contrib/tripal/tripal_biodb/src/Lock/PersistentDatabaseSharedLockBackend.php
--------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------------------------------------
 105 | WARNING | \Drupal calls should be avoided in classes, use dependency injection instead
 110 | WARNING | \Drupal calls should be avoided in classes, use dependency injection instead
--------------------------------------------------------------------------------------------------------------


FILE: /var/www/drupal/web/modules/contrib/tripal/tripal_biodb/src/Task/BioTaskBase.php
--------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
--------------------------------------------------------------------------------------
 402 | WARNING | Code after the THROW statement on line 399 cannot be executed
 405 | WARNING | Code after the THROW statement on line 399 cannot be executed
 406 | WARNING | Code after the THROW statement on line 399 cannot be executed
--------------------------------------------------------------------------------------
```

## Testing?
Mostly code review, there should be very few functional changes.
