### PR TITLE
Deprecated in Drupal 11.3 and removed in Drupal 12 additional exclude rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tripaldocker/dev/.env
 vendor
 .phpunit.result.cache
 .phpunit.cache
+.deprecation-ignore.txt
 clover.xml
 cc-test-reporter
 coverage/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../../../core/tests/bootstrap.php"
+         bootstrap="../../../modules/contrib/tripal/tripal/tests/tripal-bootstrap.php"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
@@ -36,6 +36,7 @@
       correctly.
     -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=.deprecation-ignore.txt"/> -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt"/>
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
     <env name="MINK_DRIVER_CLASS" value=""/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Tripal preprocessing of bootstrap.php.
  *
  * The purpose of this file is to append a few additional phpunit deprecation
@@ -19,7 +20,7 @@ $combined_ignore_file = __DIR__ . '/../../.deprecation-ignore.txt';
 // defined by Drupal.
 $drupal_exclude_text = file_get_contents($drupal_ignore_file);
 $tripal_exclude_text = file_get_contents($tripal_ignore_file);
- file_put_contents($combined_ignore_file, $drupal_exclude_text . $tripal_exclude_text);
+file_put_contents($combined_ignore_file, $drupal_exclude_text . $tripal_exclude_text);
 
 // Tripal preprocessing is done, now call Drupal's bootstrap.php.
 include DRUPAL_ROOT . '/core/tests/bootstrap.php';

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Tripal preprocessing of bootstrap.php.
+ *
+ * The purpose of this file is to append a few additional phpunit deprecation
+ * exclusions to those already defined by Drupal, because they are in external
+ * modules. Because there can only be one phpunit exclusion file, we first
+ * copy Drupal's exclusions, and then append the additional ones we define
+ * here. We can then proceed to call Drupal's bootstrap.php.
+ */
+
+// Define exclusion file names.
+$drupal_ignore_file = DRUPAL_ROOT . '/core/.deprecation-ignore.txt';
+$tripal_ignore_file = __DIR__ . '/tripal-deprecation-ignore.txt';
+$combined_ignore_file = __DIR__ . '/../../.deprecation-ignore.txt';
+
+// Append Tripal's phpunit deprecation exclusions to those already
+// defined by Drupal.
+$drupal_exclude_text = file_get_contents($drupal_ignore_file);
+$tripal_exclude_text = file_get_contents($tripal_ignore_file);
+ file_put_contents($combined_ignore_file, $drupal_exclude_text . $tripal_exclude_text);
+
+// Tripal preprocessing is done, now call Drupal's bootstrap.php.
+include DRUPAL_ROOT . '/core/tests/bootstrap.php';

--- a/tripal/tests/tripal-deprecation-ignore.txt
+++ b/tripal/tests/tripal-deprecation-ignore.txt
@@ -1,0 +1,19 @@
+
+# Remaining patterns are defined by Tripal.
+# We are ignoring these phpunit deprecation notices under Drupal 11.3
+# because they are in external modules.
+# These excludes have been appended excludes defined by Drupal.
+# This was done by tripal/test/tripal-bootstrap.php
+# @see Tripal PR #2361 where these were added.
+
+# Field Group Module
+# /var/www/drupal/web/core/lib/Drupal/Core/Hook/HookCollectorPass.php:591
+# field_group_module_implements_alter without a #[LegacyModuleImplementsAlter] attribute is deprecated in drupal:11.2.0 and removed in drupal:12.0.0. See https://www.drupal.org/node/3496788
+# One of the tests that triggers this: testTripalEmptyContentTypes
+%field_group_module_implements_alter without a #\[LegacyModuleImplementsAlter\] attribute%
+
+# Drupal
+# /var/www/drupal/vendor/symfony/error-handler/DebugClassLoader.php:347
+# Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.
+# One of the tests that triggers this: testTripalEmptyContentTypes
+%Method "Twig\\Extension\\ExtensionInterface::getFunctions\(\)" might add "array"%

--- a/tripal/tests/tripal-deprecation-ignore.txt
+++ b/tripal/tests/tripal-deprecation-ignore.txt
@@ -1,19 +1,19 @@
 
-# Remaining patterns are defined by Tripal.
+# Patterns starting at this point are defined by Tripal.
 # We are ignoring these phpunit deprecation notices under Drupal 11.3
 # because they are in external modules.
-# These excludes have been appended excludes defined by Drupal.
-# This was done by tripal/test/tripal-bootstrap.php
+# These excludes are appended to excludes defined by Drupal.
+# This is done by tripal/test/tripal-bootstrap.php.
 # @see Tripal PR #2361 where these were added.
 
-# Field Group Module
-# /var/www/drupal/web/core/lib/Drupal/Core/Hook/HookCollectorPass.php:591
-# field_group_module_implements_alter without a #[LegacyModuleImplementsAlter] attribute is deprecated in drupal:11.2.0 and removed in drupal:12.0.0. See https://www.drupal.org/node/3496788
-# One of the tests that triggers this: testTripalEmptyContentTypes
+# Module: Field Group Module
+# Location: /var/www/drupal/web/core/lib/Drupal/Core/Hook/HookCollectorPass.php:591
+# Deprecation: field_group_module_implements_alter without a #[LegacyModuleImplementsAlter] attribute is deprecated in drupal:11.2.0 and removed in drupal:12.0.0. See https://www.drupal.org/node/3496788
+# Example test that triggers this: testTripalEmptyContentTypes
 %field_group_module_implements_alter without a #\[LegacyModuleImplementsAlter\] attribute%
 
-# Drupal
-# /var/www/drupal/vendor/symfony/error-handler/DebugClassLoader.php:347
-# Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.
-# One of the tests that triggers this: testTripalEmptyContentTypes
+# Module: Drupal
+# Location: /var/www/drupal/vendor/symfony/error-handler/DebugClassLoader.php:347
+# Deprecation: Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.
+# Example test that triggers this: testTripalEmptyContentTypes
 %Method "Twig\\Extension\\ExtensionInterface::getFunctions\(\)" might add "array"%


### PR DESCRIPTION
# Bug Fix

### Closes #2352
### Depends on #2356

## Description

This adds some deprecation exclusion rules from external modules. This was moved from PR #2356 to separate out the types of things being done.

## Testing?

Automated tests under 11.x should pass without deprecations.
