### PR TITLE
Fix missing TripalEntityViewsData attribute

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -14,6 +14,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Component\Utility\Xss;
 use Drupal\user\UserInterface;
 use Drupal\tripal\Access\TripalEntityAccessControlHandler;
+use Drupal\tripal\Entity\TripalEntityViewsData;
 use Drupal\tripal\Form\TripalEntityForm;
 use Drupal\tripal\Form\TripalEntityDeleteForm;
 use Drupal\tripal\Form\TripalEntityUnpublishForm;
@@ -34,6 +35,7 @@ use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
     'storage' => SqlContentEntityStorage::class,
     'list_builder' => TripalEntityListBuilder::class,
     'view_builder' => EntityViewBuilder::class,
+    'views_data' => TripalEntityViewsData::class,
     'form' => [
       'default' => TripalEntityForm::class,
       'add' => TripalEntityForm::class,


### PR DESCRIPTION
# Bug Fix

### Closes #2263 

## Description
One annotation to attribute conversion was missed in PR #2239 
The result is that on Drupal 11.2 you can't make a view for any tripal content because the select item is missing.
This adds the attribute and fixes the bug.

## Testing?
Build a Drupal 11.2 docker
Structure -> Views -> +Add View
The select list under "View Settings" "Show" should now include "Tripal Content".
