### PR TITLE
Newick importer file is required, and options match tripal 3

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/NewickImporter.php
@@ -24,8 +24,9 @@ use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
   require_analysis: true,
   button_text: new TranslatableMarkup('Import Newick Tree file'),
   file_upload: true,
-  file_remote: false,
-  file_required: false,
+  file_local: true,
+  file_remote: true,
+  file_required: true,
 )]
 class NewickImporter extends ChadoImporterBase {
 


### PR DESCRIPTION
# Bug Fix

### Closes #2298

## Description

The "file_required" setting for the Newick tree importer was incorrectly set to `false`, as a file is required to import.
I also turned on the remote file option, which matches the Tripal 3 settings.

## Testing?

Run the Newick tree importer and do not specify a file. You should now get a validation error that a file is required.

<img width="747" height="716" alt="newick-no-file" src="https://github.com/user-attachments/assets/cfb131ab-b450-49f0-a499-db8bf6a3214c" />