### PR TITLE
Add Field::mainDisplayPropertyName() for use as the title/url token value and fix Field::mainDisplayPropertyName()

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -551,8 +551,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         /** @var \Drupal\Core\TypedData\TypedDataInterface $prop **/
         $props = $item->getProperties();
         $main_prop_key = NULL;
-        if (method_exists($item, 'mainPropertyName')) {
+        if (method_exists($item, 'mainDisplayPropertyName')) {
           $main_prop_key = $item->mainDisplayPropertyName();
+        }
+        elseif (method_exists($item, 'mainPropertyName')) {
+          $main_prop_key = $item->mainPropertyName();
         }
         if (is_array($props)) {
           foreach ($props as $prop) {

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -552,7 +552,7 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         $props = $item->getProperties();
         $main_prop_key = NULL;
         if (method_exists($item, 'mainPropertyName')) {
-          $main_prop_key = $item->mainPropertyName();
+          $main_prop_key = $item->mainDisplayPropertyName();
         }
         if (is_array($props)) {
           foreach ($props as $prop) {

--- a/tripal/src/TripalField/Interfaces/TripalFieldItemInterface.php
+++ b/tripal/src/TripalField/Interfaces/TripalFieldItemInterface.php
@@ -9,6 +9,17 @@ use Drupal\tripal\Entity\TripalEntityType;
 interface TripalFieldItemInterface extends FieldItemInterface {
 
   /**
+   * Returns the main property to be used for display.
+   *
+   * Note: this is used as the value for tokens for this field such as in
+   * the title and URL.
+   *
+   * @return string
+   *   The name of a property returned by tripalTypes.
+   */
+  public static function mainDisplayPropertyName();
+
+  /**
    * Returns the tripal storage plugin id for this field.
    *
    * @return string

--- a/tripal/src/TripalField/TripalFieldItemBase.php
+++ b/tripal/src/TripalField/TripalFieldItemBase.php
@@ -26,6 +26,13 @@ abstract class TripalFieldItemBase extends FieldItemBase implements TripalFieldI
   /**
    * {@inheritdoc}
    */
+  public static function mainDisplayPropertyName() {
+    return 'value';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function defaultFieldSettings() {
     $settings = [
       'termIdSpace' => '',

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -33,7 +33,15 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return 'type_id';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'term_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'analysis_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoArrayDesignTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoArrayDesignTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'array_design_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'assay_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoBiomaterialTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoBiomaterialTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'biomaterial_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactByRoleTypeDefault.php
@@ -30,7 +30,15 @@ class ChadoContactByRoleTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'contact_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoContactTypeDefault.php
@@ -30,7 +30,15 @@ class ChadoContactTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'contact_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoDbxrefTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoDbxrefTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'dbxref_accession';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureMapTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoFeatureMapTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'featuremap_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -32,7 +32,15 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'feature_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoOrganismTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoOrganismTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'organism_scientific_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProjectTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoProjectTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'project_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPropertyTypeDefault.php
@@ -29,6 +29,22 @@ class ChadoPropertyTypeDefault extends ChadoFieldItemBase {
   /**
    * {@inheritdoc}
    */
+  public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'value';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
+    return 'value';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function defaultStorageSettings() {
     $settings = parent::defaultStorageSettings();
     $settings['storage_plugin_settings']['prop_table'] = '';

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoProtocolTypeDefault.php
@@ -31,7 +31,15 @@ class ChadoProtocolTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'protocol_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPubTypeDefault.php
@@ -32,7 +32,15 @@ class ChadoPubTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'pub_title';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoRelationshipTypeDefault.php
@@ -36,7 +36,15 @@ class ChadoRelationshipTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return 'linker_id';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'value';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceChecksumTypeDefault.php
@@ -28,6 +28,15 @@ class ChadoSequenceChecksumTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'md5checksum';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'md5checksum';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceCoordinatesDefault.php
@@ -30,6 +30,15 @@ class ChadoSequenceCoordinatesDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'sequence_coordinates';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'sequence_coordinates';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceLengthTypeDefault.php
@@ -27,6 +27,15 @@ class ChadoSequenceLengthTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'seqlen';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'seqlen';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSequenceTypeDefault.php
@@ -30,6 +30,15 @@ class ChadoSequenceTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'residues';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'residues';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSourceDataTypeDefault.php
@@ -28,14 +28,23 @@ class ChadoSourceDataTypeDefault extends ChadoFieldItemBase {
   /**
    * {@inheritdoc}
    */
-  public static function mainPropertyName()  {
+  public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
     return 'sourcename';
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritdoc}
    */
-  public static function defaultFieldSettings()  {
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
+    return 'sourcename';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultFieldSettings() {
     $settings = parent::defaultFieldSettings();
     $settings['termIdSpace'] = 'local';
     $settings['termAccession'] = 'source_data';

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStockTypeDefault.php
@@ -32,7 +32,15 @@ class ChadoStockTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'stock_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoStudyTypeDefault.php
@@ -30,7 +30,15 @@ class ChadoStudyTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
-    // Overrides the default of 'value'
+    // The property that indicates if this field is empty.
+    return self::$object_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'study_name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoSynonymTypeDefault.php
@@ -30,6 +30,15 @@ class ChadoSynonymTypeDefault extends ChadoFieldItemBase {
    * {@inheritdoc}
    */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
+    return 'linker_synonym_fkey_id';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
     return 'name';
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoUnitTypeDefault.php
@@ -26,9 +26,18 @@ class ChadoUnitTypeDefault extends ChadoFieldItemBase {
 
   /**
    * {@inheritdoc}
-  */
+   */
   public static function mainPropertyName() {
+    // The property that indicates if this field is empty.
     return 'unittype_id';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainDisplayPropertyName() {
+    // The property to use in the entity title/url.
+    return 'cv_name';
   }
 
   /**

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -369,7 +369,7 @@ class ChadoPublish extends TripalBackendPublishBase {
           ];
 
           // Store the main properties for later.
-          $main_property_name = $instance->mainPropertyName();
+          $main_property_name = $instance->mainDisplayPropertyName();
           $this->main_property_names[$field_name] = $main_property_name;
 
           // Order the property types by key for easy lookup.
@@ -448,7 +448,7 @@ class ChadoPublish extends TripalBackendPublishBase {
         /** @var \Drupal\tripal\TripalField\TripalFieldItemBase $field */
         /** @var \Drupal\tripal\TripalStorage\StoragePropertyBase $prop **/
         $field = $this->field_info[$field_name]['instance'];
-        $main_prop = $field->mainPropertyName();
+        $main_prop = $field->mainDisplayPropertyName();
         $prop = $field_info['prop_types'][$main_prop];
         $prop_value = new StoragePropertyValue($field_definition->getTargetEntityTypeId(),
             $field_class::$id, $main_prop, $prop->getTerm()->getTermId(), NULL);

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
@@ -2,147 +2,147 @@ system-under-test:
   chado_version: '1.3.3.013'
 scenarios:
   -
-      field_type: chado_analysis_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAnalysisTypeDefault
-      widget_id: chado_analysis_widget_default
-      formatter_id: chado_analysis_formatter_default
+      field_type: 'chado_analysis_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAnalysisTypeDefault'
+      widget_id: 'chado_analysis_widget_default'
+      formatter_id: 'chado_analysis_formatter_default'
   -
-      field_type: chado_array_design_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoArrayDesignTypeDefault
-      widget_id: chado_array_design_widget_default
-      formatter_id: chado_array_design_formatter_default
+      field_type: 'chado_array_design_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoArrayDesignTypeDefault'
+      widget_id: 'chado_array_design_widget_default'
+      formatter_id: 'chado_array_design_formatter_default'
   -
-      field_type: chado_assay_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAssayTypeDefault
-      widget_id: chado_assay_widget_default
-      formatter_id: chado_assay_formatter_default
+      field_type: 'chado_assay_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAssayTypeDefault'
+      widget_id: 'chado_assay_widget_default'
+      formatter_id: 'chado_assay_formatter_default'
   -
-      field_type: chado_biomaterial_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBiomaterialTypeDefault
-      widget_id: chado_biomaterial_widget_default
-      formatter_id: chado_biomaterial_formatter_default
+      field_type: 'chado_biomaterial_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBiomaterialTypeDefault'
+      widget_id: 'chado_biomaterial_widget_default'
+      formatter_id: 'chado_biomaterial_formatter_default'
   -
-      field_type: chado_boolean_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBooleanTypeDefault
-      widget_id: chado_boolean_type_widget
-      formatter_id: chado_boolean_type_formatter
+      field_type: 'chado_boolean_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBooleanTypeDefault'
+      widget_id: 'chado_boolean_type_widget'
+      formatter_id: 'chado_boolean_type_formatter'
   -
-      field_type: chado_contact_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactTypeDefault
-      widget_id: chado_contact_widget_default
-      formatter_id: chado_contact_formatter_default
+      field_type: 'chado_contact_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactTypeDefault'
+      widget_id: 'chado_contact_widget_default'
+      formatter_id: 'chado_contact_formatter_default'
   -
-      field_type: chado_contact_by_role_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactByRoleTypeDefault
-      widget_id: chado_contact_widget_default
-      formatter_id: chado_contact_formatter_default
+      field_type: 'chado_contact_by_role_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactByRoleTypeDefault'
+      widget_id: 'chado_contact_widget_default'
+      formatter_id: 'chado_contact_formatter_default'
   -
-      field_type: chado_dbxref_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoDbxrefTypeDefault
-      widget_id: chado_dbxref_widget_default
-      formatter_id: chado_dbxref_formatter_default
+      field_type: 'chado_dbxref_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoDbxrefTypeDefault'
+      widget_id: 'chado_dbxref_widget_default'
+      formatter_id: 'chado_dbxref_formatter_default'
   -
-      field_type: chado_source_data_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSourceDataTypeDefault
-      widget_id: chado_source_data_widget_default
-      formatter_id: chado_source_data_formatter_default
+      field_type: 'chado_source_data_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSourceDataTypeDefault'
+      widget_id: 'chado_source_data_widget_default'
+      formatter_id: 'chado_source_data_formatter_default'
   -
-      field_type: chado_feature_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureTypeDefault
-      widget_id: chado_feature_widget_default
-      formatter_id: chado_feature_formatter_default
+      field_type: 'chado_feature_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureTypeDefault'
+      widget_id: 'chado_feature_widget_default'
+      formatter_id: 'chado_feature_formatter_default'
   -
-      field_type: chado_featuremap_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureMapTypeDefault
-      widget_id: chado_featuremap_widget_default
-      formatter_id: chado_featuremap_formatter_default
+      field_type: 'chado_featuremap_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureMapTypeDefault'
+      widget_id: 'chado_featuremap_widget_default'
+      formatter_id: 'chado_featuremap_formatter_default'
   -
-      field_type: chado_sequence_checksum_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceChecksumTypeDefault
-      widget_id: chado_sequence_checksum_widget_default
-      formatter_id: chado_sequence_checksum_formatter_default
+      field_type: 'chado_sequence_checksum_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceChecksumTypeDefault'
+      widget_id: 'chado_sequence_checksum_widget_default'
+      formatter_id: 'chado_sequence_checksum_formatter_default'
   -
-      field_type: chado_sequence_length_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceLengthTypeDefault
-      widget_id: chado_sequence_length_widget_default
-      formatter_id: chado_sequence_length_formatter_default
+      field_type: 'chado_sequence_length_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceLengthTypeDefault'
+      widget_id: 'chado_sequence_length_widget_default'
+      formatter_id: 'chado_sequence_length_formatter_default'
   -
-      field_type: chado_integer_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoIntegerTypeDefault
-      widget_id: chado_integer_type_widget
-      formatter_id: chado_integer_type_formatter
+      field_type: 'chado_integer_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoIntegerTypeDefault'
+      widget_id: 'chado_integer_type_widget'
+      formatter_id: 'chado_integer_type_formatter'
   -
-      field_type: chado_organism_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoOrganismTypeDefault
-      widget_id: chado_organism_widget_default
-      formatter_id: chado_organism_formatter_default
+      field_type: 'chado_organism_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoOrganismTypeDefault'
+      widget_id: 'chado_organism_widget_default'
+      formatter_id: 'chado_organism_formatter_default'
   -
-      field_type: chado_project_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProjectTypeDefault
-      widget_id: chado_project_widget_default
-      formatter_id: chado_project_formatter_default
+      field_type: 'chado_project_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProjectTypeDefault'
+      widget_id: 'chado_project_widget_default'
+      formatter_id: 'chado_project_formatter_default'
   -
-      field_type: chado_property_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPropertyTypeDefault
-      widget_id: chado_property_widget_default
-      formatter_id: chado_property_formatter_default
+      field_type: 'chado_property_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPropertyTypeDefault'
+      widget_id: 'chado_property_widget_default'
+      formatter_id: 'chado_property_formatter_default'
   -
-      field_type: chado_protocol_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProtocolTypeDefault
-      widget_id: chado_protocol_widget_default
-      formatter_id: chado_protocol_formatter_default
+      field_type: 'chado_protocol_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProtocolTypeDefault'
+      widget_id: 'chado_protocol_widget_default'
+      formatter_id: 'chado_protocol_formatter_default'
   -
-      field_type: chado_pub_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPubTypeDefault
-      widget_id: chado_pub_widget_default
-      formatter_id: chado_pub_formatter_default
+      field_type: 'chado_pub_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPubTypeDefault'
+      widget_id: 'chado_pub_widget_default'
+      formatter_id: 'chado_pub_formatter_default'
   -
-      field_type: chado_relationship_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoRelationshipTypeDefault
-      widget_id: chado_relationship_widget_default
-      formatter_id: chado_relationship_formatter_default
+      field_type: 'chado_relationship_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoRelationshipTypeDefault'
+      widget_id: 'chado_relationship_widget_default'
+      formatter_id: 'chado_relationship_formatter_default'
   -
-      field_type: chado_sequence_coordinates_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceCoordinatesDefault
-      widget_id: chado_sequence_coordinates_widget_default
-      formatter_id: chado_sequence_coordinates_formatter_default
+      field_type: 'chado_sequence_coordinates_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceCoordinatesDefault'
+      widget_id: 'chado_sequence_coordinates_widget_default'
+      formatter_id: 'chado_sequence_coordinates_formatter_default'
   -
-      field_type: chado_sequence_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceTypeDefault
-      widget_id: chado_sequence_widget_default
-      formatter_id: chado_sequence_formatter_default
+      field_type: 'chado_sequence_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceTypeDefault'
+      widget_id: 'chado_sequence_widget_default'
+      formatter_id: 'chado_sequence_formatter_default'
   -
-      field_type: chado_stock_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStockTypeDefault
-      widget_id: chado_stock_widget_default
-      formatter_id: chado_stock_formatter_default
+      field_type: 'chado_stock_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStockTypeDefault'
+      widget_id: 'chado_stock_widget_default'
+      formatter_id: 'chado_stock_formatter_default'
   -
-      field_type: chado_string_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStringTypeDefault
-      widget_id: chado_string_type_widget
-      formatter_id: chado_string_type_formatter
+      field_type: 'chado_string_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStringTypeDefault'
+      widget_id: 'chado_string_type_widget'
+      formatter_id: 'chado_string_type_formatter'
   -
-      field_type: chado_study_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStudyTypeDefault
-      widget_id: chado_study_widget_default
-      formatter_id: chado_study_formatter_default
+      field_type: 'chado_study_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStudyTypeDefault'
+      widget_id: 'chado_study_widget_default'
+      formatter_id: 'chado_study_formatter_default'
   -
-      field_type: chado_synonym_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSynonymTypeDefault
-      widget_id: chado_synonym_widget_default
-      formatter_id: chado_synonym_formatter_default
+      field_type: 'chado_synonym_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSynonymTypeDefault'
+      widget_id: 'chado_synonym_widget_default'
+      formatter_id: 'chado_synonym_formatter_default'
   -
-      field_type: chado_text_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoTextTypeDefault
-      widget_id: chado_text_type_widget
-      formatter_id: chado_text_type_formatter
+      field_type: 'chado_text_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoTextTypeDefault'
+      widget_id: 'chado_text_type_widget'
+      formatter_id: 'chado_text_type_formatter'
   -
-      field_type: chado_additional_type_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAdditionalTypeTypeDefault
-      widget_id: chado_additional_type_widget_default
-      formatter_id: chado_additional_type_formatter_default
+      field_type: 'chado_additional_type_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAdditionalTypeTypeDefault'
+      widget_id: 'chado_additional_type_widget_default'
+      formatter_id: 'chado_additional_type_formatter_default'
   -
-      field_type: chado_unit_type_default
-      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoUnitTypeDefault
-      widget_id: chado_unit_widget_default
-      formatter_id: chado_unit_formatter_default
+      field_type: 'chado_unit_type_default'
+      field_class: 'Drupal\tripal_chado\Plugin\Field\FieldType\ChadoUnitTypeDefault'
+      widget_id: 'chado_unit_widget_default'
+      formatter_id: 'chado_unit_formatter_default'

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
@@ -1,0 +1,148 @@
+system-under-test:
+  chado_version: '1.3.3.013'
+scenarios:
+  -
+      field_type: chado_analysis_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAnalysisTypeDefault
+      widget_id: chado_analysis_widget_default
+      formatter_id: chado_analysis_formatter_default
+  -
+      field_type: chado_array_design_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoArrayDesignTypeDefault
+      widget_id: chado_array_design_widget_default
+      formatter_id: chado_array_design_formatter_default
+  -
+      field_type: chado_assay_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAssayTypeDefault
+      widget_id: chado_assay_widget_default
+      formatter_id: chado_assay_formatter_default
+  -
+      field_type: chado_biomaterial_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBiomaterialTypeDefault
+      widget_id: chado_biomaterial_widget_default
+      formatter_id: chado_biomaterial_formatter_default
+  -
+      field_type: chado_boolean_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoBooleanTypeDefault
+      widget_id: chado_boolean_type_widget
+      formatter_id: chado_boolean_type_formatter
+  -
+      field_type: chado_contact_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactTypeDefault
+      widget_id: chado_contact_widget_default
+      formatter_id: chado_contact_formatter_default
+  -
+      field_type: chado_contact_by_role_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoContactByRoleTypeDefault
+      widget_id: chado_contact_widget_default
+      formatter_id: chado_contact_formatter_default
+  -
+      field_type: chado_dbxref_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoDbxrefTypeDefault
+      widget_id: chado_dbxref_widget_default
+      formatter_id: chado_dbxref_formatter_default
+  -
+      field_type: chado_source_data_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSourceDataTypeDefault
+      widget_id: chado_source_data_widget_default
+      formatter_id: chado_source_data_formatter_default
+  -
+      field_type: chado_feature_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureTypeDefault
+      widget_id: chado_feature_widget_default
+      formatter_id: chado_feature_formatter_default
+  -
+      field_type: chado_featuremap_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoFeatureMapTypeDefault
+      widget_id: chado_featuremap_widget_default
+      formatter_id: chado_featuremap_formatter_default
+  -
+      field_type: chado_sequence_checksum_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceChecksumTypeDefault
+      widget_id: chado_sequence_checksum_widget_default
+      formatter_id: chado_sequence_checksum_formatter_default
+  -
+      field_type: chado_sequence_length_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceLengthTypeDefault
+      widget_id: chado_sequence_length_widget_default
+      formatter_id: chado_sequence_length_formatter_default
+  -
+      field_type: chado_integer_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoIntegerTypeDefault
+      widget_id: chado_integer_type_widget
+      formatter_id: chado_integer_type_formatter
+  -
+      field_type: chado_organism_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoOrganismTypeDefault
+      widget_id: chado_organism_widget_default
+      formatter_id: chado_organism_formatter_default
+  -
+      field_type: chado_project_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProjectTypeDefault
+      widget_id: chado_project_widget_default
+      formatter_id: chado_project_formatter_default
+  -
+      field_type: chado_property_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPropertyTypeDefault
+      widget_id: chado_property_widget_default
+      formatter_id: chado_property_formatter_default
+  -
+      field_type: chado_protocol_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoProtocolTypeDefault
+      widget_id: chado_protocol_widget_default
+      formatter_id: chado_protocol_formatter_default
+  -
+      field_type: chado_pub_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoPubTypeDefault
+      widget_id: chado_pub_widget_default
+      formatter_id: chado_pub_formatter_default
+  -
+      field_type: chado_relationship_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoRelationshipTypeDefault
+      widget_id: chado_relationship_widget_default
+      formatter_id: chado_relationship_formatter_default
+  -
+      field_type: chado_sequence_coordinates_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceCoordinatesDefault
+      widget_id: chado_sequence_coordinates_widget_default
+      formatter_id: chado_sequence_coordinates_formatter_default
+  -
+      field_type: chado_sequence_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSequenceTypeDefault
+      widget_id: chado_sequence_widget_default
+      formatter_id: chado_sequence_formatter_default
+  -
+      field_type: chado_stock_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStockTypeDefault
+      widget_id: chado_stock_widget_default
+      formatter_id: chado_stock_formatter_default
+  -
+      field_type: chado_string_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStringTypeDefault
+      widget_id: chado_string_type_widget
+      formatter_id: chado_string_type_formatter
+  -
+      field_type: chado_study_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoStudyTypeDefault
+      widget_id: chado_study_widget_default
+      formatter_id: chado_study_formatter_default
+  -
+      field_type: chado_synonym_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoSynonymTypeDefault
+      widget_id: chado_synonym_widget_default
+      formatter_id: chado_synonym_formatter_default
+  -
+      field_type: chado_text_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoTextTypeDefault
+      widget_id: chado_text_type_widget
+      formatter_id: chado_text_type_formatter
+  -
+      field_type: chado_additional_type_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoAdditionalTypeTypeDefault
+      widget_id: chado_additional_type_widget_default
+      formatter_id: chado_additional_type_formatter_default
+  -
+      field_type: chado_unit_type_default
+      field_class: Drupal\tripal_chado\Plugin\Field\FieldType\ChadoUnitTypeDefault
+      widget_id: chado_unit_widget_default
+      formatter_id: chado_unit_formatter_default

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
@@ -1,5 +1,18 @@
 system-under-test:
   chado_version: '1.3.3.013'
+## Generate scenarios using the following code.
+## $field_definitions = \Drupal::service('plugin.manager.field.field_type')
+##   ->getGroupedDefinitions()['Chado Fields'];
+## $scenarios = [];
+## foreach ($field_definitions as $defn) {
+## $s[] = [
+##   'field_type' => $defn['id'],
+##   'field_class' => $defn['class'],
+##   'widget_id' => $defn['default_widget'],
+##   'formatter_id' => $defn['default_formatter']
+##   ];
+## }
+## Symfony\Component\Yaml\Yaml::dump($s);
 scenarios:
   -
       field_type: 'chado_analysis_type_default'

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest.php
@@ -66,9 +66,9 @@ class FieldStaticMethodTest extends ChadoTestKernelBase {
    * setup.
    *
    * @var array
-   *  A list of scenarios where each one has the following keys:
-   *  - id: the machine name of the field to be tested.
-   *  - class: the class defining the field to be tested.
+   *   A list of scenarios where each one has the following keys:
+   *   - id: the machine name of the field to be tested.
+   *   - class: the class defining the field to be tested.
    */
   protected array $scenarios;
 

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\Tests\tripal_chado\Kernel\ChadoField;
+
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\tripal_chado\Traits\ChadoFieldTestTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the static methods of Chado Fields.
+ *
+ * @group TripalField
+ * @group ChadoField
+ */
+#[Group('TripalField')]
+#[Group('ChadoField')]
+class FieldStaticMethodTest extends ChadoTestKernelBase {
+
+  use ChadoFieldTestTrait;
+
+  /**
+   * The theme to use when rendering content in the test environment.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The modules that this test depends on.
+   *
+   * NOTE: since this is a kernel test, these modules are not being installed
+   * but are available to be installed.
+   *
+   * @var array
+   */
+  protected static $modules = ['system', 'user', 'path', 'path_alias', 'field', 'datetime', 'tripal', 'tripal_chado'];
+
+  /**
+   * The test chado connection. It is also set in the container.
+   *
+   * @var ChadoConnection
+   */
+  protected object $chado_connection;
+
+  /**
+   * The YAML file indicating the scenarios to test and how to setup the enviro.
+   *
+   * @var string
+   */
+  protected string $yaml_info_file = __DIR__ . '/FieldStaticMethodTest-TestInfo.yml';
+
+  /**
+   * Describes the environment to setup for this test.
+   *
+   * @var array
+   *   An array with the following keys:
+   *   - chado_version: the version of chado to test under.
+   */
+  protected array $system_under_test;
+
+  /**
+   * Describes the scenarios to test.
+   *
+   * This will be used in combination with the data provider. It can't be
+   * accessed directly in the dataProvider due to the way that PHPUnit is
+   * setup.
+   *
+   * @var array
+   *  A list of scenarios where each one has the following keys:
+   *  - id: the machine name of the field to be tested.
+   *  - class: the class defining the field to be tested.
+   */
+  protected array $scenarios;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // First retrieve info from the YAML file for this particular test.
+    [$this->system_under_test, $this->scenarios] = $this->getTestInfoFromYaml($this->yaml_info_file);
+
+  }
+
+  /**
+   * Tests the static methods of the chado field types.
+   */
+  public function testStaticMethods() {
+
+    foreach ($this->scenarios as $scenario) {
+      $field_class = $scenario['field_class'];
+      $field_id = $scenario['field_type'];
+
+      $mainPropertyNameMSG = 'indicates the property required for this field not to be considered empty';
+      $mainDisplayPropertyNameMSG = 'indicates the property used as the value for field-specific Tripal Tokens';
+
+      // PROPERTY NAMES: Check that the static methods have been defined.
+      $this->assertTrue(
+        method_exists($field_class, 'mainPropertyName'),
+        "$field_id should have ::mainPropertyName() method which $mainPropertyNameMSG."
+      );
+      $this->assertTrue(
+        method_exists($field_class, 'mainDisplayPropertyName'),
+        "$field_id should have ::mainDisplayPropertyName() method which $mainDisplayPropertyNameMSG."
+      );
+
+      // PROPERTY NAMES: Check that these methods do not return NULL.
+      $main_property_name = $field_class::mainPropertyName();
+      $this->assertNotNull($main_property_name, "$field_class::mainPropertyName() should $mainPropertyNameMSG.");
+      $main_display_property_name = $field_class::mainDisplayPropertyName();
+      $this->assertNotNull($main_display_property_name, "$field_class::mainDisplayPropertyName() should $mainDisplayPropertyNameMSG.");
+
+      $storageSettingsMSG = 'defines the default settings for where this field stores its data in chado';
+      $fieldSettingsMSG = 'defines the default settings for the field itself such as the term';
+
+      // DEFAULT SETTINGS: Check that the static methods have been defined.
+      $this->assertTrue(
+        method_exists($field_class, 'defaultStorageSettings'),
+        "$field_id should have ::defaultStorageSettings() method which $storageSettingsMSG."
+      );
+      $this->assertTrue(
+        method_exists($field_class, 'defaultFieldSettings'),
+        "$field_id should have ::defaultFieldSettings() method which $fieldSettingsMSG."
+      );
+
+      // DEFAULT SETTINGS: Check that these methods do not return NULL.
+      // Storage Settings.
+      $storage_settings = $field_class::defaultStorageSettings();
+      $this->assertIsArray($storage_settings, "$field_class::defaultStorageSettings() should $storageSettingsMSG.");
+      $this->assertArrayHasKey('storage_plugin_id', $storage_settings, "$field_class::defaultStorageSettings() should define the storage_plugin_id.");
+      $this->assertEquals('chado_storage', $storage_settings['storage_plugin_id'], "$field_id doesn't have the expected storage backend despite being in the Chado Fields category.");
+      $this->assertArrayHasKey('storage_plugin_settings', $storage_settings, "$field_class::defaultStorageSettings() should define the storage_plugin_settings.");
+      $this->assertNotEmpty($storage_settings['storage_plugin_settings'], "$field_id did not define any storage_plugin_settings in $field_class::defaultStorageSettings.");
+      // Field Settings.
+      $field_settings = $field_class::defaultFieldSettings();
+      $this->assertIsArray($field_settings, "$field_class::defaultFieldSettings() should $fieldSettingsMSG.");
+      $this->assertArrayHasKey('termIdSpace', $field_settings, "$field_class::defaultFieldSettings() should define the termIdSpace.");
+      $this->assertArrayHasKey('termAccession', $field_settings, "$field_class::defaultFieldSettings() should define the termAccession.");
+    }
+  }
+
+}


### PR DESCRIPTION
# Bug Fix

### Issue #2319 

## Description
This PR defines a new method `mainDisplayPropertyName()` in Tripal/Chado Fields for use populating field-specific tokens in Title and URL formats. This is needed because the previously used `mainPropertyName()` should actually be the key property in order to properly detect empty fields.

- [x] Add the `mainDisplayPropertyName()` method to the Tripal Field Base + Interface. We return 'value' as a default since that is what is used for single property fields such as boolean, integer, string.
- [x] For every field with multiple properties, have `mainDisplayPropertyName()` return the property name previously defined by `mainPropertyName()` and update `mainPropertyName()` to return the name of the property set directly by the widget.
- [x] Update the entity and publish use of `mainPropertyName()` to `mainDisplayPropertyName()` instead. This should mean that there is no change to what to expect as the value of the title/url tokens.
- [x] Add a test for better test coverage of fields.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
There are automated tests for the title/url substitutions and these tests should continue to pass without needing to be changed. This confirms that the value returned for the tokens has not changed despite being determined by a different method.

Manual testing should include 
- making a number of Tripal Content pages and confirming that the titles and URLs still match what you expect based on the format.
- when editing content with unlimited fields, make sure to add multiple instances of each field and confirm that they are not filtered out when they are not empty ;-p also confirm that they are removed properly when they are empty although this is currently a bit fragile in the main branch.

