### PR TITLE
Apparently we can configure automated release note generation

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,32 @@
+changelog:
+  categories:
+    - title: "Deprecations"
+      labels:
+        - "Includes Deprecations"
+    - title: "Bug Fixes"
+      labels:
+        - "bug - confirmed"
+        - "bug - external"
+        - "bug - potential"
+    - title: "Content Pages, Fields + Display"
+      labels:
+        - "Group 1 -  Tripal Content Types | Terms | Fields"
+        - "Group 7 - Page Display"
+    - title: "Biological Data Storage + Import"
+      labels:
+        - "Group 2 - Data Storage | Tripal DBX | Chado"
+        - "Group 4 - Data Importing"
+    - title: "Searching + Web Services"
+      labels:
+        - "Group 5 - Search | ElasticSearch | Views"
+        - "Group 6 - Web Services"
+    - title: "Performance Improvements"
+      labels:
+        - "Group 10 - Performance"
+    - title: "General Maitenance + Automated Testing"
+      labels:
+        - "Group 0 - Maintenance | Docker | Misc"
+        - "Group 9 - Automated Testing"
+    - title: "Other Changes"
+      labels:
+        - "*" # This special label matches any content not covered by other labels

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,31 +1,31 @@
 changelog:
   categories:
-    - title: "Deprecations"
+    - title: 'Deprecations'
       labels:
-        - "Includes Deprecations"
-    - title: "Bug Fixes"
+        - 'Includes Deprecations'
+    - title: 'Bug Fixes'
       labels:
-        - "bug - confirmed"
-        - "bug - external"
-        - "bug - potential"
-    - title: "Content Pages, Fields + Display"
+        - 'bug - confirmed'
+        - 'bug - external'
+        - 'bug - potential'
+    - title: 'Content Pages, Fields + Display'
       labels:
-        - "Group 1 -  Tripal Content Types | Terms | Fields"
-        - "Group 7 - Page Display"
-    - title: "Biological Data Storage + Import"
+        - 'Group 1 -  Tripal Content Types | Terms | Fields'
+        - 'Group 7 - Page Display'
+    - title: 'Biological Data Storage + Import'
       labels:
-        - "Group 2 - Data Storage | Tripal DBX | Chado"
-        - "Group 4 - Data Importing"
-    - title: "Searching + Web Services"
+        - 'Group 2 - Data Storage | Tripal DBX | Chado'
+        - 'Group 4 - Data Importing'
+    - title: 'Searching + Web Services'
       labels:
-        - "Group 5 - Search | ElasticSearch | Views"
-        - "Group 6 - Web Services"
-    - title: "Performance Improvements"
+        - 'Group 5 - Search | ElasticSearch | Views'
+        - 'Group 6 - Web Services'
+    - title: 'Performance Improvements'
       labels:
-        - "Group 10 - Performance"
-    - title: "Automated Testing"
+        - 'Group 10 - Performance'
+    - title: 'Automated Testing'
       labels:
-        - "Group 9 - Automated Testing"
-    - title: "Other Changes"
+        - 'Group 9 - Automated Testing'
+    - title: 'Other Changes'
       labels:
-        - "*" # This special label matches any content not covered by other labels
+        - '*' # This special label matches any content not covered by other labels

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -23,9 +23,8 @@ changelog:
     - title: "Performance Improvements"
       labels:
         - "Group 10 - Performance"
-    - title: "General Maitenance + Automated Testing"
+    - title: "Automated Testing"
       labels:
-        - "Group 0 - Maintenance | Docker | Misc"
         - "Group 9 - Automated Testing"
     - title: "Other Changes"
       labels:


### PR DESCRIPTION

# Tripal 4 Core Dev Task 

### Issue #2307 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Configure automated release note generation to use categories. Specifically needed because this particular release notes is very long.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Not sure we can test it but spelling + opinions would be great!