### PR TITLE
Devcontainer not building on Mac Silicon with newest docker desktop version

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,7 +9,7 @@
       "chadoschema": "teapot"
     }
   },
-  "initializeCommand": "docker pull tripalproject/tripaldocker-drupal:drupal11.x-dev-php8.4-pgsql18",
+  "initializeCommand": "docker pull tripalproject/tripaldocker-drupal:drupal11.x-dev-php8.4-pgsql18 --platform linux/amd64",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/tripal,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/tripal",
   "customizations": {

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -76,8 +76,6 @@ jobs:
           tags: 'drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
-          multiPlatform: true
-          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
@@ -91,8 +89,6 @@ jobs:
           tags: 'drupal${{ matrix.drupal-version }}'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
-          multiPlatform: true
-          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
@@ -106,8 +102,6 @@ jobs:
           tags: 'latest'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
-          multiPlatform: true
-          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -76,6 +76,8 @@ jobs:
           tags: 'drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
+          multiPlatform: true
+          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
@@ -89,6 +91,8 @@ jobs:
           tags: 'drupal${{ matrix.drupal-version }}'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
+          multiPlatform: true
+          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
@@ -102,6 +106,8 @@ jobs:
           tags: 'latest'
           dockerfile: 'tripaldocker/drupal.Dockerfile'
           registry: 'docker.io'
+          multiPlatform: true
+          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_PASSWORD }}'
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG phpversion='8.3'
 ARG drupalversion='11.2.x-dev'
 ARG postgresqlversion='18'
-FROM tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
+FROM --platform=amd64 tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
 ## Redefine the core args so that they are within the build scope.
 ARG phpversion='8.3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG phpversion='8.3'
 ARG drupalversion='11.2.x-dev'
 ARG postgresqlversion='18'
-FROM --platform=amd64 tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
+ARG buildplatform='linux/amd64'
+FROM --platform=${buildplatform} tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
 ## Redefine the core args so that they are within the build scope.
 ARG phpversion='8.3'


### PR DESCRIPTION

# Tripal 4 Core Dev Task

### Issue #2425

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Indicates the platform `linux/amd64` in both the devcontainer pull command and dockerfile FROM. This will work on all platforms (i.e. both `linux/amd64` and `linux/arm64`) since it's just specifying which version of the base image to pull and there is only one option anyway. On Mac OSX this ensures that docker doesn't complain that it can't find the nonexistent `linux/arm64` version and just fail 🙄 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Test that you can use devcontainer with VSCode on as many different platforms as you have available.