### PR TITLE
Brittle tests: add missing return when pub test skipped

### DIFF
--- a/tripal_chado/tests/src/Functional/Plugin/TripalPubLibraryTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TripalPubLibraryTest.php
@@ -95,6 +95,7 @@ class TripalPubLibraryTest extends ChadoTestBrowserBase {
     $results = $plugin->retrieve($search_array, 1, 0);
     if ($results === NULL) {
       $this->markTestSkipped('Skipping PubMed test due to being unable to access service.');
+      return;
     }
     $this->assertEquals('30000852', $results['pubs'][0]['Publication Dbxref'], 'This should have returned the PMID');
     $this->assertEquals('National Institute of Child Health and Human Development', $results['pubs'][0]['Publisher'], 'This should have returned the Title');


### PR DESCRIPTION
# Bug Fix

### Issue #2143

## Description
In nightly test run
https://github.com/tripal/tripal/actions/runs/17707379589/job/50321311426
we hit the code in the pub importer to mark as skipped if a null was encountered.
However, it looks like the code after ran, because we didn't `return` after marking the test skipped.

```
There was 1 failure:

1) Drupal\Tests\tripal_chado\Functional\TripalPubLibraryTest::testTripalPubLibraryTestSimpleTest
This should have returned the PMID
Failed asserting that null matches expected '30000852'.

/var/www/drupal/web/modules/contrib/tripal/tripal_chado/tests/src/Functional/Plugin/TripalPubLibraryTest.php:99
```

## Testing?
This will have to just be code review as this is a very rare occurrence.

### Closing because marktestskipped already skips tests after. $results was not null, so not knowing its actual contents I am abandoning this for now.