### PR TITLE
Create tripal-specific attribute classes

### DIFF
--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalFormatterBase;
 /**
  * Plugin implementation of default Tripal boolean type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'default_tripal_boolean_type_formatter',
   label: new TranslatableMarkup('Default Boolean Type Formatter'),
   description: new TranslatableMarkup('The default boolean type formatter.'),

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalBooleanTypeFormatter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\TripalField\TripalFormatterBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\TripalField\TripalFormatterBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalIntegerTypeFormatter.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalFormatterBase;
 /**
  * Plugin implementation of default Tripal integer type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'default_tripal_integer_type_formatter',
   label: new TranslatableMarkup('Default Integer Type Formatter'),
   description: new TranslatableMarkup('The default integer type formatter.'),

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalFormatterBase;
 /**
  * Plugin implementation of default Tripal string type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'default_tripal_string_type_formatter',
   label: new TranslatableMarkup('Default String Type Formatter'),
   description: new TranslatableMarkup('The default string type formatter.'),

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalStringTypeFormatter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\TripalField\TripalFormatterBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\TripalField\TripalFormatterBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
+++ b/tripal/src/Plugin/Field/FieldFormatter/DefaultTripalTextTypeFormatter.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalFormatterBase;
 /**
  * Plugin implementation of default Tripal text type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'default_tripal_text_type_formatter',
   label: new TranslatableMarkup('Default Text Type Formatter'),
   description: new TranslatableMarkup('The default text type formatter.'),

--- a/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
 /**
  * Plugin implementation of the 'boolean' field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'tripal_boolean_type',
   category: 'tripal',
   label: new TranslatableMarkup('Tripal Boolean Field Type'),

--- a/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\TripalFieldItemBase;

--- a/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalBooleanTypeItem.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal\TripalStorage\BoolStoragePropertyType;
 

--- a/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal\TripalStorage\IntStoragePropertyType;
 

--- a/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalStorage\IntStoragePropertyType;
 /**
  * Plugin implementation of the 'integer' field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'tripal_integer_type',
   category: 'tripal',
   label: new TranslatableMarkup('Tripal Integer Field Type'),

--- a/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalIntegerTypeItem.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\TripalFieldItemBase;

--- a/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
@@ -12,7 +12,7 @@ use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
 /**
  * Plugin implementation of Tripal string field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'tripal_string_type',
   category: 'tripal',
   label: new TranslatableMarkup('Tripal String Field Type'),

--- a/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal\TripalStorage\VarCharStoragePropertyType;
 

--- a/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalStringTypeItem.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\TripalField\TripalFieldItemBase;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;
 

--- a/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\TripalFieldItemBase;

--- a/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
+++ b/tripal/src/Plugin/Field/FieldType/TripalTextTypeItem.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalStorage\TextStoragePropertyType;
 /**
  * Plugin implementation of the 'text' field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'tripal_text_type',
   category: 'tripal',
   label: new TranslatableMarkup('Tripal Text Field Type'),

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\TripalField\TripalWidgetBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalWidgetBase;
 /**
  * Plugin implementation of default Tripal boolean type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'default_tripal_boolean_type_widget',
   label: new TranslatableMarkup('Tripal Boolean Widget'),
   description: new TranslatableMarkup('The default boolean type widget.'),

--- a/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalBooleanTypeWidget.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
@@ -12,7 +12,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Plugin implementation of default Tripal integer type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'default_tripal_boolean_type_widget',
   label: new TranslatableMarkup('Tripal Boolean Widget'),
   description: new TranslatableMarkup('The default boolean type widget.'),

--- a/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
@@ -2,12 +2,11 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
-
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\TripalWidgetBase;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 
 /**
  * Plugin implementation of default Tripal integer type widget.

--- a/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalIntegerTypeWidget.php
@@ -6,7 +6,7 @@ use Drupal\tripal\TripalField\TripalWidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**

--- a/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\TripalField\TripalWidgetBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalWidgetBase;
 /**
  * Plugin implementation of default Tripal string type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'default_tripal_string_type_widget',
   label: new TranslatableMarkup('Tripal String Widget'),
   description: new TranslatableMarkup('The default string type widget.'),

--- a/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalStringTypeWidget.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\TripalField\TripalWidgetBase;
 
 /**

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -11,7 +11,7 @@ use Drupal\tripal\TripalField\TripalWidgetBase;
 /**
  * Plugin implementation of default Tripal text type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'default_tripal_text_type_widget',
   label: new TranslatableMarkup('Tripal Text Widget'),
   description: new TranslatableMarkup('The default text type widget.'),

--- a/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
+++ b/tripal/src/Plugin/Field/FieldWidget/TripalTextTypeWidget.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal/src/TripalField/Attribute/TripalFieldType.php
+++ b/tripal/src/TripalField/Attribute/TripalFieldType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\tripal\TripalField\Attribute;
+
+use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a TripalFieldType attribute for plugin discovery.
+ *
+ * This extends the Drupal core FieldType.
+ * This does not yet add any additional functionality.
+ *
+ * @ingroup field_types
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class TripalFieldType extends FieldType {
+
+  /**
+   * Constructs a TripalFieldType attribute.
+   *
+   * @inheritdoc
+   */
+ public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup|array|null $description = NULL,
+    public readonly string $category = '',
+    public readonly int $weight = 0,
+    public readonly ?string $default_widget = NULL,
+    public readonly ?string $default_formatter = NULL,
+    public readonly bool $no_ui = FALSE,
+    public readonly ?string $list_class = NULL,
+    public readonly ?int $cardinality = NULL,
+    public readonly array $constraints = [],
+    public readonly array $config_dependencies = [],
+    public readonly array $column_groups = [],
+    public readonly array $serialized_property_names = [],
+    public readonly ?string $deriver = NULL,
+    public readonly ?string $module = NULL,
+  ) { }
+
+}

--- a/tripal/src/TripalField/Attribute/TripalFieldWidget.php
+++ b/tripal/src/TripalField/Attribute/TripalFieldWidget.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\tripal\TripalField\Attribute;
+
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a TripalFieldWidget attribute for plugin discovery.
+ *
+ * This extends the Drupal core FieldWidget attribute.
+ * This does not yet add any additional functionality.
+ *
+ * @ingroup field_widget
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class TripalFieldWidget extends FieldWidget {
+
+  /**
+   * Constructs a TripalFieldFormatter attribute.
+   *
+   * @inheritdoc
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly ?TranslatableMarkup $label = NULL,
+    public readonly ?TranslatableMarkup $description = NULL,
+    public readonly array $field_types = [],
+    public readonly bool $multiple_values = FALSE,
+    public readonly ?int $weight = NULL,
+    public readonly ?string $deriver = NULL,
+  ) {}
+
+}

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAdditionalTypeFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal additional type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_additional_type_formatter_default',
   label: new TranslatableMarkup('Chado Type Reference Formatter'),
   description: new TranslatableMarkup('A Chado type reference formatter'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalBooleanTypeFormatter;
 /**
  * Plugin implementation of default Chado boolean type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_boolean_type_formatter',
   label: new TranslatableMarkup('Chado Boolean Type Formatter'),
   description: new TranslatableMarkup('The Chado boolean type formatter.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalBooleanTypeFormatter;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoBooleanFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalBooleanTypeFormatter;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalIntegerTypeFormatter;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalIntegerTypeFormatter;
 /**
  * Plugin implementation of default Chado integer type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_integer_type_formatter',
   label: new TranslatableMarkup('Chado Integer Type Formatter'),
   description: new TranslatableMarkup('The Chado integer type formatter.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoIntegerFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalIntegerTypeFormatter;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal linker property formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_property_formatter_default',
   label: new TranslatableMarkup('Chado Property'),
   description: new TranslatableMarkup('Add a property or attribute to the content type.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPropertyFormatterDefault.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Plugin implementation of Default Tripal field formatter for sequence data.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_sequence_checksum_formatter_default',
   label: new TranslatableMarkup('Chado Sequence checksum Formatter'),
   description: new TranslatableMarkup('A chado sequence checksum formatter'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceChecksumFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal string type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_sequence_coordinates_formatter_default',
   label: new TranslatableMarkup('Chado sequence coordinates default formatter'),
   description: new TranslatableMarkup('The default sequence coordinates formatter allows curators to view sequence coordinates (min, max, strand and phase) of the feature.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
@@ -10,7 +10,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal sequence coordinates table formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_sequence_coordinates_formatter_table',
   label: new TranslatableMarkup('Chado sequence coordinates table formatter'),
   description: new TranslatableMarkup('The table sequence coordinates formatter allows curators to view sequence coordinates (min, max, strand and phase) of the feature in a tabular format.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceCoordinatesFormatterTable.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of Default Tripal field formatter for sequence data.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_sequence_formatter_default',
   label: new TranslatableMarkup('Chado Sequence Residues Display'),
   description: new TranslatableMarkup('Displays chado sequence residues from the feature table on the page.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 
 /**
  * Plugin implementation of Default Tripal field formatter for sequence length.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
@@ -9,7 +9,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Plugin implementation of Default Tripal field formatter for sequence length.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_sequence_length_formatter_default',
   label: new TranslatableMarkup('Chado Sequence Length Formatter'),
   description: new TranslatableMarkup('A chado sequence length formatter'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSequenceLengthFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSourceDataFormatterDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal string type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_source_data_formatter_default',
   label: new TranslatableMarkup('Chado Source Data Formatter'),
   description: new TranslatableMarkup('The default source data widget which allows curators to manually enter analysis source data information on the content edit page.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 /**
  * Plugin implementation of default Chado string type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_string_type_formatter',
   label: new TranslatableMarkup('Chado String Type Formatter'),
   description: new TranslatableMarkup('The Chado string type formatter.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Field\FieldItemListInterface;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoStringFormatterDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalStringTypeFormatter;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Field\FieldItemListInterface;
 
 /**
  * Plugin implementation of default Chado string type formatter.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoSynonymFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of Default Tripal field formatter for synonyms.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_synonym_formatter_default',
   label: new TranslatableMarkup('Chado Synonym Formatter'),
   description: new TranslatableMarkup('A chado synonym formatter'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalTextTypeFormatter;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalTextTypeFormatter;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoTextFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal\Plugin\Field\FieldFormatter\DefaultTripalTextTypeFormatter;
 /**
  * Plugin implementation of default Chado text type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_text_type_formatter',
   label: new TranslatableMarkup('Chado Text Type Formatter'),
   description: new TranslatableMarkup('The Chado text type formatter.'),

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
 use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoUnitFormatterDefault.php
@@ -10,7 +10,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 /**
  * Plugin implementation of default Tripal unit type formatter.
  */
-#[FieldFormatter(
+#[TripalFieldFormatter(
   id: 'chado_unit_formatter_default',
   label: new TranslatableMarkup('Chado unit type formatter'),
   description: new TranslatableMarkup('A Chado unit type formatter.'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -17,7 +17,7 @@ use Drupal\tripal\Services\TripalFieldCollection;
 /**
  * Plugin implementation of Tripal additional type field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_additional_type_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Type Reference'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal analysis field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_analysis_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Analysis'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal Array Design field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_array_design_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Array Design'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal assay field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_assay_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Assay'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal biomaterial field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_biomaterial_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Biomaterial'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
 /**
  * Plugin implementation of the 'boolean' field type for Chado.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_boolean_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Boolean Field Type'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBooleanTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal contact by role field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_contact_by_role_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Contacts: Specific Role'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal contact field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_contact_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Contacts: All'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal dbxref field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_dbxref_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Database Cross Reference'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal featuremap field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_featuremap_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado FeatureMap'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal feature field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_feature_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Feature'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 /**
  * Plugin implementation of the 'integer' field type for Chado.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_integer_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Integer Field Type'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoIntegerTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal organism field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_organism_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Organism'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal project field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_project_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Project'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 /**
  * Plugin implementation of Tripal linker property field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_property_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Property'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal protocol field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_protocol_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Protocol'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal publication field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_pub_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Publication'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal relationship field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_relationship_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Relationship'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoBpCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for sequence checksum.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_sequence_checksum_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Feature Sequence Checksum'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for sequence coordinates.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_sequence_coordinates_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Sequence Coordinates'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoBoolStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal\Entity\TripalEntityType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for sequence length.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_sequence_length_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Feature Sequence Length'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for sequence data.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_sequence_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Sequence Residues'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for data source.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_source_data_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Data Source'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal stock field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_stock_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Stock'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\core\Field\FieldDefinitionInterface;
 use Drupal\core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStringTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 /**
  * Plugin implementation of string field type for Chado.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_string_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado String Field Type'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of default Tripal study field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_study_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Study'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -14,7 +14,7 @@ use Drupal\core\Form\FormStateInterface;
 /**
  * Plugin implementation of Tripal synonym field type.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_synonym_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Synonym'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal\TripalStorage\TextStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoTextTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 /**
  * Plugin implementation of the 'text' field type for Chado.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_text_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Text Field Type'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal\Entity\TripalEntityType;
 /**
  * Plugin implementation of Default Tripal field for unit of measurement.
  */
-#[FieldType(
+#[TripalFieldType(
   id: 'chado_unit_type_default',
   category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Unit'),

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Tripal additional type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_additional_type_widget_default',
   label: new TranslatableMarkup('Chado Type Reference Widget'),
   description: new TranslatableMarkup('A chado type reference widget'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAdditionalTypeWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado analysis widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_analysis_widget_default',
   label: new TranslatableMarkup('Chado Analysis Widget'),
   description: new TranslatableMarkup('The default analysis widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Array Design widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_array_design_widget_default',
   label: new TranslatableMarkup('Chado Array Design Widget'),
   description: new TranslatableMarkup('The default array design widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoArrayDesignWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado assay widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_assay_widget_default',
   label: new TranslatableMarkup('Chado Assay Widget'),
   description: new TranslatableMarkup('The default assay widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado biomaterial widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_biomaterial_widget_default',
   label: new TranslatableMarkup('Chado Biomaterial Widget'),
   description: new TranslatableMarkup('The default biomaterial widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal\Plugin\Field\FieldWidget\TripalBooleanTypeWidget;
 /**
  * Plugin implementation of default Chado boolean type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_boolean_type_widget',
   label: new TranslatableMarkup('Chado Boolean Widget'),
   description: new TranslatableMarkup('The default boolean type widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBooleanWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalBooleanTypeWidget;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado contact widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_contact_widget_default',
   label: new TranslatableMarkup('Chado Contact Widget'),
   description: new TranslatableMarkup('The default contact widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoContactWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 use Drupal\tripal_chado\Controller\ChadoDbxrefAutocompleteController;
 use Drupal\Core\Ajax\AjaxResponse;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
@@ -14,7 +14,7 @@ use Drupal\Core\Ajax\ReplaceCommand;
 /**
  * Plugin implementation of default Chado dbxref widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_dbxref_widget_default',
   label: new TranslatableMarkup('Chado Dbxref Widget'),
   description: new TranslatableMarkup('The default dbxref widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureMapWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado featuremap widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_featuremap_widget_default',
   label: new TranslatableMarkup('Chado FeatureMap Widget'),
   description: new TranslatableMarkup('The default featuremap widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado feature widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_feature_widget_default',
   label: new TranslatableMarkup('Chado Feature Widget'),
   description: new TranslatableMarkup('The default feature widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal\Plugin\Field\FieldWidget\TripalIntegerTypeWidget;
 /**
  * Plugin implementation of default Chado integer type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_integer_type_widget',
   label: new TranslatableMarkup('Chado Integer Widget'),
   description: new TranslatableMarkup('The default integer type widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalIntegerTypeWidget;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoIntegerWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\Controller\ChadoOrganismAutocompleteController;
 /**
  * Plugin implementation of default Chado organism widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_organism_widget_default',
   label: new TranslatableMarkup('Chado Organism Widget'),
   description: new TranslatableMarkup('The default organism widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 use Drupal\tripal_chado\Controller\ChadoOrganismAutocompleteController;
 

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado project widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_project_widget_default',
   label: new TranslatableMarkup('Chado Project Widget'),
   description: new TranslatableMarkup('The default project widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProjectWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Tripal linker property widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_property_select_widget_default',
   label: new TranslatableMarkup('Chado Property: Select Drop-down'),
   description: new TranslatableMarkup('Provides a configurable drop-down widget for Chado Properties.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertySelectWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Tripal linker property widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_property_string_widget_default',
   label: new TranslatableMarkup('Chado Property: Short Text'),
   description: new TranslatableMarkup('Provides a simple string widget for Chado Properties using a textfield.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyStringWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -12,7 +12,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Tripal linker property widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_property_widget_default',
   label: new TranslatableMarkup('Chado Property: Long Text'),
   description: new TranslatableMarkup('Provides a long text widget for Chado Properties using a formatted textarea.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPropertyWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado protocol widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_protocol_widget_default',
   label: new TranslatableMarkup('Chado Protocol Widget'),
   description: new TranslatableMarkup('The default protocol widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoProtocolWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado publication widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_pub_widget_default',
   label: new TranslatableMarkup('Chado Publication Widget'),
   description: new TranslatableMarkup('The default publication widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
 use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoRelationshipWidgetDefault.php
@@ -13,7 +13,7 @@ use Drupal\tripal_chado\Controller\ChadoGenericAutocompleteController;
 /**
  * Plugin implementation of default Chado relationship widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_relationship_widget_default',
   label: new TranslatableMarkup('Chado Relationship Widget'),
   description: new TranslatableMarkup('The default relationship widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceChecksumWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Sequence Checksum widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_sequence_checksum_widget_default',
   label: new TranslatableMarkup('Chado Sequence Checksum Widget'),
   description: new TranslatableMarkup('The default chado sequence checksum widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Sequence Coordinates widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_sequence_coordinates_widget_default',
   label: new TranslatableMarkup('Chado Sequence Coordinates Widget'),
   description: new TranslatableMarkup('The default chado sequence coordinates widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceCoordinatesWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceLengthWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Sequence Length widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_sequence_length_widget_default',
   label: new TranslatableMarkup('Chado Sequence Length Widget'),
   description: new TranslatableMarkup('The default chado sequence length widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Sequence Residues widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_sequence_widget_default',
   label: new TranslatableMarkup('Chado Sequence Residues Widget'),
   description: new TranslatableMarkup('The default chado sequence widget which allows curators to manually enter sequence residues on the content edit page.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSequenceWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Data Source widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_source_data_widget_default',
   label: new TranslatableMarkup('Chado Data Source Widget Default'),
   description: new TranslatableMarkup('The default source data widget which allows curators to manually enter analysis source data information on the content edit page.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSourceDataWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado stock widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_stock_widget_default',
   label: new TranslatableMarkup('Chado Stock Widget'),
   description: new TranslatableMarkup('The default stock widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal\Plugin\Field\FieldWidget\TripalStringTypeWidget;
 /**
  * Plugin implementation of default Chado string type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_string_type_widget',
   label: new TranslatableMarkup('Chado String Widget'),
   description: new TranslatableMarkup('The default string type widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStringWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalStringTypeWidget;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado study widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_study_widget_default',
   label: new TranslatableMarkup('Chado Study Widget'),
   description: new TranslatableMarkup('The default study widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Synonym widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_synonym_widget_default',
   label: new TranslatableMarkup('Chado Alias Widget'),
   description: new TranslatableMarkup('The default chado synonym widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoSynonymWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal\Plugin\Field\FieldWidget\TripalTextTypeWidget;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoTextWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal\Plugin\Field\FieldWidget\TripalTextTypeWidget;
 /**
  * Plugin implementation of default Chado text type widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_text_type_widget',
   label: new TranslatableMarkup('Chado Text Widget'),
   description: new TranslatableMarkup('The default text type widget.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
@@ -11,7 +11,7 @@ use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 /**
  * Plugin implementation of default Chado Unit widget.
  */
-#[FieldWidget(
+#[TripalFieldWidget(
   id: 'chado_unit_widget_default',
   label: new TranslatableMarkup('Chado Unit Widget Default'),
   description: new TranslatableMarkup('The default unit widget which allows curators to enter unit on the Gene Map content edit page.'),

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
 /**

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tripal_chado\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2255

## Description

PR #2239 Introduced an attribute class for field formatters, to support the `valid_tokens` attribute, which is the list of valid tokens for an entity title.
For consistency and good practices, we should create tripal-specific attribute classes for the type and widgets too, currently they are using the base Drupal attribute classes.
With this PR, all tripal and tripal_chado fields now use these tripal attribute classes.

## Testing?

There should be no functional changes, as the new attribute classes do not yet add any functionality. Mainly testing is making sure nothing has unexpectedly broken.