### PR TITLE
Fix wrong config in nightly PHPUnit runs for Drupal 10.x

### DIFF
--- a/.github/workflows/MAIN-phpunit-php8.1_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_3x.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -29,3 +30,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.3.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_4x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.4.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_5x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.5.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_3x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.3.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_4x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.4.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.5.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_3x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_3x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.3.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_4x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.4.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '4.x'
       - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g9-issue2170-wrong-config-drupal-10.x-dockers'
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes in Drupal.
   schedule:
@@ -30,3 +31,4 @@ jobs:
           pgsql-version: '17'
           drupal-version: '10.5.x-dev'
           build-image: true
+          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'


### PR DESCRIPTION
# Bug Fix

### Closes #2170 

## Description

The wrong phpunit config is being used in nightly PHPUnit test runs.
Although the docker is built with the correct version, the tripal repo is mounted in the docker when it is launched, so we need to explicitly specify the appropriate version for 10.x runs.

## Testing?
No manual testing needed, just verify that in the test output, this is no longer present:
```
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 20:
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerErrors': The attribute 'displayDetailsOnTestsThatTriggerErrors' is not allowed.
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerWarnings': The attribute 'displayDetailsOnTestsThatTriggerWarnings' is not allowed.
  - Element 'phpunit', attribute 'displayDetailsOnTestsThatTriggerDeprecations': The attribute 'displayDetailsOnTestsThatTriggerDeprecations' is not allowed.
  - Element 'phpunit', attribute 'cacheDirectory': The attribute 'cacheDirectory' is not allowed.

  Line 61:
  - Element 'bootstrap': This element is not expected. Expected is ( extension ).

  Line 95:
  - Element 'source': This element is not expected.

  Test results may not be as expected.
```