### PR TITLE
ChadoTermMapping is not a bundle

### DIFF
--- a/tripal_chado/src/Entity/ChadoTermMapping.php
+++ b/tripal_chado/src/Entity/ChadoTermMapping.php
@@ -27,7 +27,6 @@ use Drupal\tripal_chado\ListBuilders\ChadoTermMappingListBuilder;
   ],
   config_prefix: 'chado_term_mapping',
   admin_permission: 'administer tripal',
-  bundle_of: 'tripal_entity',
   entity_keys: [
     'id' => 'id',
     'label' => 'label',


### PR DESCRIPTION
# Bug Fix

### Closes #2451

## Description

On Drupal 11.2, 11.3, and 11.x we are observing a wsod.

This was quite a challenge to trace to its cause 😩.

`entity.tripal_entity.field_ui_fields` is not a route that tripal defines, but drupal creates it.

The WSOD page in question is from the route defined in `tripal_chado/tripal_chado.routing.yml`:107:
```
entity.chado_term_mapping.collection:
  path: 'admin/tripal/storage/chado/terms'
  defaults:
    _entity_list: 'chado_term_mapping'
    _title: 'Chado Term Mapping'
  requirements:
    _permission: 'administer tripal'
```

This entity list is defined in:
`tripal_chado/src/Entity/ChadoTermMapping.php`

Because it included the line
`bundle_of: 'tripal_entity',`
then Drupal goes ahead and tries to add actions to "Manage fields", "Manage form display" and "Manage display".
These are needed for when we are editing a `tripal_entity` bundle.

The mistaken inclusion of the `bundle_of` here triggers these getting added, and since the term mapping is not a bundle, no bundle id is available, and the WSOD results.

Take this out and the bug is fixed 😀.

## Testing?

You will need to test on a Drupal 11 version to see the bug.

Go to Tripal → Data Storage → Chado
Then select Chado Term Mapping
On this branch the page is displayed normally
On 4.x Observe wsod
The website encountered an unexpected error. Try again later.
```
Symfony\Component\Routing\Exception\MissingMandatoryParametersException: Some
mandatory parameters are missing ("tripal_entity_type") to generate a URL for route
"entity.tripal_entity.field_ui_fields". in
Drupal\Core\Routing\UrlGenerator->doGenerate() (line 189 of
core/lib/Drupal/Core/Routing/UrlGenerator.php).
...
```
