### PR TITLE
Add idspace name to cache key so it is unique

### DIFF
--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -555,7 +555,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
     $term->setInternalId($cvterm->cvterm_id);
 
     // Invalidate the cache for this term.
-    $cache_id = 'chado_id_space_term_' . $this->getName() . '_' . $term->getAccession();
+    $cache_id = 'chado_id_space_term_' . $term->getIdSpace() . '_' . $term->getAccession();
     \Drupal::cache()->invalidate($cache_id);
 
     return TRUE;

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -280,7 +280,6 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
     if (!$this->is_valid) {
       return NULL;
     }
-
     $cache_id = 'chado_id_space_term_' . $this->getName() . '_' . $accession;
     if ($cache = \Drupal::cache()->get($cache_id)) {
       return $cache->data;
@@ -556,7 +555,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
     $term->setInternalId($cvterm->cvterm_id);
 
     // Invalidate the cache for this term.
-    $cache_id = 'chado_id_space_term_' . $term->getAccession();
+    $cache_id = 'chado_id_space_term_' . $this->getName() . '_' . $term->getAccession();
     \Drupal::cache()->invalidate($cache_id);
 
     return TRUE;

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -281,7 +281,7 @@ class ChadoIdSpace extends TripalIdSpaceBase implements ContainerFactoryPluginIn
       return NULL;
     }
 
-    $cache_id = 'chado_id_space_term_' . $accession;
+    $cache_id = 'chado_id_space_term_' . $this->getName() . '_' . $accession;
     if ($cache = \Drupal::cache()->get($cache_id)) {
       return $cache->data;
     }

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
@@ -194,69 +194,63 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
   /**
    * Tests the ChadoIdSpace Class.
    */
-  public function testTripalIDSpaceClass() {
+  public function testTripalIdSpaceClass() {
 
-    // These are the values we'll use for the ID space and vocablary.
-    $GO_idspace = 'GO';
-    $GO_cc_namespace = 'cellular_component';
-    $GO_bp_namespace = 'biological_process';
-    $GO_mf_namespace = 'molecular_function';
-    $GO_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
-    $GO_cc_label = 'Gene Ontology Cellular Component Vocabulary';
-    $GO_bp_label = 'Gene Ontology Biological Process Vocabulary';
-    $GO_mf_label = 'Gene Ontology Molecular Function Vocabulary';
-    $GO_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
-    $GO_url = 'http://geneontology.org/';
+    // These are the values we'll use for the ID space and vocabulary.
+    $go_idspace = 'GO';
+    $go_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
+    $go_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
 
     // Make sure the IDspace doesn't yet exist.
-    $db = $this->getChadoDbRecord($GO_idspace);
+    $db = $this->getChadoDbRecord($go_idspace);
     $this->assertEmpty($db, 'The Chado db has a conflicting record.');
 
     // Create the ID space object and make sure a Chado record got created.
-    $GO = $this->idsmanager->createCollection($GO_idspace, "chado_id_space");
-    $db = $this->getChadoDbRecord($GO_idspace);
-    $this->assertTrue($db->name == $GO_idspace, 'The name was not set correctly by the ChadoIdSpace object.');
+    $go = $this->idsmanager->createCollection($go_idspace, "chado_id_space");
+    $db = $this->getChadoDbRecord($go_idspace);
+    $this->assertTrue($db->name == $go_idspace, 'The name was not set correctly by the ChadoIdSpace object.');
     $this->assertEmpty($db->description, 'The description should not be set by the ChadoIdSpace object just yet.');
     $this->assertEmpty($db->urlprefix, 'The URL prefix should not be set by the ChadoIdSpace object just yet.');
     $this->assertEmpty($db->url, 'The URL should not be set by the ChadoIdSpace object just yet.');
 
     // Set the description to make sure it gets set in Chado.
-    $GO->setDescription($GO_description);
-    $db = $this->getChadoDbRecord($GO_idspace);
-    $this->assertTrue($db->name == $GO_idspace, 'The name was not set correctly after updating by the ChadoIdSpace object.');
-    $this->assertTrue($db->description == $GO_description, 'The description was not set correctly by the ChadoIdSpace object.');
+    $go->setDescription($go_description);
+    $db = $this->getChadoDbRecord($go_idspace);
+    $this->assertTrue($db->name == $go_idspace, 'The name was not set correctly after updating by the ChadoIdSpace object.');
+    $this->assertTrue($db->description == $go_description, 'The description was not set correctly by the ChadoIdSpace object.');
     $this->assertEmpty($db->urlprefix, 'The URL prefix should not be set by the ChadoIdSpace object just yet.');
     $this->assertEmpty($db->url, 'The URL should not be set by the ChadoIdSpace object just yet.');
 
     // Set the URL prefix to make sure it gets set in Chado.
-    $GO->setURLPrefix($GO_urlprefix);
-    $db = $this->getChadoDbRecord($GO_idspace);
-    $this->assertTrue($db->name == $GO_idspace, 'The name was not set correctly after updating by the ChadoIdSpace object.');
-    $this->assertTrue($db->description == $GO_description, 'The description was not set correctly after updating by the ChadoIdSpace object.');
-    $this->assertTrue($db->urlprefix == $GO_urlprefix, 'The URL prefix was not set correctly by the ChadoIdSpace object.');
+    $go->setURLPrefix($go_urlprefix);
+    $db = $this->getChadoDbRecord($go_idspace);
+    $this->assertTrue($db->name == $go_idspace, 'The name was not set correctly after updating by the ChadoIdSpace object.');
+    $this->assertTrue($db->description == $go_description, 'The description was not set correctly after updating by the ChadoIdSpace object.');
+    $this->assertTrue($db->urlprefix == $go_urlprefix, 'The URL prefix was not set correctly by the ChadoIdSpace object.');
     $this->assertEmpty($db->url, 'The URL should not be set by the ChadoIdSpace object just yet.');
 
     // Make sure the getters work.
-    $this->assertTrue($GO->getURLPrefix() == $GO_urlprefix, "The ChadoIdSpace object did not return a correct URL prefix.");
-    $this->assertTrue($GO->getDescription() == $GO_description, "The ChadoIdSpace object did not return a correct description.");
+    $this->assertTrue($go->getURLPrefix() == $go_urlprefix, "The ChadoIdSpace object did not return a correct URL prefix.");
+    $this->assertTrue($go->getDescription() == $go_description, "The ChadoIdSpace object did not return a correct description.");
 
     // Change the description and URL prefix and make sure it updates.
-    $GO->setDescription('Changed');
-    $GO->setURLPrefix('Changed');
-    $this->assertTrue($GO->getDescription() == 'Changed', "The ChadoIdSpace object did not update the description.");
-    $this->assertTrue($GO->getURLPrefix() == 'Changed', "The ChadoIdSpace object did not update the URL prefix.");
+    $go->setDescription('Changed');
+    $go->setURLPrefix('Changed');
+    $this->assertTrue($go->getDescription() == 'Changed', "The ChadoIdSpace object did not update the description.");
+    $this->assertTrue($go->getURLPrefix() == 'Changed', "The ChadoIdSpace object did not update the URL prefix.");
 
-    // Simulate a change in the `db` record from another source. The getters should pick up the change.
-    $this->updateRecord('db', $GO_idspace, 'urlprefix', 'http://replace.me/');
-    $this->assertTrue($GO->getURLPrefix() == 'http://replace.me/', "The ChadoIdSpace object did not pick up an update to the URL prefix from an external source.");
-    $this->updateRecord('db', $GO_idspace, 'description', 'Replace Me');
-    $this->assertTrue($GO->getDescription() == 'Replace Me', "The ChadoIdSpace object did not pick up an update to the description from an external source.");
+    // Simulate a change in the `db` record from another source.
+    // The getters should pick up the change.
+    $this->updateRecord('db', $go_idspace, 'urlprefix', 'http://replace.me/');
+    $this->assertTrue($go->getURLPrefix() == 'http://replace.me/', "The ChadoIdSpace object did not pick up an update to the URL prefix from an external source.");
+    $this->updateRecord('db', $go_idspace, 'description', 'Replace Me');
+    $this->assertTrue($go->getDescription() == 'Replace Me', "The ChadoIdSpace object did not pick up an update to the description from an external source.");
 
     // Destroy the ID Space and make sure it's gone from Tripal but not Chado.
-    $this->idsmanager->removeCollection($GO_idspace);
-    $GO = $this->idsmanager->loadCollection($GO_idspace);
-    $this->assertTrue($GO === NULL, "The ID Space should be removed from Tripal.");
-    $db = $this->getChadoDbRecord($GO_idspace);
+    $this->idsmanager->removeCollection($go_idspace);
+    $go = $this->idsmanager->loadCollection($go_idspace);
+    $this->assertTrue($go === NULL, "The ID Space should be removed from Tripal.");
+    $db = $this->getChadoDbRecord($go_idspace);
     $this->assertNotFalse($db, "The ID Space was removed from Tripal but should not have been removed from Chado.");
     $this->assertEquals($db->urlprefix, 'http://replace.me/', "The ID Space should not have been changed in chado when it was removed from Tripal.");
 
@@ -267,70 +261,67 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
    */
   public function testTripalVocabClass() {
 
-    // These are the values we'll use for the ID space and vocablary.
-    $GO_idspace = 'GO';
-    $GO_cc_namespace = 'cellular_component';
-    $GO_bp_namespace = 'biological_process';
-    $GO_mf_namespace = 'molecular_function';
-    $GO_description = "The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes";
-    $GO_cc_label = 'Gene Ontology Cellular Component Vocabulary';
-    $GO_bp_label = 'Gene Ontology Biological Process Vocabulary';
-    $GO_mf_label = 'Gene Ontology Molecular Function Vocabulary';
-    $GO_urlprefix = "http://amigo.geneontology.org/amigo/term/{db}:{accession}";
-    $GO_url = 'http://geneontology.org/';
+    // These are the values we'll use for the ID space and vocabulary.
+    $go_idspace = 'GO';
+    $go_cc_namespace = 'cellular_component';
+    $go_bp_namespace = 'biological_process';
+    $go_cc_label = 'Gene Ontology Cellular Component Vocabulary';
+    $go_bp_label = 'Gene Ontology Biological Process Vocabulary';
+    $go_url = 'http://geneontology.org/';
 
     // Make sure the IDspace doesn't yet exist.
-    $db = $this->getChadoDbRecord($GO_idspace);
+    $db = $this->getChadoDbRecord($go_idspace);
     $this->assertEmpty($db, 'The Chado db has a conflicting record.');
 
     // Make sure the Vocabulary doesn't yet exist.
-    $cv = $this->getChadoCvRecord($GO_cc_namespace);
+    $cv = $this->getChadoCvRecord($go_cc_namespace);
     $this->assertEmpty($cv, 'The Chado cv has a conflicting record.');
 
     // Create the vocab.
-    $cc = $this->vmanager->createCollection($GO_cc_namespace, "chado_vocabulary");
-    $cv = $this->getChadoCvRecord($GO_cc_namespace);
-    $this->assertTrue($cv->name == $GO_cc_namespace, 'The name was not set correctly by the ChadoVocabulary object.');
+    $cc = $this->vmanager->createCollection($go_cc_namespace, "chado_vocabulary");
+    $cv = $this->getChadoCvRecord($go_cc_namespace);
+    $this->assertTrue($cv->name == $go_cc_namespace, 'The name was not set correctly by the ChadoVocabulary object.');
     $this->assertEmpty($cv->definition, 'The definition should not be set by the ChadoVocabulary object just yet.');
 
     // Set the definition to make sure it gets set in Chado.
-    $cc->setLabel($GO_cc_label);
-    $cv = $this->getChadoCvRecord($GO_cc_namespace);
-    $this->assertTrue($cv->name == $GO_cc_namespace, 'The name was not set correctly by the ChadoVocabulary object.');
-    $this->assertTrue($cv->definition == $GO_cc_label, 'The label was not set correctly by the ChadoVocabulary object.');
+    $cc->setLabel($go_cc_label);
+    $cv = $this->getChadoCvRecord($go_cc_namespace);
+    $this->assertTrue($cv->name == $go_cc_namespace, 'The name was not set correctly by the ChadoVocabulary object.');
+    $this->assertTrue($cv->definition == $go_cc_label, 'The label was not set correctly by the ChadoVocabulary object.');
 
     // Make sure the getter works.
-    $this->assertTrue($cc->getLabel() == $GO_cc_label, "The ChadoVocabulary object did not return a correct label.");
+    $this->assertTrue($cc->getLabel() == $go_cc_label, "The ChadoVocabulary object did not return a correct label.");
 
-    // Simulate a change in the `cv` record from another source. The getters should pick up the change.
-    $this->updateRecord('cv', $GO_cc_namespace, 'definition', 'Replace Me');
+    // Simulate a change in the `cv` record from another source.
+    // The getters should pick up the change.
+    $this->updateRecord('cv', $go_cc_namespace, 'definition', 'Replace Me');
     $this->assertTrue($cc->getLabel() == 'Replace Me', "The ChadoVocabulary object did not pick up an update to the label from an external source.");
 
     // Associate the IDSpace with the vocabulary,.
-    $GO = $this->idsmanager->createCollection($GO_idspace, "chado_id_space");
+    $go = $this->idsmanager->createCollection($go_idspace, "chado_id_space");
     $id_spaces = $cc->getIdSpaceNames();
-    $this->assertFalse(in_array($GO_idspace, $id_spaces), 'ID spaces should not be set yet in the ChadoVocabulary');
-    $cc->addIdSpace($GO_idspace);
+    $this->assertFalse(in_array($go_idspace, $id_spaces), 'ID spaces should not be set yet in the ChadoVocabulary');
+    $cc->addIdSpace($go_idspace);
     $id_spaces = $cc->getIdSpaceNames();
-    $this->assertTrue(in_array($GO_idspace, $id_spaces), 'The ID space is missing from the ChadoVocabulary');
+    $this->assertTrue(in_array($go_idspace, $id_spaces), 'The ID space is missing from the ChadoVocabulary');
 
     // Add a URL to the vocabulary, it should show up in the
     // database table for the ID space.
-    $db = $this->getChadoDbRecord($GO_idspace);
+    $db = $this->getChadoDbRecord($go_idspace);
     $this->assertEmpty($db->url, 'The URL should not be set by the ChadoVocabulary object just yet.');
-    $cc->setURL($GO_url);
+    $cc->setURL($go_url);
 
-    $db = $this->getChadoDbRecord($GO_idspace);
-    $this->assertTrue($db->url == $GO_url, 'The URL was not set correctly by the ChadoVocabulary object.');
-    $this->assertTrue($cc->getURL() == $GO_url, 'The URL was not retrieved by the ChadoVocabulary object.');
+    $db = $this->getChadoDbRecord($go_idspace);
+    $this->assertTrue($db->url == $go_url, 'The URL was not set correctly by the ChadoVocabulary object.');
+    $this->assertTrue($cc->getURL() == $go_url, 'The URL was not retrieved by the ChadoVocabulary object.');
 
     // Test adding a URL without an ID space.
-    $bp = $this->vmanager->createCollection($GO_bp_namespace, "chado_vocabulary");
-    $bp->setLabel($GO_bp_label);
+    $bp = $this->vmanager->createCollection($go_bp_namespace, "chado_vocabulary");
+    $bp->setLabel($go_bp_label);
     $printed_output = '';
     $expected_message = 'ChadoVocabulary: Cannot set the URL when no ID spaces are present for the vocabulary.';
     ob_start();
-    $bp->setURL($GO_url);
+    $bp->setURL($go_url);
     $printed_output = ob_get_clean();
     $this->assertStringContainsString($expected_message, $printed_output, "We did not get the log message we expected when trying to the the URL on a vocab without an ID Space.");
     // Also test getting it in the same scenario.
@@ -340,82 +331,83 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $returned_url = $bp->getURL();
     $printed_output = ob_get_clean();
     $this->assertStringContainsString($expected_message, $printed_output, "We did not get the log message we expected when trying to the the URL on a vocab without an ID Space.");
-    $this->assertFalse($returned_url == $GO_url, 'The URL should not be set without an ID Space');
+    $this->assertFalse($returned_url == $go_url, 'The URL should not be set without an ID Space');
 
     // Test adding a default vocabulary to an ID space.  This should call the
     // addIdSpace() function on the vocabulary as well.
-    $GO->setDefaultVocabulary($GO_bp_namespace);
-    $this->assertTrue($GO->getDefaultVocabulary() == $GO_bp_namespace, 'The default vocabulary was not set correctly by the ChadoIdSpace object.');
-    $bp->setURL($GO_url);
-    $this->assertTrue($bp->getURL() == $GO_url, 'The URL was not set correctly by the ChadoVocabulary after setting the default vocabulary.');
+    $go->setDefaultVocabulary($go_bp_namespace);
+    $this->assertTrue($go->getDefaultVocabulary() == $go_bp_namespace, 'The default vocabulary was not set correctly by the ChadoIdSpace object.');
+    $bp->setURL($go_url);
+    $this->assertTrue($bp->getURL() == $go_url, 'The URL was not set correctly by the ChadoVocabulary after setting the default vocabulary.');
 
     //
     // Testing multiple ID spaces per Vocabulary
     // .
-    $EDAM_data_idspace = 'data';
-    $EDAM_format_idspace = 'format';
-    $EDAM_operation_idspace = 'operation';
-    $EDAM_topic_idspace = 'topic';
-    $EDAM_namespace = 'EDAM';
-    $EDAM_data_description = "Information, represented in an information artefact.";
-    $EDAM_format_description = "A defined way or layout of representing and structuring data";
-    $EDAM_operation_description = "A function that processes a set of inputs and results in a set of outputs";
-    $EDAM_topic_description = "A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology";
-    $EDAM_label = 'Gene Ontology Cellular Component Vocabulary';
-    $EDAM_urlprefix = "http://edamontology.org/{db}_{accession}";
-    $EDAM_url = 'http://edamontology.org';
-    $edam = $this->vmanager->createCollection($EDAM_namespace, "chado_vocabulary");
-    $edam_data = $this->idsmanager->createCollection($EDAM_data_idspace, "chado_id_space");
-    $edam_format = $this->idsmanager->createCollection($EDAM_format_idspace, "chado_id_space");
-    $edam_operation = $this->idsmanager->createCollection($EDAM_operation_idspace, "chado_id_space");
-    $edam_topic = $this->idsmanager->createCollection($EDAM_topic_idspace, "chado_id_space");
-    $edam_data->setDefaultVocabulary($EDAM_namespace);
-    $edam_format->setDefaultVocabulary($EDAM_namespace);
-    $edam_operation->setDefaultVocabulary($EDAM_namespace);
-    $edam_topic->setDefaultVocabulary($EDAM_namespace);
-    $edam->setLabel($EDAM_label);
-    $edam->setURL($EDAM_url);
-    $edam_data->setURLPrefix($EDAM_urlprefix);
-    $edam_format->setURLPrefix($EDAM_urlprefix);
-    $edam_operation->setURLPrefix($EDAM_urlprefix);
-    $edam_topic->setURLPrefix($EDAM_urlprefix);
-    $edam_data->setDescription($EDAM_data_description);
-    $edam_format->setDescription($EDAM_format_description);
-    $edam_operation->setDescription($EDAM_operation_description);
-    $edam_topic->setDescription($EDAM_topic_description);
+    $edam_data_idspace = 'data';
+    $edam_format_idspace = 'format';
+    $edam_operation_idspace = 'operation';
+    $edam_topic_idspace = 'topic';
+    $edam_namespace = 'EDAM';
+    $edam_data_description = "Information, represented in an information artefact.";
+    $edam_format_description = "A defined way or layout of representing and structuring data";
+    $edam_operation_description = "A function that processes a set of inputs and results in a set of outputs";
+    $edam_topic_description = "A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology";
+    $edam_label = 'Gene Ontology Cellular Component Vocabulary';
+    $edam_urlprefix = "http://edamontology.org/{db}_{accession}";
+    $edam_url = 'http://edamontology.org';
+    $edam = $this->vmanager->createCollection($edam_namespace, "chado_vocabulary");
+    $edam_data = $this->idsmanager->createCollection($edam_data_idspace, "chado_id_space");
+    $edam_format = $this->idsmanager->createCollection($edam_format_idspace, "chado_id_space");
+    $edam_operation = $this->idsmanager->createCollection($edam_operation_idspace, "chado_id_space");
+    $edam_topic = $this->idsmanager->createCollection($edam_topic_idspace, "chado_id_space");
+    $edam_data->setDefaultVocabulary($edam_namespace);
+    $edam_format->setDefaultVocabulary($edam_namespace);
+    $edam_operation->setDefaultVocabulary($edam_namespace);
+    $edam_topic->setDefaultVocabulary($edam_namespace);
+    $edam->setLabel($edam_label);
+    $edam->setURL($edam_url);
+    $edam_data->setURLPrefix($edam_urlprefix);
+    $edam_format->setURLPrefix($edam_urlprefix);
+    $edam_operation->setURLPrefix($edam_urlprefix);
+    $edam_topic->setURLPrefix($edam_urlprefix);
+    $edam_data->setDescription($edam_data_description);
+    $edam_format->setDescription($edam_format_description);
+    $edam_operation->setDescription($edam_operation_description);
+    $edam_topic->setDescription($edam_topic_description);
 
-    // Make sure that all of the ID spaces have been aded to the vocabulary.
+    // Make sure that all of the ID spaces have been added to the vocabulary.
     $id_spaces = $edam->getIdSpaceNames();
-    $this->assertTrue(in_array($EDAM_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
-    $this->assertTrue(in_array($EDAM_format_idspace, $id_spaces), "The EDAM format ID space is missing from the vocabulary ID spaces.");
-    $this->assertTrue(in_array($EDAM_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
-    $this->assertTrue(in_array($EDAM_topic_idspace, $id_spaces), "The EDAM topic ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_format_idspace, $id_spaces), "The EDAM format ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_topic_idspace, $id_spaces), "The EDAM topic ID space is missing from the vocabulary ID spaces.");
 
-    // Just do a nother check to make sure the vocabularies and ID spaces got setup correctly.
-    $this->assertTrue($edam->getLabel() == $EDAM_label, "The EDAM label was not correctly returned.");
-    $this->assertTrue($edam->getURL() == $EDAM_url, "The EDAM URL was not correctly returned.");
-    $this->assertTrue($edam->getNameSpace() == $EDAM_namespace, "The EDAM namespace was not correctly returned.");
-    $this->assertTrue($edam_data->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM data ID Space is not correct.");
-    $this->assertTrue($edam_format->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM format ID Space is not correct.");
-    $this->assertTrue($edam_operation->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM operation ID Space is not correct.");
-    $this->assertTrue($edam_topic->getDefaultVocabulary() == $EDAM_namespace, "The default vocabulary for the EDAM topic ID Space is not correct.");
-    $this->assertTrue($edam_data->getDescription() == $EDAM_data_description, "The EDAM data ID space's description was not correctly returned.");
-    $this->assertTrue($edam_format->getDescription() == $EDAM_format_description, "The EDAM format ID space's description was not correctly returned.");
-    $this->assertTrue($edam_operation->getDescription() == $EDAM_operation_description, "The EDAM operation ID space's description was not correctly returned.");
-    $this->assertTrue($edam_topic->getDescription() == $EDAM_topic_description, "The EDAM topic ID space's description was not correctly returned.");
-    $this->assertTrue($edam_data->getURLPrefix() == $EDAM_urlprefix, "The EDAM data ID space's URL PRefix space description was not correctly returned.");
-    $this->assertTrue($edam_format->getURLPrefix() == $EDAM_urlprefix, "The EDAM format ID space's URL PRefix space description was not correctly returned.");
-    $this->assertTrue($edam_operation->getURLPrefix() == $EDAM_urlprefix, "The EDAM operation ID space's URL PRefix space description was not correctly returned.");
-    $this->assertTrue($edam_topic->getURLPrefix() == $EDAM_urlprefix, "The EDAM topic ID space's URL PRefix space description was not correctly returned.");
+    // Just do another check to make sure the vocabularies and ID spaces
+    // got setup correctly.
+    $this->assertTrue($edam->getLabel() == $edam_label, "The EDAM label was not correctly returned.");
+    $this->assertTrue($edam->getURL() == $edam_url, "The EDAM URL was not correctly returned.");
+    $this->assertTrue($edam->getNameSpace() == $edam_namespace, "The EDAM namespace was not correctly returned.");
+    $this->assertTrue($edam_data->getDefaultVocabulary() == $edam_namespace, "The default vocabulary for the EDAM data ID Space is not correct.");
+    $this->assertTrue($edam_format->getDefaultVocabulary() == $edam_namespace, "The default vocabulary for the EDAM format ID Space is not correct.");
+    $this->assertTrue($edam_operation->getDefaultVocabulary() == $edam_namespace, "The default vocabulary for the EDAM operation ID Space is not correct.");
+    $this->assertTrue($edam_topic->getDefaultVocabulary() == $edam_namespace, "The default vocabulary for the EDAM topic ID Space is not correct.");
+    $this->assertTrue($edam_data->getDescription() == $edam_data_description, "The EDAM data ID space's description was not correctly returned.");
+    $this->assertTrue($edam_format->getDescription() == $edam_format_description, "The EDAM format ID space's description was not correctly returned.");
+    $this->assertTrue($edam_operation->getDescription() == $edam_operation_description, "The EDAM operation ID space's description was not correctly returned.");
+    $this->assertTrue($edam_topic->getDescription() == $edam_topic_description, "The EDAM topic ID space's description was not correctly returned.");
+    $this->assertTrue($edam_data->getURLPrefix() == $edam_urlprefix, "The EDAM data ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_format->getURLPrefix() == $edam_urlprefix, "The EDAM format ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_operation->getURLPrefix() == $edam_urlprefix, "The EDAM operation ID space's URL PRefix space description was not correctly returned.");
+    $this->assertTrue($edam_topic->getURLPrefix() == $edam_urlprefix, "The EDAM topic ID space's URL PRefix space description was not correctly returned.");
 
     // Test removing an ID space.
-    $edam->removeIdSpace($EDAM_format_idspace);
-    $edam->removeIdSpace($EDAM_topic_idspace);
+    $edam->removeIdSpace($edam_format_idspace);
+    $edam->removeIdSpace($edam_topic_idspace);
     $id_spaces = $edam->getIdSpaceNames();
-    $this->assertTrue(in_array($EDAM_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
-    $this->assertFalse(in_array($EDAM_format_idspace, $id_spaces), "The EDAM format ID space is not missing from the vocabulary ID spaces.");
-    $this->assertTrue(in_array($EDAM_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
-    $this->assertFalse(in_array($EDAM_topic_idspace, $id_spaces), "The EDAM topic ID space is not missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_data_idspace, $id_spaces), "The EDAM data ID space is missing from the vocabulary ID spaces.");
+    $this->assertFalse(in_array($edam_format_idspace, $id_spaces), "The EDAM format ID space is not missing from the vocabulary ID spaces.");
+    $this->assertTrue(in_array($edam_operation_idspace, $id_spaces), "The EDAM operation ID space is missing from the vocabulary ID spaces.");
+    $this->assertFalse(in_array($edam_topic_idspace, $id_spaces), "The EDAM topic ID space is not missing from the vocabulary ID spaces.");
 
   }
 
@@ -425,8 +417,8 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
   public function testTripalTermClass() {
 
     // Create the GO ID space as we will use it later.
-    $GO = $this->idsmanager->createCollection('GO', "chado_id_space");
-    $GO->setURLPrefix("http://amigo.geneontology.org/amigo/term/{db}:{accession}");
+    $go = $this->idsmanager->createCollection('GO', "chado_id_space");
+    $go->setURLPrefix("http://amigo.geneontology.org/amigo/term/{db}:{accession}");
     // Same with the biological process Vocabulary.
     $bp = $this->vmanager->createCollection('biological_process', "chado_vocabulary");
     $bp->setLabel('Gene Ontology Biological Process Vocabulary');
@@ -533,7 +525,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
       ],
     ]);
 
-    // Re-run the same tests above on this recreated term.// Run a suite of tests on the term.
+    // Re-run the same tests above on this recreated term.
     $this->assertTrue($parent->getName() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect name.');
     $this->assertTrue($parent->getAccession() == '0008150', 'The "biological_process" TripalTerm returned an incorrect accession.');
     $this->assertTrue($parent->getTermId() == 'GO:0008150', 'The "biological_process" TripalTerm returned an incorrect term ID.');
@@ -638,8 +630,8 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     // We need to save the comment term first as this is used
     // for a property in our new child term below.
     $rdfs_id->saveTerm($comment);
-    $GO->saveTerm($parent);
-    $GO->saveTerm($is_a);
+    $go->saveTerm($parent);
+    $go->saveTerm($is_a);
 
     $cvterm = $this->getChadoCvtermRecord('rdfs', 'comment');
     $this->assertTrue(!empty($cvterm) and $cvterm->name == 'comment', 'The term did not save a proper cvterm record  (Test #1).');
@@ -673,12 +665,13 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
         [$parent, $is_a],
       ],
     ]);
-    $GO->saveTerm($new_child);
+    $go->saveTerm($new_child);
     $cvterm = $this->getChadoCvtermRecord('biological_process', 'behavior');
     $this->assertTrue(!empty($cvterm) and $cvterm->name == 'behavior', 'The term did not save a proper cvterm record (Test #2).');
 
-    // Now that the term is saved, load it and see if all of the attributes are properly set.
-    $new_child2 = $GO->getTerm('0007610');
+    // Now that the term is saved, load it and see if all of the attributes
+    // are properly set.
+    $new_child2 = $go->getTerm('0007610');
     $this->assertTrue($new_child2->getName() == 'behavior', 'The getTerm function did not return a term with the name loaded properly.');
     $this->assertTrue($new_child2->getDefinition() == $new_child_def, 'The getTerm function did not return a term with the definition loaded properly.');
     $this->assertFalse($new_child2->isObsolete(), 'The getTerm function did not return a term with the is_obsolete value loaded properly.');
@@ -715,8 +708,8 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $new_child2->removeSynonym('single-organism behavior');
     $new_child2->removeParent('GO', '0008150');
     $new_child2->removeProperty('rdfs', 'comment', 0);
-    $GO->saveTerm($new_child2);
-    $new_child3 = $GO->getTerm('0007610');
+    $go->saveTerm($new_child2);
+    $new_child3 = $go->getTerm('0007610');
     $this->assertTrue(count(array_keys($new_child3->getProperties())) == 0, 'Updates to a term are not removing properties correctly');
     $this->assertTrue(count($new_child3->getAltIds()) == 0, 'Updates to a term are not removing alt IDs correctly');
     $this->assertTrue(count(array_keys($new_child3->getSynonyms())) == 0, 'Updates to a term are not removing synonyms correctly');
@@ -727,8 +720,8 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $new_child3->addAltId('GO', '0044708');
     $new_child3->addParent($parent, $is_a);
     $new_child3->addProperty($comment, $new_child_comment);
-    $GO->saveTerm($new_child3);
-    $new_child4 = $GO->getTerm('0007610');
+    $go->saveTerm($new_child3);
+    $new_child4 = $go->getTerm('0007610');
     $this->assertTrue(count(array_keys($new_child4->getProperties())) == 1, 'Updates to a term are not adding properties correctly');
     $this->assertTrue(count($new_child4->getAltIds()) == 1, 'Updates to a term are not adding alt IDs correctly');
     $this->assertTrue(count(array_keys($new_child4->getSynonyms())) == 1, 'Updates to a term are not adding synonyms correctly');
@@ -737,14 +730,14 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     // Test updating of the boolean values.
     $new_child4->setIsObsolete(TRUE);
     $new_child4->setIsRelationshipType(TRUE);
-    $GO->saveTerm($new_child4);
-    $new_child5 = $GO->getTerm('0007610');
+    $go->saveTerm($new_child4);
+    $new_child5 = $go->getTerm('0007610');
     $this->assertTrue($new_child5->isRelationshipType(), 'Updates to the relationship type did not get set when updating a term.');
     $this->assertTrue($new_child5->isObsolete(), 'Updates to the obsolete value did not get set when updating a term.');
     $new_child5->setIsObsolete(FALSE);
     $new_child5->setIsRelationshipType(FALSE);
-    $GO->saveTerm($new_child5);
-    $new_child6 = $GO->getTerm('0007610');
+    $go->saveTerm($new_child5);
+    $new_child6 = $go->getTerm('0007610');
     $this->assertFalse($new_child6->isRelationshipType(), 'Updates to the relationship type did not get unset when updating a term.');
     $this->assertFalse($new_child6->isObsolete(), 'Updates to the obsolete value did not get unset when updating a term.');
 
@@ -774,7 +767,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
       ],
     ]);
 
-    $GO->saveTerm($parent);
+    $go->saveTerm($parent);
 
     // Restore the child to its full state.
     $new_child = new TripalTerm([
@@ -801,19 +794,19 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
         [$parent, $is_a],
       ],
     ]);
-    $GO->saveTerm($new_child);
+    $go->saveTerm($new_child);
 
-    $terms = $GO->getTerms('behav');
+    $terms = $go->getTerms('behav');
     $this->assertTrue(count(array_keys($terms)) == 4, 'Searching for a non exact term did not yield the correct number of matches.');
     $this->assertTrue(in_array('behavior', array_keys($terms)), 'Searching for a term did not return the matched name of a term.');
     $this->assertTrue(in_array('behavioral response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term (Test #1).');
     $this->assertTrue(in_array('behavioural response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #2).');
     $this->assertTrue(in_array('behaviour', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #3).');
-    $terms = $GO->getTerms('behav', ['exact' => TRUE]);
+    $terms = $go->getTerms('behav', ['exact' => TRUE]);
     $this->assertTrue(count(array_keys($terms)) == 0, 'Searching for an exact term that does not match anything did not return 0 matches.');
-    $terms = $GO->getTerms('behavioral response to stimulus', ['exact' => TRUE]);
+    $terms = $go->getTerms('behavioral response to stimulus', ['exact' => TRUE]);
     $this->assertTrue(count(array_keys($terms)) == 1, 'Searching for an exact term using the synonym did not return a match.');
-    $terms = $GO->getTerms('biological');
+    $terms = $go->getTerms('biological');
     $this->assertTrue(count(array_keys($terms)) == 2, 'Searching for a non exact term that should match two terms did not.');
 
     //
@@ -833,9 +826,9 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
         [$parent, $is_a],
       ],
     ]);
-    $GO->saveTerm($child);
+    $go->saveTerm($child);
 
-    $children = $GO->getChildren($parent);
+    $children = $go->getChildren($parent);
     $this->assertTrue(count($children) == 2, 'The number of children returned for the parent is incorrect.');
     $child_names = [$children[0][0]->getName(), $children[1][0]->getName()];
     $this->assertTrue(in_array('behavior', $child_names), 'The list of children for the parent does not have a correct child name (Test #1).');
@@ -848,7 +841,9 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     //
     // Create a type for the synonyms.
     $syn_vocab = $this->vmanager->createCollection("synonym_type", "chado_vocabulary");
+    $this->assertIsObject($syn_vocab, 'Synonym vocabulary not created');
     $syn_id = $this->idsmanager->createCollection('synonym_type', "chado_id_space");
+    $this->assertIsObject($syn_id, 'Synonym ID space not created');
     $exact = new TripalTerm();
     $exact->setName('exact');
     $exact->setIdSpace('synonym_type');
@@ -880,8 +875,8 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
         [$parent, $is_a],
       ],
     ]);
-    $GO->saveTerm($new_child);
-    $new_child = $GO->getTerm('0007610');
+    $go->saveTerm($new_child);
+    $new_child = $go->getTerm('0007610');
     $synonyms = $new_child->getSynonyms();
     $this->assertTrue(count(array_keys($synonyms)) == 4, 'The number of synonyms returned is not correct.');
     $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing (Test #1).');
@@ -912,14 +907,14 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
         [$parent, $is_a],
       ],
     ]);
-    $GO->saveTerm($new_child);
-    $new_child = $GO->getTerm('0007610');
+    $go->saveTerm($new_child);
+    $new_child = $go->getTerm('0007610');
     $synonyms = $new_child->getSynonyms();
     $this->assertTrue(count($synonyms) == 0, 'There should be no synonyms but some were returned.');
     $new_child->addSynonym('behavioral response to stimulus', $exact);
     $new_child->addSynonym('behaviour', $exact);
-    $GO->saveTerm($new_child);
-    $new_child = $GO->getTerm('0007610');
+    $go->saveTerm($new_child);
+    $new_child = $go->getTerm('0007610');
     $synonyms = $new_child->getSynonyms();
     $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #3).');
     $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #2).');
@@ -934,7 +929,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $expected_message = 'ChadoIdSpace::saveTerm(). The term, ":" is not valid and cannot be saved.';
     $dummy->setName('dummy');
     ob_start();
-    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #1)');
+    $this->assertFalse($go->saveTerm($dummy), 'An invalid term did not return False when saving (Test #1)');
     $printed_output = ob_get_clean();
     $this->assertStringContainsString(
       $expected_message,
@@ -946,7 +941,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $expected_message = 'ChadoIdSpace::saveTerm(). The term, ":" is not valid and cannot be saved.';
     $dummy->setDefinition('dummy');
     ob_start();
-    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #2)');
+    $this->assertFalse($go->saveTerm($dummy), 'An invalid term did not return False when saving (Test #2)');
     $printed_output = ob_get_clean();
     $this->assertStringContainsString(
       $expected_message,
@@ -958,7 +953,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $expected_message = 'ChadoIdSpace::saveTerm(). The term, ":dummy" is not valid and cannot be saved.';
     $dummy->setAccession('dummy');
     ob_start();
-    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #3)');
+    $this->assertFalse($go->saveTerm($dummy), 'An invalid term did not return False when saving (Test #3)');
     $printed_output = ob_get_clean();
     $this->assertStringContainsString(
       $expected_message,
@@ -970,7 +965,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $expected_message = 'ChadoIdSpace::saveTerm(). The term, "GO:dummy" is not valid and cannot be saved.';
     $dummy->setIdSpace('GO');
     ob_start();
-    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #4)');
+    $this->assertFalse($go->saveTerm($dummy), 'An invalid term did not return False when saving (Test #4)');
     $printed_output = ob_get_clean();
     $this->assertStringContainsString(
       $expected_message,
@@ -979,7 +974,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     );
 
     $dummy->setVocabulary('biological_process');
-    $this->assertTrue($GO->saveTerm($dummy), 'A valid term did not return True when saving');
+    $this->assertTrue($go->saveTerm($dummy), 'A valid term did not return True when saving');
 
     // Try to save a term that doesn't belong to the idSpace.
     $expected_message = 'ChadoIdSpace::saveTerm(). The term, "GO:dummy", does not have the same ID space as this one.';
@@ -1059,6 +1054,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
 
   /**
    * Testing idSpace and Vocabulary collection with missing db or cv.
+   *
    * This can happen when a TripalTerm is created and then the underlying
    * cv/db is deleted.
    *

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
@@ -1117,13 +1117,13 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $ret_idspace = $this->idsmanager->loadCollection($db_name, "chado_id_space");
     $this->assertIdSpaceEquals(
       ['name' => $db_name, 'description' => '', 'chado_record' => TRUE],
-      $idspace,
+      $ret_idspace,
       "ID Space loaded with missing chado.db record: "
     );
     $ret_vocab = $this->vmanager->loadCollection($cv_name, "chado_vocabulary");
     $this->assertVocabEquals(
       ['name' => $cv_name, 'definition' => '', 'chado_record' => TRUE],
-      $vocab,
+      $ret_vocab,
       "Vocab loaded with missing chado.cv record: "
     );
 

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalVocabTerms/ChadoVocabTermsTest.php
@@ -620,7 +620,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     $parents = $child->getParents();
     $this->assertEmpty($parents, 'The "biological phase" TripalTerm should not have any parents after they were removed.');
 
-    // Make sure the isVald works.
+    // Make sure the isValid works.
     $dummy = new TripalTerm();
     $this->assertFalse($dummy->isValid(), 'The dummy TripalTerm reports it is valid when it is not (Test 1).');
     $dummy->setName('dummy');
@@ -635,7 +635,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
     //
     // Inserting (Saving) Terms to Chado.
     //
-    // We need to save the comment term first s this is used
+    // We need to save the comment term first as this is used
     // for a property in our new child term below.
     $rdfs_id->saveTerm($comment);
     $GO->saveTerm($parent);
@@ -1062,7 +1062,7 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
    * This can happen when a TripalTerm is created and then the underlying
    * cv/db is deleted.
    *
-   * Tests that loading a collection whose undelying record is gone recreates
+   * Tests that loading a collection whose underlying record is gone recreates
    * the record in the underlying backend (Issue #1354; PR #2185).
    */
   public function testIssue1354() {
@@ -1127,6 +1127,58 @@ class ChadoVocabTermsTest extends ChadoTestKernelBase {
       "Vocab loaded with missing chado.cv record: "
     );
 
+  }
+
+  /**
+   * Testing caching of terms in different ID spaces but same accession.
+   *
+   * Cache key should be unique for terms with the same accession
+   * Issue #2328 PR #2330.
+   */
+  public function testIssue2328() {
+
+    $db_name_1 = 'some_db_1';
+    $db_name_2 = 'some_db_2';
+    $cv_name_1 = 'some_cv_1';
+    $cv_name_2 = 'some_cv_2';
+    $common_accession = '0000042';
+
+    $idspace_1 = $this->idsmanager->createCollection($db_name_1, 'chado_id_space');
+    $this->assertIsObject($idspace_1, 'Failure to create an id space');
+    $idspace_2 = $this->idsmanager->createCollection($db_name_2, 'chado_id_space');
+    $this->assertIsObject($idspace_2, 'Failure to create an id space');
+    $vocab_1 = $this->vmanager->createCollection($cv_name_1, 'chado_vocabulary');
+    $this->assertIsObject($vocab_1, 'Failure to create a vocabulary');
+    $vocab_2 = $this->vmanager->createCollection($cv_name_2, 'chado_vocabulary');
+    $this->assertIsObject($vocab_2, 'Failure to create a vocabulary');
+
+    $term_1 = new TripalTerm();
+    $this->assertIsObject($term_1, 'Failure to create an empty TripalTerm');
+    $term_1->setName('Name 1');
+    $term_1->setIdSpacePlugin('chado_id_space');
+    $term_1->setVocabularyPlugin('chado_vocabulary');
+    $term_1->setIdSpace($db_name_1);
+    $term_1->setVocabulary($cv_name_1);
+    $term_1->setAccession($common_accession);
+    $idspace_1->saveTerm($term_1);
+
+    $term_2 = new TripalTerm();
+    $this->assertIsObject($term_2, 'Failure to create an empty TripalTerm');
+    $term_2->setName('Name 2');
+    $term_2->setIdSpacePlugin('chado_id_space');
+    $term_2->setVocabularyPlugin('chado_vocabulary');
+    $term_2->setIdSpace($db_name_2);
+    $term_2->setVocabulary($cv_name_2);
+    $term_2->setAccession($common_accession);
+    $idspace_2->saveTerm($term_2);
+
+    // Tests caching of terms in different vocab but same accession.
+    $term_1 = $idspace_1->getTerm($common_accession, []);
+    $id_1 = $term_1->getTermId();
+    $this->assertEquals('some_db_1:0000042', $id_1, 'Did not retrieve expected term ID');
+    $term_2 = $idspace_2->getTerm($common_accession, []);
+    $id_2 = $term_2->getTermId();
+    $this->assertEquals('some_db_2:0000042', $id_2, 'Did not retrieve expected term ID');
   }
 
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2328 

## Description
The caching in this situation is returning **any cached term with the same accession** 😱.
The fix is to add the namespace to the cache key.
This may cause infrequent and non-visible use of incorrect terms, so this is high priority.

## Testing?
See issue for code to evaluate

An additional phpunit test is added to catch the original issue. Without the change to the cache key made by this PR, the test catches this:
```
   │ Did not retrieve expected term ID
   │ Failed asserting that two strings are equal.
   │ --- Expected
   │ +++ Actual
   │ @@ @@
   │ -'some_db_2:0000042'
   │ +'some_db_1:0000042'
```
