### PR TITLE
Fix wrong phpunit config version for 11.2

### DIFF
--- a/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
@@ -31,4 +31,3 @@ jobs:
           pgsql-version: '17'
           drupal-version: '11.2.x-dev'
           build-image: true
-          phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'


### PR DESCRIPTION
# Bug Fix

### Closes #2257

## Description

Somehow I ended up specifying the wrong phpunit config file for Drupal 11.2 in #2242

This is a one line change (deletion actually).

## Testing?

This workflow only runs after merge, which is why it was missed, so code review and then check after merge.

This block of warnings should no longer be present:
```
There were 105 PHPUnit test runner warnings:

1) Cannot add file /var/www/drupal/web/modules/contrib/tripal/tripal/tests/src/Functional/Entity/EntityAccessTest.php
to test suite "functional" as it was already added to test suite "tripal"
...
```

