### PR TITLE
Add missing use statements to entity hook

### DIFF
--- a/tripal/src/Hook/TripalEntityHooks.php
+++ b/tripal/src/Hook/TripalEntityHooks.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\tripal\Hook;
 
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Render\Markup;
 use Drupal\tripal\Entity\TripalEntity;
 
 /**


### PR DESCRIPTION
# Bug Fix

### Closes #2373 

## Description

Adds the two missing `use` statements for the preprocess_field hook

## Testing?

Move the title field for some content type out of the hidden section, and then view an entity of that type.
You should not have a wsod any more, and you should see the title field displayed.
