### PR TITLE
Add another EBI OLS known error message

### DIFF
--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -300,12 +300,17 @@ class OboImporterTest extends ChadoTestKernelBase {
     catch(\Exception $e) {
       // If we get a specific known message due to the EBI OLS external
       // database being down, then mark this test as skipped.
+      $skip_reasons = [];
       foreach ($this->mock_messages as $message) {
         foreach ($this->known_external_messages as $pattern) {
           if (preg_match($pattern, $message)) {
-            $this->markTestSkipped();
+            $skip_reasons[$message] = 1;
           }
         }
+      }
+      if ($skip_reasons) {
+        $this->markTestSkipped("We received only known external error messages and chose to ignore them. Specifically:\n"
+          . implode("\n", array_keys($skip_reasons)));
       }
       // For anything else, rethrow the exception so we see the problem.
       throw $e;

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -96,6 +96,18 @@ class OboImporterTest extends ChadoTestKernelBase {
   protected array $scenarios;
 
   /**
+   * Messages encountered when EBI OLS is down or broken.
+   *
+   * @var array
+   *   A list of error messages encountered when the external
+   *   web site is down or not functioning normally.
+   */
+  protected array $known_external_messages = [
+    '/Cannot find the ontology via an EBI OLS lookup/',
+    '/Service Temporarily Unavailable/',
+  ];
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -286,11 +298,13 @@ class OboImporterTest extends ChadoTestKernelBase {
       $obo_importer->run();
     }
     catch(\Exception $e) {
-      // If we get a specific message due to the EBI OLS external database
-      // being down, then mark this test as skipped.
+      // If we get a specific known message due to the EBI OLS external
+      // database being down, then mark this test as skipped.
       foreach ($this->mock_messages as $message) {
-        if (preg_match('/Cannot find the ontology via an EBI OLS lookup/', $message)) {
-          $this->markTestSkipped();
+        foreach ($this->known_external_messages as $pattern) {
+          if (preg_match($pattern, $message)) {
+            $this->markTestSkipped();
+          }
         }
       }
       // For anything else, rethrow the exception so we see the problem.

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -100,11 +100,14 @@ class OboImporterTest extends ChadoTestKernelBase {
    *
    * @var array
    *   A list of error messages encountered when the external
-   *   web site is down or not functioning normally.
+   *   web site is down or not functioning normally are tagged
+   *   with 'skip', messages normally encountered are tagged
+   *   with 'normal'.
    */
-  protected array $known_external_messages = [
-    '/Cannot find the ontology via an EBI OLS lookup/',
-    '/Service Temporarily Unavailable/',
+  protected array $message_actions = [
+    '/a lookup will be performed with the EBI Ontology Lookup Service/' => 'normal',
+    '/Cannot find the ontology via an EBI OLS lookup/' => 'skip',
+    '/Service Temporarily Unavailable/' => 'skip',
   ];
 
   /**
@@ -300,20 +303,28 @@ class OboImporterTest extends ChadoTestKernelBase {
     catch(\Exception $e) {
       // If we get a specific known message due to the EBI OLS external
       // database being down, then mark this test as skipped.
-      $skip_reasons = [];
+      $skip_triggered = [];
       foreach ($this->mock_messages as $message) {
-        foreach ($this->known_external_messages as $pattern) {
+        $matched = FALSE;
+        foreach ($this->message_actions as $pattern => $action) {
           if (preg_match($pattern, $message)) {
-            $skip_reasons[$message] = 1;
+            if ($action == 'skip') {
+              $skip_triggered[] = $message;
+            }
+            $matched = TRUE;
           }
         }
+        $this->assertTrue($matched, 'An exception caused an error: '
+          . $e->getMessage() . ' and the unexpected logger message was: ' . $message);
       }
-      if ($skip_reasons) {
+      if ($skip_triggered) {
         $this->markTestSkipped("We received only known external error messages and chose to ignore them. Specifically:\n"
-          . implode("\n", array_keys($skip_reasons)));
+          . implode("\n", $skip_triggered));
       }
-      // For anything else, rethrow the exception so we see the problem.
-      throw $e;
+      else {
+        // If the exception did not create a logger message, rethrow.
+        throw $e;
+      }
     }
 
     // Test that any expected warning was generated.

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -306,21 +306,24 @@ class OboImporterTest extends ChadoTestKernelBase {
       $skip_triggered = [];
       foreach ($this->mock_messages as $message) {
         // For each expected external message...
+        $matched_any = FALSE;
         foreach ($this->message_actions as $pattern => $action) {
           // If it's in our list with an action of skip
           // then we indicate the test should be skipped.
           if (preg_match($pattern, $message)) {
+            $matched_any = TRUE;
             // Note: an action of normal will simply be ignored
             // since it would fall into an 'else' here.
             if ($action == 'skip') {
               $skip_triggered[] = $message;
             }
           }
-          // If it doesn't match our pattern then we want to
-          // immediately rethrow the exception!
-          else {
-            throw $e;
-          }
+        }
+        if (!$matched_any) {
+          // If it doesn't match any of our pattern then it is a new
+          // unanticipated error and we want to immediately rethrow
+          // the exception!
+          $this->fail('Unanticipated error: ' . $message);
         }
       }
       // If any of the known external error messages were caught

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -305,24 +305,32 @@ class OboImporterTest extends ChadoTestKernelBase {
       // database being down, then mark this test as skipped.
       $skip_triggered = [];
       foreach ($this->mock_messages as $message) {
-        $matched = FALSE;
+        // For each expected external message...
         foreach ($this->message_actions as $pattern => $action) {
+          // If it's in our list with an action of skip
+          // then we indicate the test should be skipped.
           if (preg_match($pattern, $message)) {
+            // Note: an action of normal will simply be ignored
+            // since it would fall into an 'else' here.
             if ($action == 'skip') {
               $skip_triggered[] = $message;
             }
-            $matched = TRUE;
+          }
+          // If it doesn't match our pattern then we want to
+          // immediately rethrow the exception!
+          else {
+            throw $e;
           }
         }
-        $this->assertTrue($matched, 'An exception caused an error: '
-          . $e->getMessage() . ' and the unexpected logger message was: ' . $message);
       }
+      // If any of the known external error messages were caught
+      // then we want to skip here.
       if ($skip_triggered) {
         $this->markTestSkipped("We received only known external error messages and chose to ignore them. Specifically:\n"
           . implode("\n", $skip_triggered));
       }
+      // If the exception did not create a logger message, rethrow.
       else {
-        // If the exception did not create a logger message, rethrow.
         throw $e;
       }
     }

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -321,8 +321,7 @@ class OboImporterTest extends ChadoTestKernelBase {
         }
         if (!$matched_any) {
           // If it doesn't match any of our pattern then it is a new
-          // unanticipated error and we want to immediately rethrow
-          // the exception!
+          // unanticipated error and we want to immediately fail.
           $this->fail('Unanticipated error: ' . $message);
         }
       }
@@ -332,9 +331,9 @@ class OboImporterTest extends ChadoTestKernelBase {
         $this->markTestSkipped("We received only known external error messages and chose to ignore them. Specifically:\n"
           . implode("\n", $skip_triggered));
       }
-      // If the exception did not create a logger message, rethrow.
+      // If the exception did not create a logger message, fail now.
       else {
-        throw $e;
+        $this->fail('Unanticipated exception: ' . $e->getMessage());
       }
     }
 


### PR DESCRIPTION
# Bug Fix

### Issue #2143

## Description

This adds another error message to watch for since the EBI OLS external database has been having problems lately.

## Testing?

Test should be marked skipped again. As of submission of the PR, the new 503 error is gone, but the original error is still present.