### PR TITLE
Update ChadoTestTrait to resolve PHP 8.4 deprecations and meet coding standards

### DIFF
--- a/tripal_chado/tests/src/Traits/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoTestTrait.php
@@ -298,10 +298,11 @@ trait ChadoTestTrait  {
 
   /**
    * Gets a new Chado schema for testing.
-   * Retrieves the current test schema.
-   * If there is not currently a test schema set-up then one will be created.
    *
-   * @param int $init_level
+   * Retrieves the current test schema. If there is not currently a test schema
+   * set-up then one will be created.
+   *
+   * @param int|null $init_level
    *   One of the constant to select the schema initialization level.
    *   If this is supplied then it forces a new connection to be made for
    *   backwards compatibility.
@@ -311,7 +312,7 @@ trait ChadoTestTrait  {
    * @return \Drupal\tripal\TripalDBX\TripalDbxConnection
    *   A bio database connection using the generated schema.
    */
-  protected function getTestSchema(int $init_level = NULL, string $version = '1.3') {
+  protected function getTestSchema(?int $init_level = NULL, string $version = '1.3') {
 
     if ($init_level !== NULL) {
       return $this->createTestSchema($init_level, $version);

--- a/tripal_chado/tests/src/Traits/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoTestTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\Tests\tripal_chado\Traits;
 
 use Drupal\tripal\TripalDBX\TripalDbx;
@@ -18,20 +19,26 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Tripal')]
 #[Group('Tripal Chado')]
 
-trait ChadoTestTrait  {
+trait ChadoTestTrait {
 
   /**
    * Tripal DBX tool instance.
+   *
+   * @var \Drupal\tripal\TripalDBX\TripalDbx
    */
   protected $tripal_dbx = NULL;
 
   /**
    * Real (Drupal live, not test) config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
    */
   protected $realConfigFactory;
 
   /**
    * Base name for test schemas.
+   *
+   * @var array
    */
   protected $testSchemaBaseNames;
 
@@ -52,6 +59,8 @@ trait ChadoTestTrait  {
 
   /**
    * A string indicating the name of the current chado test schema.
+   *
+   * @var string
    */
   protected $testSchemaName = NULL;
 
@@ -69,7 +78,8 @@ trait ChadoTestTrait  {
   protected static $db = NULL;
 
   /**
-   * Returns the chado cvterm_id for the term with the given ID space + accession.
+   * Gets the chado cvterm_id for the term with the given ID space + accession.
+   *
    * This is completely independant of Tripal terms.
    */
   protected function getCvtermID($idspace, $accession) {
@@ -116,7 +126,7 @@ trait ChadoTestTrait  {
    * @param string $dbname
    *   The name of the database to lookup.
    *
-   * @return object|FALSE
+   * @return object|false
    *   An object containing the columns of the db table (e.g. name).
    *   Returns FALSE if the db record doesn't exist.
    */
@@ -141,7 +151,7 @@ trait ChadoTestTrait  {
    * @param string $cvterm_name
    *   The name of the cvterm to lookup.
    *
-   * @return object|FALSE
+   * @return object|false
    *   An object containing the columns of the cvterm table (e.g. name).
    *   Returns FALSE if the cvterm record doesn't exist.
    */
@@ -176,8 +186,7 @@ trait ChadoTestTrait  {
             $errors[] =
               'Unable to remove temporary tests schema "'
               . $test_schema
-              . '": ' . $e->getMessage()
-            ;
+              . '": ' . $e->getMessage();
           }
         }
       }
@@ -226,15 +235,14 @@ trait ChadoTestTrait  {
   protected function initTripalDbx() {
     $this->tripal_dbx = \Drupal::service('tripal.dbx');
     // Hack to clear TripalDbx cache on each run.
-    $clear = function() {
+    $clear = function () {
       TripalDbx::$drupalSchema = NULL;
       TripalDbx::$reservedSchemaPatterns = NULL;
     };
     $clear->call(new TripalDbx());
     // Adds live schema reservation.
     $reserved_schema_patterns = $this->realConfigFactory->get('tripal.settings')
-      ->get('reserved_schema_patterns', [])
-    ;
+      ->get('reserved_schema_patterns', []);
     foreach ($reserved_schema_patterns as $pattern => $description) {
       $this->tripal_dbx->reserveSchemaPattern($pattern, $description);
     }
@@ -246,8 +254,7 @@ trait ChadoTestTrait  {
   protected function allowTestSchemas() {
     $this->testSchemaBaseNames = $this->realConfigFactory
       ->get('tripal.settings')
-      ->get('test_schema_base_names', [])
-    ;
+      ->get('test_schema_base_names', []);
     $this->tripal_dbx->freeSchemaPattern(
       $this->testSchemaBaseNames['chado'],
       TRUE
@@ -339,8 +346,7 @@ trait ChadoTestTrait  {
   protected function createTestSchema(int $init_level = 0, string $version = '1.3') {
     $schema_name = $this->testSchemaBaseNames['chado']
       . '_'
-      . bin2hex(random_bytes(8))
-    ;
+      . bin2hex(random_bytes(8));
     $tripaldbx_db = new ChadoConnection($schema_name);
     // Make sure schema is free.
     if ($tripaldbx_db->schema()->schemaExists()) {
@@ -388,19 +394,19 @@ trait ChadoTestTrait  {
         break;
 
       case static::PREPARE_TEST_CHADO:
-          $tripaldbx_db->schema()->createSchema();
-          $this->assertTrue($tripaldbx_db->schema()->schemaExists(), 'Test schema created.');
-          $success = $tripaldbx_db->executeSqlFile(
-            $chado_schema_file,
-            ['chado' => $schema_name]);
-          $this->assertTrue($success, 'Chado schema loaded.');
-          $this->assertGreaterThan(100, $tripaldbx_db->schema()->getSchemaSize(), 'Test schema not empty.');
+        $tripaldbx_db->schema()->createSchema();
+        $this->assertTrue($tripaldbx_db->schema()->schemaExists(), 'Test schema created.');
+        $success = $tripaldbx_db->executeSqlFile(
+          $chado_schema_file,
+          ['chado' => $schema_name]);
+        $this->assertTrue($success, 'Chado schema loaded.');
+        $this->assertGreaterThan(100, $tripaldbx_db->schema()->getSchemaSize(), 'Test schema not empty.');
 
-          // Add version information to the schema so the tests don't fail.
-          $success = $tripaldbx_db->executeSqlFile(__DIR__ . '/../../fixtures/fill_chado_test_prepare.sql',
-              ['chado' => $schema_name]);
-          $this->assertTrue($success, 'Prepared chado records added.');
-          break;
+        // Add version information to the schema so the tests don't fail.
+        $success = $tripaldbx_db->executeSqlFile(__DIR__ . '/../../fixtures/fill_chado_test_prepare.sql',
+            ['chado' => $schema_name]);
+        $this->assertTrue($success, 'Prepared chado records added.');
+        break;
 
       case static::INIT_DUMMY:
         $tripaldbx_db->schema()->createSchema();
@@ -441,13 +447,13 @@ trait ChadoTestTrait  {
       $this->setChadoTestSchemaVersion($tripaldbx_db, $version);
     }
 
-    // Make sure that any other connections to TripalDBX will see this new test schema as
-    // the default schema.
+    // Make sure that any other connections to TripalDBX will see this new test
+    // schema as the default schema.
     $config = \Drupal::service('config.factory')->getEditable('tripal_chado.settings');
     $config->set('default_schema', $schema_name)->save();
 
-    // As a safety check, make sure that the tripalDBX object is using the test schema.
-    // We don't want to perform tests in a live schema.
+    // As a safety check, make sure that the tripalDBX object is using the test
+    // schema. We don't want to perform tests in a live schema.
     $this->assertTrue($tripaldbx_db->getSchemaName() == $schema_name, 'TripalDBX is not using the test schema.');
 
     // Set this to be the Chado connection used in the current test schema.
@@ -460,7 +466,10 @@ trait ChadoTestTrait  {
   /**
    * Sets the chado version of the test schema.
    *
-   * @return void
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
+   *   The test schema to set the version for.
+   * @param string $version
+   *   The version of Chado to set (e.g. 1.3).
    */
   protected function setChadoTestSchemaVersion(ChadoConnection &$chado_connection, string $version) {
 
@@ -495,14 +504,12 @@ trait ChadoTestTrait  {
   /**
    * Updates an existing test schema to a new version.
    *
-   * @param ChadoConnection $chado_connection
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
    *   The test schema to migrate.
    * @param string $current_version
    *   The current version of the test schema (e.g. 1.3).
    * @param string $version_to_upgrade_to
    *   The version to upgrade the test schema to (e.g. 1.3.3.013).
-   *
-   * @return void
    */
   protected function upgradeTestSchema(ChadoConnection &$chado_connection, string $current_version, string $version_to_upgrade_to) {
 
@@ -595,9 +602,7 @@ trait ChadoTestTrait  {
    * @param \Drupal\tripal\TripalDBX\TripalDbxConnection $tripaldbx_db
    *   A bio database connection using the test schema.
    */
-  protected function freeTestSchema(
-    \Drupal\tripal\TripalDBX\TripalDbxConnection $tripaldbx_db
-  ) {
+  protected function freeTestSchema(\Drupal\tripal\TripalDBX\TripalDbxConnection $tripaldbx_db) {
     self::$testSchemas[$tripaldbx_db->getSchemaName()] = FALSE;
     try {
       $tripaldbx_db->schema()->dropSchema();
@@ -607,23 +612,21 @@ trait ChadoTestTrait  {
     }
   }
 
-
   /**
-   * Warns test developers if they are missing required modules in a kernel test.
+   * Warns test developers if required modules are missing in a kernel test.
    *
    * This is needed because otherwise the exceptions thrown are not very obvious
    * and complicate debugging kernel tests.
    *
    * @param array $functionality
-   *  A list of functionality you need to support. Although this method handles
-   *  dependencies, you should include all items in the supported keys below
-   *  that you need. This is because in some cases you will want to mock rather
-   *  then include in your kernel tests and this way, this method supports that.
-   *  Supported keys are:
-   *   - TripalTerm
-   *   - TripalEntity
-   *   - ChadoField
-   * @return void
+   *   A list of functionality you need to support. Although this method handles
+   *   dependencies, you should include all items in the supported keys below
+   *   that you need. This is because in some cases you will want to mock rather
+   *   than include in your kernel tests. This way, this method supports that.
+   *   Supported keys are:
+   *     - TripalTerm
+   *     - TripalEntity
+   *     - ChadoField.
    */
   protected function suggestRequiredModules(array $functionality) {
     $suggested_modules = [];
@@ -669,4 +672,5 @@ trait ChadoTestTrait  {
     $modules_array_code = 'protected static $modules = [\'' . implode("','", $suggested_modules) . '\'];';
     $this->assertEmpty($missing_modules, 'You are missing some modules in your static $modules array. For the functionality you requested, we suggest the following: ' . $modules_array_code);
   }
+
 }

--- a/tripal_chado/tests/src/Traits/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoTestTrait.php
@@ -86,7 +86,7 @@ trait ChadoTestTrait {
    *
    * This is completely independant of Tripal terms.
    */
-  protected function getCvtermID($idspace, $accession) {
+  protected function getCvtermID($idspace, $accession) { // phpcs:ignore
     $connection = $this->getTestSchema();
 
     $query = $connection->select('1:cvterm', 'cvt');

--- a/tripal_chado/tests/src/Traits/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoTestTrait.php
@@ -2,7 +2,11 @@
 
 namespace Drupal\Tests\tripal_chado\Traits;
 
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\DatabaseStorage;
+use Drupal\Core\Database\Database;
 use Drupal\tripal\TripalDBX\TripalDbx;
+use Drupal\tripal\TripalDBX\TripalDbxConnection;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Symfony\Component\Yaml\Yaml;
 use PHPUnit\Framework\Attributes\Group;
@@ -208,12 +212,12 @@ trait ChadoTestTrait {
     // Then instantiate a new config factory that will use that database through
     // a new instance of config storage using that database.
     // Get Drupal real database.
-    $drupal_db = \Drupal\Core\Database\Database::getConnection(
+    $drupal_db = Database::getConnection(
       'default',
       'simpletest_original_default'
     );
     // Instantiate a new config storage.
-    $config_storage = new \Drupal\Core\Config\DatabaseStorage(
+    $config_storage = new DatabaseStorage(
       $drupal_db,
       'config'
     );
@@ -222,7 +226,7 @@ trait ChadoTestTrait {
     // Get a typed config (note: this will use the test config storage).
     $typed_config = \Drupal::service('config.typed');
     // Instanciate a new config factory.
-    $this->realConfigFactory = new \Drupal\Core\Config\ConfigFactory(
+    $this->realConfigFactory = new ConfigFactory(
       $config_storage,
       $event_dispatcher,
       $typed_config
@@ -602,7 +606,7 @@ trait ChadoTestTrait {
    * @param \Drupal\tripal\TripalDBX\TripalDbxConnection $tripaldbx_db
    *   A bio database connection using the test schema.
    */
-  protected function freeTestSchema(\Drupal\tripal\TripalDBX\TripalDbxConnection $tripaldbx_db) {
+  protected function freeTestSchema(TripalDbxConnection $tripaldbx_db) {
     self::$testSchemas[$tripaldbx_db->getSchemaName()] = FALSE;
     try {
       $tripaldbx_db->schema()->dropSchema();


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #2339 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR applies the code change brought up in issue #2339 to the ChadoTestTrait in order to comply with PHP 8.4 and remove deprecation errors in methods that use the `getTestSchema()` method.

 https://github.com/tripal/tripal/blob/96967cb5ffd9f5b228f299959ffb8c4cc37d597a/tripal_chado/tests/src/Traits/ChadoTestTrait.php#L314

This line has been updated to:
```
protected function getTestSchema(?int $init_level = NULL, string $version = '1.3') {
```
and $init_level parameter in the docblock is now typed `int|null`.

In a separate commit, fixes have been made to the "easier" PHP coding standard issues. Some issues have been left alone due to probable downstream consequences - in particular, renaming the `getCvtermID()` method. 😅 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
This PR is missing automated tests. I gave it a try but I'm feeling very out of element here. Please feel free to contribute a test if you know how to write one and where to put it. Even if it is *just* for `getTestSchema()` method 😁

Also, ensure all existing automated tests in Tripal's workflows still pass and have not been affected by the code changes made in this PR!