### PR TITLE
Add missing optional parameter to getChadoForeignKeyDef()

### DIFF
--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -471,7 +471,7 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
     $object_pkey_col = self::getPrimaryKey($linked_table, $schema);
     $all_tables = $schema->getTables(['type' => 'table']);
     foreach (array_keys($all_tables) as $table) {
-      $foreign_keys = self::getChadoForeignKeyDef($table, $schema);
+      $foreign_keys = self::getChadoForeignKeyDef($table, NULL, $schema);
       if ($foreign_keys) {
         // For "single-hop" logic, we add this table if there is a
         // foreign key to our linked_table.


### PR DESCRIPTION
# Bug Fix

### Closes #2253

## Description

This bug was introduce in PR #2260 when we moved the position of the `$schema` parameter. In this one case, the optional second table parameter was not present, and so the function call now fails.



## Testing?

1. Go to Tripal → Page Structure
2. For any content type, select "Manage Fields".
3. For any field, select "Edit".
4. On this branch the error should not occur. On 4.x we had:
`The website encountered an unexpected error. Try again later.`

`TypeError: Drupal\tripal_chado\TripalField\ChadoFieldItemBase::getChadoForeignKeyDef(): Argument #2 ($right_table) must be of type ?string, Drupal\tripal_chado\Database\ChadoSchema given, called in /var/www/drupal/web/modules/contrib/tripal/tripal_chado/src/TripalField/ChadoFieldItemBase.php on line 474 in Drupal\tripal_chado\TripalField\ChadoFieldItemBase::getChadoForeignKeyDef() (line 1293 of modules/contrib/tripal/tripal_chado/src/TripalField/ChadoFieldItemBase.php).`
