### PR TITLE
Method to update a table schema without data loss

### DIFF
--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -276,7 +276,7 @@ abstract class TripalDbxSchema extends PgSchema {
    *     - 'blob_fields' that lists all the blob fields in the table.
    *     - 'sequences' that lists the sequences used in that table.
    */
-  public function queryTableInformation(string $table) {
+  public function queryTableInformation($table) {
 
     // Generate a key to reference this table's information on.
     $key = $this->connection
@@ -376,7 +376,7 @@ EOD;
    * @return bool
    *   TRUE if the given index exists, otherwise FALSE.
    */
-  public function indexExists(string $table, string $index_name, bool $exact_name = FALSE) :bool {
+  public function indexExists($table, $index_name, bool $exact_name = FALSE) :bool {
     if ($exact_name) {
       return (bool) $this->connection
         ->query("SELECT 1 FROM pg_indexes WHERE indexname = '{$index_name}'")
@@ -1195,6 +1195,100 @@ EOD;
           WHERE schemaname=:schema AND tablename = :table',
           [':table' => $table, ':schema' => $this->getSchemaName()])
       ->fetchField();
+  }
+
+  /**
+   * Update the schema of an existing table.
+   *
+   * To support schema changes without data loss, the following
+   * steps are performed:
+   * 1. Start a transaction.
+   * 2. Get current sequence values.
+   * 3. Create a temporary table to hold the existing data.
+   * 4. Delete the original table. This is done now so that there
+   *    is no conflict with existing sequence or constraint names
+   *    when we create the new table under the original name.
+   * 5. Create the updated table under the original table name,
+   *    using the new schema.
+   * 6. Copy data from the temporary to the new table.
+   * 7. Set sequence values.
+   * 8. Delete the temporary table.
+   * 9. Release the transaction.
+   *
+   * @param string $table_name
+   *   The name of the table to be updated.
+   * @param array $table_schema
+   *   The table definition array.
+   *
+   * @return void
+   *   No return value.
+   *
+   * @throws \Drupal\tripal\TripalDBX\Exceptions\SchemaException
+   *   If $table_name does not exist.
+   */
+  public function updateTableSchema(string $table_name, array $table_schema): void {
+
+    $temp_table_name = $table_name . '_' . uniqid();
+
+    // Get the schema of the existing table.
+    $old_schema = $this->connection->schema()->getTableDef($table_name, ['source' => 'database', 'format' => 'drupal']);
+    if (!$old_schema) {
+      throw new SchemaException("Table \"$table_name\" has no schema");
+    }
+
+    // Generate a list of columns to copy to the updated table.
+    // If a column is dropped in the new schema, then don't copy it.
+    $old_columns = array_keys($old_schema['fields']);
+    $new_columns = array_keys($table_schema['fields']);
+    $copy_columns = array_intersect($old_columns, $new_columns);
+
+    // 1. Start a transaction.
+    $this->connection->addSavepoint();
+    try {
+
+      // 2. Get sequence values
+      $sql = "SELECT SPLIT_PART(c.column_default, '''', 2) AS sequence_name"
+        . " FROM information_schema.columns AS c"
+        . " WHERE c.table_name = 'stock_analysis' AND c.column_default LIKE 'nextval(%'";
+      $results = $this->connection->query($sql, []);
+      $sequences = [];
+      foreach ($results as $r) {
+        $sql = 'SELECT nextval(:id)';
+        $value = $this->connection->query($sql, [':id' => $r->sequence_name])->fetchField();
+        // SELECT nextval increments the counter.
+        $sequences[$r->sequence_name] = $value - 1;
+      }
+      // 3. Create a temporary table to hold the existing data.
+      $sql = "CREATE TABLE $temp_table_name AS TABLE $table_name";
+      $this->connection->query($sql, []);
+
+      // 4. Delete the original table.
+      $this->dropTable($table_name);
+
+      // 5. Create the updated table under the original table name,
+      // using the new schema.
+      $this->createTable($table_name, $table_schema);
+
+      // 6. Copy data from the temporary to the new table.
+      $columns = implode(',', $copy_columns);
+      $sql = "INSERT INTO $table_name SELECT $columns FROM $temp_table_name";
+      $this->connection->query($sql, []);
+
+      // 7. Set sequence values.
+      foreach ($sequences as $id => $value) {
+        $sql = 'SELECT setval(:id, :value)';
+        $this->connection->query($sql, [':id' => $id, ':value' => $value]);
+      }
+
+      // 8. Delete the temporary table.
+      $this->dropTable($temp_table_name);
+    }
+    catch (\Throwable $e) {
+      $this->connection->rollbackSavepoint();
+      throw $e;
+    }
+    // 9. Release the transaction
+    $this->connection->releaseSavepoint();
   }
 
 }

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -17,11 +17,11 @@ use Drupal\tripal\TripalDBX\Exceptions\SchemaException;
  * there is a single schema. As such the core Drupal implementations focus on
  * managing tables within a single schema.
  *
- * This implementation extends that table-management functionality to also include
- * Schema-focused management including creation, cloning, renaming, dropping
- * and definition export. Additionally, it removes the assumption of a single
- * schema by allowing the default schema to be set based on a Tripal DBX
- * connection.
+ * This implementation extends that table-management functionality to also
+ * include Schema-focused management including creation, cloning, renaming,
+ * dropping, and definition export. Additionally, it removes the assumption of
+ * a single schema by allowing the default schema to be set based on a Tripal
+ * DBX connection.
  *
  * Here are some useful functions to know that are inherited from Drupal Schema
  * classes (core + PgSchema implementation):
@@ -42,9 +42,9 @@ abstract class TripalDbxSchema extends PgSchema {
    *
    * OVERRIDES \Drupal\Core\Database\Schema:$defaultSchema.
    *
-   * Drupal assumes that the default schema name is public. However, for multiple
-   * schema support, we need to set this dynamically in the constructor and
-   * thus set it to empty here.
+   * Drupal assumes that the default schema name is public. However, for
+   * multiple schema support, we need to set this dynamically in the
+   * constructor and thus set it to empty here.
    *
    * @var string
    */
@@ -55,7 +55,8 @@ abstract class TripalDbxSchema extends PgSchema {
    *
    * OVERRIDES \Drupal\Core\Database\Schema:$quotedDefaultSchema.
    *
-   * Same reasoning as above since this is generated based on the default schema.
+   * Same reasoning as above since this is generated based on the
+   * default schema.
    *
    * @var string
    */
@@ -86,8 +87,8 @@ abstract class TripalDbxSchema extends PgSchema {
    *   - 'source': either 'database' to extract data from database or 'file' to
    *     get the data from a static YAML file.
    *     Default: 'file'.
-   *   - 'version': version of the Tripal DBX managed schema to fetch from a file.
-   *     Ignored for 'database' source.
+   *   - 'version': version of the Tripal DBX managed schema to fetch from a
+   *     file. Ignored for 'database' source.
    *     Default: implementation specific.
    *   - 'format': return format, either 'SQL' for an array of SQL string,
    *     'Drupal' for Drupal schema API, 'none' to return nothing or anything
@@ -97,7 +98,7 @@ abstract class TripalDbxSchema extends PgSchema {
    *     Default: TripalDbx::parseTableDdl data structure structure.
    *   - 'clear': if not empty, cache will be cleared.
    *
-   * @return
+   * @return array
    *   An array with details for the current schema version as defined by
    *   $parameters values.
    *
@@ -114,12 +115,12 @@ abstract class TripalDbxSchema extends PgSchema {
    *
    * The TripalDbxSchema object should be instantiated by the
    * TripalDbxConnection::schema() method in order to avoid issues when the
-   * default Tripal DBX managed schema name is changed in the TripalDbxConnection
-   * object which could lead to issues.
+   * default Tripal DBX managed schema name is changed in the
+   * TripalDbxConnection object which could lead to issues.
    *
    * If you choose to instantiate a TripalDbxSchema object yourself, you are
-   * responsible to not change the Tripal DBX managed schema name of the connection
-   * object used to instantiate this TripalDbxSchema.
+   * responsible to not change the Tripal DBX managed schema name of the
+   * connection object used to instantiate this TripalDbxSchema.
    *
    * @param \Drupal\tripal\TripalDBX\TripalDbxConnection $connection
    *   A Tripal DBX connection object.
@@ -127,7 +128,7 @@ abstract class TripalDbxSchema extends PgSchema {
    * @throws \Drupal\tripal\TripalDBX\Exceptions\SchemaException
    */
   public function __construct(
-    \Drupal\tripal\TripalDBX\TripalDbxConnection $connection
+    TripalDbxConnection $connection,
   ) {
     $schema_name = $connection->getSchemaName();
     // Get a TripalDbx object.
@@ -143,7 +144,7 @@ abstract class TripalDbxSchema extends PgSchema {
   }
 
   /**
-   *
+   * Class initialization.
    */
   public function initialize() {
     if (!$this->initialized) {
@@ -161,8 +162,7 @@ abstract class TripalDbxSchema extends PgSchema {
         $logger = \Drupal::service('tripal.logger');
         $sql_cloner_path =
           \Drupal::service('extension.list.module')->getPath('tripal')
-          . '/src/TripalDBX/pg-clone-schema/clone_schema.sql'
-        ;
+          . '/src/TripalDBX/pg-clone-schema/clone_schema.sql';
         // Retrieve the SQL file.
         $sql = file_get_contents($sql_cloner_path);
         if (!$sql) {
@@ -207,8 +207,9 @@ abstract class TripalDbxSchema extends PgSchema {
    *
    * OVERRIDES \Drupal\Core\Database\Schema:findTables().
    *
-   * NOTE: In Drupal 10 individually prefixed tables will no longer be supported.
-   *  At this point we should re-evaluate if this override is still needed.
+   * NOTE: In Drupal 10 individually prefixed tables will no longer be
+   *  supported. At this point we should re-evaluate if this override is
+   *  still needed.
    *
    * Overrides the PostgreSQL implementation for two reasons:
    *  1. Switch back to the generic Drupal implementation to prepare for other
@@ -218,6 +219,7 @@ abstract class TripalDbxSchema extends PgSchema {
    *
    * @param string $table_expression
    *   An SQL expression, for example "cache_%" (without the quotes).
+   *
    * @return array
    *   Both the keys and the values are the matching tables.
    */
@@ -239,7 +241,7 @@ abstract class TripalDbxSchema extends PgSchema {
       ->compile($this->connection, $this);
     $results = $this->connection
       ->query("SELECT table_name AS table_name FROM information_schema.tables WHERE " . (string) $condition, $condition
-      ->arguments());
+        ->arguments());
     foreach ($results as $table) {
       $tables[$table->table_name] = $table->table_name;
     }
@@ -266,14 +268,15 @@ abstract class TripalDbxSchema extends PgSchema {
    * isn't clear, if this function is removed then tests will fail due to
    * incorrect table prefixing.
    *
-   * @param string $table_name
+   * @param string $table
    *   The non-prefixed name of the table.
+   *
    * @return object
-   *    An object with two member variables:
+   *   An object with two member variables:
    *     - 'blob_fields' that lists all the blob fields in the table.
    *     - 'sequences' that lists the sequences used in that table.
    */
-  public function queryTableInformation($table) {
+  public function queryTableInformation(string $table) {
 
     // Generate a key to reference this table's information on.
     $key = $this->connection
@@ -316,9 +319,10 @@ OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')
 EOD;
         $result = $this->connection
           ->query($sql, [
-          ':key' => $key,
-        ]);
-      } catch (\Exception $e) {
+            ':key' => $key,
+          ]);
+      }
+      catch (\Exception $e) {
         $this->connection
           ->rollbackSavepoint();
         throw $e;
@@ -355,24 +359,24 @@ EOD;
    *
    * OVERRIDES \Drupal\Core\Database\Schema:indexExists().
    *
-   * Our version of this method adds an optional parameter $exact_name to support
-   * exact name matches since many biological data-focused databases will not
-   * follow the Drupal index naming pattern. For example, Chado does not follow
-   * this pattern.
+   * Our version of this method adds an optional parameter $exact_name to
+   * support exact name matches since many biological data-focused databases
+   * will not follow the Drupal index naming pattern. For example, Chado does
+   * not follow this pattern.
    *
-   * @param $table
+   * @param string $table
    *   The name of the table in Tripal DBX managed schema.
-   * @param $name
+   * @param string $index_name
    *   The full name of the index (including the '_idx' part for instance).
    * @param bool $exact_name
    *   If FALSE, Drupal will append to the given name the '__idx' suffix (added
    *   when ::addIndex is used) and will adjust the name if needed (length). If
    *   TRUE, the function assumes the given index name is complete.
    *
-   * @return
+   * @return bool
    *   TRUE if the given index exists, otherwise FALSE.
    */
-   public function indexExists($table, $index_name, bool $exact_name = FALSE) {
+  public function indexExists(string $table, string $index_name, bool $exact_name = FALSE) :bool {
     if ($exact_name) {
       return (bool) $this->connection
         ->query("SELECT 1 FROM pg_indexes WHERE indexname = '{$index_name}'")
@@ -386,7 +390,7 @@ EOD;
   /**
    * Returns the size in bytes of a PostgreSQL schema.
    *
-   * @return integer
+   * @return int
    *   The size in bytes of the schema or 0 if the size is not available.
    *
    * @throws \Drupal\tripal\TripalDBX\Exceptions\SchemaException
@@ -421,7 +425,7 @@ EOD;
    *
    * @param string $function_name
    *   The name of the function.
-   * @param array $func_parameters
+   * @param array $function_parameters
    *   An ordered array of input parameter types that are part of the function
    *   signature.
    *
@@ -432,10 +436,9 @@ EOD;
    */
   public function functionExists(
     string $function_name,
-    array $function_parameters
+    array $function_parameters,
   ) :bool {
     $schema_name = $this->defaultSchema;
-    $db_name = $this->connection->getDatabaseName();
 
     if (empty($function_name) || !is_array($function_parameters)) {
       throw new SchemaException('Invalid parameters for functionExists().');
@@ -515,7 +518,7 @@ EOD;
   public function sequenceExists(
     ?string $table_name = NULL,
     ?string $column_name = NULL,
-    ?string &$sequence_name = NULL
+    ?string &$sequence_name = NULL,
   ) :bool {
 
     $schema_name = $this->defaultSchema;
@@ -577,14 +580,14 @@ EOD;
    *   The type of constraint. Should be one of "PRIMARY KEY", "UNIQUE", or
    *   "FOREIGN KEY".
    *
-   * @return
+   * @return bool
    *   TRUE if the constraint exists and FALSE otherwise.
    */
   public function constraintExists(
     $table,
     $constraint_name,
-    ?string $type = NULL
-  ) {
+    ?string $type = NULL,
+  ) :bool {
     // Use parent method if no type was specified.
     if (empty($type)) {
       return parent::constraintExists($table, $constraint_name);
@@ -603,8 +606,7 @@ EOD;
         ':name' => $constraint_name,
         ':type' => $type,
       ])
-      ->fetchField()
-    ;
+      ->fetchField();
 
     return !empty($constraint_exists);
   }
@@ -617,17 +619,17 @@ EOD;
    * @param ?string $column
    *   (optional) The name of the primary key column.
    *
-   * @return
+   * @return bool
    *   TRUE if the primary key meets all the requirements and FALSE otherwise.
    */
   public function primaryKeyExists(
     string $table,
-    ?string $column = NULL
+    ?string $column = NULL,
   ) :bool {
 
     // If they didn't supply the column, then we can look it up.
     if ($column === NULL) {
-      $parameters = ['source' => 'database', 'format' => 'Drupal',];
+      $parameters = ['source' => 'database', 'format' => 'Drupal'];
 
       // Cache the table schema so we don't fetch it thousands of times.
       $cache_id = 'table_def_' . $table . '_' . $parameters;
@@ -683,8 +685,9 @@ EOD;
    * @param string $right_table
    *   The name of the table the foreign key refers to. For the example
    *   above it would be cvterm.
+   *
    * @return array
-   *    The foreign key definition
+   *   The foreign key definition
    */
   public function getForeignKeyDef(string $left_table, string $right_table) {
     $left_def = $this->getTableDef($left_table, ['format' => 'Drupal']);
@@ -703,6 +706,7 @@ EOD;
    * @param string $right_table
    *   The name of the table the foreign key refers to. For the example
    *   above it would be cvterm.
+   *
    * @return bool
    *   TRUE if a foreign key exists, FALSE if not.
    */
@@ -724,15 +728,15 @@ EOD;
    *   The name of the column that is a foreign key in. E.g. 'type_id' for
    *     the feature.type_id => cvterm.cvterm_id foreign key.
    *
-   * @return
+   * @return bool
    *   TRUE if the constraint exists and FALSE otherwise.
    */
   public function foreignKeyConstraintExists(
     string $base_table,
-    string $base_column
-  ) {
-    // Since we don't have a constraint name, we have to use the known pattern for
-    // creating these names in order to make this check.
+    string $base_column,
+  ) :bool {
+    // Since we don't have a constraint name, we have to use the known pattern
+    // for creating these names in order to make this check.
     // This is due to PostgreSQL not storing column information for constraints
     // in the information_schema tables.
     $constraint_name = $base_table . '_' . $base_column . '_fkey';
@@ -772,7 +776,7 @@ EOD;
    *     or a tripal materialized view, or 'other' for other elements.
    */
   public function getTables(
-    array $include = []
+    array $include = [],
   ) :array {
     static $type_to_name = [
       'r' => 'table',
@@ -791,7 +795,7 @@ EOD;
     ];
     $schema_name = $this->defaultSchema;
     $include_types = [];
-    foreach ($include as $index => $type_name) {
+    foreach ($include as $type_name) {
       if (array_key_exists($type_name, $name_to_type)) {
         $include_types[$name_to_type[$type_name]] = TRUE;
       }
@@ -824,8 +828,7 @@ EOD;
           ':schema_name' => $schema_name,
           ':object_types[]' => $include_types,
         ]
-      )
-    ;
+      );
 
     $tables = [];
     // Get original schema to differentiate base and custom.
@@ -841,8 +844,7 @@ EOD;
     foreach ($results as $table) {
       $table_status = array_key_exists($table->relname, $schema_def)
         ? 'base'
-        : 'custom'
-      ;
+        : 'custom';
       if (('r' != $table->relkind)
           || ($base_tables && ($table_status == 'base'))
           || ($custom_tables && ($table_status == 'custom'))
@@ -871,8 +873,8 @@ EOD;
    *     checked, and the lookup will be done in the specified order,
    *     e.g. ['file', 'database'].
    *     Default: 'file'.
-   *   - 'version': version of the Tripal DBX managed schema to fetch from a file.
-   *     Ignored fot 'database' source.
+   *   - 'version': version of the Tripal DBX managed schema to fetch from a
+   *     file. Ignored fot 'database' source.
    *     Default: implementation specific.
    *   - 'format': return format, either 'sql' for an array of SQL string,
    *     'drupal' for Drupal schema API, 'none' to return nothing or anything
@@ -884,7 +886,7 @@ EOD;
    *     Default: TripalDbx::parseTableDdl data structure structure.
    *   - 'clear': if not empty, cache will be cleared.
    *
-   * @return
+   * @return array
    *   An array with details from the specified source for the specified table
    *   using the specified format or an empty array if table not found.
    */
@@ -895,8 +897,7 @@ EOD;
     $sources = (array) ($parameters['source'] ?? 'file');
     $format = strtolower($parameters['format'] ?? '');
     $version = $parameters['version']
-      ?? $this->connection->getVersion()
-    ;
+      ?? $this->connection->getVersion();
     if (!empty($parameters['clear'])) {
       $table_structures = [];
     }
@@ -930,12 +931,12 @@ EOD;
       if (!$table_def && 'tripal' == $source) {
         $valid_source = TRUE;
         $table_def = [];
-        $query = $this->connection->select('tripal_custom_tables','ct');
+        $query = $this->connection->select('tripal_custom_tables', 'ct');
         $query->fields('ct', ['schema']);
         $query->condition('ct.table_name', $table);
         $schema = $query->execute()->fetchField();
         if ($schema) {
-          $table_def = unserialize($schema);
+          $table_def = unserialize($schema, ['allowed_classes' => FALSE]);
         }
       }
       if (!$table_def && 'database' == $source) {
@@ -974,7 +975,7 @@ EOD;
   /**
    * Retrieves the table DDL (table data definition language).
    *
-   * @param string $table
+   * @param string $table_name
    *   The name of the table to retrieve.
    * @param bool $clear_cache
    *   If TRUE, cache is cleared.
@@ -985,7 +986,7 @@ EOD;
    */
   public function getTableDdl(
     string $table_name,
-    bool $clear_cache = FALSE
+    bool $clear_cache = FALSE,
   ) :string {
     static $db_ddls = [];
 
@@ -1005,7 +1006,7 @@ EOD;
       ";
       $result = $this->connection->query(
           $sql_query,
-          [':schema' => $schema_name, ':table' => $table_name, ]
+          [':schema' => $schema_name, ':table' => $table_name]
       );
       $table_raw_definition = '';
       if ($result) {
@@ -1019,7 +1020,7 @@ EOD;
   /**
    * Retrieves tables referencing a given one.
    *
-   * @param string $table
+   * @param string $table_name
    *   The name of the table used as foreign table by other tables.
    * @param bool $clear_cache
    *   If TRUE, cache is cleared.
@@ -1031,7 +1032,7 @@ EOD;
    */
   public function getReferencingTables(
     string $table_name,
-    bool $clear_cache = FALSE
+    bool $clear_cache = FALSE,
   ) :array {
     static $db_dependencies = [];
 
@@ -1066,12 +1067,12 @@ EOD;
       ";
       $all_referencing = $this->connection->query(
           $sql_query,
-          [':schema' => $schema_name, ':table' => $table_name, ]
+          [':schema' => $schema_name, ':table' => $table_name]
       );
       $referencing_tables = [];
       foreach ($all_referencing as $referencing) {
         $referencing_tables[$referencing->deptable] = [
-          $referencing->column => $referencing->depcolumn
+          $referencing->column => $referencing->depcolumn,
         ];
       }
       $db_dependencies[$cache_key] = $referencing_tables;
@@ -1105,16 +1106,13 @@ EOD;
    *
    * @param string $source_schema
    *   Source schema to clone.
-   * @param ?string $target_schema
-   *   Destination schema that will be created and filled with a copy of
-   *   $source_schema. If not set, current schema will be the target.
    *
    * @return int
    *   The new schema size in bytes or 0 if the operation failed or the schema
    *   to clone was empty.
    */
   public function cloneSchema(
-    string $source_schema
+    string $source_schema,
   ) :int {
     $target_schema = $this->defaultSchema;
     // Clone schema.
@@ -1145,12 +1143,15 @@ EOD;
    * @param string $new_schema_name
    *   New name to use.
    *
+   * @return void
+   *   No return value.
+   *
    * @throws \Drupal\Core\Database\DatabaseExceptionWrapper
    * @throws \Drupal\tripal\TripalDBX\Exceptions\SchemaException
    *   if there is no current schema name.
    */
   public function renameSchema(
-      string $new_schema_name
+    string $new_schema_name,
   ) :void {
     if (empty($this->defaultSchema)) {
       throw new SchemaException('Unable to rename current schema: no current schema set.');
@@ -1183,7 +1184,7 @@ EOD;
    * We needed to override it because core Drupal makes some assumptions
    * when building the where condition that do not match our multi-schema setup.
    */
-  public function tableExists($table, $add_prefix = true) {
+  public function tableExists($table, $add_prefix = TRUE) {
 
     // We can't use \Drupal::database()->select() here
     // because it would prefix information_schema.tables
@@ -1195,4 +1196,5 @@ EOD;
           [':table' => $table, ':schema' => $this->getSchemaName()])
       ->fetchField();
   }
+
 }

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -1211,9 +1211,10 @@ EOD;
    * 5. Create the updated table under the original table name,
    *    using the new schema.
    * 6. Copy data from the temporary to the new table.
-   * 7. Set sequence values.
+   * 7. Set sequence values unless table was empty.
    * 8. Delete the temporary table.
    * 9. Release the transaction.
+   * 10. Clear the static caches in getTableDdl() and getTableDef().
    *
    * @param string $table_name
    *   The name of the table to be updated.
@@ -1246,10 +1247,10 @@ EOD;
     $this->connection->addSavepoint();
     try {
 
-      // 2. Get sequence values
+      // 2. Get sequence values.
       $sql = "SELECT SPLIT_PART(c.column_default, '''', 2) AS sequence_name"
         . " FROM information_schema.columns AS c"
-        . " WHERE c.table_name = 'stock_analysis' AND c.column_default LIKE 'nextval(%'";
+        . " WHERE c.table_name = '$table_name' AND c.column_default LIKE 'nextval(%'";
       $results = $this->connection->query($sql, []);
       $sequences = [];
       foreach ($results as $r) {
@@ -1258,6 +1259,7 @@ EOD;
         // SELECT nextval increments the counter.
         $sequences[$r->sequence_name] = $value - 1;
       }
+
       // 3. Create a temporary table to hold the existing data.
       $sql = "CREATE TABLE $temp_table_name AS TABLE $table_name";
       $this->connection->query($sql, []);
@@ -1274,10 +1276,12 @@ EOD;
       $sql = "INSERT INTO $table_name SELECT $columns FROM $temp_table_name";
       $this->connection->query($sql, []);
 
-      // 7. Set sequence values.
+      // 7. Set sequence values unless table was empty.
       foreach ($sequences as $id => $value) {
-        $sql = 'SELECT setval(:id, :value)';
-        $this->connection->query($sql, [':id' => $id, ':value' => $value]);
+        if ($value) {
+          $sql = 'SELECT setval(:id, :value)';
+          $this->connection->query($sql, [':id' => $id, ':value' => $value]);
+        }
       }
 
       // 8. Delete the temporary table.
@@ -1287,8 +1291,15 @@ EOD;
       $this->connection->rollbackSavepoint();
       throw $e;
     }
+
     // 9. Release the transaction
     $this->connection->releaseSavepoint();
+
+    // 10. Clear the static caches in getTableDdl() and getTableDef().
+    // Unfortunately we can't clear them just for this table.
+    $this->getTableDdl($table_name, TRUE);
+    $this->getTableDef($table_name, ['clear' => TRUE, 'format' => 'none']);
+
   }
 
 }

--- a/tripal_chado/src/ChadoCustomTables/ChadoCustomTable.php
+++ b/tripal_chado/src/ChadoCustomTables/ChadoCustomTable.php
@@ -269,13 +269,15 @@ class ChadoCustomTable {
       }
 
       // If the table name is the same and the user is forcing a change then
-      // create the table if it doesn't exist. If it does exist then drop it
-      // and recreate it.
+      // create the table if it doesn't exist. If it does exist then update
+      // the schema, this preserves any records in the table.
       if ($force == TRUE and $this->table_name == $table_schema['table']) {
         if ($chado->schema()->tableExists($this->table_name)) {
-          $chado->schema()->dropTable($this->table_name);
+          $chado->schema()->updateTableSchema($this->table_name, $table_schema);
         }
-        $chado->schema()->createTable($this->table_name, $table_schema);
+        else {
+          $chado->schema()->createTable($this->table_name, $table_schema);
+        }
       }
 
       // If the table name is different in the provided schema but the user is

--- a/tripal_chado/src/Form/ChadoCustomTableForm.php
+++ b/tripal_chado/src/Form/ChadoCustomTableForm.php
@@ -164,7 +164,7 @@ class ChadoCustomTableForm extends FormBase {
       $form['force_drop'] = [
         '#type' => 'checkbox',
         '#title' => t('Re-create table'),
-        '#description' => t('Check this box if your table already exists and you would like to drop it and recreate it.'),
+        '#description' => t('Check this box if your table already exists and you would like to drop it and recreate it. Existing records will be copied to the new table.'),
         '#default_value' => $default_force_drop,
       ];
     }

--- a/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
@@ -228,6 +228,46 @@ class ChadoCustomTableTest extends ChadoTestBrowserBase {
       }
     }
 
+    // Test updating schema on a table with data. First add data.
+    for ($i = 1; $i <= 5; $i++) {
+      $chado->insert('1:' . $table_name2)
+        ->fields([
+          'name' => 'name' . $i,
+          'type_id' => $i,
+          'description' => 'description' . $i,
+        ])
+        ->execute();
+    }
+    // Add a new 'rank' column to the schema.
+    $schema_array3 = $schema_array2;
+    $schema_array3['fields']['rank']['type'] = 'int';
+    $schema_array3['fields']['rank']['not null'] = FALSE;
+    // Update schema.
+    $chado->schema()->updateTableSchema($table_name2, $schema_array3);
+    // Get schema from database to verify.
+    $table_def = $chado->schema()->getTableDef($table_name2, ['source' => 'database', 'format' => 'drupal']);
+    $this->assertArrayHasKey('rank', $table_def['fields'], 'rank column was not added to table in database');
+    // Insert another row to verify sequences are updated.
+    $chado->insert('1:' . $table_name2)
+      ->fields([
+        'name' => 'name6',
+        'type_id' => 6,
+        'description' => 'description6',
+      ])
+      ->execute();
+    // Get count and values of records to verify data is retained.
+    $n = 0;
+    $results = $chado->select('1:' . $table_name2, 't')
+      ->fields('t')
+      ->execute();
+    while ($result = $results->fetchAssoc()) {
+      $n++;
+      $this->assertEquals('name' . $n, $result['name'], "Record $n name not as expected");
+      $this->assertEquals($n, $result['type_id'], "Record $n type_id not as expected");
+      $this->assertEquals('description' . $n, $result['description'], "Record $n description not as expected");
+    }
+    $this->assertEquals(6, $n, 'Did not retrieve expected number of records from table with updated schema');
+
     // Test table deletion.
     // We should be able to call delete() on a table not in chado.
     $table_name3 = 'noschemaadded';


### PR DESCRIPTION
# New Feature

### Closes #2337

### ~~Would benefit from #2336 but not dependent on it~~ Merged

## Description

This provides a way to update a table schema without having to do it through SQL commands.
Currently chado custom tables only support this by destroying and recreating the table, which means all data is lost 😲.
This PR adds a new function in tripal/src/TripalDBX/TripalDbxSchema.php
updateTableSchema($table_name, $schema)

This function is then used in `ChadoCustomTable.php` when a schema is changed.

Additional code in the test is added to cover this new functionality.

Coding standards were (mostly) limited to the first commit 4a40a1f - this has been transferred to PR #2358

This does not support adding a column with a NOT NULL constraint if there is data in the table. If you really wanted to do that, you could add first without the constraint, then populate the column, then update a second time with the constraint.

## What is horribly wrong?

With the method used here, if there are foreign keys, they would have to be found and removed at the start, and regenerated at the end. This is not implemented, and this is already starting to get really ugly, so I am doubtful that this is even a good approach.

## Testing?

`analysis_organism` is a chado custom table present in a default tripal installation

1. Create an analysis
2. Create an organism
3. `INSERT INTO analysis_organism (analysis_id, organism_id) values (1, 1);`
4. `SELECT * FROM analysis_organism;`
` analysis_id | organism_id`
`-------------+-------------`
`           1 |           1`
`(1 row)`
5. Tripal -> Data Storage -> Chado -> Chado Custom Tables
6. For `analysis_organism` select "Edit"
7. Check "Re-create table"
8. Add a `type_id` column
```
...
    'organism_id' => array (
      'size' => 'big',
      'type' => 'int',
      'not null' => true,
    ),
    'type_id' => [
      'type' => 'int',
      'not null' => false,
    ],
  ),
  'indexes' => array (
...
```
9. Save
10. `SELECT * FROM analysis_organism;`
` analysis_id | organism_id | type_id`
`-------------+-------------+---------`
`           1 |           1 |`
`(1 row)`
Note new column is added, but data is retained.