### PR TITLE
Replace invalid placeholders

### DIFF
--- a/tripal/src/api/tripal.upload.api.php
+++ b/tripal/src/api/tripal.upload.api.php
@@ -161,9 +161,9 @@ function tripal_file_upload($type, $filename, $action = NULL, $chunk = 0) {
   // $user_dir = tripal_get_user_files_dir($uid); //old
   $user_dir = \Drupal::service('file_system')->realpath(tripal_get_user_files_dir($uid));
   if (!tripal_is_user_files_dir_writeable($uid)) {
-    $message = "The user's data directory is not writeable: !user_dir";
+    $message = "The user's data directory is not writeable: @user_dir";
     \Drupal::logger('tripal')->error($message, [
-      '!user_dir' => $user_dir,
+      '@user_dir' => $user_dir,
     ]);
     $result = [
       'status' => 'failed',

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -1441,8 +1441,8 @@ class OBOImporter extends ChadoImporterBase {
       // Before we try to look for the replacement term, let's try to find it.
       // in our list of cached terms.
       if (array_key_exists($replaced_by, $this->termStanzaCache['ids'])) {
-        $this->logger->notice(t("Found term @term replaced by @replaced in the term cache.",
-          ['@term' => $id, '@replaced' => $replaced_by]));
+        $this->logger->notice(t("Found term, @replaced in the term cache.",
+          ['@replaced' => $replaced_by]));
         return $this->termStanzaCache['ids'][$id];
       }
 
@@ -1450,8 +1450,8 @@ class OBOImporter extends ChadoImporterBase {
       $rpair = explode(":", $replaced_by, 2);
       $found = $this->lookupTerm($rpair[0], $rpair[1]);
       if ($found) {
-        $this->logger->notice(t("Found term @term replaced by @replaced in the local data store.",
-          ['@term' => $id, '@replaced' => $replaced_by]));
+        $this->logger->notice(t("Found term, @replaced in the local data store.",
+          ['@replaced' => $replaced_by]));
         return $found;
       }
 

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -1320,8 +1320,8 @@ class OBOImporter extends ChadoImporterBase {
     else {
       $ontology_results =  $this->oboEbiLookup($id, 'query');
       if ($ontology_results === FALSE OR !is_array($ontology_results)) {
-        throw new \Exception(t('Did not get a response from EBI OLS trying to lookup ontology: !id',
-          ['!id' => $ontologyID]));
+        throw new \Exception(t('Did not get a response from EBI OLS trying to lookup ontology: @id',
+          ['@id' => $ontologyID]));
       }
       // If results were received but the number of results is 0, do a query-non-local lookup.
       if ($ontology_results['response']['numFound'] == 0) {
@@ -1441,8 +1441,8 @@ class OBOImporter extends ChadoImporterBase {
       // Before we try to look for the replacement term, let's try to find it.
       // in our list of cached terms.
       if (array_key_exists($replaced_by, $this->termStanzaCache['ids'])) {
-        $this->logger->notice(t("Found term, @replaced in the term cache.",
-          ['@term' => $id, '!replaced' => $replaced_by]));
+        $this->logger->notice(t("Found term @term replaced by @replaced in the term cache.",
+          ['@term' => $id, '@replaced' => $replaced_by]));
         return $this->termStanzaCache['ids'][$id];
       }
 
@@ -1450,7 +1450,7 @@ class OBOImporter extends ChadoImporterBase {
       $rpair = explode(":", $replaced_by, 2);
       $found = $this->lookupTerm($rpair[0], $rpair[1]);
       if ($found) {
-        $this->logger->notice(t("Found term, @replaced in the local data store.",
+        $this->logger->notice(t("Found term @term replaced by @replaced in the local data store.",
           ['@term' => $id, '@replaced' => $replaced_by]));
         return $found;
       }

--- a/tripal_chado/src/api/ChadoSchema.php
+++ b/tripal_chado/src/api/ChadoSchema.php
@@ -637,8 +637,8 @@ class ChadoSchema {
       tripal_report_error(
         'ChadoSchema',
         TRIPAL_WARNING,
-        'Unable to check the type of !table!column since it doesn\'t appear to exist in your site database.',
-        ['!column' => $column, '!table' => $table]
+        'Unable to check the type of @table.@column since it doesn\'t appear to exist in your site database.',
+        ['@column' => $column, '@table' => $table]
       );
       return FALSE;
     }
@@ -654,8 +654,8 @@ class ChadoSchema {
         tripal_report_error(
           'ChadoSchema',
           TRIPAL_WARNING,
-          'Unable to check the type of !table!column due to being unable to find the schema definition.',
-          ['!column' => $column, '!table' => $table]
+          'Unable to check the type of @table.@column due to being unable to find the schema definition.',
+          ['@column' => $column, '@table' => $table]
         );
         return FALSE;
       }

--- a/tripal_chado/src/api/tripal_chado.cv.api.php
+++ b/tripal_chado/src/api/tripal_chado.cv.api.php
@@ -618,8 +618,8 @@ function chado_insert_cvterm($term, $options = [], $schema_name = NULL) {
     $dbxref = $result[0];
     if (!$dbxref) {
       tripal_report_error('tripal_cv', TRIPAL_ERROR,
-        'Unable to access the dbxref record for the :term cvterm. Term Record: !record',
-        [':term' => $name, '!record' => print_r($cvterm, TRUE)]
+        'Unable to access the dbxref record for the :term cvterm. Term Record: @record',
+        [':term' => $name, '@record' => print_r($cvterm, TRUE)]
       );
       return FALSE;
     }

--- a/tripal_chado/src/api/tripal_chado.query.api.php
+++ b/tripal_chado/src/api/tripal_chado.query.api.php
@@ -498,8 +498,8 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
   $table_desc = chado_get_schema($table, $chado_schema_name);
   if (!$table_desc) {
     tripal_report_error('tripal_chado', TRIPAL_WARNING,
-      'chado_insert_record; There is no table description for !table_name',
-      ['!table_name' => $table], ['print' => $print_errors]
+      'chado_insert_record; There is no table description for @table_name',
+      ['@table_name' => $table], ['print' => $print_errors]
     );
     return;
   }
@@ -531,16 +531,16 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
 
       if (sizeof($results) > 1) {
         tripal_report_error('tripal_chado', TRIPAL_ERROR,
-          'chado_insert_record: Too many records match the criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_insert_record: Too many records match the criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
       }
       elseif (sizeof($results) < 1) {
         tripal_report_error('tripal_chado', TRIPAL_DEBUG,
-          'chado_insert_record: no record matches criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_insert_record: no record matches criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
@@ -582,8 +582,8 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
           $table, $ukselect_cols, $ukselect_vals, [], $chado_schema_name);
         if ($select_record) {
           tripal_report_error('tripal_chado', TRIPAL_ERROR,
-            "chado_insert_record; Cannot insert duplicate record into $table table: !values",
-            ['!values' => print_r($values, TRUE)], ['print' => $print_errors]
+            "chado_insert_record; Cannot insert duplicate record into $table table: @values",
+            ['@values' => print_r($values, TRUE)], ['print' => $print_errors]
           );
           return FALSE;
         }
@@ -605,8 +605,8 @@ function chado_insert_record($table, $values, $options = [], $chado_schema_name 
         );
         if ($select_record) {
           tripal_report_error('tripal_chado', TRIPAL_ERROR,
-            'chado_insert_record; Cannot insert duplicate primary key into !table table: !values',
-            ['!table' => $table, '!values' => print_r($values, TRUE)],
+            'chado_insert_record; Cannot insert duplicate primary key into @table table: @values',
+            ['@table' => $table, '@values' => print_r($values, TRUE)],
             ['print' => $print_errors]
           );
           return FALSE;
@@ -858,16 +858,16 @@ function chado_update_record($table, $match, $values, $options = NULL, $chado_sc
         $table_desc, $field, $value, [], $chado_schema_name);
       if (sizeof($results) > 1) {
         tripal_report_error('tripal_chado', TRIPAL_ERROR,
-          'chado_update_record: When trying to find record to update, too many records match the criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_update_record: When trying to find record to update, too many records match the criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
       }
       elseif (sizeof($results) < 1) {
         tripal_report_error('tripal_chado', TRIPAL_DEBUG,
-          'chado_update_record: When trying to find record to update, no record matches criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_update_record: When trying to find record to update, no record matches criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
@@ -890,16 +890,16 @@ function chado_update_record($table, $match, $values, $options = NULL, $chado_sc
         $table_desc, $field, $value, $foreign_options, $chado_schema_name);
       if (sizeof($results) > 1) {
         tripal_report_error('tripal_chado', TRIPAL_ERROR,
-          'chado_update_record: When trying to find update values, too many records match the criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_update_record: When trying to find update values, too many records match the criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
       }
       elseif (sizeof($results) < 1) {
         tripal_report_error('tripal_chado', TRIPAL_DEBUG,
-          'chado_update_record: When trying to find update values, no record matches criteria supplied for !foreign_key foreign key constraint (!criteria)',
-          ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)],
+          'chado_update_record: When trying to find update values, no record matches criteria supplied for @foreign_key foreign key constraint (@criteria)',
+          ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)],
           ['print' => $print_errors]
         );
         return FALSE;
@@ -1062,8 +1062,8 @@ function chado_delete_record($table, $match, $options = NULL, $chado_schema_name
   $fields = $table_desc['fields'];
   if (empty($table_desc)) {
     tripal_report_error('tripal_chado', TRIPAL_WARNING,
-      'chado_delete_record; There is no table description for !table_name',
-      ['!table_name' => $table], ['print' => $print_errors]
+      'chado_delete_record; There is no table description for @table_name',
+      ['@table_name' => $table], ['print' => $print_errors]
     );
   }
 
@@ -1080,12 +1080,12 @@ function chado_delete_record($table, $match, $options = NULL, $chado_schema_name
           $table_desc, $field, $value, [], $chado_schema_name);
         if (sizeof($results) > 1) {
           tripal_report_error('tripal_chado', TRIPAL_ERROR,
-            'chado_delete_record: When trying to find record to delete, too many records match the criteria supplied for !foreign_key foreign key constraint (!criteria)',
-            ['!foreign_key' => $field, '!criteria' => print_r($value, TRUE)]);
+            'chado_delete_record: When trying to find record to delete, too many records match the criteria supplied for @foreign_key foreign key constraint (@criteria)',
+            ['@foreign_key' => $field, '@criteria' => print_r($value, TRUE)]);
           return FALSE;
         }
         elseif (sizeof($results) < 1) {
-          //tripal_report_error('tripal_chado', TRIPAL_ERROR, 'chado_delete_record: When trying to find record to delete, no record matches criteria supplied for !foreign_key foreign key constraint (!criteria)', array('!foreign_key' => $field, '!criteria' => print_r($value,TRUE)));
+          //tripal_report_error('tripal_chado', TRIPAL_ERROR, 'chado_delete_record: When trying to find record to delete, no record matches criteria supplied for @foreign_key foreign key constraint (@criteria)', array('@foreign_key' => $field, '@criteria' => print_r($value,TRUE)));
         }
         else {
           $delete_matches[$field] = $results[0];
@@ -1331,8 +1331,8 @@ function chado_select_record($table, $columns, $values, $options = NULL, $chado_
   $table_desc = chado_get_schema($table, $chado_schema_name);
   if (!is_array($table_desc)) {
     tripal_report_error('tripal_chado', TRIPAL_WARNING,
-      'chado_insert_record; There is no table description for !table_name',
-      ['!table_name' => $table], ['print' => $print_errors]
+      'chado_insert_record; There is no table description for @table_name',
+      ['@table_name' => $table], ['print' => $print_errors]
     );
     return FALSE;
   }


### PR DESCRIPTION
# Bug Fix

### Closes #2224

## Description
The Drupal 7 !variable, which inserts your value exactly as is, without running any sanitization functions, was deprecated.
Example error message:
`Placeholders must begin with one of the following "@", ":" or "%", invalid placeholder (!id) with string: "Did not get a response from EBI OLS trying to lookup ontology: !id"`
I have replaced them with @ placeholders.
In many cases these are deprecated functions, but why not fix them all?
In one pair of cases there were extra placeholders

## Testing?
This is mainly code review, as the placeholders are in error messages that are rarely encountered.
