### PR TITLE
Chado custom tables do not have foreign keys

### DIFF
--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -51,8 +51,7 @@ class ChadoSchema extends TripalDbxSchema {
           \Drupal::service('extension.list.module')->getPath('tripal_chado')
           . '/chado_schema/schema-definition/version-'
           . $version
-          . '.yml'
-        ;
+          . '.yml';
 
         // Make sure we got a valid version format.
         if (!preg_match('/^\d\.\d\.?\d?\.?\d*$/', $version)
@@ -91,13 +90,14 @@ class ChadoSchema extends TripalDbxSchema {
    * function retrieves only the list of tables that are considered 'base'
    * tables.
    *
-   * @return
+   * @return array
    *   An array of base table names.
    */
-  public function getMainTables() {
+  public function getMainTables(): array {
 
     // Initialize the base tables with those tables that are missing a type.
-    // Ideally they should have a type, but that's for a future version of Chado.
+    // Ideally they should have a type, but that's for a future version
+    // of Chado.
     $base_tables = [
       'organism',
       'project',
@@ -107,9 +107,9 @@ class ChadoSchema extends TripalDbxSchema {
       'assay',
     ];
 
-    // We'll use the cvterm table to guide which tables are base tables. Typically
-    // base tables (with a few exceptions) all have a type.  Iterate through the
-    // referring tables.
+    // We'll use the cvterm table to guide which tables are base tables.
+    // Typically base tables (with a few exceptions) all have a type.
+    // Iterate through the referring tables.
     $schema = $this->getTableDef('cvterm', []);
     if (isset($schema['referring_tables']) && is_array($schema['referring_tables'])) {
       foreach ($schema['referring_tables'] as $tablename) {
@@ -117,7 +117,8 @@ class ChadoSchema extends TripalDbxSchema {
         $is_base_table = TRUE;
 
         // Ignore the cvterm tables + chadoprop tables.
-        if (in_array($tablename, ['cvterm_dbxref', 'cvterm_relationship', 'cvtermpath', 'cvtermprop', 'chadoprop', 'cvtermsynonym'])) {
+        if (in_array($tablename,
+            ['cvterm_dbxref', 'cvterm_relationship', 'cvtermpath', 'cvtermprop', 'chadoprop', 'cvtermsynonym'])) {
           $is_base_table = FALSE;
         }
         // Ignore relationship linked tables.
@@ -147,7 +148,7 @@ class ChadoSchema extends TripalDbxSchema {
     // Remove any linker tables that have snuck in.  Linker tables are those
     // whose foreign key constraints link to two or more base table.
     $final_list = [];
-    foreach ($base_tables as $i => $tablename) {
+    foreach ($base_tables as $tablename) {
       // A few tables break our rule and seems to look
       // like a linking table, but we want to keep it as a base table.
       if ($tablename == 'biomaterial' or $tablename == 'assay' or $tablename == 'arraydesign') {
@@ -163,7 +164,7 @@ class ChadoSchema extends TripalDbxSchema {
       $num_links = 0;
       $schema = $this->getTableDef($tablename, []);
       $fkeys = $schema['foreign keys'] ?? [];
-      foreach ($fkeys as $fkid => $details) {
+      foreach ($fkeys as $details) {
         $fktable = $details['table'];
         if (in_array($fktable, $base_tables)) {
           $num_links++;
@@ -207,11 +208,12 @@ class ChadoSchema extends TripalDbxSchema {
    *   An object containing the chado_table and chado_field properties or NULL
    *   if if no mapping was found for the term.
    *
-  public function getCvtermMapping($params) {
-    return chado_get_cvterm_mapping($params);
-  }*/
+   * public function getCvtermMapping($params) {
+   *   return chado_get_cvterm_mapping($params);
+   * }
+   */
 
-   /***
+  /**
    * Retrieve the default chado schema.
    *
    * This method ensures that we support multiple chado instances

--- a/tripal_chado/src/Database/ChadoSchema.php
+++ b/tripal_chado/src/Database/ChadoSchema.php
@@ -233,4 +233,37 @@ class ChadoSchema extends TripalDbxSchema {
     return \Drupal::config('tripal_chado.settings')->get('default_schema');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function createTableSql($name, $table) {
+    $statements = parent::createTableSql($name, $table);
+
+    // Create any specified foreign keys in the postgresql database.
+    if (array_key_exists('foreign keys', $table)) {
+      foreach ($table['foreign keys'] as $table => $def) {
+        $foreign_table = $def['table'];
+        // Defaults here reflect the most common chado usage.
+        $on_delete = $def['on delete'] ?? 'ON DELETE CASCADE';
+        $deferrable = $def['deferrable'] ?? 'DEFERRABLE INITIALLY DEFERRED';
+        foreach ($def['columns'] as $this_column => $foreign_column) {
+          $fk_name = $name . '_' . $this_column . '_fkey';
+          $statement = 'ALTER TABLE ONLY ' . $name
+            . ' ADD CONSTRAINT ' . $fk_name
+            . ' FOREIGN KEY (' . $this_column . ')'
+            . ' REFERENCES ' . $foreign_table . '(' . $foreign_column . ')';
+          if ($on_delete) {
+            $statement .= ' ' . $on_delete;
+          }
+          if ($deferrable) {
+            $statement .= ' ' . $deferrable;
+          }
+          $statements[] = $statement;
+        }
+      }
+    }
+
+    return $statements;
+  }
+
 }

--- a/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
@@ -105,6 +105,14 @@ class ChadoCustomTableTest extends ChadoTestBrowserBase {
     $existing_schema = $custom_table_obj->getTableSchema();
     $this->assertEquals($existing_schema, $schema_array, 'Custom table schema is not as expected.');
 
+    // Test that the schema in postgresql contains foreign keys (Issue #2335).
+    $db_schema_def = $chado->schema()->getTableDef($table_name, ['source' => 'database', 'format' => 'drupal']);
+    $this->assertArrayHasKey('foreign keys', $db_schema_def, 'Custom table schema foreign keys were not saved to the database.');
+    $this->assertEquals(count($db_schema_def['foreign keys']), count($schema_array['foreign keys']), 'Custom table schema number of foreign keys in the database do not match expected.');
+    // Note that the array keys will be different, 'cvterm' in our schema
+    // vs. 'file_type_id_fkey' in the db.
+    $this->assertEquals(reset($db_schema_def['foreign keys']), reset($schema_array['foreign keys']), 'Custom table schema foreign keys in the database do not match expected.');
+
     // Test manager find by name.
     $found_id = $manager->findByName('i_do_not_exist');
     $this->assertFalse($found_id, 'Found an ID for a table that does not exist.');


### PR DESCRIPTION
# Bug Fix

### Closes #2335

## Description

Explained better in the issue, but when we create a table from a table schema that contains foreign keys,
the foreign keys are not saved to the postgresql database.

## Testing?

Note that I did all of the coding standards changes first in the first commit [07fd00e](https://github.com/tripal/tripal/pull/2336/commits/07fd00e81ca565165aedd99f683da723ba2b3db8)

Testing is pretty well described in the issue.

I have added some asserts to the phpunit tests for chado custom tables to check for this.

If you want to **test my tests**, you can temporarily rename `createTableSql()` in `tripal_chado/src/Database/ChadoSchema.php` by adding a few extra letters and run `phpunit --filter=ChadoCustomTableTest`
