### PR TITLE
Added field group deprecations  related to theme and plugins.

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -12,6 +12,36 @@
 # Example test that triggers this: testTripalEmptyContentTypes
 %field_group_module_implements_alter without a #\[LegacyModuleImplementsAlter\] attribute%
 
+# Module: Field Group Module
+# Location: /var/www/drupal/web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:52
+# Deprecation: Providing a file for theme hook horizontal_tabs is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3549500
+# Example test that triggers this is TripalCultivate::installTest. Triggered whenever a Tripal module with layouts including vertical or horizontal tabs is installed or such layouts are applied.
+%Providing a file for theme hook horizontal_tabs is deprecated%
+
+# Module: Field Group Module
+# Location: /var/www/drupal/web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:52
+# Deprecation: Providing template_preprocess_horizontal_tabs() is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3504125
+# Example test that triggers this is TripalCultivate::installTest. Triggered whenever a Tripal module with layouts including vertical or horizontal tabs is installed or such layouts are applied.
+%Providing template_preprocess_horizontal_tabs\(\) is deprecated%
+
+# Module: Field Group Module
+# Location: /var/www/drupal/web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:52
+# Deprecation: Providing a file for theme hook field_group_html_element is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3549500
+# Example test that triggers this is TripalCultivate::installTest. Triggered whenever a Tripal module with layouts including vertical or horizontal tabs is installed or such layouts are applied.
+%Providing a file for theme hook field_group_html_element is deprecated%
+
+# Module: Field Group Module
+# Location: /var/www/drupal/web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:52
+# Deprecation: Providing template_preprocess_field_group_html_element() is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. Use initial preprocess for template_preprocess instead. See https://www.drupal.org/node/3504125
+# Example test that triggers this is TripalCultivate::installTest. Triggered whenever a Tripal module with layouts including vertical or horizontal tabs is installed or such layouts are applied.
+%Providing template_preprocess_field_group_html_element\(\) is deprecated%
+
+# Module: Field Group Module
+# Location: /var/www/drupal/web/modules/contrib/TripalCultivate/tests/src/Functional/InstallTest.php:119
+# Deprecation: Not supporting attribute discovery in Drupal\field_group\FieldGroupFormatterPluginManager is deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. Provide an Attribute class and an Annotation class for BC. See https://www.drupal.org/node/3395582
+# Example test that triggers this is TripalCultivate::installTest. Triggered whenever a Tripal module with layouts including vertical or horizontal tabs is installed or such layouts are applied.
+%Not supporting attribute discovery in Drupal\\field_group\\FieldGroupFormatterPluginManager is deprecated%
+
 # Module: Drupal
 # Location: /var/www/drupal/vendor/symfony/error-handler/DebugClassLoader.php:347
 # Deprecation: Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Drupal\devel\Twig\Extension\Debug" now to avoid errors or add an explicit @return annotation to suppress this message.


### PR DESCRIPTION

# Tripal 4 Core Dev Task

### Issue #2434 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The field group module is throwing additional deprecation noticed in extension modules. We are not seeing them in core because 1) we do not have as good of coverage and 2) core layouts do not yet use horizontal or vertical tabs.

This PR adds these deprecations to our ignore list. They are being ignored in Tripal Core because Field Group is a core Tripal Layout dependency and these deprecations are being thrown in extension modules when Tripal Layout is used in supported ways.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
There are no tests in Tripal core that currently throw these deprecations.

Our tests should show if there is a syntax error in the added ignore patterns though.

If you want to test this in situ, you can do so using the InstallTest in TripalCultivate as follows:

1. Create a TripalCultivate docker container on branch `g5.102-resolveDeprecations`.
2. Replace the `/var/www/drupal/web/modules/contrib/tripal/.tripal-deprecation-ignore.txt` file inside the container with the modified one in this PR.
3. Within the TripalCultivate module directory (`/var/www/drupal/web/modules/contrib/TripalCultivate`) run the PHPUnit test using `phpunit tests/src/Functional/InstallTest.php`
4. Notice that without the change to the Tripal file, there are many deprecations and with there are only 3 deprecations, none of which relate to field group or horizontal tabs.