### PR TITLE
Editing single-hop property field fixed

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -878,6 +878,33 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
   /**
+   * Returns the name of the main property for a field.
+   *
+   * The main property name defaults to 'value', but a field can define
+   * a function mainPropertyName() to indicate a different name.
+   *
+   * @param string $field_name
+   *   The machine name of the field.
+   *
+   * @return string
+   *   The main property name for this field.
+   */
+  public function getMainPropertyName(string $field_name): string {
+    $main_property_name = 'value';
+    /** @var \Drupal\Core\Field\FieldItemList $items **/
+    $items = $this->get($field_name);
+    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item **/
+    foreach ($items as $item) {
+      if (method_exists($item, 'mainPropertyName')) {
+        $main_property_name = $item->mainPropertyName();
+      }
+      // We only need to examine the first item.
+      break;
+    }
+    return $main_property_name;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage): void {
@@ -935,6 +962,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $delta_remove = [];
     $fields = $this->getFields();
     foreach ($fields as $field_name => $items) {
+      $main_property_name = $this->getMainPropertyName($field_name);
       foreach($items as $item) {
 
         // If it is not a TripalField then skip it.
@@ -1003,9 +1031,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // For properties or other single-hop fields we send all NULL values.
           // Chado storage has already done its work, so now remove this
           // delta so that Drupal doesn't make a blank field table entry.
-          $remove = $this->allNull($store_values);
-          foreach ($store_values as $value) {
+          $remove = FALSE;
+          foreach ($store_values as $key => $value) {
             if ($value === 0) {
+              $remove = TRUE;
+            }
+            if ($key == $main_property_name && ($value === NULL || $value == '')) {
               $remove = TRUE;
             }
           }

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -1028,7 +1028,9 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           // If there is an integer zero value in $store_values, this means
           // that we chose "- Select -" in a widget, or removed the row with
           // the "Remove" button.
-          // For properties or other single-hop fields we send all NULL values.
+          // For properties or other single-hop fields we check the main property
+          // value for a NULL or empty string. Note that in this case, other
+          // $store_values may not be empty, e.g. type_id for a property.
           // Chado storage has already done its work, so now remove this
           // delta so that Drupal doesn't make a blank field table entry.
           $remove = FALSE;

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -997,12 +997,13 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
             $delta_remove[$field_name][] = $delta;
           }
 
-          // If there is a zero value in $store_values, this means that
-          // we chose "- Select -" in a widget, or removed the row with the
-          // "Remove" button.
+          // If there is an integer zero value in $store_values, this means
+          // that we chose "- Select -" in a widget, or removed the row with
+          // the "Remove" button.
+          // For properties or other single-hop fields we send all NULL values.
           // Chado storage has already done its work, so now remove this
           // delta so that Drupal doesn't make a blank field table entry.
-          $remove = FALSE;
+          $remove = $this->allNull($store_values);
           foreach ($store_values as $value) {
             if ($value === 0) {
               $remove = TRUE;

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -1038,7 +1038,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
             if ($value === 0) {
               $remove = TRUE;
             }
-            if ($key == $main_property_name && ($value === NULL || $value == '')) {
+            if ($key == $main_property_name && ($value === NULL || $value === '')) {
               $remove = TRUE;
             }
           }

--- a/tripal_chado/src/TripalField/ChadoWidgetBase.php
+++ b/tripal_chado/src/TripalField/ChadoWidgetBase.php
@@ -537,7 +537,7 @@ abstract class ChadoWidgetBase extends TripalWidgetBase {
         // This item was removed from the form. Add back a value
         // so that chado storage knows to remove the chado record.
         $values[$next_delta][$linker_key] = $linker_id;
-        $values[$next_delta][$val] = '';
+        $values[$next_delta][$val] = NULL;
         $next_delta++;
       }
     }

--- a/tripal_chado/src/TripalField/ChadoWidgetBase.php
+++ b/tripal_chado/src/TripalField/ChadoWidgetBase.php
@@ -537,7 +537,7 @@ abstract class ChadoWidgetBase extends TripalWidgetBase {
         // This item was removed from the form. Add back a value
         // so that chado storage knows to remove the chado record.
         $values[$next_delta][$linker_key] = $linker_id;
-        $values[$next_delta][$val] = NULL;
+        $values[$next_delta][$val] = '';
         $next_delta++;
       }
     }

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1060,6 +1060,9 @@ class ChadoRecords  {
    *   The alias for the column.
    * @param mixed $value
    *   The value to set for the field.
+   * @param bool $set_value
+   *   The value that is being set is a valid value. Set to FALSE when
+   *   clearing a value by setting it to zero.
    *
    * @throws \Exception
    *   If the base_table, table_alias or delta don't exist then an error is
@@ -1069,7 +1072,7 @@ class ChadoRecords  {
    *   TRUE if the value was set, FALSE otherwise
    */
   protected function setColumnValue(string $base_table, string $table_alias,
-      int $delta, string $column_alias, $value) : bool {
+      int $delta, string $column_alias, $value, $set_value = TRUE) : bool {
 
     if (!array_key_exists($base_table, $this->records)) {
       throw new \Exception("ChadoRecords::setColumnValue(): The base table has not been added to the ChadoRecords object: $base_table.");
@@ -1090,7 +1093,9 @@ class ChadoRecords  {
 
     // Set the value.
     $this->records[$base_table]['tables'][$table_alias]['items'][$delta]['values'][$column_alias] = $value;
-    $this->records[$base_table]['tables'][$table_alias]['items'][$delta]['has_values'] = TRUE;
+    if ($set_value) {
+      $this->records[$base_table]['tables'][$table_alias]['items'][$delta]['has_values'] = TRUE;
+    }
     return TRUE;
   }
 
@@ -1888,7 +1893,7 @@ class ChadoRecords  {
       }
 
       // Unset the record Id for this deleted record.
-      $this->setColumnValue($base_table, $table_alias, $delta, $pkey, 0);
+      $this->setColumnValue($base_table, $table_alias, $delta, $pkey, 0, FALSE);
     }
   }
 


### PR DESCRIPTION
# Bug Fix

### Closes #2269 

## Description

The changes here fix a bug when editing unlimited cardinality properties on any content type.

The fix for the "Remove" button involves updating the ChadoRecords setColumnValue() function to indicate when we are clearing a value in deleteRecord(), don't set the `has_values` flag.

The fix for deleting the property value by clearing the field in the widget involves knowing the main property name for a field. If the value for this is either NULL or an empty string, we remove this delta in TripalEntity preSave even though other properties may have values.

## Testing?

Test on any field that has properties with unlimited cardinality. A handy field to test with is the Germplasm Collection in the "Germplasm Content Types" collection. Both the "Germplasm Collection Type" and "Description" properties are currently unlimited cardinality.
Create several properties and save. Then edit, and remove the property with the "Remove" button, and by clearing the value from the field.
