### PR TITLE
Need to double quote some shell variables

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -62,9 +62,9 @@ jobs:
       - name: 'Build Docker Image'
         run: |
           docker build --tag=tripaldocker:localdocker \
-            --build-arg phpversion="${{ matrix.php-version }}" \
-            --build-arg drupalversion="${{ matrix.drupal-version }}" \
-            --build-arg postgresqlversion="${{ matrix.pgsql-version }}" \
+            --build-arg phpversion='${{ matrix.php-version }}' \
+            --build-arg drupalversion='${{ matrix.drupal-version }}' \
+            --build-arg postgresqlversion='${{ matrix.pgsql-version }}' \
             --build-arg chadoschema='teacup' ./
       # Just spin up docker the good ol' fashion way.
       - name: 'Spin up Local Docker'

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -62,9 +62,9 @@ jobs:
       - name: 'Build Docker Image'
         run: |
           docker build --tag=tripaldocker:localdocker \
-            --build-arg phpversion='${{ matrix.php-version }}' \
-            --build-arg drupalversion='${{ matrix.drupal-version }}' \
-            --build-arg postgresqlversion='${{ matrix.pgsql-version }}' \
+            --build-arg phpversion="${{ matrix.php-version }}" \
+            --build-arg drupalversion="${{ matrix.drupal-version }}" \
+            --build-arg postgresqlversion="${{ matrix.pgsql-version }}" \
             --build-arg chadoschema='teacup' ./
       # Just spin up docker the good ol' fashion way.
       - name: 'Spin up Local Docker'

--- a/.github/workflows/MAIN-composerInstall.yml
+++ b/.github/workflows/MAIN-composerInstall.yml
@@ -70,9 +70,9 @@ jobs:
         env:
           BRANCH_NAME: '${{ github.head_ref || github.ref_name }}'
         run: |
-          if [ '$BRANCH_NAME' = '4.x' ]; then
+          if [ "$BRANCH_NAME" = '4.x' ]; then
             docker exec --workdir=/var/www/drupal drupaldocker composer require --dev tripal/tripal:4.x-dev --no-interaction --with-all-dependencies
           else
-            docker exec --workdir=/var/www/drupal drupaldocker composer require --dev 'tripal/tripal:dev-$BRANCH_NAME' --no-interaction --with-all-dependencies
+            docker exec --workdir=/var/www/drupal drupaldocker composer require --dev "tripal/tripal:dev-$BRANCH_NAME" --no-interaction --with-all-dependencies
           fi
           docker exec drupaldocker /var/www/drupal/vendor/drush/drush/drush pm-install tripal tripal_biodb tripal_chado tripal_layout --yes


### PR DESCRIPTION
# Bug Fix

### Issue #2208

## Description

After merging PR #2234 there are these composer install errors here https://github.com/tripal/tripal/actions/runs/16240610935
```

Run if [ '$BRANCH_NAME' = '4.x' ]; then
./composer.json has been updated
Running composer update tripal/tripal --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires tripal/tripal dev-$BRANCH_NAME, found tripal/tripal[dev-tv4g0-issue2034-migrate-tripal3-url-aliases, ..., dev-1369-tv3-gff3-landmark-fixes-from-tv4-into-tv3, 4.0-alpha1, 4.0-alpha2, 4.x-dev] but it does not match the constraint.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```
Note the single quotes around `'$BRANCH_NAME'`

## Testing?
You can test the changes locally. Replicate the failing actions with the offending single quotes replaced by double quotes in two places
```
BRANCH_NAME='tv4g0-2208-codeclimateToQltyCloud'
DOCKER_IMAGE='tripalproject/tripaldocker-drupal:drupal11.0.x-dev-php8.3-pgsql17'
docker run --publish=8080:80 --name=drupaldocker -tid $DOCKER_IMAGE
if [ "$BRANCH_NAME" = '4.x' ]; then
  echo "did if"
  docker exec --workdir=/var/www/drupal drupaldocker composer require --dev tripal/tripal:4.x-dev --no-interaction --with-all-dependencies
else
  echo "did else"
  docker exec --workdir=/var/www/drupal drupaldocker composer require --dev "tripal/tripal:dev-$BRANCH_NAME" --no-interaction --with-all-dependencies
fi
```