### PR TITLE
Add missing "1:" prefix in select in ChadoRecords et al.

### DIFF
--- a/tripal/src/TripalDBX/TripalDbxConnection.php
+++ b/tripal/src/TripalDBX/TripalDbxConnection.php
@@ -41,7 +41,7 @@ use Drupal\tripal\TripalDBX\Exceptions\ConnectionException;
  * query builder as shown in this next example:
  *
  * $dbxdb = \Drupal::service('tripal_chado.database');
- * $query = $dbxdb->select('feature', 'x');
+ * $query = $dbxdb->select('1:feature', 'x');
  * $query->condition('x.is_obsolete', 'f', '=');
  * $query->fields('x', ['name', 'residues']);
  * $query->range(0, 10);

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoDbxrefWidgetDefault.php
@@ -32,7 +32,7 @@ class ChadoDbxrefWidgetDefault extends ChadoWidgetBase {
 
     // Get the list of databases
     $databases = [];
-    $query = $chado->select('db', 'd');
+    $query = $chado->select('1:db', 'd');
     $query->fields('d', ['db_id', 'name']);
     $query->orderBy('name');
     $results = $query->execute();

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoUnitWidgetDefault.php
@@ -47,12 +47,12 @@ class ChadoUnitWidgetDefault extends ChadoWidgetBase {
 
     $chado = \Drupal::service('tripal_chado.database');
 
-    $query = $chado->select( 'cvterm', 'cvt' );
-    $query->leftJoin ('cv', 'cv', 'cvt.cv_id = cv.cv_id ');
-    $query->leftJoin ('dbxref', 'dbx', 'cvt.dbxref_id = dbx.dbxref_id');
-    $query->leftJoin ('db', 'db', 'db.db_id = db.db_id');
-    $query->addField( 'cvt', 'name', 'cvt_name');
-    $query->addField( 'cvt', 'cvterm_id', 'unittype_id');
+    $query = $chado->select('1:cvterm', 'cvt');
+    $query->leftJoin ('1:cv', 'cv', 'cvt.cv_id = cv.cv_id ');
+    $query->leftJoin ('1:dbxref', 'dbx', 'cvt.dbxref_id = dbx.dbxref_id');
+    $query->leftJoin ('1:db', 'db', 'db.db_id = db.db_id');
+    $query->addField('cvt', 'name', 'cvt_name');
+    $query->addField('cvt', 'cvterm_id', 'unittype_id');
 
     // Use a condition groups to build a section of where clause as follows:
     // ((db.name = :term1db AND dbx.accession = :term1acc) OR (db.name = :term2db AND dbx.accession = :term2acc))

--- a/tripal_chado/src/TripalStorage/ChadoRecords.php
+++ b/tripal_chado/src/TripalStorage/ChadoRecords.php
@@ -1283,7 +1283,7 @@ class ChadoRecords {
         }
 
         // Check if the id is present in the FK table.
-        $query = $this->connection->select($fk_table, 'fk');
+        $query = $this->connection->select('1:' . $fk_table, 'fk');
         $query->fields('fk', [$rcol]);
         $query->condition($rcol, $col_val);
         $fk_id = $query->execute()->fetchField();


### PR DESCRIPTION
# Bug Fix

### Closes #2326

## Description

The affected select statement is missing the `1:` prefix. During automated tests it may fail to find the table as a result.

Then I thought I should check if this is the case anywhere else. I found two widgets lacking the `1:` prefix, and one comment.

## Testing?
Code review should show this is a correct change.
Automated testing will hopefully cover this later as we add widget tests 🙈