### PR TITLE
Fix discover bug by checking for foreign key in both directions

### DIFF
--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -994,8 +994,10 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
         // Some materialized views may look like a linker table, but if
         // there is no primary key, we can't use it, e.g. analysis_organism.
         $linker_pkey = self::getPrimaryKey($linking_table, $options['chado']->schema());
+        // Make sure a foreign key exists in both directions.
         $fk_def = self::getChadoForeignKeyDef($linking_table, $options['table'], $options['chado']->schema());
-        if ($linker_pkey && $fk_def) {
+        $bt_fk_def = self::getChadoForeignKeyDef($linking_table, $options['base_table'], $options['chado']->schema());
+        if ($linker_pkey && $fk_def && $bt_fk_def) {
           $linker_fkey_column = array_keys($fk_def['columns'])[0];
           // Check for existing fields of this type.
           if (array_key_exists($options['id'], $field_types)) {


### PR DESCRIPTION
# Bug Fix

### Closes #2304 

## Description

During field discovery, a linking table needs to have a foreign key both to the linked table, but also to the base table.
This second foreign key was never actually checked, so in the case of the "special" linking table `featureanalysis` a bug showed up and this table was used to link contact and analysis which resulted in a wsod.

## Testing?
Tripal -> Page Structure -> **Contact** -> Manage Fields
+Check for new fields
You should **not** see this field in the list any more: Analysis (contact_analysis): Apply analytical methods to existing data of a specific type.