### PR TITLE
Make tripal_layout module uninstallable

### DIFF
--- a/tripal_layout/config/install/tripal_layout.tripal_layout_default_form.general_form.yml
+++ b/tripal_layout/config/install/tripal_layout.tripal_layout_default_form.general_form.yml
@@ -1,6 +1,12 @@
 id: 'general_form'
 label: 'General Content Types'
 description: 'Layouts for general content types (analysis, organism, etc.) based on Chado and added via the Tripal Chado module.'
+dependencies:
+  module:
+    - 'tripal_layout'
+  enforced:
+    module:
+      - 'tripal_layout'
 layouts:
   - tripal_entity_type: "organism"
     field_groups:

--- a/tripal_layout/config/install/tripal_layout.tripal_layout_default_view.general_view.yml
+++ b/tripal_layout/config/install/tripal_layout.tripal_layout_default_view.general_view.yml
@@ -1,6 +1,12 @@
 id: 'general_view'
 label: 'General Content Types'
 description: 'Layouts for general content types (analysis, organism, etc.) based on Chado and added via the Tripal Chado module.'
+dependencies:
+  module:
+    - 'tripal_layout'
+  enforced:
+    module:
+      - 'tripal_layout'
 layouts:
   - tripal_entity_type: "organism"
     hidden:

--- a/tripal_layout/config/install/tripal_layout.tripal_layout_default_view.genomic_view.yml
+++ b/tripal_layout/config/install/tripal_layout.tripal_layout_default_view.genomic_view.yml
@@ -1,6 +1,12 @@
 id: 'genomic_view'
 label: 'Genomic Content Types'
 description: 'Layouts for genomic content types (gene, mRNA, etc.) based on Chado and added via the Tripal Chado module.'
+dependencies:
+  module:
+    - 'tripal_layout'
+  enforced:
+    module:
+      - 'tripal_layout'
 layouts:
   - tripal_entity_type: "gene"
     hidden:


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2411

## Description

This adds dependencies in the yaml files in the tripal_layout module, that ensures that if the module is uninstalled, then its configurations are also removed.

This is mainly a test case for best practice of any add-on tripal module on how to make its configurations go away if the module is uninstalled.

## Testing?

See how I tested this in issue #2411

## But?

This is a draft because on 4.x the configurations are deleted after module uninstall even without this change.
