### PR TITLE
There is no username arg for trp-import-types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN service apache2 start \
 RUN service apache2 start \
   && service postgresql start \
   && if [ "$installchado" = "TRUE" ]; then \
-  vendor/bin/drush trp-import-types --collection_id=general_chado --username=drupaladmin; \
+  vendor/bin/drush trp-import-types --collection_id=general_chado; \
   fi \
   && curl https://qlty.sh | sh || true \
   && service apache2 stop \

--- a/tripal/src/Commands/TripalCommands.php
+++ b/tripal/src/Commands/TripalCommands.php
@@ -211,7 +211,7 @@ class TripalCommands extends DrushCommands {
       Note: fields will also be added automatically if the TripalField-Collection YAML file has the same id.',
   )]
   #[CLI\Usage(
-    name: 'drush trp-import-types --username=[USERNAME] --collection_id=genomic_chado',
+    name: 'drush trp-import-types --collection_id=genomic_chado',
     description: 'Runs a job importing the genomic content types focused on a Chado backend.',
   )]
   public function tripalImportContentTypes(array $options = ['collection_id' => NULL]) {


### PR DESCRIPTION
# Bug Fix

### Closes #2432

## Description

Converting drush commands to attributes has better enforced arguments.
Before, this was valid
`drush trp-import-types --collection_id=general_chado --username=xxsuper-fake-namexx`
but now it causes (as it should) an error
`The "--username" option does not exist`

This PR takes the inappropriate username argument out of the Dockerfile.

## Testing?

Easy to test, build a docker and make sure the general content types have been created.

In automated tests this section **should be present**
```
#11 0.132 Starting Apache httpd web server: apache2.
#11 1.252 Starting PostgreSQL 14 database server: main.
#11 3.847  [notice] Creating Tripal Content Types from: General Content Types (Chado)
#11 4.095  [notice] Content type, "Organism", created.
#11 4.200  [notice] Content type, "Species Tree", created.
#11 4.250  [notice] Content type, "Analysis", created.
#11 4.303  [notice] Content type, "Project", created.
#11 4.354  [notice] Content type, "Study", created.
#11 4.404  [notice] Content type, "Contact", created.
#11 4.453  [notice] Content type, "Publication", created.
#11 4.502  [notice] Content type, "Protocol", created.
#11 4.531  [notice] Attaching fields to Tripal content types from: Default Chado Fields
#11 4.700  [notice] Added field, "organism_genus", to content type: "organism".
#11 4.782  [notice] Added field, "organism_species", to content type: "organism".
#11 4.882  [notice] Added field, "organism_infraspecific_type", to content type: "organism".
#11 4.964  [notice] Added field, "organism_infraspecific_name", to content type: "organism".
...
```