### PR TITLE
Deprecated in Drupal 11.3 and removed in Drupal 12 for external modules

### DIFF
--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -96,10 +96,14 @@ jobs:
           docker exec tripaldocker service postgresql restart
           docker exec tripaldocker bash -c 'export drupalversion="'${{ matrix.drupal-version }}'"; \
             if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
-            echo "Drupal version is ${drupalversion}, copying phpunit config for 10.x" \
-            && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
+            echo "Drupal version is ${drupalversion}, copying config for phpunit 9" \
+            && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
             && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
-            else echo "Drupal version is ${drupalversion}, using default phpunit config for 11.x"; fi'
+            elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1"); then \
+            echo "Drupal version is ${drupalversion}, copying config for phpunit 10" \
+            && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
+            && mv web/modules/contrib/tripal/phpunit.10.xml web/modules/contrib/tripal/phpunit.xml; \
+            else echo "Drupal version is ${drupalversion}, using config for phpunit 11"; fi'
       # Runs the PHPUnit tests.
       - name: 'Run PHPUnit Tests'
         run: |

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -99,7 +99,7 @@ jobs:
             echo "Drupal version is ${drupalversion}, copying config for phpunit 9" \
             && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
             && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
-            elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1"); then \
+            elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1.x-dev"); then \
             echo "Drupal version is ${drupalversion}, copying config for phpunit 10" \
             && mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
             && mv web/modules/contrib/tripal/phpunit.10.xml web/modules/contrib/tripal/phpunit.xml; \

--- a/.github/workflows/ALL-testCoverage-qltycloud.yml
+++ b/.github/workflows/ALL-testCoverage-qltycloud.yml
@@ -1,4 +1,4 @@
-name: 'Test Coverage on Drupal 11.1.x-dev + PHP 8.3'
+name: 'Test Coverage on Drupal 11.2.x-dev + PHP 8.3'
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
         run: |
           docker build --tag=tripaldocker:localdocker \
             --build-arg phpversion='8.4' \
-            --build-arg drupalversion='11.1.x-dev' \
+            --build-arg drupalversion='11.2.x-dev' \
             --build-arg postgresqlversion='17' \
             --build-arg chadoschema='teacup' ./
       # Just spin up docker the good ol' fashion way.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,11 @@ RUN service apache2 start \
   && allmodules="${tripalmodules} ${modules}" \
   && vendor/bin/drush en ${allmodules} -y \
   && if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
-     mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.10.5.xml \
+     mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
      && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
+     elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1"); then \
+     mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
+     && mv web/modules/contrib/tripal/phpunit.10.xml web/modules/contrib/tripal/phpunit.xml; \
   fi \
   && service apache2 stop \
   && service postgresql stop

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN service apache2 start \
   && if $(dpkg --compare-versions "${drupalversion}" "le" "10.9"); then \
      mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
      && mv web/modules/contrib/tripal/phpunit.9.6.xml web/modules/contrib/tripal/phpunit.xml; \
-     elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1"); then \
+     elif $(dpkg --compare-versions "${drupalversion}" "le" "11.1.x-dev"); then \
      mv web/modules/contrib/tripal/phpunit.xml web/modules/contrib/tripal/phpunit.11.xml \
      && mv web/modules/contrib/tripal/phpunit.10.xml web/modules/contrib/tripal/phpunit.xml; \
   fi \

--- a/phpunit.10.xml
+++ b/phpunit.10.xml
@@ -64,7 +64,6 @@
   <!-- Settings for coverage reports. -->
   <source
     ignoreSuppressionOfDeprecations="true"
-    ignoreIndirectDeprecations="true"
     >
     <include>
       <directory suffix=".php">tripal/src</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -62,7 +62,9 @@
     </testsuite>
   </testsuites>
   <!-- Settings for coverage reports. -->
-  <source ignoreSuppressionOfDeprecations="true">
+  <source
+    ignoreSuppressionOfDeprecations="true"
+    ignoreIndirectDeprecations="true">
     <include>
       <directory suffix=".php">tripal/src</directory>
       <file>tripal/tripal.module</file>


### PR DESCRIPTION
# Bug Fix

### Closes #2352

## Description

This deals with two deprecations described in issue #2352, i.e.
 - field_group_module_implements_alter without a #[LegacyModuleImplementsAlter] attribute is deprecated in drupal:11.2.0 and removed in drupal:12.0.0. See https://www.drupal.org/node/3496788
 - Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.

We do not actually fix them! Because they are in external modules, what we do is ignore them 🙈 by using `ignoreIndirectDeprecations`.
This is of course not ideal, but they do need to be dealt with in their respective modules.
There is precedent, Drupal is currently ignoring several deprecations. Look in a docker at the file
`/var/www/drupal/web/core/.deprecation-ignore.txt` to see them. They reference https://www.drupal.org/node/3285162 for more details. This is a more fine-grained approach to know exactly what you are ignoring. PR #2361 was an attempt to use this approach, but is a lot more complicated and maybe less maintainable than this approach.

## Testing?

Phpunit should pass for 11.x without any deprecation messages.
