### PR TITLE
Fix invalid menu machine name

### DIFF
--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -25,10 +25,10 @@ function tripal_install() {
 
   // Add the Data Search Menu for Tripal specific searches.
   $storage = Drupal::entityTypeManager()->getStorage('menu');
-  $menu = $storage->load('data_search');
+  $menu = $storage->load('data-search');
   if (is_null($menu)) {
     $storage->create([
-      'id' => 'data_search',
+      'id' => 'data-search',
       'label' => t('Data Search'),
       'description' => t('The Data Search menu contains links to search tools for finding biological data.'),
     ])->save();
@@ -1045,5 +1045,28 @@ function tripal_update_10402() {
   // Delete the configuration.
   if ($config) {
     \Drupal::configFactory()->getEditable('tripaldbx.settings')->delete();
+  }
+}
+
+/**
+ * Renames /data_search menu to /data-search.
+ */
+function tripal_update_10403() {
+  // This hook added with PR #2283.
+  // Menu machine names cannot have underscores. The old menu name
+  // does not actually work, so just delete it.
+  $menu_storage = Drupal::entityTypeManager()->getStorage('menu');
+  $old_menu = $menu_storage->load('data_search');
+  if (!empty($old_menu)) {
+    $old_menu->delete();
+  }
+  $new_menu = $menu_storage->load('data-search');
+  if (empty($new_menu)) {
+    // Create the new menu.
+    $menu_storage->create([
+      'id' => 'data-search',
+      'label' => t('Data Search'),
+      'description' => t('The Data Search menu contains links to search tools for finding biological data.'),
+    ])->save();
   }
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2282 

## Description
The Tripal module defined a top-level menu item `data_search` - however this is an invalid machine name.
This PR introduces an update hook to remove this menu (it is invalid so nobody will have used it) and create it again as `data-search`.

## Context
This menu was used in Tripal 3 to provide links to all of the available drupal views for the various tripal content types.
A site may choose to not display this menu at all, but instead add all or some of the available views to a "Search" menu item on the site's main navigation menu, or not use the views at all in favor of other search options.

## Testing?
 1. Build a docker on 4.x, then switch to this branch to test the update hook.
 2. `drush updatedb` to run the hook
 ```
 -------- ----------- --------------- -------------------------------------- 
  Module   Update ID   Type            Description                           
 -------- ----------- --------------- -------------------------------------- 
  tripal   10403       hook_update_n   10403 - Renames /data_search menu to  
                                       /data-search.                         
 -------- ----------- --------------- -------------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: tripal_update_10403
>  [notice] Update completed: tripal_update_10403
 [success] Finished performing updates.
```
 3. Go to Structure -> Menus -> Data Search -> Edit
 and confirm you can add things to the menu and save it.
 4. To see the menu add it to the header block
 Structure -> Block Layout
 on "Primary Menu" click "Place Block"
then for "Data Search" click "Place Block"
