### PR TITLE
Add use statement missed in PR #2242

### DIFF
--- a/tripal/tests/src/Kernel/Entity/TripalEntitySettingsFormTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntitySettingsFormTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\tripal\Kernel\Entity;
 
 use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the tripal entity settings form.


### PR DESCRIPTION
# Bug Fix

### Issue #2217 

## Description
This is a one line fix that is causing a deprecation message on 11.2

## Testing?
On 4.x
```
There were 2 PHPUnit test runner deprecations:

1) Metadata found in doc-comment for class Drupal\Tests\tripal\Kernel\Entity\TripalEntitySettingsFormTest. Metadata in
doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for class Drupal\Tests\tripal\Kernel\Entity\TripalEntitySettingsFormTest. Metadata in
doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

```
On this branch that message no longer appears
