### PR TITLE
Do not load config if module not active

### DIFF
--- a/tripal/src/api/tripal.api.php
+++ b/tripal/src/api/tripal.api.php
@@ -1,9 +1,13 @@
 <?php
 
+/**
+ * @file
+ * Provides an application programming interface (API) for tripal.
+ */
+
 use Drupal\Core\Extension\ExtensionDiscovery;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Config\FileStorage;
-
 
 /**
  * Loads a Tripal managed Configuration Entity.
@@ -19,7 +23,6 @@ use Drupal\Core\Config\FileStorage;
  *   The ID of a Configuration Entity type.
  */
 function tripal_load_configuration($module, $config_type) {
-
   // Get the config entity storage class and definition class.
   $config_storage = \Drupal::entityTypeManager()->getStorage($config_type);
   $definition = \Drupal::entityTypeManager()->getDefinition($config_type);
@@ -32,22 +35,28 @@ function tripal_load_configuration($module, $config_type) {
   $listing = new ExtensionDiscovery(\Drupal::root());
   $modules = $listing->scan('module');
 
+  // Get the list of active modules.
+  $active_modules = array_keys(\Drupal::moduleHandler()->getModuleList());
+
   // Iterate through the list of modules and look for configurations.
   // If any are found but not installed, then install those.
   foreach ($modules as $module) {
-    $extension_path = $module->getPath();
-    $config_path = $extension_path . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
-    if (is_dir($config_path)) {
-      $file_storage = new FileStorage($config_path);
-      $configs = $file_storage->listAll($definition->getConfigPrefix());
-      foreach ($configs as $config_file) {
+    // Only install configuration if the module is enabled.
+    if (in_array($module->getName(), $active_modules)) {
+      $extension_path = $module->getPath();
+      $config_path = $extension_path . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
+      if (is_dir($config_path)) {
+        $file_storage = new FileStorage($config_path);
+        $configs = $file_storage->listAll($definition->getConfigPrefix());
+        foreach ($configs as $config_file) {
 
-        // If a configuration has been found that matches the requested type
-        // then add it only if it doesn't already exist.
-        if (!in_array($config_file, $config_list)) {
-          $config = $file_storage->read($config_file);
-          $mapping = $config_storage->create($config);
-          $mapping->save();
+          // If a configuration has been found that matches the requested type
+          // then add it only if it doesn't already exist.
+          if (!in_array($config_file, $config_list)) {
+            $config = $file_storage->read($config_file);
+            $mapping = $config_storage->create($config);
+            $mapping->save();
+          }
         }
       }
     }

--- a/tripal_layout/src/Services/TripalLayoutRebuildService.php
+++ b/tripal_layout/src/Services/TripalLayoutRebuildService.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ExtensionDiscovery;
+use Drupal\Core\Extension\ModuleHandler;
 
 /**
  * Service for handling tripal_layout's rebuild logic.
@@ -24,7 +25,14 @@ class TripalLayoutRebuildService {
    *
    * @var Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entity_type_manager;
+  protected EntityTypeManagerInterface $entity_type_manager;
+
+  /**
+   * The Drupal module handler service.
+   *
+   * @var Drupal\Core\Extension\ModuleHandler
+   */
+  protected ModuleHandler $module_handler;
 
   /**
    * Constructs a new TripalLayoutRebuildService object.
@@ -33,13 +41,17 @@ class TripalLayoutRebuildService {
    *   The drupal root path.
    * @param Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The drupal entity type manager service.
+   * @param Drupal\Core\Extension\ModuleHandler $module_handler
+   *   The drupal module handler service.
    */
   public function __construct(
     string $root,
     EntityTypeManagerInterface $entity_type_manager,
+    ModuleHandler $module_handler,
   ) {
     $this->drupal_root = $root;
     $this->entity_type_manager = $entity_type_manager;
+    $this->module_handler = $module_handler;
   }
 
   /**
@@ -79,34 +91,40 @@ class TripalLayoutRebuildService {
       ->getStorage($config_entity_type)
       ->loadByProperties([]);
 
+    // Get the list of active modules.
+    $active_modules = $this->module_handler->getModuleList();
+
     // Iterate through the config/install directory of all installed modules
     // looking for YAML files encoding this config entity type.
     $listing = new ExtensionDiscovery($this->drupal_root);
     $modules = $listing->scan('module');
     foreach ($modules as $module) {
-      $extension_path = $module->getPath();
-      $config_path = $extension_path . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
-      if (is_dir($config_path)) {
-        $file_storage = new FileStorage($config_path);
-        $configs = $file_storage->listAll($definition->getConfigPrefix());
-        foreach ($configs as $config_file) {
+      // Only install configuration if the module is enabled.
+      if (in_array($module->getName(), $active_modules)) {
+        $extension_path = $module->getPath();
+        $config_path = $extension_path . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
+        if (is_dir($config_path)) {
+          $file_storage = new FileStorage($config_path);
+          $configs = $file_storage->listAll($definition->getConfigPrefix());
+          foreach ($configs as $config_file) {
 
-          // Now for each YAML file found for our config entity type:
-          // -- Read Config from file.
-          $current_config = $file_storage->read($config_file);
-          // -- Extract the ID of the config entity.
-          $parts = explode('.', $config_file);
-          $config_entity_id = $parts[2];
-          // -- If it matches an existing entity then update it.
-          if (array_key_exists($config_entity_id, $existing_entities)) {
-            $config_entity = $existing_entities[$config_entity_id];
-            $config_entity = $config_storage->updateFromStorageRecord($config_entity, $current_config);
-            $config_entity->save();
-          }
-          // -- If it is new, then create a new entity.
-          else {
-            $config_entity = $config_storage->createFromStorageRecord($current_config);
-            $config_entity->save();
+            // Now for each YAML file found for our config entity type:
+            // -- Read Config from file.
+            $current_config = $file_storage->read($config_file);
+            // -- Extract the ID of the config entity.
+            $parts = explode('.', $config_file);
+            $config_entity_id = $parts[2];
+            // -- If it matches an existing entity then update it.
+            if (array_key_exists($config_entity_id, $existing_entities)) {
+              $config_entity = $existing_entities[$config_entity_id];
+              $config_entity = $config_storage->updateFromStorageRecord($config_entity, $current_config);
+              $config_entity->save();
+            }
+            // -- If it is new, then create a new entity.
+            else {
+              $config_entity = $config_storage->createFromStorageRecord($current_config);
+              $config_entity->save();
+            }
           }
         }
       }

--- a/tripal_layout/src/Services/TripalLayoutRebuildService.php
+++ b/tripal_layout/src/Services/TripalLayoutRebuildService.php
@@ -92,7 +92,7 @@ class TripalLayoutRebuildService {
       ->loadByProperties([]);
 
     // Get the list of active modules.
-    $active_modules = $this->module_handler->getModuleList();
+    $active_modules = array_keys($this->module_handler->getModuleList());
 
     // Iterate through the config/install directory of all installed modules
     // looking for YAML files encoding this config entity type.

--- a/tripal_layout/tripal_layout.services.yml
+++ b/tripal_layout/tripal_layout.services.yml
@@ -6,3 +6,4 @@ services:
     arguments:
       - '%app.root%'
       - '@entity_type.manager'
+      - '@module_handler'


### PR DESCRIPTION
# Bug Fix

### Closes #2414

## Description

This bug shows up in the case where an extension module is installed which uses any of these three configuration types: `tripal.tripalentitytype_collection.*`, `tripal.tripal_content_terms.*`, or `tripal.tripalfield_collection.*`.
If the module is present, but not yet enabled, then when the cache is rebuilt, the module configuration is loaded. Then when you later go to enable the module, it fails with an error like

`Configuration objects (tripal.tripal_content_terms.trpcultivate_terms,` etc.`) provided by trpcultivate already exist in active configuration`

This will affect any extension module that adds a new tripal content type or new tripal fields, thus high priority!

The bug also exists in the tripal_layout module for config types `tripal_layout.tripal_layout_default_form.*` and `tripal_layout.tripal_layout_default_view.*`

## Testing?

You will need a non-core extension module. I suggest tripal cultivate core module. Regardless of the module used, the key steps are:
1. Install the module but do not enable it yet
2. Rebuild cache
3. Enable the module

See https://github.com/TripalCultivate/TripalCultivate/issues/99 for detailed steps to test using the tripal cutivate module.