### PR TITLE
Support postgresql 18 - 1 of 2 - no merge required

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -33,6 +33,7 @@ jobs:
           - '15'
           - '16'
           - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -29,6 +29,7 @@ jobs:
           - '15'
           - '16'
           - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'


### PR DESCRIPTION
# New Feature

### Issue #2354 

## Description

In preparation of supporting postgresql 18, this PR just adds building of docker images on version 18.

Other changes will follow in the second part #2369.

## Testing?

I think I can manually dispatch the workflows to test.

Once that is done, this PR does not actually need to be merged, the changes here are included in #2369 