### PR TITLE
add missing StringTranslationTrait

### DIFF
--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -3,6 +3,7 @@
 namespace Drupal\tripal_chado\Plugin\TripalBackendPublish;
 
 use Drupal\Component\Utility\Xss;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalBackendPublish\Attribute\TripalBackendPublish;
 use Drupal\tripal\TripalBackendPublish\Exceptions\TripalPublishException;
@@ -18,6 +19,8 @@ use Drupal\tripal\TripalStorage\StoragePropertyValue;
   description: new TranslatableMarkup('Creates Tripal content based on records in a chado database.'),
 )]
 class ChadoPublish extends TripalBackendPublishBase {
+
+  use StringTranslationTrait;
 
   /**
    * The base table of the bundle.

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -220,13 +220,13 @@ class ChadoPublish extends TripalBackendPublishBase {
                             . ', expected 4, found ' . count($cols);
                 return $errormsg;
               }
-            }
-            // The columns are:
-            // bundle_name(not used), chado_table, pkey_id, entity_id.
-            $this->migration_data[$cols[1]][$cols[2]] = $cols[3];
-            $n_records++;
-            if ($cols[3] > $this->max_migrated_entity_id) {
-              $this->max_migrated_entity_id = $cols[3];
+              // The columns are:
+              // bundle_name(not used), chado_table, pkey_id, entity_id.
+              $this->migration_data[$cols[1]][$cols[2]] = $cols[3];
+              $n_records++;
+              if ($cols[3] > $this->max_migrated_entity_id) {
+                $this->max_migrated_entity_id = $cols[3];
+              }
             }
           }
         }


### PR DESCRIPTION
# Bug Fix

### Closes #2321

## Description

1. Fixes the failure due to the missing StringTranslationTrait. https://github.com/tripal/tripal/pull/2322/commits/97796093c9dc668489d45147c39efb83f3c378b7
2. Fixes the count of the number of lines of migration data loaded, it was off by one. https://github.com/tripal/tripal/pull/2322/commits/78b1419305ffa4f2495806f169ad2788bcb9a9b3

## Testing?

This will test both places described in the linked issue #2321 
```
cd /var/www/drupal
echo -e "Publication\tpub\t1\t234" > migration.txt
drush trp-chado-pub pub --migration-file=/var/www/drupal/migration.txt
```
Publication should proceed without errors
```
 [notice] Initializing publish
 [notice] Loaded 1 records of migration data, maximum entity ID is 234  (* was 2 before commit 78b1419)
 [notice] Finding all candidate records in the "pub" chado table
 [notice] Preparing to publish 1 "pub" records
 [notice] Step 1 of 6: Find matching records
 [notice] Step 2 of 6: Generate page titles
 [notice] Step 3 of 6: Find existing published entity titles
 [notice] Step 4 of 6: Updating existing page titles
 [notice] Step 5 of 6: Publishing 1 new entities
 [notice] Step 6 of 6: Adding field items to published entities
 [notice]   Published 1 items for field "pub_is_obsolete"
 [notice]   Published 1 items for field "pub_miniref"
 [notice]   Published 1 items for field "pub_type"
 [notice]   Published 1 items for field "pub_uniquename"
 [warning] WARNING: 1 entities have blank titles. You should either update the source records, or modify the title format tokens, and then republish.
[site http://default] [TRIPAL] WARNING: 1 entities have blank titles. You should either update the source records, or modify the title format tokens, and then republish.
 [notice] Publish completed. Published 1 new entities, added 4 new field values.
```