### PR TITLE
Update Test Coverage Workflow to run on 4.x

### DIFF
--- a/.github/workflows/ALL-testCoverage-qltycloud.yml
+++ b/.github/workflows/ALL-testCoverage-qltycloud.yml
@@ -1,6 +1,9 @@
 name: 'Test Coverage on Drupal 11.1.x-dev + PHP 8.3'
 
 on:
+  push:
+    branches:
+      - '4.x'
   workflow_dispatch:
   pull_request:
     types: ['opened', 'synchronize']


### PR DESCRIPTION
# Bug Fix

### Issue 🙈 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When analyzing the change in test coverage for my recent performance PR I noticed that QLTY Cloud was reporting a decrease in coverage for files that should not be impacted by my PR. Needless to say I was concerned and did some digging which caused me to notice that coverage had not been run on 4.x in 2 months!!! 🙈 We need coverage run on 4.x since it is used in the comparison to say how much our PRs are affecting the diff and total coverage!

This PR adds the 4.x branch into those test coverage should be run on.

NOTE: I manually triggered the test coverage workflow for 4.x tonight as shown in this screenshot from our github action logs.

<img width="1229" height="432" alt="Screenshot 2025-09-07 at 9 54 25 PM" src="https://github.com/user-attachments/assets/39277a36-4982-4c40-a6c2-d4b8b7af4ddf" />

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This is literally a workflow only change. As such it's really just a code review. GitHub should scream if there is any syntax issues in the workflow.