### PR TITLE
Add php 8.4 support - 1 of 2

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '4.x'
-      - 'tv4g0-2208-codeclimateToQltyCloud'
+      - 'tv4g0-issue2247-support-php-8.4'
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -27,6 +27,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         pgsql-version:
           - '13'
           - '14'
@@ -96,10 +97,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }},installchado=FALSE'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.3 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -110,8 +111,8 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.3, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'latest'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '4.x'
-      - 'tv4g0-issue2247-support-php-8.4'
+      - 'tv4g0-issue2247-support-php-8.4-docker'
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -41,6 +41,12 @@ jobs:
           - '11.2.x-dev'
           - '11.x-dev'
         exclude:
+          ## Only Drupal 11.x supports PHP 8.4
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          ## Drupal 11.x requires PHP 8.3+
           - php-version: '8.1'
             drupal-version: '11.1.x-dev'
           - php-version: '8.2'
@@ -53,6 +59,7 @@ jobs:
             drupal-version: '11.x-dev'
           - php-version: '8.2'
             drupal-version: '11.x-dev'
+          ## Drupal 11.x requires PostgreSQL 16+
           - pgsql-version: '13'
             drupal-version: '11.1.x-dev'
           - pgsql-version: '14'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -104,10 +104,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }},installchado=FALSE'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.3 + postgresql 17
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -118,8 +118,8 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.3, PgSQL 17'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'latest'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -37,6 +37,12 @@ jobs:
           - '11.2.x-dev'
           - '11.x-dev'
         exclude:
+          ## Only Drupal 11.x supports PHP 8.4
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          ## Drupal 11.x requires PHP 8.3+
           - php-version: '8.1'
             drupal-version: '11.1.x-dev'
           - php-version: '8.2'
@@ -49,6 +55,7 @@ jobs:
             drupal-version: '11.x-dev'
           - php-version: '8.2'
             drupal-version: '11.x-dev'
+          ## Drupal 11.x requires PostgreSQL 16+
           - pgsql-version: '13'
             drupal-version: '11.1.x-dev'
           - pgsql-version: '14'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -23,6 +23,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         pgsql-version:
           - '13'
           - '14'
@@ -82,10 +83,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.3 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -97,8 +98,8 @@ jobs:
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.3, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'latest'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -90,10 +90,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.3 + postgresql 17
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -105,8 +105,8 @@ jobs:
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.3, PgSQL 17'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'latest'


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Issue #2247 

## Description

This only adds building of php 8.4 dockers, so that part 2 of this PR will have dockers available for tests.

## Testing?
?
8.4 images should be present after merge and workflow has run at https://hub.docker.com/r/tripalproject/tripaldocker-drupal/tags