### PR TITLE
Add getter and setter for chado buddy schema name

### DIFF
--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -74,6 +74,32 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
   }
 
   /**
+   * Returns the currently active chado schema name.
+   *
+   * @return string
+   *   The name of the active chado schema.
+   */
+  public function getSchemaName(): string {
+    return $this->chado_connection->getSchemaName();
+  }
+
+  /**
+   * Sets the current chado schema name.
+   *
+   * @var string $schema_name
+   *   The name of the chado schema to be used.
+   *
+   * @return void
+   *   No return value.
+   *
+   * @throws Drupal\tripal\TripalDBX\Exceptions\ConnectionException
+   *   If schema name is not valid.
+   */
+  public function setSchemaName(string $schema_name): void {
+    $this->chado_connection->setSchemaName($schema_name);
+  }
+
+  /**
    * Retrieve a list of table columns for one or more chado tables.
    *
    * Schema information is cached for better performance.

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoBuddyBaseTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoBuddyBaseTest.php
@@ -214,7 +214,8 @@ class ChadoBuddyBaseTest extends ChadoTestKernelBase {
     $exception_message = '';
     try {
       $instance->setSchemaName('0Invalid');
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
     $this->assertStringContainsString('Could not use the schema name', $exception_message,

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoBuddyBaseTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoBuddyBaseTest.php
@@ -107,7 +107,7 @@ class ChadoBuddyBaseTest extends ChadoTestKernelBase {
    * Tests focused on basic getter/setters.
    *
    * Specifically, label(), description(), makeAlias(), unmakeAlias(),
-   * removeTablePrefix().
+   * removeTablePrefix(), getSchemaName(), setSchemaName().
    */
   public function testChadoBuddyGetterSetters() {
 
@@ -198,6 +198,27 @@ class ChadoBuddyBaseTest extends ChadoTestKernelBase {
     $expected_values = ['real_name_no_dot' => 'newton', 'name.fictional.indeed' => 'dumbledore'];
     $dereferenced_values = $removeTablePrefix->invoke($instance, $referenced_values);
     $this->assertEquals($expected_values, $dereferenced_values, 'Unexpected dereferenced values from removeTablePrefix()');
+
+    // Test schema getter/setter.
+    $current_schema = $instance->getSchemaName();
+    $this->assertStringContainsString('_test_chado_', $current_schema,
+      'Test chado schema starts with _test_chado_');
+    $instance->setSchemaName('valid_but_new');
+    $new_schema = $instance->getSchemaName();
+    $this->assertEquals('valid_but_new', $new_schema,
+      'Setting schema to a new name');
+    $instance->setSchemaName($current_schema);
+    $new_schema = $instance->getSchemaName();
+    $this->assertEquals($current_schema, $new_schema,
+      'Resetting schema back to default');
+    $exception_message = '';
+    try {
+      $instance->setSchemaName('0Invalid');
+    } catch (\Exception $e) {
+      $exception_message = $e->getMessage();
+    }
+    $this->assertStringContainsString('Could not use the schema name', $exception_message,
+      "We didn't get the exception message we expected for an invalid schema name");
   }
 
   /**


### PR DESCRIPTION
# New Feature and Bug Fix

### Closes #2409

## Description

This adds a getter and setter function to Chado Buddies to change the chado schema name.

## Testing?

I added phpunit test assertions for the new functions. @laceysanderson has a good use case that can test this
