### PR TITLE
Support postgresql 18 - 2 of 2

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -5,11 +5,11 @@
     "args": {
       "drupalversion": "11.x-dev",
       "phpversion": "8.4",
-      "postgresqlversion": "17",
+      "postgresqlversion": "18",
       "chadoschema": "teapot"
     }
   },
-  "initializeCommand": "docker pull tripalproject/tripaldocker-drupal:drupal11.x-dev-php8.4-pgsql17",
+  "initializeCommand": "docker pull tripalproject/tripaldocker-drupal:drupal11.x-dev-php8.4-pgsql18",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/tripal,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/tripal",
   "customizations": {

--- a/.github/workflows/ALL-phpunit.yml
+++ b/.github/workflows/ALL-phpunit.yml
@@ -21,7 +21,7 @@ jobs:
           - '8.4'
         pgsql-version:
           - '14'
-          - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'
@@ -72,7 +72,7 @@ jobs:
           # will be tested on merge to 4.x.
           # Note: Drupal 11.1 is already only tested on one postgresql
           # version since it requires 16+.
-          - pgsql-version: '17'
+          - pgsql-version: '18'
             drupal-version: '10.5.x-dev'
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-qltycloud.yml
+++ b/.github/workflows/ALL-testCoverage-qltycloud.yml
@@ -25,7 +25,7 @@ jobs:
           docker build --tag=tripaldocker:localdocker \
             --build-arg phpversion='8.4' \
             --build-arg drupalversion='11.2.x-dev' \
-            --build-arg postgresqlversion='17' \
+            --build-arg postgresqlversion='18' \
             --build-arg chadoschema='teacup' ./
       # Just spin up docker the good ol' fashion way.
       - name: 'Spin up Local Docker'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -33,6 +33,7 @@ jobs:
           - '15'
           - '16'
           - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -98,10 +98,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }},installchado=FALSE'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 18
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '18' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -112,8 +112,8 @@ jobs:
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 18'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '18' }}
         with:
           image: 'tripalproject/tripaldocker'
           tags: 'latest'

--- a/.github/workflows/MAIN-composerInstall.yml
+++ b/.github/workflows/MAIN-composerInstall.yml
@@ -26,7 +26,7 @@ jobs:
           - '8.4'
         pgsql-version:
           - '14'
-          - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'
@@ -65,9 +65,9 @@ jobs:
           # will be tested on merge to 4.x.
           # Note: Drupal 11.1 is already only tested on one postgresql
           # version since it requires 16+.
-          - pgsql-version: '17'
+          - pgsql-version: '18'
             drupal-version: '10.4.x-dev'
-          - pgsql-version: '17'
+          - pgsql-version: '18'
             drupal-version: '10.5.x-dev'
     steps:
       # Spin up docker container with Drupal pre-requisites installed but not Tripal yet.

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_4x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.1'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.4.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.1_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.1_D10_5x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.1'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.5.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_4x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.2'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.4.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.2_D10_5x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.2'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.5.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_4x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.3'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.4.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D10_5x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.3'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '10.5.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.9.6.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D11_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_1x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.3'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '11.1.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.10.xml'

--- a/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_2x.yml
@@ -27,6 +27,6 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.3'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '11.2.x-dev'
           build-image: true

--- a/.github/workflows/MAIN-phpunit-php8.4_D11_1x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D11_1x.yml
@@ -27,7 +27,7 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.4'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '11.1.x-dev'
           build-image: true
           phpunit-command-options: '-c /var/www/drupal/web/modules/contrib/tripal/phpunit.10.xml'

--- a/.github/workflows/MAIN-phpunit-php8.4_D11_2x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D11_2x.yml
@@ -27,6 +27,6 @@ jobs:
           directory-name: 'tripal'
           modules: 'tripal tripal_biodb tripal_chado'
           php-version: '8.4'
-          pgsql-version: '17'
+          pgsql-version: '18'
           drupal-version: '11.2.x-dev'
           build-image: true

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -29,6 +29,7 @@ jobs:
           - '15'
           - '16'
           - '17'
+          - '18'
         drupal-version:
           - '10.4.x-dev'
           - '10.5.x-dev'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -84,10 +84,10 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
-      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 17
+      ## Build Images tagged drupal{VER} focused on php 8.4 + postgresql 18
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
         name: 'Build & push Docker image Drupal focused Docker images.'
-        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        if: ${{ matrix.php-version == '8.4' && matrix.pgsql-version == '18' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'drupal${{ matrix.drupal-version }}'
@@ -99,8 +99,8 @@ jobs:
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
       - uses: 'mr-smithers-excellent/docker-build-push@v6'
-        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 17'
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
+        name: 'Build latest using 11.2.x-dev, PHP 8.4, PgSQL 18'
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '18' }}
         with:
           image: 'tripalproject/tripaldocker-drupal'
           tags: 'latest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG phpversion='8.3'
 ARG drupalversion='11.2.x-dev'
-ARG postgresqlversion='17'
+ARG postgresqlversion='18'
 FROM tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
 ## Redefine the core args so that they are within the build scope.
 ARG phpversion='8.3'
 ARG drupalversion='11.2.x-dev'
-ARG postgresqlversion='17'
+ARG postgresqlversion='18'
 
 ## Now define the args only needed within the build scope.
 ARG modules='devel devel_php field_group field_group_table'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Target Drupal Version 11.2.x-dev](https://img.shields.io/badge/Target%20Drupal%20Version-11.2.x-informational)
 
-Tested on ![PostgreSQL 14](https://img.shields.io/badge/PostreSQL-14-success) - ![PostgreSQL 17](https://img.shields.io/badge/PostreSQL-17-success)
+Tested on ![PostgreSQL 14](https://img.shields.io/badge/PostreSQL-14-success) - ![PostgreSQL 18](https://img.shields.io/badge/PostreSQL-18-success)
 
 The following table proves the compatibility for the current development version of Tripal.
 
@@ -48,6 +48,7 @@ This project uses QLTY Cloud to determine the quality of our codebase and the co
 | 4.0-alpha1 | >=9.2 <=10.0        | >=8.0 <=8.1 | >=13 <=16  |
 | 4.0-alpha2 | >=10.0 <= 10.1      | >=8.1 <=8.2 | >=13 <=16  |
 | 4.0-alpha3 | >=10.4 <= 11.2      | >=8.1 <=8.3 | >=13 <=17  |
+| 4.0-dev    | >=10.4 <= 11.x.dev  | >=8.1 <=8.4 | >=14 <=18  |
 
 ## Current Timeline
 

--- a/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
@@ -612,8 +612,6 @@ on multiple lines.';
 ";
     $table_ddl = $scmock->getTableDdl('testtable');
     $this->assertNotEmpty($table_ddl, 'Got a table DDL.');
-#print "CP4 expected ";var_dump($expected);//@@@
-#print "CP5 actual ";var_dump($table_ddl);//@@@
     $this->assertEquals($expected, $table_ddl, 'Table DDL ok.');
 
     // Schema renaming.

--- a/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Kernel/TripalDBX/SchemaTest.php
@@ -304,6 +304,9 @@ class SchemaTest extends TripalTestKernelBase {
     $scmock = $this->getTripalDbxSchemaMock($tdbx);
     $schema_name = $scmock->getSchemaName();
     $this->assertEquals($sch_1, $schema_name, 'Schema name set.');
+    $psql_version = $tdbx->version();
+    // Remove distro info, e.g. "13.22 (Debian 13.22-1.pgdg12+1)" -> "13.22".
+    $psql_version = preg_replace('/[^\d\.].*$/', '', $psql_version);
 
     // Check schema does not exist.
     $exists = $scmock->schemaExists();
@@ -560,11 +563,29 @@ class SchemaTest extends TripalTestKernelBase {
         'othertesttable' => ['id' => 'fk',],
       ],
     ];
+
+    // Postgresql 18 handles constraints a bit differently, so we will expect
+    // a few more items here.
+    if (version_compare($psql_version, '18.0') >= 0) {
+      $expected['constraints']['testtable_fieldbool_not_null'] = 'NOT NULL fieldbool';
+      $expected['constraints']['testtable_fieldtext_not_null'] = 'NOT NULL fieldtext';
+      $expected['constraints']['testtable_id_not_null'] = 'NOT NULL id';
+    }
+
     $this->assertEquals(
       $expected,
       $table_def,
       'Table definition ok.'
     );
+
+    // Again a few more items expected under postgresql 18.
+    $extra_if_18 = '';
+    if (version_compare($psql_version, '18.0') >= 0) {
+      $extra_if_18 = ",
+  CONSTRAINT testtable_fieldbool_not_null NOT NULL fieldbool,
+  CONSTRAINT testtable_fieldtext_not_null NOT NULL fieldtext,
+  CONSTRAINT testtable_id_not_null NOT NULL id";
+    }
 
     // DDL.
     $expected =
@@ -581,7 +602,7 @@ class SchemaTest extends TripalTestKernelBase {
   fieldbytea bytea NULL DEFAULT 'x'::bytea,
   CONSTRAINT testtable_pkey PRIMARY KEY (id),
   CONSTRAINT testtable_c1 UNIQUE (fieldbigint, fieldsmallint),
-  CONSTRAINT testtable_foreign_id_fkey FOREIGN KEY (foreign_id) REFERENCES othertesttable(id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED
+  CONSTRAINT testtable_foreign_id_fkey FOREIGN KEY (foreign_id) REFERENCES othertesttable(id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED$extra_if_18
 );
 CREATE UNIQUE INDEX testtable_c1 ON $test_schema.testtable USING btree (fieldbigint, fieldsmallint);
 CREATE UNIQUE INDEX testtable_c2 ON $test_schema.testtable USING btree (fieldbigint, fieldsmallint);
@@ -591,6 +612,8 @@ on multiple lines.';
 ";
     $table_ddl = $scmock->getTableDdl('testtable');
     $this->assertNotEmpty($table_ddl, 'Got a table DDL.');
+#print "CP4 expected ";var_dump($expected);//@@@
+#print "CP5 actual ";var_dump($table_ddl);//@@@
     $this->assertEquals($expected, $table_ddl, 'Table DDL ok.');
 
     // Schema renaming.

--- a/tripaldocker/drupal.Dockerfile
+++ b/tripaldocker/drupal.Dockerfile
@@ -3,7 +3,7 @@ FROM php:${phpversion}-apache-bookworm
 
 ARG phpversion='8.3'
 ARG drupalversion='11.2.x-dev'
-ARG postgresqlversion='17'
+ARG postgresqlversion='18'
 ARG modules='devel devel_php field_group field_group_table'
 ARG chadoschema='chado'
 ARG installchado=TRUE


### PR DESCRIPTION
# New Feature

### Closes #2354 

## Description

This adds postgresql 18 to our supported version list, and replaces 17 with 18 in various test workflows.

## Testing?

Automated tests and try building and using a bleeding-edge docker.