### PR TITLE
Remove deprecated functions from importers

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
          beStrictAboutChangesToGlobalState="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"

--- a/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/FASTAImporter.php
@@ -803,16 +803,14 @@ class FASTAImporter extends ChadoImporterBase {
             return 0;
           }
 
-          // the changes to the uniquename don't conflict so proceed with the update
-          $values = ['uniquename' => $uname];
-          $match = [
-            'name' => $name,
-            'organism_id' => $organism_id,
-            'type_id' => $cvterm->cvterm_id,
-          ];
-
-          // perform the update
-          $success = chado_update_record('feature', $match, $values);
+          // The changes to the uniquename don't conflict so proceed
+          // with the update.
+          $query = $this->connection->update('1:feature');
+          $query->condition('name', $name, '=');
+          $query->condition('organism_id', $organism_id, '=');
+          $query->condition('type_id', $cvterm->cvterm_id, '=');
+          $query->fields(['uniquename' => $uname]);
+          $success = $query->execute();
           if (!$success) {
             $this->logger->error("Failed to update feature '@name' ('@uname')",
               ['@name' => $name, '@uname' => $uname]
@@ -828,13 +826,12 @@ class FASTAImporter extends ChadoImporterBase {
         // we want to update the name.
         $values = [];
         if ($name) {
-          $values = ['name' => $name];
-          $match = [
-            'uniquename' => $uname,
-            'organism_id' => $organism_id,
-            'type_id' => $cvterm->cvterm_id,
-          ];
-          $success = chado_update_record('feature', $match, $values);
+          $query = $this->connection->update('1:feature');
+          $query->condition('uniquename', $uname, '=');
+          $query->condition('organism_id', $organism_id, '=');
+          $query->condition('type_id', $cvterm->cvterm_id, '=');
+          $query->fields(['name' => $name]);
+          $success = $query->execute();
           if (!$success) {
             $this->logger->error("Failed to update feature '@name' ('@uname')",
               ['@name' => $name, '@uname' => $uname]

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -1451,7 +1451,10 @@ class GFF3Importer extends ChadoImporterBase implements ContainerFactoryPluginIn
         'seqlen' => strlen($residues),
         'md5checksum' => md5($residues),
       ];
-      chado_update_record('feature', ['feature_id' => $feature_id], $values, NULL, $this->chado_schema_main);
+      $query = $this->connection->update('1:feature');
+      $query->condition('feature_id', $feature_id, '=');
+      $query->fields($values);
+      $query->execute();
       $count++;
       $this->setItemsHandled($count);
     }

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -103,9 +103,11 @@ class NewickImporter extends ChadoImporterBase {
       '#maxlength' => 255,
     ];
 
-    $so_cv = chado_get_cv(['name' => 'sequence']);
-    $cv_id = $so_cv->cv_id;
-    if (!$so_cv) {
+    $query = $this->connection->select('1:cv', 'cv');
+    $query->condition('cv.name', 'sequence', '=');
+    $query->addField('cv', 'cv_id', 'cv_id');
+    $cv_id = $query->execute()->fetchField();
+    if (!$cv_id) {
       \Drupal::messenger()->addError(t("The Sequence Ontology does not appear to be imported.
          Please import the Sequence Ontology before adding a tree."));
     }

--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -66,6 +66,16 @@ class NewickImporter extends ChadoImporterBase {
     $match = '';
     // $load_later = FALSE;  // Default is to combine tree import with current job
 
+    // Confirm we have the sequence ontology before we go any further.
+    $query = $this->connection->select('1:cv', 'cv');
+    $query->condition('cv.name', 'sequence', '=');
+    $query->addField('cv', 'cv_id', 'cv_id');
+    $cv_id = $query->execute()->fetchField();
+    if (!$cv_id) {
+      \Drupal::messenger()->addError(t("The Sequence Ontology does not appear to be imported. Please import the Sequence Ontology before adding a tree."));
+      return [];
+    }
+
     // get the sequence ontology CV ID
     $cv_results = $chado->select('1:cv', 'cv')
       ->fields('cv')
@@ -102,15 +112,6 @@ class NewickImporter extends ChadoImporterBase {
       '#description' => t('Enter the name used to refer to this phylogenetic tree.'),
       '#maxlength' => 255,
     ];
-
-    $query = $this->connection->select('1:cv', 'cv');
-    $query->condition('cv.name', 'sequence', '=');
-    $query->addField('cv', 'cv_id', 'cv_id');
-    $cv_id = $query->execute()->fetchField();
-    if (!$cv_id) {
-      \Drupal::messenger()->addError(t("The Sequence Ontology does not appear to be imported.
-         Please import the Sequence Ontology before adding a tree."));
-    }
 
     $form['leaf_type'] = [
       '#title' => t('Tree Type'),

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2110,12 +2110,14 @@ class OBOImporter extends ChadoImporterBase {
    */
   private function getCachedTermStanza($id) {
     if ($this->cache_type == 'table') {
-      $values = ['id' => $id];
-      $result = chado_select_record('tripal_obo_temp', ['stanza'], $values);
-      if (count($result) == 0) {
+      $query = $this->connection->select('1:tripal_obo_temp', 't');
+      $query->condition('t.id', $id, '=');
+      $query->addField('t', 'stanza', 'stanza');
+      $stanza = $query->execute()->fetchField();
+      if (!$stanza) {
         return FALSE;
       }
-      return unserialize(base64_decode($result['stanza']));
+      return unserialize(base64_decode($stanza));
     }
 
     if (array_key_exists($id, $this->termStanzaCache['ids'])) {
@@ -2296,7 +2298,9 @@ class OBOImporter extends ChadoImporterBase {
         'stanza' => base64_encode(serialize($stanza)),
         'type' => $type,
       ];
-      $success = chado_insert_record('tripal_obo_temp', $values);
+      $query = $this->connection->insert('1:tripal_obo_temp');
+      $query->fields($values);
+      $success = $query->execute();
       if (!$success) {
         throw new \Exception("Cannot insert stanza into temporary table.");
       }

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -789,8 +789,8 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
     $query = $this->connection->select('1:organism_dbxref', 'ox');
     $query->condition('ox.organism_id', $organism_id, '=');
     $query->condition('ox.dbxref_id', $dbxref_record->getValue('dbxref.dbxref_id'), '=');
-    $count = $query->countQuery()->execute();
-    if (!$count) {
+    $count = $query->countQuery()->execute()->fetchField();
+    if ($count < 1) {
       $this->dbxref_buddy->associateDbxref('organism', $organism_id, $dbxref_record, $options);
     }
   }

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -489,10 +489,11 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
       $full_infra = $matches[3];
 
       // Get the CV term for the rank.
-      $type = chado_get_cvterm([
-        'name' => preg_replace('/ /', '_', $rank),
-        'cv_id' => ['name' => 'taxonomic_rank'],
-      ], [], $this->chado_schema_main);
+      $query = $this->connection->select('1:cvterm', 't');
+      $query->join('1:cv', 'cv', '"t".cv_id = "cv".cv_id');
+      $query->condition('t.name', preg_replace('/ /', '_', $rank), '=');
+      $query->condition('cv.name', 'taxonomic_rank', '=');
+      $cvterm_id = $query->execute()->fetchField();
 
       // Remove the rank from the infraspecific name.
       $abbrev = chado_abbreviate_infraspecific_rank($rank);
@@ -503,7 +504,7 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
         'genus' => $genus,
         'species' => $species,
         'abbreviation' => $genus[0] . '. ' . $species . ' ' . $full_infra,
-        'type_id' => $type->cvterm_id,
+        'type_id' => $cvterm_id,
         'infraspecific_name' => $infra,
       ];
       $organism_id = $this->connection->insert('1:organism')
@@ -678,9 +679,10 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
             case 'CommonName':
               // If we had to add the organism then include the common name too.
               if ($adds_organism) {
-                $organism->common_name = $name;
-                $values = ['organism_id' => $organism->id];
-                chado_update_record('organism', $values, $organism, NULL, $this->chado_schema_main);
+                $query = $this->connection->update('1:organism');
+                $query->condition('organism_id', $organism->id, '=');
+                $query->fields(['common_name' => $name]);
+                $query->execute();
               }
             case 'Includes':
               $this->addProperty($organism->organism_id, 'other_name', $name, $name_ranks[$type]);

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -782,7 +782,17 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
       'pkey' => 'organism_id',
     ];
     $dbxref_record = $this->dbxref_buddy->upsertDbxref($values, []);
-    $this->dbxref_buddy->associateDbxref('organism', $organism_id, $dbxref_record, $options);
+
+    // Determine if the dbxref is already linked, and if not, link it.
+    // This will be moved to the buddy function later.
+    // @see issue #2300
+    $query = $this->connection->select('1:organism_dbxref', 'ox');
+    $query->condition('ox.organism_id', $organism_id, '=');
+    $query->condition('ox.dbxref_id', $dbxref_record->getValue('dbxref.dbxref_id'), '=');
+    $count = $query->countQuery()->execute();
+    if (!$count) {
+      $this->dbxref_buddy->associateDbxref('organism', $organism_id, $dbxref_record, $options);
+    }
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -67,9 +67,9 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
 
   /**
    * Options for file retrieval from NCBI.
-   *  
-   * NOTE: NCBI accepts 3 requests/second by default but will allow 
-   * 10 requests/second if an API key is provided. This is defined  
+   *
+   * NOTE: NCBI accepts 3 requests/second by default but will allow
+   * 10 requests/second if an API key is provided. This is defined
    * via the rate_limit key.
    *
    * @var array
@@ -489,7 +489,8 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
       $full_infra = $matches[3];
 
       // Get the CV term for the rank.
-      $query = $this->connection->select('1:cvterm', 't');
+      $query = $this->connection->select('1:cvterm', 't')
+        ->fields('t', ['cvterm_id']);
       $query->join('1:cv', 'cv', '"t".cv_id = "cv".cv_id');
       $query->condition('t.name', preg_replace('/ /', '_', $rank), '=');
       $query->condition('cv.name', 'taxonomic_rank', '=');

--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -432,38 +432,33 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
 
     // First check the taxid to see if it's present and associated with an
     // organism already.
-    $values = [
-      'db_id' => [
-        'name' => 'NCBITaxon',
-      ],
-      'accession' => $taxid,
-    ];
-    $columns = ['dbxref_id'];
-    $dbxref = chado_select_record('dbxref', $columns, $values, NULL, $this->chado_schema_main);
-    if (count($dbxref) > 0) {
-      $columns = ['organism_id'];
-      $values = ['dbxref_id' => $dbxref[0]->dbxref_id];
-      $organism_dbxref = chado_select_record('organism_dbxref', $columns, $values, NULL, $this->chado_schema_main);
-      if (count($organism_dbxref) > 0) {
-        $organism_id = $organism_dbxref[0]->organism_id;
-        $columns = ['*'];
-        $values = ['organism_id' => $organism_id];
-        $organism = chado_select_record('organism', $columns, $values, NULL, $this->chado_schema_main);
-        if (count($organism) > 0) {
-          $organism = $organism[0];
-        }
-      }
+    $query = $this->connection->select('1:dbxref', 'x');
+    $query->join('1:db', 'db', '"x".db_id = "db".db_id');
+    $query->join('1:organism_dbxref', 'ox', '"x".dbxref_id = "ox".dbxref_id');
+    $query->join('1:organism', 'o', '"ox".organism_id = "o".organism_id');
+    $query->condition('db.name', 'NCBITaxon', '=');
+    $query->condition('x.accession', $taxid, '=');
+    $query->fields('o');
+    $results = $query->execute()->fetchAll();
+    if (count($results) > 0) {
+      $organism = $results[0];
     }
 
     // If the caller did not provide an organism then we want to try and
     // add one. But, it only makes sense to add one if this record
     // is of rank species.
     if (!$organism) {
-      // We do the lookup in two steps so that there is no error message for
-      // missing (new) organisms from chado_get_organism().
+      // We do the lookup in two steps so that there is no error if
+      // we don't retrieve an organism_id.
       $organism_ids = chado_get_organism_id_from_scientific_name($sci_name, []);
       if ($organism_ids) {
-        $organism = chado_get_organism(['organism_id' => $organism_ids[0]], [], $this->chado_schema_main);
+        $query = $this->connection->select('1:organism', 'o');
+        $query->condition('o.organism_id', $organism_ids[0], '=');
+        $query->fields('o');
+        $results = $query->execute()->fetchAll();
+        if (count($results) > 0) {
+          $organism = $results[0];
+        }
       }
     }
     return $organism;

--- a/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
@@ -290,9 +290,12 @@ class TreeGenerator extends ChadoImporterBase {
    * Used when tree generation is cancelled due to lack of any valid organisms.
    */
   protected function removeTree($tree_name) {
-    $phylotree = chado_select_record('phylotree', ['*'], ['name' => $tree_name], NULL, $this->chado_schema_main);
-    if ($phylotree) {
-      chado_delete_phylotree($phylotree[0]->phylotree_id, $this->chado_schema_main);
+    $query = $this->connection->select('1:phylotree', 't');
+    $query->condition('t.name', $tree_name, '=');
+    $query->addField('t', 'phylotree_id', 'phylotree_id');
+    $phylotree_id = $query->execute()->fetchField();
+    if ($phylotree_id) {
+      chado_delete_phylotree($phylotree_id, $this->chado_schema_main);
     }
   }
 
@@ -457,12 +460,11 @@ class TreeGenerator extends ChadoImporterBase {
       }
     }
     else {
-      $node_values = [
-        'phylotree_id' => $phylotree_id,
-        'label' => $node_name,
-      ];
-      $columns = ['*'];
-      $phylonode = chado_select_record('phylonode', $columns, $node_values, NULL, $this->chado_schema_main);
+      $query = $this->connection->select('1:phylonode', 'n');
+      $query->condition('n.phylotree_id', $phylotree_id, '=');
+      $query->condition('n.label', $node_name, '=');
+      $query->fields('n');
+      $phylonode = $query->execute()->fetchAll();
       if (count($phylonode) == 0) {
         $lineage_nodes[$node_name] = NULL;
         $lineage_good = FALSE;
@@ -471,12 +473,12 @@ class TreeGenerator extends ChadoImporterBase {
         $phylonode = $phylonode[0];
         $lineage_nodes[$node_name] = $phylonode;
 
-        $prop_values = [
-          'phylonode_id' => $phylonode->phylonode_id,
-          'type_id' => $this->rank_cvterm_id,
-        ];
-        $columns = ['*'];
-        $phylonodeprop = chado_select_record('phylonodeprop', $columns, $prop_values, NULL, $this->chado_schema_main);
+        $query = $this->connection->select('1:phylonodeprop', 'np');
+        $query->condition('np.phylonode_id', $phylonode->phylonode_id, '=');
+        $query->condition('np.type_id', $this->rank_cvterm_id, '=');
+        $query->fields('np');
+        $phylonodeprop = $query->execute()->fetchAll();
+
         return $phylonodeprop;
       }
     }

--- a/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
@@ -156,7 +156,9 @@ class TreeGenerator extends ChadoImporterBase {
     $this->tree = $this->rebuildTree($root_taxon);
 
     // Clean out the phylonodes for this tree in the event this is a reload.
-    chado_delete_record('phylonode', ['phylotree_id' => $this->phylotree->phylotree_id], NULL, $this->chado_schema_main);
+    $query = $chado->delete('1:phylonode');
+    $query->condition('phylotree_id', $this->phylotree->phylotree_id, '=');
+    $query->execute();
 
     // Set the number of items to handle.
     $this->setTotalItems(count($this->all_orgs));
@@ -255,7 +257,10 @@ class TreeGenerator extends ChadoImporterBase {
   protected function initTree($tree_name) {
     // Add the taxonomy tree record into the phylotree table. If the tree
     // already exists then don't insert it again.
-    $phylotree = chado_select_record('phylotree', ['*'], ['name' => $tree_name], NULL, $this->chado_schema_main);
+    $query = $this->connection->select('1:phylotree', 't');
+    $query->fields('t');
+    $query->condition('t.name', $tree_name, '=');
+    $phylotree = $query->execute()->fetchAll();
     if (count($phylotree) == 0) {
       // Add the taxonomic tree.
       $phylotree = [

--- a/tripal_chado/src/api/tripal_chado.organism.api.php
+++ b/tripal_chado/src/api/tripal_chado.organism.api.php
@@ -182,10 +182,11 @@ function chado_get_organism_scientific_name($organism, $schema_name = NULL) {
     }
   }
   else {
-    $rank_term = chado_get_cvterm(['cvterm_id' => $organism->type_id], [], $schema_name);
-    if ($rank_term) {
-      $rank = $rank_term->name;
-    }
+    $chado = \Drupal::service('tripal_chado.database');
+    $query = $chado->select('1:cvterm', 't');
+    $query->condition('t.cvterm_id', $organism->type_id, '=');
+    $query->addField('t', 'name', 'name');
+    $rank = $query->execute()->fetchField();
   }
 
   if ($rank) {

--- a/tripal_chado/src/api/tripal_chado.phylotree.api.php
+++ b/tripal_chado/src/api/tripal_chado.phylotree.api.php
@@ -774,7 +774,7 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = [], 
   // Get the vocabulary terms used to describe nodes in the tree if one
   // wasn't provided.
   if (count($vocab) == 0) {
-    $vocab = chado_phylogeny_get_node_types_vocab($chado, $options, $schema_name);
+    $vocab = chado_phylogeny_get_node_types_vocab($options, $schema_name);
   }
 
   if (is_array($tree) and array_key_exists('name', $tree)) {

--- a/tripal_chado/src/api/tripal_chado.phylotree.api.php
+++ b/tripal_chado/src/api/tripal_chado.phylotree.api.php
@@ -997,7 +997,9 @@ function chado_phylogeny_lookup_organism_by_name($name, $schema_name = 'chado') 
  *
  * @ingroup tripal_phylotree_api
  */
-function chado_phylogeny_get_node_types_vocab($chado, $options, $schema_name = 'chado') {
+function chado_phylogeny_get_node_types_vocab($options, $schema_name = 'chado') {
+  $chado = \Drupal::service('tripal_chado.database');
+  $chado->setSchemaName($schema_name);
   // Get the three default vocabulary terms used to describe nodes in the tree.
   $terms = ['leaf' => 'phylo_leaf', 'internal' => 'phylo_interior', 'root' => 'phylo_root'];
   $vocab = [];

--- a/tripal_chado/src/api/tripal_chado.phylotree.api.php
+++ b/tripal_chado/src/api/tripal_chado.phylotree.api.php
@@ -252,12 +252,19 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings, $s
         'name' => $db_name,
       ],
     ];
-    $dbxref = chado_generate_var('dbxref', $values, [], $schema_name);
+    $query = $chado->select('1:dbxref', 'x');
+    $query->join('1:db', 'db', '"x".db_id = "db".db_id');
+    $query->condition('x.accession', $accession, '=');
+    $query->condition('db.name', $db_name, '=');
+    $query->addField('x', 'dbxref_id', 'dbxref_id');
+    $dbxref_id = $query->execute()->fetchField();
 
-    if (!$dbxref) {
-
-      $db = chado_generate_var('db', ['name' => $db_name], [], $schema_name);
-      if (!$db) {
+    if (!$dbxref_id) {
+      $query = $chado->select('1:db', 'DB');
+      $query->condition('DB.name', $db_name, '=');
+      $query->addField('DB', 'db_id', 'db_id');
+      $db_id = $query->execute()->fetchField();
+      if (!$db_id) {
         $errors['dbxref'] = t(
             'dbxref could not be created for %dbname:%dbxref, this DB does not exist.',
             ['%dbname' => $db_name, '%dbxref' => $dbxref]);
@@ -265,11 +272,11 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings, $s
       }
 
       // Here we create the new dbxref for the specified new accession.
-      $dbxref = $chado->insert('1:dbxref')->fields([
+      $dbxref_id = $chado->insert('1:dbxref')->fields([
         'accession' => $values['accession'],
-        'db_id' => $db->db_id
+        'db_id' => $db_id,
       ])->execute();
-      if (!$dbxref) {
+      if (!$dbxref_id) {
         $errors['dbxref'] = t(
             'dbxref could not be created for %dbname:%dbxref.',
             ['%dbname' => $db_name, '%dbxref' => $dbxref]);
@@ -277,15 +284,7 @@ function chado_validate_phylotree($val_type, &$options, &$errors, &$warnings, $s
       }
     }
 
-    if (is_object($dbxref)) {
-      $options['dbxref_id'] = $dbxref->dbxref_id;
-    }
-    elseif (is_array($dbxref)) {
-      $options['dbxref_id'] = $dbxref['dbxref_id'];
-    }
-    else {
-      $options['dbxref_id'] = $dbxref;
-    }
+    $options['dbxref_id'] = $dbxref_id;
   }
 
   // Make sure the tree name is unique.
@@ -775,7 +774,7 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = [], 
   // Get the vocabulary terms used to describe nodes in the tree if one
   // wasn't provided.
   if (count($vocab) == 0) {
-    $vocab = chado_phylogeny_get_node_types_vocab($options, $schema_name);
+    $vocab = chado_phylogeny_get_node_types_vocab($chado, $options, $schema_name);
   }
 
   if (is_array($tree) and array_key_exists('name', $tree)) {
@@ -794,12 +793,12 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = [], 
     // Set the type of node.
     // echo "DEBUG Check is_root\n";
     if (isset($tree['is_root']) && $tree['is_root'] == true) {
-      $values['type_id'] = $vocab['root']->cvterm_id;
+      $values['type_id'] = $vocab['root'];
     }
     else {
       // echo "DEBUG Check is_internal\n";
       if (isset($tree['is_internal']) && $tree['is_internal'] == true) {
-        $values['type_id'] = $vocab['internal']->cvterm_id;
+        $values['type_id'] = $vocab['internal'];
         $values['parent_phylonode_id'] = $parent['phylonode_id'];
         // TODO: a feature may be associated here but it is recommended that it
         // be a feature of type SO:match and should represent the alignment of
@@ -807,7 +806,7 @@ function chado_phylogeny_import_tree(&$tree, $phylotree, $options, $vocab = [], 
       }
       else {
         if (isset($tree['is_leaf']) && $tree['is_leaf']) {
-          $values['type_id'] = $vocab['leaf']->cvterm_id;
+          $values['type_id'] = $vocab['leaf'];
           $values['parent_phylonode_id'] = $parent['phylonode_id'];
 
           // Match this leaf node with an organism or feature depending on the
@@ -998,26 +997,25 @@ function chado_phylogeny_lookup_organism_by_name($name, $schema_name = 'chado') 
  *
  * @ingroup tripal_phylotree_api
  */
-function chado_phylogeny_get_node_types_vocab($options, $schema_name = 'chado') {
+function chado_phylogeny_get_node_types_vocab($chado, $options, $schema_name = 'chado') {
   // Get the three default vocabulary terms used to describe nodes in the tree.
   $terms = ['leaf' => 'phylo_leaf', 'internal' => 'phylo_interior', 'root' => 'phylo_root'];
   $vocab = [];
   foreach ($terms as $key => $name) {
-    $values = [
-      'name' => $name,
-      'cv_id' => [
-        'name' => 'local',
-      ],
-    ];
-    $cvterm = chado_generate_var('cvterm', $values, [], $schema_name);
-    if (!$cvterm) {
+    $query = $chado->select('1:cvterm', 't');
+    $query->join('1:cv', 'cv', '"t".cv_id = "cv".cv_id');
+    $query->condition('t.name', $name, '=');
+    $query->condition('cv.name', 'local', '=');
+    $query->addField('t', 'cvterm_id', 'cvterm_id');
+    $cvterm_id = $query->execute()->fetchField();
+    if (is_null($cvterm_id)) {
       \Drupal::service('tripal.logger')->error(
         "Could not find the leaf vocabulary term: '%name'. It should " .
         "already be present as part of the local vocabulary.",
         ['%name' => $name], $options['message_opts']);
       return FALSE;
     }
-    $vocab[$key] = $cvterm;
+    $vocab[$key] = $cvterm_id;
   }
   return $vocab;
 }
@@ -1051,6 +1049,8 @@ function chado_phylogeny_get_node_types_vocab($options, $schema_name = 'chado') 
  * @ingroup tripal_phylotree_api
  */
 function chado_phylogeny_import_tree_file($file_name, $format, $options = [], $job_id = NULL, $schema_name = 'chado') {
+  $chado = \Drupal::service('tripal_chado.database');
+  $chado->setSchemaName($schema_name);
 
   // Set some option details.
   if (!array_key_exists('leaf_type', $options)) {
@@ -1094,19 +1094,20 @@ function chado_phylogeny_import_tree_file($file_name, $format, $options = [], $j
   }
 
   // Get the phylotree record.
-  $values = ['phylotree_id' => $options['phylotree_id']];
-  $phylotree = chado_generate_var('phylotree', $values, [], $schema_name);
+  $query = $chado->select('1:phylotree', 'T');
+  $query->fields('T', ['phylotree_id', 'analysis_id', 'name', 'dbxref_id', 'comment', 'type_id']);
+  $query->condition('T.phylotree_id', $options['phylotree_id'], '=');
+  $phylotree = $query->execute()->fetchAll();
 
-  if (!$phylotree) {
+  if (!$phylotree || count($phylotree) < 1) {
     \Drupal::service('tripal.logger')->error(
       'Could not find the phylotree using the ID provided: %phylotree_id.',
       ['%phylotree_id' => $options['phylotree_id']], $options['message_opts']);
     return FALSE;
   }
+  $phylotree = $phylotree[0];
 
   // $transaction = db_transaction(); // OLD T3
-  $chado = \Drupal::service('tripal_chado.database');
-  $chado->setSchemaName($schema_name);
   $transaction_chado = $chado->startTransaction();
   // print "\nNOTE: Loading of this tree file is performed using a database transaction. \n" .
   //   "If the load fails or is terminated prematurely then the entire set of \n" .
@@ -1132,10 +1133,12 @@ function chado_phylogeny_import_tree_file($file_name, $format, $options = [], $j
     // Iterate through the tree nodes and add them to Chado in accordance
     // with the details in the $options array.
     chado_phylogeny_import_tree($tree, $phylotree, $options, [], NULL, $schema_name);
-  } catch (Exception $e) {
-    // $transaction->rollback(); // OLD T3
+  }
+  catch (Exception $e) {
     $transaction_chado->rollback();
-    watchdog_exception($options['message_type'], $e);
+    \Drupal::service('tripal.logger')->error(
+      $options['message_type'] . ': ' . $e->getMessage()
+    );
   }
 }
 

--- a/tripal_chado/tests/src/Kernel/api/ChadoOrganismAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoOrganismAPITest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\tripal_chado\Kernel\Api;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Group;
-
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 /**
  * Tests for API functions dealing with organisms.

--- a/tripal_chado/tests/src/Kernel/api/ChadoOrganismAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoOrganismAPITest.php
@@ -36,6 +36,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[CoversFunction('chado_get_organism_select_options')]
 #[CoversFunction('chado_abbreviate_infraspecific_rank')]
 #[CoversFunction('chado_unabbreviate_infraspecific_rank')]
+#[IgnoreDeprecations]
 class ChadoOrganismAPITest extends ChadoTestKernelBase {
 
   /**

--- a/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
@@ -85,8 +85,8 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
             'common_name' => 'False Tripal',
             'abbreviation' => 'T. ' . $species . ' subsp. sativus',
            ];
-    $query = $this->chado_connection->insert('1:organism');
-    $organism_id = $query->fields($org);
+    $query = $this->chado_connection->insert('1:organism')
+      ->fields($org);
     $organism_id = $query->execute();
     $this->assertEquals('1', $organism_id, 'Unable to insert test organism 1.');
     $organism_ids[0] = $organism_id;

--- a/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
@@ -115,7 +115,7 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
     // Test chado_phylogeny_get_node_types_vocab().
     // This function is expected to return an array with three terms.
     // It returns FALSE on error.
-    $vocab = chado_phylogeny_get_node_types_vocab($this->chado_connection, [], $this->schemaName);
+    $vocab = chado_phylogeny_get_node_types_vocab([], $this->schemaName);
     $this->assertIsArray($vocab, 'Did not return an array from chado_phylogeny_get_node_types_vocab()');
     $this->assertEquals(count($vocab), 3, 'Did not return the expected three node types from chado_phylogeny_get_node_types_vocab()');
   }

--- a/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
@@ -93,8 +93,8 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
 
     $org['infraspecific_name'] = 'selvaticus';
     $org['abbreviation'] = 'T. ' . $species . ' subsp. selvaticus';
-    $query = $this->chado_connection->insert('1:organism');
-    $organism_id = $query->fields($org);
+    $query = $this->chado_connection->insert('1:organism')
+      ->fields($org);
     $organism_id = $query->execute();
     $this->assertEquals('2', $organism_id, 'Unable to insert test organism 2.');
     $organism_ids[1] = $organism_id;

--- a/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
+++ b/tripal_chado/tests/src/Kernel/api/ChadoPhylogenyAPITest.php
@@ -68,9 +68,11 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
     $this->schemaName = $this->chado_connection->getSchemaName();
 
     // Lookup cvterm_id for 'subspecies'
-    $cvterm = chado_get_cvterm(['name' => 'subspecies'], [], $this->schemaName);
-    $this->assertNotNull($cvterm, 'Unable to retrieve cvterm for "subspecies" using chado_get_cvterm()');
-    $subspecies_id = $cvterm->cvterm_id;
+    $query = $this->chado_connection->select('1:cvterm', 't');
+    $query->condition('name', 'subspecies', '=');
+    $query->addField('t', 'cvterm_id', 'cvterm_id');
+    $subspecies_id = $query->execute()->fetchField();
+    $this->assertNotNull($subspecies_id, 'Unable to retrieve cvterm_id for "subspecies"');
 
     // Create two test organisms of the same genus and species
     $species = 'bogusii' . uniqid();
@@ -83,15 +85,19 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
             'common_name' => 'False Tripal',
             'abbreviation' => 'T. ' . $species . ' subsp. sativus',
            ];
-    $dbq = chado_insert_record('organism', $org, [], $this->schemaName);
-    $this->assertNotNull($dbq, 'Unable to insert test organism 1.');
-    $organism_ids[0] = $dbq['organism_id'];
+    $query = $this->chado_connection->insert('1:organism');
+    $organism_id = $query->fields($org);
+    $organism_id = $query->execute();
+    $this->assertEquals('1', $organism_id, 'Unable to insert test organism 1.');
+    $organism_ids[0] = $organism_id;
 
     $org['infraspecific_name'] = 'selvaticus';
     $org['abbreviation'] = 'T. ' . $species . ' subsp. selvaticus';
-    $dbq = chado_insert_record('organism', $org, [], $this->schemaName);
-    $this->assertNotNull($dbq, 'Unable to insert test organism 2.');
-    $organism_ids[1] = $dbq['organism_id'];
+    $query = $this->chado_connection->insert('1:organism');
+    $organism_id = $query->fields($org);
+    $organism_id = $query->execute();
+    $this->assertEquals('2', $organism_id, 'Unable to insert test organism 2.');
+    $organism_ids[1] = $organism_id;
 
     // Test chado_phylogeny_lookup_organism_by_name().
     // This function is expected to return an organism_id. It returns FALSE if
@@ -109,7 +115,7 @@ class ChadoPhylogenyAPITest extends ChadoTestKernelBase {
     // Test chado_phylogeny_get_node_types_vocab().
     // This function is expected to return an array with three terms.
     // It returns FALSE on error.
-    $vocab = chado_phylogeny_get_node_types_vocab([], $this->schemaName);
+    $vocab = chado_phylogeny_get_node_types_vocab($this->chado_connection, [], $this->schemaName);
     $this->assertIsArray($vocab, 'Did not return an array from chado_phylogeny_get_node_types_vocab()');
     $this->assertEquals(count($vocab), 3, 'Did not return the expected three node types from chado_phylogeny_get_node_types_vocab()');
   }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2295 

### ~~Depends on #2221~~ (Merged)

### ~~Depends on #2294~~ (Merged)

## Description

PR #2294 will deprecate a number of `chado_` api functions inherited from Tripal 3.

This PR replaces them in various importers.

## Testing?

~~Before testing `git merge origin/tv4g2-1341-deprecateChadoQueryAPI` so that deprecated functions show up in testing.~~
Automated tests should now catch any missed deprecations

Run each of the importers to verify that I have not broken anything.
To test obo importer on a local file you can use `modules/contrib/tripal/tripal_chado/tests/fixtures/obo_loader/test_EDAM.obo`