### PR TITLE
Fixes "Organism Autocomplete adds trailing whitespace when infraspecific name is not present"

### DIFF
--- a/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
@@ -13,12 +13,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class ChadoGenericAutocompleteController extends ControllerBase {
 
   /**
-   * Contains default values for options needed for this controllers methods.
+   * Contains default values for options needed for this controller's methods.
    *
    * These options are set when ::getDefaultOptions() is called.
    *
    * @var array
-   *   Populated by it's getter, this array will contain the default values for
+   *   Populated by its getter, this array will contain the default values for
    *   the options used in the various form methods.
    *   Keys match those defined for the ::getFormElement() $options paramater.
    */
@@ -98,7 +98,7 @@ class ChadoGenericAutocompleteController extends ControllerBase {
    * @param string $base_table
    *   Chado base table name.
    * @param string $column_name
-   *   Name of chado base column  in the specified table to be returned.
+   *   Name of chado base column in the specified table to be returned.
    * @param string $type_column
    *   If the base table has a type column, the column name. This is
    *   usually "type_id". Use a single character placeholder if absent.
@@ -120,7 +120,7 @@ class ChadoGenericAutocompleteController extends ControllerBase {
    *   name is added to the end of the key/value surrounded by square brackets.
    *   If the include_pkey property is TRUE then the primary key value is
    *   appended to the end of both the key and value surrounded by curved
-   *   brackets. e.g. 'ftbA-1 [gene] (42)'.
+   *   brackets, e.g. 'ftbA-1 [gene] (42)'.
    */
   public function handleGenericAutocomplete(
     Request $request,
@@ -168,9 +168,9 @@ class ChadoGenericAutocompleteController extends ControllerBase {
             $value .= ' (' . $record->pkey . ')';
           }
           $response[] = [
-          // Value returned and value displayed by textfield.
+            // Value returned and value displayed by textfield.
             'value' => $value,
-          // Value shown in the list of options.
+            // Value shown in the list of options.
             'label' => $value,
           ];
         }
@@ -293,7 +293,7 @@ class ChadoGenericAutocompleteController extends ControllerBase {
    * @return int
    *   Primary key ID number of the record, or 0 if an unparsable $value was
    *   passed, which can happen if the user did not let the autocomplete
-   *   supply a value. (e.g. 12).
+   *   supply a value, (e.g. 12).
    */
   public static function getPkeyId(string $value): int {
     $id = 0;

--- a/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tripal_chado\Controller;
 
+use Drupal\pgsql\Driver\Database\pgsql\Select;
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -69,13 +70,23 @@ class ChadoGenericAutocompleteController extends ControllerBase {
 
   /**
    * Controls whether a leading wildcard character is included.
+   *
    * Used by derived classes.
+   *
+   * @var string
+   *   Must be one of the following:
+   *   - CONTAINS: a leading wildcard character is added to the query allowing
+   *     an internal string match.
+   *   - STARTS_WITH: no leading wildcard character is added to the query,
+   *     requiring the beginning of the string to match.
    */
   protected string $match_operator = 'CONTAINS';
 
   /**
-   * Controller autocomplete method to use for any chado table
-   * where the returned value is from a single column.
+   * Generic Chado autocomplete method.
+   *
+   * NOTE: This is suitable to use for any chado table where the returned value
+   * is from a single column.
    *
    * For simplicity, this autocomplete assumes that the primary key
    * of the base table is the base table name + '_id', and that the
@@ -85,47 +96,52 @@ class ChadoGenericAutocompleteController extends ControllerBase {
    * autocomplete value includes the primary key numeric value in
    * parentheses at the end, e.g. "Impressive Publication (42)".
    *
-   * @param Request request
-   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   Represents the current HTTP request.
    * @param string $base_table
-   *   Chado base table name
-   *
+   *   Chado base table name.
    * @param string $column_name
-   *   Name of chado base column to be returned
-   *
+   *   Name of chado base column  in the specified table to be returned.
    * @param string $type_column
    *   If the base table has a type column, the column name. This is
    *   usually "type_id". Use a single character placeholder if absent.
-   *
    * @param string $property_table
-   *   Property table name, use same name as base table if not needed
-   *
+   *   Property table name, use same name as base table if not needed.
    * @param int $match_limit
-   *   Desired number of matching names to suggest.
-   *   Default to 10 items.
-   *   If set to zero, then autocomplete is disabled.
-   *   Must be declared in autocomplete route parameter e.g. ['match_limit' => 15].
-   *
+   *   Desired number of matching names to suggest. See ::getDefaultOptions()
+   *   for the default value. If set to zero, then autocomplete is disabled.
+   *   Define in autocomplete route parameter e.g. ['match_limit' => 15].
    * @param int $type_id
-   *   Publication type set in pub.type_id to restrict publications to specific type.
-   *   Default to 0, return publications regardless of type.
-   *   Must be declared in autocomplete route parameter e.g. ['type_id' => 0].
+   *   Restricts the results returned to a specific type. This must be a value
+   *   present in the $type_column and also present in the chado cvterm table.
+   *   Set to 0 in order to not restrict to a specific type.
+   *   Define in autocomplete route parameter e.g. ['type_id' => 0].
    *
-   * @return Json Object
-   *   Matching publication rows in an array where pub title
-   *   is both the value to the array keys label and value.
+   * @return Symfony\Component\HttpFoundation\JsonResponse
+   *   Matching table results in an array where the value of the $column_name
+   *   column is both the key and the value. If $type_id is provided, the type
+   *   name is added to the end of the key/value surrounded by square brackets.
+   *   If the include_pkey property is TRUE then the primary key value is
+   *   appended to the end of both the key and value surrounded by curved
+   *   brackets. e.g. 'ftbA-1 [gene] (42)'.
    */
-  public function handleGenericAutocomplete(Request $request,
-     string $base_table, string $column_name, string $type_column, string $property_table,
-     int $match_limit = 10, int $type_id = 0) {
+  public function handleGenericAutocomplete(
+    Request $request,
+    string $base_table,
+    string $column_name,
+    string $type_column,
+    string $property_table,
+    int $match_limit = 10,
+    int $type_id = 0,
+  ) {
 
     // Array to hold matching records.
     $response = [];
 
-    // The string to autocomplete from the form input
+    // The string to autocomplete from the form input.
     $string = trim($request->query->get('q'));
 
-    // Generate a database query
+    // Generate a database query.
     $options = [
       'base_table' => $base_table,
       'column_name' => $column_name,
@@ -138,25 +154,27 @@ class ChadoGenericAutocompleteController extends ControllerBase {
     $query = self::getQuery($string, $options);
 
     if ($query) {
-      // Perform the database query
+      // Perform the database query.
       $results = $query->execute();
 
-      // Compose the response
+      // Compose the response.
       if ($results) {
         while ($record = $results->fetchObject()) {
-          // Strip HTML tags if present, e.g. in Pub title
+          // Strip HTML tags if present, e.g. in Pub title.
           $value = strip_tags($record->value);
-          // Append the type when available
+          // Append the type when available.
           if (property_exists($record, 'type') and $record->type) {
             $value .= ' [' . $record->type . ']';
           }
-          // Append the chado pkey id value
+          // Append the chado pkey id value.
           if ($this->include_pkey) {
             $value .= ' (' . $record->pkey . ')';
           }
           $response[] = [
-            'value' => $value, // Value returned and value displayed by textfield.
-            'label' => $value, // Value shown in the list of options.
+          // Value returned and value displayed by textfield.
+            'value' => $value,
+          // Value shown in the list of options.
+            'label' => $value,
           ];
         }
       }
@@ -173,29 +191,34 @@ class ChadoGenericAutocompleteController extends ControllerBase {
    * @param string $string
    *   The string to be autocompleted, used to limit the query.
    *   The string "%" has the special meaning of return all records.
-   *
    * @param array $options
    *   The following keys are used:
-   *     base_table - Chado base table name (required)
-   *     column_name - Name of chado base column to be returned (required)
-   *     pkey_id - The primary key of the base table, defaults to base_table . "_id"
-   *     type_column - If the base table has a type column, holds the column name. This is
-   *                   usually "type_id". Use a single character placeholder if absent.
-   *     property_table - Property table name, use same name as base table if not needed
-   *     property_type_column - type column in property table, defaults to "type_id"
-   *     type_id - Used to restrict records to those of a specific type.
-   *               Default to 0, return records regardless of type.
-   *               Must be declared in autocomplete route parameter e.g. ['type_id' => 0].
-   *     match_operator - Either 'CONTAINS' (default) or 'STARTS_WITH'.
-   *     match_limit - Desired number of autocomplete matching names to suggest, default 10.
-   *                   If zero, there is no limit.
+   *   - base_table (string): Chado base table name (required; e.g. pub).
+   *   - column_name (string): Name of chado column to be returned (e.g. title).
+   *   - pkey_id (string): The primary key of the base table, defaults to
+   *     base_table + "_id" (e.g. pub_id)
+   *   - type_column (string): If the base table has a type column, holds the
+   *     column name. This is usually "type_id". Use a single character
+   *     placeholder if absent (e.g. "-").
+   *   - property_table (string): the name of the property table name associated
+   *     with this base table. If the type is stored in the base table then use
+   *     same name as base table here. (e.g. pubprop)
+   *   - property_type_column (string): type column in property table,
+   *     defaults to "type_id". This is only used if the property_table is not
+   *     the same as the base table.
+   *   - type_id (int): Used to restrict records to those of a specific type.
+   *     Set to 0 in order to not restrict to a specific type.
+   *     Define in autocomplete route parameter e.g. ['type_id' => 0].
+   *   - match_operator (string): Either 'CONTAINS' (default) or 'STARTS_WITH'.
+   *   - match_limit (int): Desired number of autocomplete matching names to
+   *     suggest, default 10. If zero, there is no limit.
    *
-   * @return ?\Drupal\pgsql\Driver\Database\pgsql\Select $query
+   * @return ?\Drupal\pgsql\Driver\Database\pgsql\Select
    *   A database query object
    */
-  public static function getQuery(string $string, array $options): ?\Drupal\pgsql\Driver\Database\pgsql\Select {
+  public static function getQuery(string $string, array $options): ?Select {
 
-    // Set defaults
+    // Set defaults.
     $options['pkey_id'] ??= $options['base_table'] . '_id';
     $options['type_column'] ??= '.';
     $options['property_table'] ??= $options['base_table'];
@@ -211,7 +234,7 @@ class ChadoGenericAutocompleteController extends ControllerBase {
 
       $connection = \Drupal::service('tripal_chado.database');
 
-      // Sanitization, placeholders cannot be used for column and table names
+      // Sanitization, placeholders cannot be used for column and table names.
       $base_table = $connection->escapeTable($options['base_table']);
       $pkey_id = $connection->escapeTable($options['pkey_id']);
       $column_name = $connection->escapeTable($options['column_name']);
@@ -261,17 +284,19 @@ class ChadoGenericAutocompleteController extends ControllerBase {
   }
 
   /**
-   * Fetch the pkey id number, given an autocomplete value with a numeric
-   * ID in parentheses at the end of the string.
+   * Fetch the pkey id number from an autocomplete value.
+   *
+   * Assumes the primary key value is present at the end of the string in
+   * curved brackets.
    *
    * @param string $value
    *   A value from an autocomplete with the ID in parentheses at the end,
-   *   earlier parentheses are ignored, e.g. "Some (Big) Analysis (12)"
+   *   earlier parentheses are ignored, e.g. "Some (Big) Analysis (12)".
    *
    * @return int
    *   Primary key ID number of the record, or 0 if an unparsable $value was
    *   passed, which can happen if the user did not let the autocomplete
-   *   supply a value.
+   *   supply a value. (e.g. 12).
    */
   public static function getPkeyId(string $value): int {
     $id = 0;

--- a/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
@@ -12,8 +12,58 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class ChadoGenericAutocompleteController extends ControllerBase {
 
   /**
-   * Controls whether the primary key is included in the response in
-   * parentheses. Used by derived classes.
+   * Contains default values for options needed for this controllers methods.
+   *
+   * These options are set when ::getDefaultOptions() is called.
+   *
+   * @var array
+   *   Populated by it's getter, this array will contain the default values for
+   *   the options used in the various form methods.
+   *   Keys match those defined for the ::getFormElement() $options paramater.
+   */
+  protected static array $default_options = [];
+
+  /**
+   * Retrieves the default options used by the form element methods.
+   *
+   * @return array
+   *   The default values for the options used in the various form methods.
+   *   Keys match those defined for the ::getFormElement() $options paramater.
+   */
+  public static function getDefaultOptions(): array {
+
+    // We can use static in-memory caching to save grabbing from settings
+    // multiple times in a single page load.
+    if (!empty($this->default_options)) {
+      return $this->default_options;
+    }
+
+    // If the options have not been set yet, then we need to grab them from
+    // the tripal config settings.
+    $settings = \Drupal::config('tripal.settings');
+    $default_options = [
+      'select_limit' => $settings->get('tripal_entity_type.widget_global_select_limit') ?? 50,
+      'match_limit' => $settings->get('tripal_entity_type.match_limit') ?? 10,
+      'match_operator' => $settings->get('tripal_entity_type.match_operator') ?? 'CONTAINS',
+      'size' => $settings->get('tripal_entity_type.size'),
+      'placeholder' => $settings->get('tripal_entity_type.placeholder'),
+    ];
+    $this->default_options = $default_options;
+
+    // Sync the match operator property with the settings.
+    $this->match_operator = $default_options['match_operator'];
+
+    return $default_options;
+  }
+
+  /**
+   * Indicates if the primary key should be added to the response.
+   *
+   * Used by derived classes.
+   *
+   * @var bool
+   *   If TRUE then the primary key is added to the end of the response string
+   *   within curved brackets. If FALSE then it is not.
    */
   protected bool $include_pkey = TRUE;
 

--- a/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoGenericAutocompleteController.php
@@ -35,8 +35,8 @@ class ChadoGenericAutocompleteController extends ControllerBase {
 
     // We can use static in-memory caching to save grabbing from settings
     // multiple times in a single page load.
-    if (!empty($this->default_options)) {
-      return $this->default_options;
+    if (!empty(static::$default_options)) {
+      return static::$default_options;
     }
 
     // If the options have not been set yet, then we need to grab them from
@@ -49,10 +49,7 @@ class ChadoGenericAutocompleteController extends ControllerBase {
       'size' => $settings->get('tripal_entity_type.size'),
       'placeholder' => $settings->get('tripal_entity_type.placeholder'),
     ];
-    $this->default_options = $default_options;
-
-    // Sync the match operator property with the settings.
-    $this->match_operator = $default_options['match_operator'];
+    static::$default_options = $default_options;
 
     return $default_options;
   }

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -34,9 +34,10 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     // The string to autocomplete from the form input.
     $string = trim($request->query->get('q'));
 
+    $default_options = $this->getDefaultOptions();
     $options = [
-      'match_limit' => $match_limit,
-      'match_operator' => $this->match_operator,
+      'match_limit' => $match_limit ?? $default_options['match_limit'],
+      'match_operator' => $default_options['match_operator'],
     ];
 
     $query = $this->getQuery($string, $options);
@@ -79,8 +80,9 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   public static function getQuery(string $string, array $options): ?Select {
 
     // Set defaults.
-    $options['match_operator'] ??= 'CONTAINS';
-    $options['match_limit'] ??= 10;
+    $default_options = $this->getDefaultOptions();
+    $options['match_operator'] ??= $default_options['match_operator'];
+    $options['match_limit'] ??= $default_options['match_limit'];
 
     // Generate a query only if $string is at least a character
     // long and result count is set to a value greater than 0.
@@ -172,17 +174,8 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
    */
   public static function getFormElement(array $element, mixed $default, array $options = []): ?array {
 
-    $settings = \Drupal::config('tripal.settings');
-
     // Set the default options if they are not provided.
-    $default_options = [
-      'select_limit' => $settings->get('tripal_entity_type.widget_global_select_limit') ?? 50,
-      'match_limit' => $settings->get('tripal_entity_type.match_limit') ?? 10,
-      'match_operator' => $settings->get('tripal_entity_type.match_operator') ?? 'CONTAINS',
-      'size' => $settings->get('tripal_entity_type.size'),
-      'placeholder' => $settings->get('tripal_entity_type.placeholder'),
-    ];
-
+    $default_options = $this->getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -232,17 +225,9 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
    *   A form element array, either a select element.
    */
   public static function getSelectElement(array $element, mixed $default, array $options = []): ?array {
-    $settings = \Drupal::config('tripal.settings');
 
     // Set the default options if they are not provided.
-    $default_options = [
-      'select_limit' => $settings->get('tripal_entity_type.widget_global_select_limit') ?? 50,
-      'match_limit' => $settings->get('tripal_entity_type.match_limit') ?? 10,
-      'match_operator' => $settings->get('tripal_entity_type.match_operator') ?? 'CONTAINS',
-      'size' => $settings->get('tripal_entity_type.size'),
-      'placeholder' => $settings->get('tripal_entity_type.placeholder'),
-    ];
-
+    $default_options = $this->getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -285,17 +270,9 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
    *   A form element array, an autocomplete.
    */
   public static function getAutocompleteElement(array $element, mixed $default, array $options = []): ?array {
-    $settings = \Drupal::config('tripal.settings');
 
     // Set the default options if they are not provided.
-    $default_options = [
-      'select_limit' => $settings->get('tripal_entity_type.widget_global_select_limit') ?? 50,
-      'match_limit' => $settings->get('tripal_entity_type.match_limit') ?? 10,
-      'match_operator' => $settings->get('tripal_entity_type.match_operator') ?? 'CONTAINS',
-      'size' => $settings->get('tripal_entity_type.size'),
-      'placeholder' => $settings->get('tripal_entity_type.placeholder'),
-    ];
-
+    $default_options = $this->getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -357,6 +334,10 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     // Construct a query
     // A single wildcard indicates that all records are to be returned.
     $string = '%';
+
+    // Get the default options.
+    $options['select_limit'] ??= $this->getDefaultOptions()['select_limit'];
+
     // Add one to select limit so we know if it is exceeded.
     $count_options = $options;
     $count_options['match_limit'] = $options['select_limit'] + 1;

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -34,7 +34,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     // The string to autocomplete from the form input.
     $string = trim($request->query->get('q'));
 
-    $default_options = $this->getDefaultOptions();
+    $default_options = static::getDefaultOptions();
     $options = [
       'match_limit' => $match_limit ?? $default_options['match_limit'],
       'match_operator' => $default_options['match_operator'],
@@ -80,7 +80,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   public static function getQuery(string $string, array $options): ?Select {
 
     // Set defaults.
-    $default_options = $this->getDefaultOptions();
+    $default_options = static::getDefaultOptions();
     $options['match_operator'] ??= $default_options['match_operator'];
     $options['match_limit'] ??= $default_options['match_limit'];
 
@@ -174,7 +174,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   public static function getFormElement(array $element, mixed $default, array $options = []): ?array {
 
     // Set the default options if they are not provided.
-    $default_options = $this->getDefaultOptions();
+    $default_options = static::getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -226,7 +226,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   public static function getSelectElement(array $element, mixed $default, array $options = []): ?array {
 
     // Set the default options if they are not provided.
-    $default_options = $this->getDefaultOptions();
+    $default_options = static::getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -277,7 +277,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   public static function getAutocompleteElement(array $element, mixed $default, array $options = []): ?array {
 
     // Set the default options if they are not provided.
-    $default_options = $this->getDefaultOptions();
+    $default_options = static::getDefaultOptions();
     foreach ($default_options as $key => $value) {
       if (!isset($options[$key])) {
         $options[$key] = $value;
@@ -342,7 +342,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     $string = '%';
 
     // Get the default options.
-    $options['select_limit'] ??= $this->getDefaultOptions()['select_limit'];
+    $options['select_limit'] ??= static::getDefaultOptions()['select_limit'];
 
     // Add one to select limit so we know if it is exceeded.
     $count_options = $options;

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -100,10 +100,12 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
       $query->addField('BT', 'organism_id', 'pkey');
       $query->addField('BT', 'abbreviation', 'abbreviation');
       $query->addField('BT', 'common_name', 'common_name');
-      $query->addExpression("CONCAT_WS(' ', genus, species, name, infraspecific_name)", 'organism');
+      $query->addExpression("RTRIM(CONCAT_WS(' ', genus, species, name, infraspecific_name))", 'organism');
 
       // A single "%" wildcard is used to indicate that we should return
       // all records. This is used for a form select element.
+      // Note: We don't need to trim here since this is a partial string
+      // comparison.
       if ($string != '%') {
         $query->where("CONCAT_WS(' ', genus, species, name, infraspecific_name) ILIKE :value",
             [':value' => $condition_value]);

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -160,14 +160,13 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
    *   The default value, either an integer pkey ID or a string.
    * @param array $options
    *   The following keys are used:
-   *   select_limit - The maximum number of options to show in a select list.
-   *                If the number of possible options exceeds this limit,
-   *               an autocomplete text field is returned instead.
-   *              A value of zero means always use an autocomplete.
-   *   match_operator - Either 'CONTAINS' (default) or 'STARTS_WITH'.
-   *   match_limit - Desired number of autocomplete matching names to suggest.
-   *   size - The size of the textfield for autocomplete.
-   *   placeholder - Placeholder text for the autocomplete textfield.
+   *   - select_limit: The maximum number of options to show in a select list
+   *   before switching to an autocomplete instead. A value of zero means always
+   *   use an autocomplete.
+   *   - match_operator: Either 'CONTAINS' (default) or 'STARTS_WITH'.
+   *   - match_limit: Desired number of autocomplete matching names to suggest.
+   *   - size: The size of the textfield for autocomplete.
+   *   - placeholder: Placeholder text for the autocomplete textfield.
    *
    * @return array|null
    *   A form element array, either a select or an autocomplete.
@@ -233,8 +232,12 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
         $options[$key] = $value;
       }
     }
+
+    // Retrieve the organism to provide in the select list.
     $select_options = self::getSelectOptions($options);
     natcasesort($select_options);
+
+    // Determine the default value.
     $default_id = 0;
     if (gettype($default) == 'integer') {
       $default_id = $default;
@@ -242,6 +245,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     elseif (gettype($default) == 'string') {
       $default_id = self::getPkeyId($default);
     }
+
     $element = [
       '#type' => 'select',
       '#options' => $select_options,
@@ -249,6 +253,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
       '#empty_option' => t('- Select -'),
     ];
     $element['#element_validate'] = [[static::class, 'validateAutocomplete']];
+
     return $element;
   }
 
@@ -331,7 +336,8 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
    *   infraspecific columns.
    */
   public static function getSelectOptions(array $options): ?array {
-    // Construct a query
+
+    // Construct a query.
     // A single wildcard indicates that all records are to be returned.
     $string = '%';
 
@@ -341,14 +347,17 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
     // Add one to select limit so we know if it is exceeded.
     $count_options = $options;
     $count_options['match_limit'] = $options['select_limit'] + 1;
+
     $query = self::getQuery($string, $count_options);
     $results = $query->execute();
+
     $select_options = [];
     while ($record = $results->fetchObject()) {
       // Strip HTML tags if present, but this is not likely for organism.
       $organism = strip_tags($record->abbreviation ?: $record->organism ?? '');
       $select_options[$record->pkey] = $organism;
     }
+
     return $select_options;
   }
 

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -268,7 +268,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
   }
 
   /**
-   * Provides a Drupal textfield form element that autocompletes with chado organisms.
+   * Provides a textfield form element that autocompletes with chado organisms.
    *
    * @param array $element
    *   The form element array to be populated.


### PR DESCRIPTION
# Bug Fix

### Issue #2302 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This has apparently been a problem for awhile and applies to both the new `Drupal\tripal_chado\Controller\ChadoOrganismFormElementController` and the old `Drupal\tripal_chado\Controller\ChadoOrganismAutocompleteController`.

Specifically, the getQuery() method uses PostgreSQL concatenation to generate the scientific name (`organism` alias) of the organism. If the abbreviation is present then that is used and if not, this scientific name is used.

```php
$query = $connection->select('1:organism', 'BT');
$query->leftJoin('1:cvterm', 'T', '"BT".type_id = "T".cvterm_id');
$query->addField('BT', 'organism_id', 'pkey');
$query->addField('BT', 'abbreviation', 'abbreviation');
$query->addField('BT', 'common_name', 'common_name');
$query->addExpression("CONCAT_WS(' ', genus, species, name, infraspecific_name)", 'organism');
```

This results in the following options:

<img width="791" height="103" alt="Image" src="https://github.com/user-attachments/assets/cfe8975b-f607-42ab-9d76-db579a536db7" />

### Tasks

- [x] Add `RTRIM()` to the expression to ensure trailing whitespace is removed.
- [x] Add static getDefaultOptions() method to the generic controller to harmonize the default values for options to a single place and pave the road for adding form element handlers to all other autocompletes.
- [x] Improve adherance to coding standards in both the new organism controller and the generic autocomplete controller.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Automated testing

Both of these classes had full automated test coverage already. I did not make any changes to ensure nothing was broken in the process.

### Manual testing

1. Add a number of different organism with various combinations of infraspecific name/type and not. Also make sure to not set the abbreviation when testing the whitespace bug as abbreviation takes precedence.
2. Using `drush php:cli` you can use the following command to get the select options making it easy to check for trailing whitespace.

```php
Drupal\tripal_chado\Controller\ChadoOrganismFormElementController::getSelectOptions([]);
```