### PR TITLE
Ensure Tripal Field UI "Type Table and Column" uses the right column

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAdditionalTypeTypeDefault.php
@@ -456,8 +456,8 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
       foreach ($fkey_list as $type_table) {
         $fk_def = self::getChadoForeignKeyDef($type_table, 'cvterm', $schema);
         if ($fk_def) {
-          foreach ($fk_def['columns'] as $column_name) {
-            $fkey = $type_table . self::$table_column_delimiter . $column_name;
+          foreach ($fk_def['columns'] as $left_column => $right_column) {
+            $fkey = $type_table . self::$table_column_delimiter . $left_column;
             $type_fkeys[$fkey] = $fkey;
           }
         }
@@ -472,6 +472,7 @@ class ChadoAdditionalTypeTypeDefault extends ChadoFieldItemBase {
         $type_fkeys = ['' => '- Select table and column -'] + $type_fkeys;
       }
     }
+
     return $type_fkeys;
   }
 


### PR DESCRIPTION
# Bug Fix

### Issue #2428 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As described in the issue, a bug arose where the left and right column in a join are different (e.g. stock.type_id -> cvterm.cvterm_id). On 4.x the right column is always shown in the drop down such as in the following screenshot. 
<img width="775" height="560" alt="Image" src="https://github.com/user-attachments/assets/12670703-add2-464a-9b7f-a74cbb1f40af" />

This right column (i.e. cvterm_id) then is assigned as the type column in the Type field which is not correct. This PR switches to use the left column so that these cases can be distinguished. I chose not to change the format right now as shown in the screenshot.
<img width="717" height="578" alt="Screenshot 2026-02-19 at 12 09 28 PM" src="https://github.com/user-attachments/assets/b40bb057-6351-4615-a284-3b081009d6d9" />

### Note

- Do we want to keep this format @dsenalik?
- I need to explore whether this is a problem outside the ChadoAdditionalType field.


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### ChadoAdditionalType field

1. Insert some test data into chado. The code sample here inserts 3 breeding cross progeny.

```sql
SET search_path TO 'teapot';
INSERT INTO organism (genus, species) VALUES ('Tripalus', 'databasica');
SELECT cvt.cvterm_id, cvt.name as term, db.name as idspace, dbx.accession FROM cvterm cvt LEFT JOIN dbxref dbx ON dbx.dbxref_id=cvt.dbxref_id LEFT JOIN db ON db.db_id=dbx.db_id WHERE cvt.name='progeny';
INSERT INTO stock (organism_id, type_id, name, uniquename) VALUES (1, 247, '1234S', 'Cross:1');
INSERT INTO stock (organism_id, type_id, name, uniquename) VALUES (1, 247, '5678S', 'Cross:2');
INSERT INTO stock (organism_id, type_id, name, uniquename) VALUES (1, 247, '9876S', 'Cross:3');
```
 
3. Import the Germplasm Content Type Collection by going to Tripal > Page Structure > Import type collection".
4. Go to Tripal > Page Structure > Manage fields for the Breeding Cross Progeny content type. Edit the "Type" field and confirm that the "Type Table and Column" is set and that the options are as follows.
<img width="717" height="578" alt="Screenshot 2026-02-19 at 12 09 28 PM" src="https://github.com/user-attachments/assets/b40bb057-6351-4615-a284-3b081009d6d9" />
 
6. Click save to ensure the settings are updated by the selection in this drop-down.
7. Now publish our test content by going to Admin > Tripal > Content and clicking on "Publish Tripal Content". Choose "Breeding Cross Progeny" as the content type. Confirm it publishes without error.