### PR TITLE
We missed one Drupal 10.x - PHP 8.4 incompatibility

### DIFF
--- a/.github/workflows/MAIN-composerInstall.yml
+++ b/.github/workflows/MAIN-composerInstall.yml
@@ -33,6 +33,11 @@ jobs:
           - '11.1.x-dev'
           - '11.2.x-dev'
         exclude:
+          # Only Drupal 11.x supports PHP 8.4
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
           # Drupal 11+ requires at least php 8.3.
           - php-version: '8.1'
             drupal-version: '11.1.x-dev'


### PR DESCRIPTION
# Bug Fix

### Issue #2247

## Description

This fixes one case we missed where Drupal 10.x does not support PHP 8.4
<img width="354" height="816" alt="10 x-8 4" src="https://github.com/user-attachments/assets/9ac923f6-b063-436b-86ab-c99f51dbf8e0" />

## Testing?
Code review, this only shows up after a PR merge 🙈
