### PR TITLE
Updating TripalEntity and TripalEntityType to match coding standards.

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal\Entity;
 
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\ContentEntityBase;
@@ -14,7 +15,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Component\Utility\Xss;
 use Drupal\user\UserInterface;
 use Drupal\tripal\Access\TripalEntityAccessControlHandler;
-use Drupal\tripal\Entity\TripalEntityViewsData;
 use Drupal\tripal\Form\TripalEntityForm;
 use Drupal\tripal\Form\TripalEntityDeleteForm;
 use Drupal\tripal\Form\TripalEntityUnpublishForm;
@@ -68,6 +68,8 @@ use Drupal\tripal\TripalField\Interfaces\TripalFieldItemInterface;
   field_ui_base_route: 'entity.tripal_entity_type.edit_form',
 )]
 /**
+ * Entity defining biological content for Tripal.
+ *
  * @todo Remove this annotation when we no longer support Drupal 10.x.
  *
  * @ContentEntityType(
@@ -133,23 +135,24 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *    - exception (bool): indicates if an exception was thrown.
    *    - exception_message (string): the message string of the exception.
    *    - message (string): describes the error encountered. May include tokens.
-   *    - message_args (array): an array of tokens with their value for the message.
+   *    - message_args (array): tokens with their value for the message.
    */
   protected $post_save_errors = [];
 
   /**
-   * An array of potential token replacement values where the key is
-   * the token name and the value is its value.
+   * An array of potential token replacement values.
    *
-   * @var array $token_values.
+   * @var array
+   *   They key is the token name and the value is its value.
    */
   protected $token_values = [];
 
   /**
    * Save bundles to avoid repeated lookup.
    *
-   * @var array $bundle_cache.
-   *   Key is bundle ID, value is instance of Drupal\tripal\Entity\TripalEntityType
+   * @var array
+   *   Associative array where the key is bundle ID, value is instance of
+   *   Drupal\tripal\Entity\TripalEntityType.
    */
   protected $bundle_cache = [];
 
@@ -157,23 +160,25 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * Constructs a new Tripal entity object, without permanently saving it.
    *
    * @code
-      $values = [
-        'title' => 'laceytest'.time(),
-        'type' => 'organism',
-        'uid' => 1,
-      ];
-      $entity = \Drupal\tripal\Entity\TripalEntity::create($values);
-      $entity->save();
+   * $values = [
+   *   'title' => 'laceytest'.time(),
+   *   'type' => 'organism',
+   *   'uid' => 1,
+   * ];
+   * $entity = \Drupal\tripal\Entity\TripalEntity::create($values);
+   * $entity->save();
    * @endcode
    *
    * @param array $values
+   *   An associative array where the following are supported and *required:
    *   - *title: the title of the entity.
    *   - *user_id: the user_id of the user who authored the content.
    *   - *type: the type of tripal entity this is (e.g. organism)
    *   - status: whether the entity is published or not (boolean)
    *   - created: the unix timestamp for when this content was created.
+   *
    * @return object
-   *  The newly created entity.
+   *   The newly created entity.
    */
   public static function create(array $values = []) {
     return parent::create($values);
@@ -184,18 +189,19 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    */
   public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
     parent::preCreate($storage_controller, $values);
-    $values += array(
+    $values += [
       'uid' => \Drupal::currentUser()->id(),
-    );
+    ];
   }
 
   /**
-   * Allows bundles to be stored in the bundle cache for better performance
+   * Allows bundles to be stored in the bundle cache for better performance.
    *
    * @param string $bundle_id
-   *   The bundle identifier, e.g. 'organism'
+   *   The bundle identifier, e.g. 'organism'.
    * @param Drupal\tripal\Entity\TripalEntityType $bundle
-   *   The bundle object, or NULL can be passed to invalidate current cached value.
+   *   The bundle object to be cached, or NULL can be passed to invalidate
+   *   current cached value.
    */
   public function setBundleCache(string $bundle_id, ?TripalEntityType $bundle) {
     if ($bundle) {
@@ -219,7 +225,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $bundle = $this->bundle_cache[$bundle_id];
     }
     if (!$bundle) {
-      $bundle = \Drupal\tripal\Entity\TripalEntityType::load($bundle_id);
+      $bundle = TripalEntityType::load($bundle_id);
       $this->setBundleCache($bundle_id, $bundle);
     }
     return $bundle;
@@ -241,15 +247,15 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $tripal_allowed_tags = explode(' ', $tag_string ?? '');
 
     $title = $this->getTitle();
-    $sanitized_value = \Drupal\Component\Utility\Xss::filter($title, $tripal_allowed_tags);
-    return \Drupal\Core\Render\Markup::create($sanitized_value);
+    $sanitized_value = Xss::filter($title, $tripal_allowed_tags);
+    return Markup::create($sanitized_value);
   }
 
   /**
    * {@inheritdoc}
    */
   public function setTitle($title = NULL) {
-    // If no title was passed, construct an entity title
+    // If no title was passed, construct an entity title.
     if (!$title) {
       $bundle = $this->getBundle();
 
@@ -262,7 +268,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $title = $token_parser->replaceTokens($title_format, $token_values);
     }
 
-    // HTML token filtering for titles
+    // HTML token filtering for titles.
     $tag_string = \Drupal::config('tripal.settings')->get('tripal_entity_type.allowed_title_tags') ?? '';
     $allowed_title_tags = explode(' ', $tag_string);
     $title = Xss::filter($title, $allowed_title_tags);
@@ -283,7 +289,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    *
    * @param string $default_alias
    *   Either an empty string if default alias is desired,
-   *   or an alias that may optionally contain tokens
+   *   or an alias that may optionally contain tokens.
    *
    * @return string
    *   The default entity alias, e.g. "/project/1234"
@@ -302,7 +308,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $token_values = $this->getBundleEntityTokenValues($default_alias, $bundle);
     $default_alias = $token_parser->replaceTokens($default_alias, $token_values);
 
-    // We don't allow HTML tags in the alias
+    // We don't allow HTML tags in the alias.
     $default_alias = strip_tags($default_alias);
 
     // Ensure there is a leading slash.
@@ -310,7 +316,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       $default_alias = '/' . $default_alias;
     }
 
-    // Drupal handles url escaping, but we prefer to replace spaces with dashes
+    // Drupal handles url escaping, but we prefer to replace spaces with dashes.
     $default_alias = str_replace(' ', '-', $default_alias);
 
     return $default_alias;
@@ -335,8 +341,12 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * @param string $path_alias
    *   The alias to use. It can contain tokens that correspond to field values.
    *   Tokens should be be compatible with those returned by
-   *   tripal_get_entity_tokens(). If empty, then use the default alias template.
-   *   If $path_alias is specified, then any existing alias will be updated.
+   *   tripal_get_entity_tokens(). If empty, then use the default alias
+   *   template. If $path_alias is specified, then any existing alias will
+   *   be updated.
+   * @param bool $during_save
+   *   Indicates if this is being called during the save process or outside
+   *   of it. If you are unsure then leave it at the default ;-p.
    *
    * @return string
    *   Returns the path alias that was used with tokens replaced
@@ -347,7 +357,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // at the very end.
     $duplicates = [];
 
-    // Check if an alias already exists for this entity's system path
+    // Check if an alias already exists for this entity's system path.
     $existing_alias = $this->getAlias();
 
     // Gets and uses default template, or replaces tokens
@@ -357,13 +367,14 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // Check if the specified alias already exists for a different entity.
     // Drupal will check for this for the value from the entity form, but we
     // need to check again for our processed value after token replacement, etc.
-    // If it is a duplicate, we remove the alias, and the entity form can complain.
+    // If it is a duplicate then we remove the alias, and the entity form
+    // can complain to the user.
     if (!$existing_alias or ($existing_alias['alias'] != $new_alias)) {
       $entities = \Drupal::entityTypeManager()->getStorage('path_alias')->loadByProperties(['alias' => $new_alias]);
       if ($entities) {
 
         // Reset the internal path field.
-        $path_item =  $this->path->first();
+        $path_item = $this->path->first();
         $path_item->set('alias', '');
         $path_item->set('pid', NULL);
 
@@ -376,14 +387,15 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       }
     }
 
-    // If an alias does not exist, then create one
+    // If an alias does not exist, then create one.
     if (!$existing_alias and $new_alias and empty($duplicates)) {
-      // the field will create the alias for us so just ensure its set to the new one.
+      // The field will create the alias for us so we just need to ensure
+      // its set to the new one here.
       if ($during_save) {
-        $path_item =  $this->path->first();
+        $path_item = $this->path->first();
         $path_item->set('alias', $new_alias);
       }
-      // we have to create the path alias ourselves.
+      // We have to create the path alias ourselves.
       else {
         $system_path = '/bio_data/' . $this->getID();
         $new_alias_object = \Drupal::entityTypeManager()->getStorage('path_alias')->create([
@@ -394,8 +406,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           throw new \Exception("We were unable to create the alias: '" . $new_alias . "'");
         }
         $new_alias_object->save();
-        // and update the internal path field.
-        $path_item =  $this->path->first();
+        // And update the internal path field.
+        $path_item = $this->path->first();
         $path_item->set('alias', $new_alias);
         $path_item->set('pid', $new_alias_object->id());
       }
@@ -412,15 +424,15 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       if (empty($duplicates)) {
         $existing_alias_object->setAlias($new_alias);
         $existing_alias_object->save();
-        $path_item =  $this->path->first();
+        $path_item = $this->path->first();
         $path_item->set('alias', $new_alias);
         $path_item->set('pid', $existing_alias['id']);
       }
       // If there are duplcates then we just remove the alias.
-      // An exception will be thrown below to help inform the user what happened.
+      // An exception will be thrown below to inform the user what happened.
       else {
         $existing_alias_object->delete();
-        $path_item =  $this->path->first();
+        $path_item = $this->path->first();
         $path_item->set('alias', '');
         $path_item->set('pid', NULL);
       }
@@ -525,16 +537,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   /**
    * Stores token replacement values for the current entity.
    *
-   * @param array
+   * @param array $extra_values
    *   Any additional key value pairs to store along with the
-   *   values retrieved here, as generated by getBundleEntityTokenValues()
+   *   values retrieved here, as generated by getBundleEntityTokenValues().
    *
    * @return void
-   *   Values are stored in the class variable $this->token_values
+   *   Values are stored in the class variable $this->token_values.
    */
   public function setTokenValues($extra_values = []) {
     $field_values = $this->getFieldValues();
-    // Convert to a simple key=>value array
+    // Convert to a simple key=>value array.
     $processed_values = $this->processFieldValues($field_values);
     // Merge in any passed values and store.
     // Note: We pass in the original token values to ensure that any values set
@@ -586,12 +598,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
   /**
+   * Helper method used for token replacement.
+   *
    * Flattens the field values to be suitable for use as values
-   * for token replacement. Only returns the first value for
-   * Values with cardinality > 1.
+   * for token replacement.
+   *
+   * WARNING: Only returns the first value for fields with cardinality > 1.
    *
    * @param array $field_values
    *   Values nested array from $this->getFieldValues()
+   *
    * @return array
    *   Associative array of key => value pairs
    */
@@ -610,16 +626,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
   }
 
   /**
-   * Retrieve values for tokens that are specific to bundles or
-   * entities and include them with existing token values.
+   * Retrieve values for bundle or entity-specific tokens.
+   *
    * These are special tokens like '[TripalEntityType__entity_id]',
    * and for efficiency we only retrieve the value if the token is
    * present in the tokenized string.
    *
    * @param string $tokenized_string
-   *   The string containing tokens
+   *   The string containing tokens.
    * @param \Drupal\tripal\Entity\TripalEntityType $bundle
-   *   The bundle
+   *   The bundle.
    *
    * @return array
    *   Associative array of all tokens and their values,
@@ -638,7 +654,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $value = NULL;
 
         // Look for values for bundle or entity related tokens.
-        if (($token === 'TripalEntityType__entity_id') OR ($token === 'TripalBundle__bundle_id')) {
+        if (($token === 'TripalEntityType__entity_id') or ($token === 'TripalBundle__bundle_id')) {
           $value = $bundle->getID();
         }
         elseif ($token == 'TripalEntityType__label') {
@@ -656,7 +672,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         elseif ($token == 'TripalEntityType__term_label') {
           $value = $bundle->getTerm()->getName();
         }
-        // We skip over any tokens other than those defined here
+        // We skip over any tokens other than those defined here.
         if (!is_null($value)) {
           $values[$token] = $value;
         }
@@ -679,43 +695,43 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
       ->setTranslatable(TRUE)
-      ->setDisplayOptions('view', array(
+      ->setDisplayOptions('view', [
         'region' => 'hidden',
         'label' => 'above',
         'type' => 'author',
         'weight' => 0,
-      ))
-      ->setDisplayOptions('form', array(
+      ])
+      ->setDisplayOptions('form', [
         'type' => 'entity_reference_autocomplete',
         'weight' => 5,
-        'settings' => array(
+        'settings' => [
           'match_operator' => 'CONTAINS',
           'size' => '60',
           'autocomplete_type' => 'tags',
           'placeholder' => '',
-        ),
-      ))
+        ],
+      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
     $fields['title'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Title'))
       ->setDescription(t('The title of this specific piece of Tripal Content. This will be automatically updated based on the title format defined by administrators.'))
-      ->setSettings(array(
+      ->setSettings([
         'max_length' => 1024,
         'text_processing' => 0,
-      ))
+      ])
       ->setDefaultValue('')
-      ->setDisplayOptions('view', array(
+      ->setDisplayOptions('view', [
         'region' => 'hidden',
         'label' => 'above',
         'type' => 'string',
         'weight' => -4,
-      ))
-      ->setDisplayOptions('form', array(
+      ])
+      ->setDisplayOptions('form', [
         'type' => 'string_textfield',
         'weight' => -4,
-      ))
+      ])
       ->setDisplayConfigurable('view', TRUE);
 
     $fields['path'] = BaseFieldDefinition::create('path')
@@ -733,8 +749,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       ->setDefaultValue(TRUE);
 
     $fields['created'] = BaseFieldDefinition::create('created')
-    ->setLabel(t('Authored on'))
-    ->setDescription(t('The date and time that this Tripal Content was created.'))
+      ->setLabel(t('Authored on'))
+      ->setDescription(t('The date and time that this Tripal Content was created.'))
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', [
         'region' => 'hidden',
@@ -770,6 +786,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
    * This function also returns an array of TripalStorage objects.
    *
    * @param TripalEntity $entity
+   *   The entity to retrieve a values array for.
+   * @param bool $ignore_cached_fields
+   *   Whether or not to ignore the cache. Specifically, if TRUE then values
+   *   will be retrieved fresh from the storage backend even if they were
+   *   already cached. If FALSE then the cached value will be used.
    *
    * @return array
    *   The returned array has two elements: an array of values as described
@@ -782,16 +803,15 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
     // Specifically, for each field...
     foreach ($fields as $field_name => $items) {
-      foreach($items as $item) {
+      foreach ($items as $item) {
 
         // If it is not a TripalField then skip it.
-        if (! $item instanceof TripalFieldItemInterface) {
+        if (!$item instanceof TripalFieldItemInterface) {
           continue;
         }
 
         $delta = $item->getName();
         $tsid = $item->tripalStorageId();
-
 
         // If the Tripal Storage Backend is not set on a Tripal-based field,
         // we will log an error and not support the field. If developers want
@@ -825,7 +845,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
         // Only setup TripalStorage for this field if it is not cached
         // or if we are not ignoring cached fields right now.
-        if (!$is_cached OR ($ignore_cached_fields == FALSE)) {
+        if (!$is_cached or ($ignore_cached_fields == FALSE)) {
 
           // Add the field definition to the storage for this field.
           $tripal_storages[$tsid]->addFieldDefinition($field_name, $item->getFieldDefinition());
@@ -889,7 +909,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     // underlying data store.
     foreach ($values as $tsid => $tsid_values) {
 
-      // Do an insert
+      // Do an insert.
       if ($this->isDefaultRevision() and $this->isNewRevision()) {
         try {
           $tripal_storages[$tsid]->insertValues($tsid_values);
@@ -905,7 +925,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $values[$tsid] = $tsid_values;
       }
 
-      // Do an Update
+      // Do an Update.
       else {
         try {
           $tripal_storages[$tsid]->updateValues($tsid_values);
@@ -926,7 +946,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       // to set them... if it did, then the following loadValues would not be
       // needed since the values would already be set.
       // @todo look into fixing insert/update to return all values.
-      // NOTE: We use FALSE here so that the values are loaded from the database.
+      // NOTE: We use FALSE here so the values are loaded from the database.
       $tripal_storages[$tsid]->loadValues($tsid_values, FALSE);
     }
 
@@ -935,7 +955,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $delta_remove = [];
     $fields = $this->getFields();
     foreach ($fields as $field_name => $items) {
-      foreach($items as $item) {
+      foreach ($items as $item) {
 
         // If it is not a TripalField then skip it.
         if (!($item instanceof TripalFieldItemInterface)) {
@@ -968,7 +988,8 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           $prop_value = $prop_info['value'];
 
           // Store the values of any properties with a "store" action.
-          // There will usually only be one, exceptions are dbxref, relationship.
+          // There will usually only be one, exceptions are dbxref,
+          // relationship.
           $action = '';
           if ($prop_type) {
             $action = $prop_type->getStorageSettings()['action'] ?? '';
@@ -1046,7 +1067,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $title = $this->setTitle();
     $base_table = $storage->getBaseTable();
     $entity_id = $this->id();
-    if ($base_table AND $entity_id) {
+    if ($base_table and $entity_id) {
       try {
         \Drupal::service('database')->update($base_table)
           ->fields(['title' => $title])
@@ -1066,7 +1087,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
           'message_args' => [':title' => $title, ':bundle' => $this->getBundle()->label()],
         ];
       }
-      // If title is blank or is only HTML tokens, show a warning
+      // If title is blank or is only HTML tokens, show a warning.
       if (!trim(strip_tags($title))) {
         $this->post_save_errors[] = [
           'code' => 'TITLE-DB-SAVE',
@@ -1089,7 +1110,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     try {
       $this->setAlias($path_alias, TRUE);
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       // Throwing an exception in postSave() mangles the entity!
       // Warn the curator that the URL alias was not set so they can fix it.
       // This entity will just not have an alias.
@@ -1138,7 +1159,6 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
       // @todo it would be great to skip the entity entirely if it is
       // fully cached.
-
       // Create a values array appropriate for `loadValues()`
       [$values, $tripal_storages] = TripalEntity::getValuesArray($entity, TRUE);
 
@@ -1169,17 +1189,17 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
 
           // Create a fieldItemlist and iterate through it.
           $items = $field_type_manager->createFieldItemList($entity, $field_name, $entity->get($field_name)->getValue());
-          foreach($items as $item) {
+          foreach ($items as $item) {
 
             // If it is not a TripalField then skip it.
-            if (! $item instanceof TripalFieldItemInterface) {
+            if (!$item instanceof TripalFieldItemInterface) {
               continue;
             }
             $delta = $item->getName();
             $tsid = $item->tripalStorageId();
 
             // If the Tripal Storage Backend is not set on a Tripal-based field,
-            // we will log an error and not support the field. If developers want
+            // we log an error and not support the field. If developers want
             // to use Drupal storage for a Tripal-based field then they need to
             // indicate that by using our Drupal SQL Storage option OR by not
             // creating a Tripal-based field at all depending on their needs.
@@ -1215,7 +1235,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     $violations = parent::validate();
 
     // Create a values array appropriate for `loadValues()`
-    list($values, $tripal_storages) = TripalEntity::getValuesArray($this);
+    [$values, $tripal_storages] = TripalEntity::getValuesArray($this);
 
     // Iterate through the different Tripal Storage objects and run the
     // validateValues() function for the values that belong to it.
@@ -1252,10 +1272,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     parent::delete();
 
     // Create a values array appropriate for `deleteValues()`
-    list($values, $tripal_storages) = TripalEntity::getValuesArray($this);
+    [$values, $tripal_storages] = TripalEntity::getValuesArray($this);
 
     // Call the deleteValues() function for each storage type.
-    $delete_success = False;
+    $delete_success = FALSE;
     foreach ($values as $tsid => $tsid_values) {
       try {
         $delete_success = $tripal_storages[$tsid]->deleteValues($tsid_values);

--- a/tripal/src/Entity/TripalEntityInterface.php
+++ b/tripal/src/Entity/TripalEntityInterface.php
@@ -13,8 +13,6 @@ use Drupal\user\EntityOwnerInterface;
  */
 interface TripalEntityInterface extends ContentEntityInterface, EntityChangedInterface, EntityOwnerInterface {
 
-  // Add get/set methods for your configuration properties here.
-
   /**
    * Gets the Tripal Content type.
    *
@@ -56,7 +54,8 @@ interface TripalEntityInterface extends ContentEntityInterface, EntityChangedInt
    * Sets the published status of a Tripal Content.
    *
    * @param bool $published
-   *   TRUE to set this Tripal Content to published, FALSE to set it to unpublished.
+   *   TRUE to set this Tripal Content to published,
+   *   FALSE to set it to unpublished.
    *
    * @return \Drupal\tripal\Entity\TripalEntityInterface
    *   The called Tripal Content entity.

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -216,7 +216,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *      -.
    *
    * @return TripalEntityType
-   *   An TripalEntityType with the values passed in set appropriately.
+   *   A TripalEntityType with the values passed in set appropriately.
    */
   public static function create(array $values = []) {
 

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -64,6 +64,8 @@ use Drupal\tripal\Routing\TripalEntityTypeHtmlRouteProvider;
   ],
 )]
 /**
+ * Defines the Tripal Content type entity.
+ *
  * @todo Remove this annotation when we no longer support Drupal 10.x.
  *
  * @ConfigEntityType(
@@ -121,7 +123,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
   /**
    * The Tripal Content type ID.
    *
-   * @var integer
+   * @var int
    */
   protected $id;
 
@@ -177,30 +179,32 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
   /**
    * Indicates that empty fields should be hidden.
    *
-   * @var boolean
+   * @var bool
    */
   protected $hide_empty_field;
 
   /**
    * Indicates that AJAX should be used to load fields.
    *
-   * @var boolean
+   * @var bool
    */
   protected $ajax_field;
 
-  // --------------------------------------------------------------------------
-  //                             CREATE + SAVE
-  //
-  // Tripal Entity Types are created using the Drupal Entity API.
-  // To create new type, you will use the static create function we extended
-  // below to pass in the info for the new type and then call the save method on
-  // the created object to permanently save it to your site.
-  //
-  //    $new_entityType = TripalEntityType::create($details);
-  //    if (is_object($entityType)) {
-  //      $new_entityType->save();
-  //    }
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to creating and saving content.
+   *
+   * @section CREATE + SAVE
+   *
+   * Tripal Entity Types are created using the Drupal Entity API.
+   * To create new type, you will use the static create function we extended
+   * below to pass in the info for the new type and then call the save method on
+   * the created object to permanently save it to your site.
+   *
+   * $new_entityType = TripalEntityType::create($details);
+   * if (is_object($entityType)) {
+   *   $new_entityType->save();
+   * }
+   */
 
   /**
    * Contructs a new TripalEntityType object without permanently saving it.
@@ -208,10 +212,11 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * Extends EntityBase::create() with support for TripalTerm as a value.
    *
    * @param array $values
-   *    An array of values to set, keyed by property name. Supported keys are:
-   *      -
+   *   An array of values to set, keyed by property name. Supported keys are:
+   *      -.
+   *
    * @return TripalEntityType
-   *    An TripalEntityType with the values passed in set appropriately.
+   *   An TripalEntityType with the values passed in set appropriately.
    */
   public static function create(array $values = []) {
 
@@ -239,10 +244,9 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     // Let the parent implementation finish creating the object.
     // NOTE: We do things in this order because a configuration entity cannot
     // save an object to its storage. Thus we need to extract the term strings
-    // for storage and retrieve the Term object later if requested via getTerm().
+    // for storage and retrieve the Term object later if requested.
     return parent::create($values);
   }
-
 
   /**
    * Saves the new TripalEntityType permanently.
@@ -256,20 +260,20 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * @return int
    *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
    */
-   public function save() {
+  public function save() {
 
-     // Set defaults for anything not already set.
-     $this->setDefaults();
+    // Set defaults for anything not already set.
+    $this->setDefaults();
 
-     // Validate the values before trying to save.
-     $this->validate();
+    // Validate the values before trying to save.
+    $this->validate();
 
-     // Save the rest of the entity using the parent implementation.
-     // This is when the id is assigned.
-     $return_status = parent::save();
+    // Save the rest of the entity using the parent implementation.
+    // This is when the id is assigned.
+    $return_status = parent::save();
 
-     return $return_status;
-   }
+    return $return_status;
+  }
 
   /**
    * Validate the expected values before saving.
@@ -297,16 +301,17 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
     // Check that the TripalTerm exists with the ID Space and Accession
     // added to this type when it was created.
-
     // If not, then create the TripalTerm, TripalIDSpace and TripalVocabulary.
   }
 
-  // --------------------------------------------------------------------------
-  //                            FIELD MANAGEMT
-  //
-  // TripalEntity uses mostly TripalFields and any entity-wide functions needed
-  // for TripalFields are below.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to managing fields.
+   *
+   * @section FIELD MANAGEMT
+   *
+   * TripalEntity uses mostly TripalFields and any entity-wide functions needed
+   * for TripalFields are below.
+   */
 
   /**
    * Update Drupal field schema to match that defined by each field.
@@ -344,7 +349,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $drupal_table_mapping = $sql_storage->getTableMapping();
 
     // Now for each field instance...
-    foreach ($field_instances as $key => $field_def) {
+    foreach ($field_instances as $field_def) {
       $field_name = $field_def->getName();
       $field_storage_def = $field_def->getFieldStorageDefinition();
 
@@ -362,7 +367,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
       // Now for each property of the current field, check to see if the
       // corresponding drupal table column exists.
-      foreach($current_schema_columns as $property_name => $column_schema) {
+      foreach ($current_schema_columns as $property_name => $column_schema) {
         $property_column_name = $drupal_table_mapping->getFieldColumnName($field_storage_def, $property_name);
         $column_exists = $schema->fieldExists($drupal_table, $property_column_name);
 
@@ -383,13 +388,15 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     return $columns_added;
   }
 
-  // --------------------------------------------------------------------------
-  //                          MAIN SETTER / GETTERS
-  //
-  // The following methods allow the main properties of the Tripal Entity Type
-  // to be set or retrieved. These properties include machine name, term
-  // help text and category.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to getting and setting properties.
+   *
+   * @section MAIN SETTER / GETTERS
+   *
+   * The following methods allow the main properties of the Tripal Entity Type
+   * to be set or retrieved. These properties include machine name, term
+   * help text and category.
+   */
 
   /**
    * Set defaults of values which are not yet set.
@@ -526,15 +533,17 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $this->category = $category;
   }
 
-  // --------------------------------------------------------------------------
-  //                              TITLE FORMATS
-  //
-  // The following methods all pertain to setting titles for Tripal Content
-  // Pages. Specifically, curators can set the title of a specific page or
-  // allow the default pattern to generate the title. The pattern is specified
-  // for all pages of a given Tripal Entity Type and is known as a
-  // "Title Format" and can be set when the type is created or edited.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to generating titles via a format with tokens.
+   *
+   * @section TITLE FORMATS
+   *
+   * The following methods all pertain to setting titles for Tripal Content
+   * Pages. Specifically, curators can set the title of a specific page or
+   * allow the default pattern to generate the title. The pattern is specified
+   * for all pages of a given Tripal Entity Type and is known as a
+   * "Title Format" and can be set when the type is created or edited.
+   */
 
   /**
    * {@inheritdoc}
@@ -557,6 +566,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
   /**
    * {@inheritdoc}
+   *
    * @todo add to docs
    */
   public function getDefaultTitleFormat() {
@@ -570,8 +580,8 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $format = 'Unknown ' . date('Ymd-h:i:sA');
 
     // A) Check to see if more informed modules have suggested a title for this
-    //    type. Invoke hook_tripal_default_title_format() to get all suggestions
-    //    from other modules.
+    // type. Invoke hook_tripal_default_title_format() to get all suggestions
+    // from other modules.
     $suggestions = \Drupal::moduleHandler()->invokeAll(
       'tripal_default_title_format',
       [$this, $tokens]
@@ -590,8 +600,8 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       $format = $suggestions[$lightest_key]['format'];
     }
     // B) Generate our own ugly title by simply using the entity ID to
-    //    guarantee uniqueness. This will happen when a site admin is
-    //    creating a new content type through the UI.
+    // guarantee uniqueness. This will happen when a site admin is
+    // creating a new content type through the UI.
     else {
       $format = 'Entity [TripalEntity__entity_id]';
     }
@@ -599,14 +609,16 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     return $format;
   }
 
-  // --------------------------------------------------------------------------
-  //                             URL ALIAS FORMATS
-  //
-  // The following methods all pertain to setting aliases for Tripal Content
-  // Pages. This allows administrators to set readable, more friendly URLs
-  // for their biological content in bulk through the use of tokens and
-  // patterns.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to generating URL alias' via a format with tokens.
+   *
+   * @section URL ALIAS FORMATS
+   *
+   * The following methods all pertain to setting aliases for Tripal Content
+   * Pages. This allows administrators to set readable, more friendly URLs
+   * for their biological content in bulk through the use of tokens and
+   * patterns.
+   */
 
   /**
    * {@inheritdoc}
@@ -627,16 +639,19 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     $this->url_format = $url_format;
   }
 
-  // --------------------------------------------------------------------------
-  //                                  TOKENS
-  //
-  // The following methods relate to Tripal Entity Type tokens. These tokens
-  // are based on the fields for a given Tripal Entity Type and can be used
-  // to indicate general patterns to allow bulk assignment of titles and URLs.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to handling tokens.
+   *
+   * @section TOKENS
+   *
+   * The following methods relate to Tripal Entity Type tokens. These tokens
+   * are based on the fields for a given Tripal Entity Type and can be used
+   * to indicate general patterns to allow bulk assignment of titles and URLs.
+   */
 
   /**
    * {@inheritdoc}
+   *
    * @todo add to docs.
    */
   public function getTokens($options = []) {
@@ -704,7 +719,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     ];
 
     $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions('tripal_entity', $this->id);
-    foreach ($instances as $instance_name => $instance) {
+    foreach ($instances as $instance) {
 
       $use_field = TRUE;
       $field_name = $instance->getName();
@@ -723,7 +738,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       // Iterate through the TripalEntity fields and see if they have
       // sub-elements, if so, add those as tokens too.
       // @todo handle sub-elements once TripalField's are implemented.
-
       // If we have no elements to add then just add the field as is.
       if ($use_field) {
         // Build the token from the field information.
@@ -741,13 +755,15 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     return $tokens;
   }
 
-  // --------------------------------------------------------------------------
-  //                             FIELD DISPLAY
-  //
-  // The following methods pertain to what fields are displayed and how they
-  // are loaded. For example, administrators can choose to hide empty fields
-  // or have all fields loaded by AJAX to speed up page loading times.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods related to field display.
+   *
+   * @section FIELD DISPLAY
+   *
+   * The following methods pertain to what fields are displayed and how they
+   * are loaded. For example, administrators can choose to hide empty fields
+   * or have all fields loaded by AJAX to speed up page loading times.
+   */
 
   /**
    * {@inheritdoc}
@@ -791,18 +807,20 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     return $this->hide_empty_field;
   }
 
-  // --------------------------------------------------------------------------
-  //                             TYPE SORTING
-  //
-  // The following methods pertain to sorting Tripal Entity Types for listing.
-  // --------------------------------------------------------------------------
+  /**
+   * Methods relating to sorting of types.
+   *
+   * @section TYPE SORTING
+   *
+   * The following methods pertain to sorting Tripal Entity Types for listing.
+   */
 
   /**
    * Sorts Tripal Entity Types first by category and then by Label.
    *
-   * @param $a
+   * @param TripalEntityTypeInterface $a
    *   The first Tripal Entity Type object.
-   * @param $b
+   * @param TripalEntityTypeInterface $b
    *   The second Tripal Entity Type object.
    */
   public static function sortByCategory(TripalEntityTypeInterface $a, TripalEntityTypeInterface $b) {

--- a/tripal/src/Entity/TripalEntityTypeInterface.php
+++ b/tripal/src/Entity/TripalEntityTypeInterface.php
@@ -9,7 +9,6 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  */
 interface TripalEntityTypeInterface extends ConfigEntityInterface {
 
-
   /**
    * Gets the Tripal Entity Type label (e.g. gene).
    *
@@ -41,7 +40,7 @@ interface TripalEntityTypeInterface extends ConfigEntityInterface {
    * Sets the Tripal Entity Type CV Term ID Space.
    *
    * @param string $termIdSpace
-   *   The new Tripal Controlled Vocabulary Term ID Space
+   *   The new Tripal Controlled Vocabulary Term ID Space.
    *
    * @return \Drupal\tripal\Entity\TripalEntityTypeInterface
    *   The called Tripal Entity Type entity.
@@ -60,7 +59,7 @@ interface TripalEntityTypeInterface extends ConfigEntityInterface {
    * Sets the Tripal Entity Type CV Term Accession.
    *
    * @param string $termAccession
-   *   The new Tripal Controlled Vocabulary Term Accession
+   *   The new Tripal Controlled Vocabulary Term Accession.
    *
    * @return \Drupal\tripal\Entity\TripalEntityTypeInterface
    *   The called Tripal Entity Type entity.
@@ -68,7 +67,7 @@ interface TripalEntityTypeInterface extends ConfigEntityInterface {
   public function setTermAccession(string $termAccession);
 
   /**
-   * Gets the Tripal Entity Type CV Term Object based off its CV Term ID Space and Accession.
+   * Gets the TripalTerm describing the type this TripalEntityType represents.
    *
    * @return \Drupal\tripal\TripalVocabTerms\TripalTerm
    *   The Tripal Controlled Vocabulary Term Object.
@@ -164,26 +163,33 @@ interface TripalEntityTypeInterface extends ConfigEntityInterface {
   /**
    * Retrieves the indicator for whether to hide empty fields or not.
    *
-   * @return
+   * @return bool
    *   true if empty fields should be hidden and false otherwise.
    */
   public function getEmptyFieldDisplay();
 
   /**
-   * Configures the entity such that fields will be loaded via AJAX after page load.
+   * Indicates that fields will be loaded via AJAX after page load.
+   *
+   * @todo this functionality is not yet implemented.
    */
   public function enableAJAXLoading();
 
   /**
-   * Configures the entity such that fields will be loaded on page load.
+   * Indicates that fields will be loaded on page load.
+   *
+   * @todo this functionality is not yet implemented.
    */
   public function disableAJAXLoading();
 
   /**
    * Retrieves the indicator for whether to load fields using AJAX or not.
    *
-   * @return
+   * @todo this functionality is not yet implemented.
+   *
+   * @return bool
    *   true if AJAX should be used to load fields and false otherwise.
    */
   public function getAJAXLoadingStatus();
+
 }


### PR DESCRIPTION

# Tripal 4 Core Dev Task

### Issue #2195 

## Description

From the issue:
> I'm going to test out an approach in branch tv4g10-2195-tripalContentPerformance where we cache the TripalStorage-related objects to reduce repeated set-up through page-loads and what-not. This will make changes mostly to the TripalEntity class.

This PR literally just updates the files I may touch to accomplish the above task to match coding standards. This is it's own PR to make the future work easier to review.

## Testing?
There should not be any functional changes. Therefore, a code review and making sure the tests still pass should be sufficient.
