### PR TITLE
Tripal chado services coding standards

### DIFF
--- a/tripal_chado/src/Services/ChadoCustomTableManager.php
+++ b/tripal_chado/src/Services/ChadoCustomTableManager.php
@@ -6,29 +6,31 @@ use Drupal\Core\Database\Connection;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\ChadoCustomTables\ChadoCustomTable;
 
+/**
+ * Provides functions to manage custom tables in chado.
+ */
 class ChadoCustomTableManager {
 
   /**
    * The Drupal database connection.
    */
   public Connection $connection;
-  
+
   /**
    * The chado connection used to query chado.
    */
   public ChadoConnection $chado_connection;
 
-
   /**
    * Instantiates a new ChadoCustomTableManager object.
-   * 
-   * @param \Drupal\Core\Database\Connection
-   *  The database connection object.
-   * @param Drupal\tripal_chado\Database\ChadoConnection
+   *
+   * @param \Drupal\Core\Database\Connection $drupal_connection
+   *   The database connection object.
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
    *   The chado connection used to query chado.
    */
-  public function __construct(Connection $connection, ChadoConnection $chado_connection) {
-    $this->connection = $connection;
+  public function __construct(Connection $drupal_connection, ChadoConnection $chado_connection) {
+    $this->drupal_connection = $connection;
     $this->chado_connection = $chado_connection;
   }
 
@@ -46,6 +48,7 @@ class ChadoCustomTableManager {
    *   schema is specified then the default schema is used.
    *
    * @return \Drupal\tripal_chado\ChadoCustomTables\ChadoCustomTable
+   *   A custom table object for the newly created table.
    */
   public function create(string $table_name, ?string $chado_schema = NULL) {
     // If the schema is not specified, get the default one.
@@ -64,7 +67,7 @@ class ChadoCustomTableManager {
    *   A ChadoCustomTable object or NULL if not found.
    */
   public function loadById(int $id) {
-    $query = $this->connection->select('tripal_custom_tables','tct');
+    $query = $this->drupal_connection->select('tripal_custom_tables', 'tct');
     $query->fields('tct', ['table_name', 'chado']);
     $query->condition('tct.table_id', $id);
     $record = $query->execute()->fetchAssoc();
@@ -114,7 +117,7 @@ class ChadoCustomTableManager {
     if ($chado_schema === NULL) {
       $chado_schema = $this->chado_connection->schema()->getDefault();
     }
-    $query = $this->connection->select('tripal_custom_tables','tct');
+    $query = $this->drupal_connection->select('tripal_custom_tables', 'tct');
     $query->fields('tct', ['table_id']);
     $query->condition('tct.chado', $chado_schema);
     $query->condition('tct.table_name', $table_name);
@@ -129,8 +132,8 @@ class ChadoCustomTableManager {
    *   schema is specified then the default schema is used.
    *
    * @return array
-   *  An associative array of custom tables with the key being the id and
-   *  the value the table name.
+   *   An associative array of custom tables with the key being the id and
+   *   the value the table name.
    */
   public function getTables(?string $chado_schema = NULL) {
     $tables = [];
@@ -139,7 +142,7 @@ class ChadoCustomTableManager {
     if ($chado_schema === NULL) {
       $chado_schema = $this->chado_connection->schema()->getDefault();
     }
-    $query = $this->connection->select('tripal_custom_tables','tct');
+    $query = $this->drupal_connection->select('tripal_custom_tables', 'tct');
     $query->fields('tct', ['table_id', 'table_name']);
     $query->condition('tct.chado', $chado_schema);
     $query->orderBy('table_name');
@@ -149,4 +152,5 @@ class ChadoCustomTableManager {
     }
     return $tables;
   }
+
 }

--- a/tripal_chado/src/Services/ChadoFieldDebugger.php
+++ b/tripal_chado/src/Services/ChadoFieldDebugger.php
@@ -2,14 +2,17 @@
 
 namespace Drupal\tripal_chado\Services;
 
-use \Drupal\tripal_chado\Database\ChadoConnection;
-use \Drupal\tripal\Services\TripalLogger;
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalStorage\ChadoRecords;
 use Drupal\tripal_chado\Plugin\TripalStorage\ChadoStorage;
 
 /**
- * Provides debugging functionality for Chado data loading in fields extending
- * the ChadoFieldItemBase that use properties to automatically load the data.
+ * Provides debugging functionality for Chado data loading in fields.
+ *
+ * This provides debugging for fields that extend the ChadoFieldItemBase that
+ * use properties to automatically load the data.
  *
  * THIS SERVICE SHOULD ONLY BE CALLED BY CHADO STORAGE.
  *
@@ -36,10 +39,10 @@ class ChadoFieldDebugger {
   /**
    * The module handler class, used to check if devel module is enabled.
    */
-  public \Drupal\Core\Extension\ModuleHandler $module_handler;
+  public ModuleHandler $module_handler;
 
   /**
-   * The logger class to use to providing our debugging messages to the developer.
+   * The logger class which provides our debugging messages to the developer.
    */
   public TripalLogger $logger;
 
@@ -51,36 +54,36 @@ class ChadoFieldDebugger {
   public array $fields2debug = [];
 
   /**
-   * A simple flag to indicate if there are any fields to be debugged
-   * for performances sake.
+   * Flag indicates if there are fields to be debugged for performances sake.
    */
   public bool $has_fields2debug = FALSE;
 
   /**
-   * Store status so it only needs to be looked up once
+   * Store status so it only needs to be looked up once.
    *
-   * @var bool|NULL $develIsInstalled
+   * @var bool|null
    */
   protected bool|NULL $develIsInstalled = NULL;
 
   /**
-   * Object constructor for the Chado Field debugger
+   * Object constructor for the Chado Field debugger.
    *
-   * @param Drupal\tripal_chado\Database\ChadoConnection
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
    *   The chado connection used to query chado.
-   * @param Drupal\Core\Extension\ModuleHandler
+   * @param Drupal\Core\Extension\ModuleHandler $module_handler
    *   The drupal module handler service.
-   * @param Drupal\tripal\Services\TripalLogger
-   *   The logger class to use to providing our debugging messages to the developer.
+   * @param Drupal\tripal\Services\TripalLogger $logger
+   *   The logger class which provides our debugging messages to the developer.
    */
-  public function __construct(ChadoConnection $connection, \Drupal\Core\Extension\ModuleHandler $module_handler, TripalLogger $logger) {
-    $this->chado_connection = $connection;
+  public function __construct(ChadoConnection $chado_connection, ModuleHandler $module_handler, TripalLogger $logger) {
+    $this->chado_connection = $chado_connection;
     $this->module_handler = $module_handler;
     $this->logger = $logger;
   }
 
   /**
    * A wrapper for the devel module dpm() function.
+   *
    * If that module is not installed and enabled, we will
    * do slightly more primitive output with print_r statements.
    *
@@ -88,17 +91,20 @@ class ChadoFieldDebugger {
    *   The variable to print out, can be any type.
    * @param string $message
    *   An optional message to display with the variable.
+   *
    * @return void
+   *   No return value.
    */
-  protected function cfd_dpm(mixed $variable, string $message = '') {
+  protected function cfdDpm(mixed $variable, string $message = '') {
     // Devel module status only needs to be retrieved once, but rebuilding
     // cache will reset this if necessary if the module status changes.
     if (is_null($this->develIsInstalled)) {
       $this->develIsInstalled = $this->module_handler->moduleExists('devel');
     }
 
-    // Select the method to display the debugging information
+    // Select the method to display the debugging information.
     if ($this->develIsInstalled) {
+      // phpcs:ignore
       dpm($variable, $message);
     }
     else {
@@ -109,7 +115,7 @@ class ChadoFieldDebugger {
   }
 
   /**
-   * A way for ChadoStorage to tell this service which fields should be debugged.
+   * Lets ChadoStorage tell this service which fields should be debugged.
    */
   public function addFieldToDebugger(string $field_name) {
     $this->fields2debug[$field_name] = $field_name;
@@ -117,7 +123,8 @@ class ChadoFieldDebugger {
   }
 
   /**
-   * Prints out the values array in a readable manner for debuggin purposes.
+   * Prints out the values array in a readable manner for debugging purposes.
+   *
    * This is called by ChadoStorage::buildChadoRecords().
    */
   public function reportValues(array $values, string $message) {
@@ -126,9 +133,7 @@ class ChadoFieldDebugger {
       return;
     }
 
-    $debugging_fields = [];
     $all_fields = [];
-    $i = 0;
     foreach ($values as $field_name => $level1) {
 
       $all_fields[$field_name] = [];
@@ -141,13 +146,13 @@ class ChadoFieldDebugger {
       }
     }
 
-    $this->cfd_dpm($all_fields, $message);
+    $this->cfdDpm($all_fields, $message);
   }
 
   /**
    * Summarize the current state of chadostorage.
    *
-   * @param ChadoStorage $chadostorage
+   * @param \Drupal\tripal_chado\Plugin\TripalStorage\ChadoStorage $chadostorage
    *   The current chadostorage object for interrogation.
    * @param string $message
    *   A short message describing where this method was called from.
@@ -166,7 +171,7 @@ class ChadoFieldDebugger {
       $field_definition = $chadostorage->getFieldDefinition($field_name);
       $state[$field_name] = [
         'field name' => $field_name,
-        'field definition added' =>  is_object($field_definition),
+        'field definition added' => is_object($field_definition),
         'field settings' => (is_object($field_definition)) ? $field_definition->getSettings() : NULL,
         'number of properties' => count($field_properties),
         'properties' => [],
@@ -185,16 +190,17 @@ class ChadoFieldDebugger {
       }
     }
 
-    $this->cfd_dpm($state, $message);
+    $this->cfdDpm($state, $message);
   }
 
   /**
    * This will summarize the results of ChadoStorage::buildChadoRecords().
    *
    * @param array $records
-   *   This is an instance of the TripalStorage ChadoRecords class which contains
-   *   all the information of records to be inserted/modifiedin chado.
-   *   generated using the Drupal Query Builder in the ChadoStorage::*Values() methods.
+   *   This is an instance of the TripalStorage ChadoRecords class which
+   *   contains all the information of records to be inserted/modified in
+   *   chado. Generated using the Drupal Query Builder in the
+   *   ChadoStorage::*Values() methods.
    */
   public function summarizeBuiltRecords(ChadoRecords $records) {
 
@@ -202,12 +208,13 @@ class ChadoFieldDebugger {
       return;
     }
 
-    $this->cfd_dpm($records->getRecordsArray(), 'The array describing the record queries to be generated');
-    $this->cfd_dpm($records->getBaseTables(), 'The known primary keys for our base records');
+    $this->cfdDpm($records->getRecordsArray(), 'The array describing the record queries to be generated');
+    $this->cfdDpm($records->getBaseTables(), 'The known primary keys for our base records');
   }
 
   /**
    * This function will print out the query generated by the query builder.
+   *
    * It is expected that this function will be called right before
    * query->execute() is called in all the ChadoStorage::*ChadoRecord() methods.
    *
@@ -237,20 +244,21 @@ class ChadoFieldDebugger {
      *  - $updateQuery->arguments() only provides the conditional arguments,
      *    not those being updated (facepalm; see Drupal Issue #2005626)
      *
-    $quoted = [];
-    foreach ((array) $query->arguments() as $index => $val) {
-      $key = 'db_placeholder_' . $index;
-      $quoted[$key] = is_null($val) ? 'NULL' : $this->chado_connection->quote($val);
-    }
-    $sql = strtr($sql, $quoted);
+     * $quoted = [];
+     * foreach ((array) $query->arguments() as $index => $val) {
+     *   $key = 'db_placeholder_' . $index;
+     *   $quoted[$key] =
+     *     is_null($val) ? 'NULL' : $this->chado_connection->quote($val);
+     * }
+     * $sql = strtr($sql, $quoted);
     */
 
-    $this->cfd_dpm($sql, $message . ' (See Records for parameters)');
+    $this->cfdDpm($sql, $message . ' (See Records for parameters)');
 
   }
 
   /**
-   * Print some sort of header to make reading all the output easier ;-p
+   * Print some sort of header to make reading all the output easier ;-p.
    */
   public function printHeader(string $process_name) {
 
@@ -281,4 +289,5 @@ class ChadoFieldDebugger {
       [], ['drupal_set_message' => TRUE, 'logger' => FALSE]
     );
   }
+
 }

--- a/tripal_chado/src/Services/ChadoMviewsManager.php
+++ b/tripal_chado/src/Services/ChadoMviewsManager.php
@@ -6,19 +6,21 @@ use Drupal\Core\Database\Connection;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\ChadoCustomTables\ChadoMview;
 
+/**
+ * Provides functions for working with materialized views in chado.
+ */
 class ChadoMviewsManager extends ChadoCustomTableManager {
-
 
   /**
    * Instantiates a new ChadoCustomTableManager object.
    *
-   * @param \Drupal\Core\Database\Connection
-   *  The database connection object.
-   * @param Drupal\tripal_chado\Database\ChadoConnection
+   * @param \Drupal\Core\Database\Connection $drupal_connection
+   *   The database connection object.
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
    *   The chado connection used to query chado.
    */
-  public function __construct(Connection $connection, ChadoConnection $chado_connection) {
-    $this->connection = $connection;
+  public function __construct(Connection $drupal_connection, ChadoConnection $chado_connection) {
+    $this->drupal_connection = $drupal_connection;
     $this->chado_connection = $chado_connection;
   }
 
@@ -36,6 +38,7 @@ class ChadoMviewsManager extends ChadoCustomTableManager {
    *   schema is specified then the default schema is used.
    *
    * @return \Drupal\tripal_chado\ChadoCustomTables\ChadoCustomTable
+   *   A chado custom table object for the newly created table.
    */
   public function create(string $table_name, ?string $chado_schema = NULL) {
     $mview = new ChadoMview($table_name, $chado_schema);
@@ -46,14 +49,13 @@ class ChadoMviewsManager extends ChadoCustomTableManager {
    * Loads a materialized view whose Id matches the one provided.
    *
    * @param int $id
-   *   The ID of the materialized view
+   *   The ID of the materialized view.
    *
    * @return \Drupal\tripal_chado\ChadoCustomTables\ChadoMview
    *   A ChadoMview object or NULL if not found.
    */
   public function loadById(int $id) {
-    $public = \Drupal::database();
-    $query = $public->select('tripal_mviews','tm');
+    $query = $this->drupal_connection->select('tripal_mviews', 'tm');
     $query->join('tripal_custom_tables', 'tct', 'tct.table_id = tm.table_id');
     $query->fields('tct', ['table_name']);
     $query->fields('tct', ['chado']);
@@ -99,8 +101,7 @@ class ChadoMviewsManager extends ChadoCustomTableManager {
    *   The id of the matching materialized view.
    */
   public function findByName(string $table_name, ?string $chado_schema = NULL) {
-    $public = \Drupal::database();
-    $query = $public->select('tripal_mviews','tm');
+    $query = $this->drupal_connection->select('tripal_mviews', 'tm');
     $query->fields('tm', ['mview_id']);
     $query->join('tripal_custom_tables', 'tct', 'tm.table_id = tct.table_id');
     $query->condition('tct.chado', $chado_schema);
@@ -116,14 +117,13 @@ class ChadoMviewsManager extends ChadoCustomTableManager {
    *   no schema is specified then the default schema is used.
    *
    * @return array
-   *  An associatve array of the materialized views with the key being the id
-   *  and the value the table name.
+   *   An associatve array of the materialized views with the key being the id
+   *   and the value the table name.
    */
   public function getTables(?string $chado_schema = NULL) {
     $tables = [];
 
-    $public = \Drupal::database();
-    $query = $public->select('tripal_mviews','tm');
+    $query = $this->drupal_connection->select('tripal_mviews', 'tm');
     $query->join('tripal_custom_tables', 'tct', 'tm.table_id = tct.table_id');
     $query->fields('tct', ['table_id', 'table_name']);
     $query->fields('tm', ['mview_id']);
@@ -135,4 +135,5 @@ class ChadoMviewsManager extends ChadoCustomTableManager {
     }
     return $tables;
   }
+
 }

--- a/tripal_chado/src/Services/ChadoTermsInit.php
+++ b/tripal_chado/src/Services/ChadoTermsInit.php
@@ -4,8 +4,10 @@ namespace Drupal\tripal_chado\Services;
 
 use Drupal\tripal\TripalVocabTerms\TripalTerm;
 
-
-class ChadoTermsInit{
+/**
+ * Installs tripal_chado module content terms.
+ */
+class ChadoTermsInit {
 
   /**
    * Instantiates a new ChadoTermsInit object.
@@ -18,9 +20,10 @@ class ChadoTermsInit{
    * Gets a controlled vocabulary object.
    *
    * @param string $name
-   *   The name of the vocabulary
+   *   The name of the vocabulary.
    *
    * @return \Drupal\tripal\TripalVocabTerms\TripalVocabularyBase
+   *   A tripal vocabulary object.
    */
   private function getVocabulary($name) {
     $vmanager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
@@ -38,9 +41,10 @@ class ChadoTermsInit{
    * Gets a controlled vocabulary IDspace object.
    *
    * @param string $name
-   *   The name of the IdSpace
+   *   The name of the IdSpace.
    *
    * @return \Drupal\tripal\TripalVocabTerms\TripalIdSpaceBase
+   *   A tripal ID space object.
    */
   private function getIdSpace($name) {
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
@@ -90,7 +94,7 @@ class ChadoTermsInit{
         // If so, that IdSpace should have been created prior to
         // this vocabulary using it.
         if (!array_key_exists('isBorrowed', $idSpace_info) or
-            $idSpace_info['urlPrefix']['isBorrowed'] !== True) {
+            $idSpace_info['urlPrefix']['isBorrowed'] !== TRUE) {
           $idspace->setDefaultVocabulary($vocab_info['name']);
           $vocab->addIdSpace($idSpace_info['name']);
         }
@@ -104,7 +108,7 @@ class ChadoTermsInit{
       // Step 3: Add the terms.
       if (array_key_exists('terms', $vocab_info)) {
         foreach ($vocab_info['terms'] as $term_info) {
-          list($idSpace_name, $accession) = explode(':', $term_info['id']);
+          [$idSpace_name, $accession] = explode(':', $term_info['id']);
           $idspace = $this->getIdSpace($idSpace_name);
           if ($idspace) {
             $term = new TripalTerm([
@@ -112,7 +116,7 @@ class ChadoTermsInit{
               'accession' => $accession,
               'idSpace' => $idSpace_name,
               'vocabulary' => $vocab_info['name'],
-              'definition' => array_key_exists('description', $term_info) ? $term_info['description'] : '' ,
+              'definition' => array_key_exists('description', $term_info) ? $term_info['description'] : '',
             ]);
             $idspace->saveTerm($term);
           }
@@ -120,4 +124,5 @@ class ChadoTermsInit{
       }
     }
   }
+
 }


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2285

## Description

This fixes the use of a locally declared service instead of the injected service as described in issue #2285.
For good measure, all coding standards violations in this and other tripal_chado services have been corrected.

## Testing?

Simply building a docker and doing a cache rebuild should test all of the affected services.