### PR TITLE
New Chado buddy delete functions

### DIFF
--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -35,11 +35,6 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
   const SUCCESS = 4;
 
   /**
-   * Indicates an operation, e.g. delete, failed.
-   */
-  const FAILURE = 5;
-
-  /**
    * Provides the TripalDBX connection to chado.
    *
    * @var Drupal\tripal_chado\Database\ChadoConnection

--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -597,7 +597,7 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
    *   No return value.
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
-   *   If there are more than one records.
+   *   If there is more than one record.
    */
   protected function throwIfMultipleRecords(array $records, string $key, string $message, array $conditions): void {
     if (count($records) > 1) {
@@ -609,6 +609,46 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
         . implode(', ', $values)
         . ") matched the specified conditions\n"
         . print_r($conditions, TRUE));
+    }
+  }
+
+  /**
+   * Generates an exception if a record is referenced through a foreign key.
+   *
+   * @param string $table
+   *   The chado table of interest.
+   * @param int $pkey
+   *   The primary key value of the record in table $table.
+   * @param string $context
+   *   The context in which this was called, e.g. "deleteDb", "deleteCv".
+   *
+   * @return void
+   *   No return value.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If there is one or more referencing records.
+   */
+  protected function throwIfReferencingRecords(string $table, int $pkey, string $context): void {
+    $table_def = $this->chado_connection->schema()->getTableDef($table, ['source' => 'database', 'format' => 'default']);
+    // Format is [referencing_table =>
+    // [table column (xx_id) => referencing_table column], ].
+    $foreign_keys = $table_def['referenced_by'] ?? [];
+    $references = [];
+    foreach ($foreign_keys as $referencing_table => $keydef) {
+      foreach ($keydef as $refkey) {
+        $query = $this->chado_connection->select('1:' . $referencing_table);
+        $query->condition($refkey, $pkey, '=');
+        $n = $query->countQuery()->execute()->fetchField();
+        if ($n) {
+          $references[] = "$n record(s) in table \"$referencing_table\"";
+        }
+      }
+    }
+
+    // If there are any referencing records then throw an exeption.
+    if ($references) {
+      throw new ChadoBuddyException("ChadoBuddy $context error, records from the following tables reference the $table record $pkey: "
+        . implode(', ', $references) . '.');
     }
   }
 

--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -25,6 +25,21 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
   const EXISTING = 2;
 
   /**
+   * Indicates a record did not exist.
+   */
+  const NON_EXISTING = 3;
+
+  /**
+   * Indicates an operation, e.g. delete, succeeded.
+   */
+  const SUCCESS = 4;
+
+  /**
+   * Indicates an operation, e.g. delete, failed.
+   */
+  const FAILURE = 5;
+
+  /**
    * Provides the TripalDBX connection to chado.
    *
    * @var Drupal\tripal_chado\Database\ChadoConnection
@@ -568,6 +583,37 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
     if (!array_key_exists(0, $output_records) or !($output_records[0] instanceof ChadoBuddyRecord)) {
       $calling_function = debug_backtrace()[1]['function'];
       throw new ChadoBuddyException("ChadoBuddy $calling_function error, the array passed to validateOutput does not contain a ChadoBuddyRecord");
+    }
+  }
+
+  /**
+   * Generates an exception when more than one record is retrieved.
+   *
+   * @param array $records
+   *   An array of buddy records.
+   * @param string $key
+   *   The key to retrieve from each record for the exception message.
+   * @param string $message
+   *   Text to include in the exception message.
+   * @param array $conditions
+   *   The query conditions that retrieved the records.
+   *
+   * @return void
+   *   No return value.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If there are more than one records.
+   */
+  protected function throwIfMultipleRecords(array $records, string $key, string $message, array $conditions): void {
+    if (count($records) > 1) {
+      $values = [];
+      foreach ($records as $record) {
+        $values[] = $record->getValue($key);
+      }
+      throw new ChadoBuddyException("ChadoBuddy $message error, more than one record ("
+        . implode(', ', $values)
+        . ") matched the specified conditions\n"
+        . print_r($conditions, TRUE));
     }
   }
 

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1191,6 +1191,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
+   *   - Foreign key references exist to the record.
    *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the cvterm.
    */

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1068,6 +1068,10 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
+   *     - fail_when_referenced (bool; default TRUE)
+   *       If TRUE, throw an exception when the cv indicated is referenced
+   *       by other records and cascade is FALSE. If FALSE, return
+   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the CV was
@@ -1077,10 +1081,11 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
-   *   - the conditions match more then one record.
+   *   - Foreign key references exist to the record.
+   *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the cv.
    */
-  public function deleteCv(array $conditions, array $options = []): ?bool {
+  public function deleteCv(array $conditions, array $options = []): int {
     $valid_tables = ['cv'];
     $valid_columns = $this->getTableColumns($valid_tables);
     $conditions = $this->dereferenceBuddyRecord($conditions);
@@ -1104,9 +1109,14 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
         }
       }
 
-      // If there are referencing records and cascade is not set, do nothing.
+      // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return self::FAILURE;
+        if ($options['fail_when_referenced'] ?? TRUE) {
+          throw new ChadoBuddyException('ChadoBuddy deleteCv error, cannot delete the cv, other records reference it');
+        }
+        else {
+          return self::FAILURE;
+        }
       }
       else {
         // Perform the record deletion. This might fail if
@@ -1168,18 +1178,23 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     - drop_dbxref
    *       If TRUE, then delete the dbxref record used by the term.
    *       Default is FALSE.
+   *     - fail_when_referenced (bool; default TRUE)
+   *       If TRUE, throw an exception when the cvterm indicated is referenced
+   *       by other records and cascade is FALSE. If FALSE, return
+   *       ChadoBuddyPluginBase::FAILURE.
    *
-   * @return bool|null
-   *   Returns TRUE if the cvterm was deleted.
-   *   Returns FALSE if the cvterm was not deleted.
-   *   Returns NULL if the cvterm did not exist.
+   * @return int
+   *   Indicates whether the cvterm was
+   *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
+   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
+   *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
-   *   - the conditions match more then one record.
+   *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the cvterm.
    */
-  public function deleteCvterm(array $conditions, array $options = []): ?bool {
+  public function deleteCvterm(array $conditions, array $options = []): int {
     $valid_tables = ['cvterm', 'cv', 'dbxref'];
     $valid_columns = $this->getTableColumns($valid_tables);
     $conditions = $this->dereferenceBuddyRecord($conditions);
@@ -1205,9 +1220,14 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
         }
       }
 
-      // If there are referencing records and cascade is not set, do nothing.
+      // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return self::FAILURE;
+        if ($options['fail_when_referenced'] ?? TRUE) {
+          throw new ChadoBuddyException('ChadoBuddy deleteCvterm error, cannot delete the cvterm, other records reference it');
+        }
+        else {
+          return self::FAILURE;
+        }
       }
       else {
         $transaction = $this->chado_connection->startTransaction();

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -560,9 +560,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateCv error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'cv.cv_id', 'updateCv', $conditions);
     // Update query will only be based on the cv.cv_id,
     // which we get from the retrieved record.
     $cv_id = $existing_records[0]->getValue('cv.cv_id');
@@ -639,9 +637,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateCvterm error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'cvterm.cvterm_id', 'updateCvterm', $conditions);
     // Only update the dbxref if it is being changed.
     $existing_values = $existing_records[0]->getValues();
     $update_dbxref = FALSE;
@@ -748,9 +744,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateCvterm error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'cvtermsynonym.cvtermsynonym_id', 'updateCvtermSynonym', $conditions);
     // This function will only update the cvtermsynonym table.
     // The update query will only be based on the cvtermsynonym_id,
     // which we get from the retrieved record.
@@ -812,9 +806,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
     $existing_records = $this->getCv($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertCv error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'cv.cv_id', 'upsertCv', $values);
       $new_record = $this->updateCv($values, $conditions, $options);
     }
     else {
@@ -873,9 +865,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
     $existing_records = $this->getCvterm($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertCvterm error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'cvterm.cvterm_id', 'upsertCvterm', $values);
       $new_record = $this->updateCvterm($values, $conditions, $options);
     }
     else {
@@ -938,9 +928,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
     $existing_records = $this->getCvtermSynonym($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertCvtermSynonym error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'cvtermsynonym.cvtermsynonym_id', 'upsertCvtermSynonym', $values);
       $new_record = $this->updateCvtermSynonym($values, $conditions, $options);
     }
     else {
@@ -969,7 +957,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     known, then pass it in as this option for better performance.
    *   - pub_id (string): The name of the column linking to the publication.
    *   - is_not (string): The name of the column indicating if the cvterm
-   *    association is a NOT association.
+   *     association is a NOT association.
    *   - rank (string): The name of the column indicating the rank.
    *   - cvterm_type_id (string): The name of the column indicating the type of
    *     cvterm association being made via foreign key to cvterm.cvterm_id.
@@ -1071,6 +1059,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     - buddy_record (object): a ChadoBuddyRecord can be used
    *       in place of or in addition to other keys.
    * @param array $options
+   *   An associative array of options with the following keys supported:
    *     - cascade
    *       If TRUE, then delete even if there are foreign keys in use.
    *       If ON DELETE CASCADE is defined for the foreign key, then
@@ -1080,10 +1069,11 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
    *
-   * @return bool|NULL
-   *   Returns TRUE if the CV was deleted.
-   *   Returns FALSE if the CV was not deleted.
-   *   Returns NULL if the CV did not exist.
+   * @return int
+   *   Indicates whether the CV was
+   *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
+   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
+   *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   If an error is encountered. This is most likely that another table
@@ -1096,11 +1086,8 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     $this->validateInput($conditions, $valid_columns);
     $existing_records = $this->getCv($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteCv error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'cv.cv_id', 'deleteCv', $conditions);
       $cv_id = $existing_records[0]->getValue('cv.cv_id');
-
       // Determine if there are referencing records.
       $table_def = $this->chado_connection->schema()->getTableDef('cv', ['source' => 'database', 'format' => 'default']);
       // Format is [referencing_table =>
@@ -1118,7 +1105,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
       // If there are referencing records and cascade is not set, do nothing.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return FALSE;
+        return self::FAILURE;
       }
       else {
         // Perform the record deletion. This might fail if
@@ -1127,7 +1114,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
         $query->condition('cv_id', $cv_id, '=');
         try {
           $query->execute();
-          return TRUE;
+          return self::SUCCESS;
         }
         catch (\Exception $e) {
           throw new ChadoBuddyException('ChadoBuddy deleteCv database error ' . $e->getMessage());
@@ -1135,7 +1122,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
       }
     }
     else {
-      return NULL;
+      return self::NON_EXISTING;
     }
   }
 
@@ -1168,6 +1155,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     - buddy_record (object): a ChadoBuddyRecord can be used
    *       in place of or in addition to other keys.
    * @param array $options
+   *   An associative array of options with the following keys supported:
    *     - cascade
    *       If TRUE, then delete even if there are foreign keys in use.
    *       If ON DELETE CASCADE is defined for the foreign key, then
@@ -1196,9 +1184,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     $this->validateInput($conditions, $valid_columns);
     $existing_records = $this->getCvterm($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteCvterm error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'cvterm.cvterm_id', 'deleteCvterm', $conditions);
       $cvterm_id = $existing_records[0]->getValue('cvterm.cvterm_id');
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
 
@@ -1219,7 +1205,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
       // If there are referencing records and cascade is not set, do nothing.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return FALSE;
+        return self::FAILURE;
       }
       else {
         $transaction = $this->chado_connection->startTransaction();
@@ -1245,11 +1231,11 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
             throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting dbxref: ' . $e->getMessage());
           }
         }
-        return TRUE;
+        return self::SUCCESS;
       }
     }
     else {
-      return NULL;
+      return self::NON_EXISTING;
     }
   }
 

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1097,7 +1097,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     $existing_records = $this->getCv($conditions, $options);
     if (count($existing_records) > 0) {
       if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteCv error, more than one record matched the specified values\n" . print_r($values, TRUE));
+        throw new ChadoBuddyException("ChadoBuddy deleteCv error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
       }
       $cv_id = $existing_records[0]->getValue('cv.cv_id');
 
@@ -1197,7 +1197,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     $existing_records = $this->getCvterm($conditions, $options);
     if (count($existing_records) > 0) {
       if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteCvterm error, more than one record matched the specified values\n" . print_r($values, TRUE));
+        throw new ChadoBuddyException("ChadoBuddy deleteCvterm error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
       }
       $cvterm_id = $existing_records[0]->getValue('cvterm.cvterm_id');
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
@@ -1222,6 +1222,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
         return FALSE;
       }
       else {
+        $transaction = $this->chado_connection->startTransaction();
         try {
           // Perform the record deletion. This might fail if
           // a foreign key is not defined as ON DELETE CASCADE.
@@ -1240,6 +1241,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
             $query->execute();
           }
           catch (\Exception $e) {
+            $transaction->rollback();
             throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting dbxref: ' . $e->getMessage());
           }
         }

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1134,6 +1134,118 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
   }
 
   /**
+   * Delete a controlled vocabulary term.
+   *
+   * We provide an option to also delete the dbxref.
+   *
+   * @param array $conditions
+   *   An associative array of the conditions to find the record to delete:
+   *     - cv.cv_id
+   *     - cv.name
+   *     - cv.definition
+   *     - cvterm.cvterm_id
+   *     - cvterm.cv_id
+   *     - cvterm.name
+   *     - cvterm.definition
+   *     - cvterm.is_obsolete
+   *     - cvterm.is_relationshiptype
+   *     - dbxref.dbxref_id
+   *     - dbxref.db_id
+   *     - dbxref.description
+   *     - dbxref.accession
+   *     - dbxref.version
+   *     - db.db_id
+   *     - db.name
+   *     - db.description
+   *     - db.urlprefix
+   *     - db.url
+   *     - buddy_record (object): a ChadoBuddyRecord can be used
+   *       in place of or in addition to other keys.
+   * @param array $options
+   *     - cascade
+   *       If TRUE, then delete even if there are foreign keys in use.
+   *       If ON DELETE CASCADE is defined for the foreign key, then
+   *       those records will also be deleted. If not, an exception will
+   *       be thrown.
+   *       Default is FALSE, and in this case, if any such referencing
+   *       records exist, the delete will be skipped and this function
+   *       will return FALSE.
+   *     - drop_dbxref
+   *       If TRUE, then delete the dbxref record used by the term.
+   *       Default is FALSE.
+   *
+   * @return bool|NULL
+   *   Returns TRUE if the cvterm was deleted.
+   *   Returns FALSE if the cvterm was not deleted.
+   *   Returns NULL if the cvterm did not exist.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If an error is encountered. This is most likely that another table
+   *   is referencing this CV.
+   */
+  public function deleteCvterm(array $conditions, array $options = []): ?bool {
+    $valid_tables = ['cvterm', 'cv', 'dbxref'];
+    $valid_columns = $this->getTableColumns($valid_tables);
+    $conditions = $this->dereferenceBuddyRecord($conditions);
+    $this->validateInput($conditions, $valid_columns);
+    $existing_records = $this->getCvterm($conditions, $options);
+    if (count($existing_records) > 0) {
+      if (count($existing_records) > 1) {
+        throw new ChadoBuddyException("ChadoBuddy deleteCvterm error, more than one record matched the specified values\n" . print_r($values, TRUE));
+      }
+      $cvterm_id = $existing_records[0]->getValue('cvterm.cvterm_id');
+      $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
+
+      // Determine if there are referencing records.
+      $table_def = $this->chado_connection->schema()->getTableDef('cv', ['source' => 'database', 'format' => 'default']);
+      // Format is [referencing_table =>
+      // [cvterm column (cvterm_id) => referencing_table column], ].
+      $foreign_keys = $table_def['referenced_by'] ?? [];
+      $total_references = 0;
+      foreach ($foreign_keys as $referencing_table => $keydef) {
+        foreach ($keydef as $pkey => $refkey) {
+          $query = $this->chado_connection->select('1:' . $referencing_table);
+          $query->condition($refkey, $cvterm_id, '=');
+          $n = $query->countQuery()->execute()->fetchField();
+          $total_references += $n;
+        }
+      }
+
+      // If there are referencing records and cascade is not set, do nothing.
+      if ($total_references && !($options['cascade'] ?? FALSE)) {
+        return FALSE;
+      }
+      else {
+        try {
+          // Perform the record deletion. This might fail if
+          // a foreign key is not defined as ON DELETE CASCADE.
+          $query = $this->chado_connection->delete('1:cvterm');
+          $query->condition('cvterm_id', $cvterm_id, '=');
+          $query->execute();
+        }
+        catch (\Exception $e) {
+          throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting cvterm: ' . $e->getMessage());
+        }
+        // If drop_dbxref is set, delete the dbxref.
+        if ($options['drop_dbxref'] ?? FALSE) {
+          try {
+            $query = $this->chado_connection->delete('1:dbxref');
+            $query->condition('dbxref_id', $dbxref_id, '=');
+            $query->execute();
+          }
+          catch (\Exception $e) {
+            throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting dbxref: ' . $e->getMessage());
+          }
+        }
+        return TRUE;
+      }
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
    * Adds not NULL columns to options.
    *
    * If there are additional not NULL columns in the linking table,

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1096,7 +1096,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
       $foreign_keys = $table_def['referenced_by'] ?? [];
       $total_references = 0;
       foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $pkey => $refkey) {
+        foreach ($keydef as $refkey) {
           $query = $this->chado_connection->select('1:' . $referencing_table);
           $query->condition($refkey, $cv_id, '=');
           $n = $query->countQuery()->execute()->fetchField();
@@ -1169,7 +1169,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *       If TRUE, then delete the dbxref record used by the term.
    *       Default is FALSE.
    *
-   * @return bool|NULL
+   * @return bool|null
    *   Returns TRUE if the cvterm was deleted.
    *   Returns FALSE if the cvterm was not deleted.
    *   Returns NULL if the cvterm did not exist.
@@ -1197,7 +1197,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
       $foreign_keys = $table_def['referenced_by'] ?? [];
       $total_references = 0;
       foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $pkey => $refkey) {
+        foreach ($keydef as $refkey) {
           $query = $this->chado_connection->select('1:' . $referencing_table);
           $query->condition($refkey, $cvterm_id, '=');
           $n = $query->countQuery()->execute()->fetchField();

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1068,15 +1068,10 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
-   *     - fail_when_referenced (bool; default TRUE)
-   *       If TRUE, throw an exception when the cv indicated is referenced
-   *       by other records and cascade is FALSE. If FALSE, return
-   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the CV was
    *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
-   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
@@ -1111,12 +1106,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
       // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        if ($options['fail_when_referenced'] ?? TRUE) {
-          throw new ChadoBuddyException('ChadoBuddy deleteCv error, cannot delete the cv, other records reference it');
-        }
-        else {
-          return self::FAILURE;
-        }
+        throw new ChadoBuddyException('ChadoBuddy deleteCv error, cannot delete the cv, other records reference it');
       }
       else {
         // Perform the record deletion. This might fail if
@@ -1178,15 +1168,10 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     - drop_dbxref
    *       If TRUE, then delete the dbxref record used by the term.
    *       Default is FALSE.
-   *     - fail_when_referenced (bool; default TRUE)
-   *       If TRUE, throw an exception when the cvterm indicated is referenced
-   *       by other records and cascade is FALSE. If FALSE, return
-   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the cvterm was
    *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
-   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
@@ -1223,12 +1208,7 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
 
       // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        if ($options['fail_when_referenced'] ?? TRUE) {
-          throw new ChadoBuddyException('ChadoBuddy deleteCvterm error, cannot delete the cvterm, other records reference it');
-        }
-        else {
-          return self::FAILURE;
-        }
+        throw new ChadoBuddyException('ChadoBuddy deleteCvterm error, cannot delete the cvterm, other records reference it');
       }
       else {
         $transaction = $this->chado_connection->startTransaction();

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1076,8 +1076,9 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
-   *   If an error is encountered. This is most likely that another table
-   *   is referencing this CV.
+   *   Thrown in the following cases:
+   *   - the conditions match more then one record.
+   *   - SQL error encountered when deleting the cv.
    */
   public function deleteCv(array $conditions, array $options = []): ?bool {
     $valid_tables = ['cv'];
@@ -1174,8 +1175,9 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *   Returns NULL if the cvterm did not exist.
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
-   *   If an error is encountered. This is most likely that another table
-   *   is referencing this CV.
+   *   Thrown in the following cases:
+   *   - the conditions match more then one record.
+   *   - SQL error encountered when deleting the cvterm.
    */
   public function deleteCvterm(array $conditions, array $options = []): ?bool {
     $valid_tables = ['cvterm', 'cv', 'dbxref'];

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1089,37 +1089,23 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
     if (count($existing_records) > 0) {
       $this->throwIfMultipleRecords($existing_records, 'cv.cv_id', 'deleteCv', $conditions);
       $cv_id = $existing_records[0]->getValue('cv.cv_id');
-      // Determine if there are referencing records.
-      $table_def = $this->chado_connection->schema()->getTableDef('cv', ['source' => 'database', 'format' => 'default']);
-      // Format is [referencing_table =>
-      // [cv column (cv_id) => referencing_table column], ].
-      $foreign_keys = $table_def['referenced_by'] ?? [];
-      $total_references = 0;
-      foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $refkey) {
-          $query = $this->chado_connection->select('1:' . $referencing_table);
-          $query->condition($refkey, $cv_id, '=');
-          $n = $query->countQuery()->execute()->fetchField();
-          $total_references += $n;
-        }
+
+      // Throw an exception if there are referencing records and cascade
+      // is not set.
+      if (!($options['cascade'] ?? FALSE)) {
+        $this->throwIfReferencingRecords('cv', $cv_id, 'deleteCv');
       }
 
-      // If there are referencing records and cascade is not set.
-      if ($total_references && !($options['cascade'] ?? FALSE)) {
-        throw new ChadoBuddyException('ChadoBuddy deleteCv error, cannot delete the cv, other records reference it');
+      // Perform the record deletion. This might fail if
+      // a foreign key is not defined as ON DELETE CASCADE.
+      $query = $this->chado_connection->delete('1:cv');
+      $query->condition('cv_id', $cv_id, '=');
+      try {
+        $query->execute();
+        return self::SUCCESS;
       }
-      else {
-        // Perform the record deletion. This might fail if
-        // a foreign key is not defined as ON DELETE CASCADE.
-        $query = $this->chado_connection->delete('1:cv');
-        $query->condition('cv_id', $cv_id, '=');
-        try {
-          $query->execute();
-          return self::SUCCESS;
-        }
-        catch (\Exception $e) {
-          throw new ChadoBuddyException('ChadoBuddy deleteCv database error ' . $e->getMessage());
-        }
+      catch (\Exception $e) {
+        throw new ChadoBuddyException('ChadoBuddy deleteCv database error ' . $e->getMessage());
       }
     }
     else {
@@ -1191,51 +1177,36 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
       $cvterm_id = $existing_records[0]->getValue('cvterm.cvterm_id');
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
 
-      // Determine if there are referencing records.
-      $table_def = $this->chado_connection->schema()->getTableDef('cv', ['source' => 'database', 'format' => 'default']);
-      // Format is [referencing_table =>
-      // [cvterm column (cvterm_id) => referencing_table column], ].
-      $foreign_keys = $table_def['referenced_by'] ?? [];
-      $total_references = 0;
-      foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $refkey) {
-          $query = $this->chado_connection->select('1:' . $referencing_table);
-          $query->condition($refkey, $cvterm_id, '=');
-          $n = $query->countQuery()->execute()->fetchField();
-          $total_references += $n;
-        }
+      // Throw an exception if there are referencing records and cascade
+      // is not set.
+      if (!($options['cascade'] ?? FALSE)) {
+        $this->throwIfReferencingRecords('cvterm', $cvterm_id, 'deleteCvterm');
       }
 
-      // If there are referencing records and cascade is not set.
-      if ($total_references && !($options['cascade'] ?? FALSE)) {
-        throw new ChadoBuddyException('ChadoBuddy deleteCvterm error, cannot delete the cvterm, other records reference it');
+      $transaction = $this->chado_connection->startTransaction();
+      try {
+        // Perform the record deletion. This might fail if
+        // a foreign key is not defined as ON DELETE CASCADE.
+        $query = $this->chado_connection->delete('1:cvterm');
+        $query->condition('cvterm_id', $cvterm_id, '=');
+        $query->execute();
       }
-      else {
-        $transaction = $this->chado_connection->startTransaction();
+      catch (\Exception $e) {
+        throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting cvterm: ' . $e->getMessage());
+      }
+      // If drop_dbxref is set, delete the dbxref.
+      if ($options['drop_dbxref'] ?? FALSE) {
         try {
-          // Perform the record deletion. This might fail if
-          // a foreign key is not defined as ON DELETE CASCADE.
-          $query = $this->chado_connection->delete('1:cvterm');
-          $query->condition('cvterm_id', $cvterm_id, '=');
+          $query = $this->chado_connection->delete('1:dbxref');
+          $query->condition('dbxref_id', $dbxref_id, '=');
           $query->execute();
         }
         catch (\Exception $e) {
-          throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting cvterm: ' . $e->getMessage());
+          $transaction->rollback();
+          throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting dbxref: ' . $e->getMessage());
         }
-        // If drop_dbxref is set, delete the dbxref.
-        if ($options['drop_dbxref'] ?? FALSE) {
-          try {
-            $query = $this->chado_connection->delete('1:dbxref');
-            $query->condition('dbxref_id', $dbxref_id, '=');
-            $query->execute();
-          }
-          catch (\Exception $e) {
-            $transaction->rollback();
-            throw new ChadoBuddyException('ChadoBuddy deleteCvterm database error deleting dbxref: ' . $e->getMessage());
-          }
-        }
-        return self::SUCCESS;
       }
+      return self::SUCCESS;
     }
     else {
       return self::NON_EXISTING;

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -1052,6 +1052,88 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
   }
 
   /**
+   * Delete a controlled vocabulary.
+   *
+   * Note that the cvterm and cvtermpath tables have foreign keys to the
+   * cv table. If a record in cv is deleted, it can cascade to delete
+   * records in those tables!
+   *
+   * @param array $conditions
+   *   An associative array of the conditions to find the record to delete:
+   *     - cv.cv_id
+   *     - cv.name
+   *     - buddy_record (object): a ChadoBuddyRecord can be used
+   *       in place of or in addition to other keys.
+   * @param array $options
+   *     - cascade
+   *       If TRUE, then delete even if there are foreign keys in use.
+   *       If ON DELETE CASCADE is defined for the foreign key, then
+   *       those records will also be deleted. If not, an exception will
+   *       be thrown.
+   *       Default is FALSE, and in this case, if any such referencing
+   *       records exist, the delete will be skipped and this function
+   *       will return FALSE.
+   *
+   * @return bool|NULL
+   *   Returns TRUE if the CV was deleted.
+   *   Returns FALSE if the CV was not deleted.
+   *   Returns NULL if the CV did not exist.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If an error is encountered. This is most likely that another table
+   *   is referencing this CV.
+   */
+  public function deleteCv(array $conditions, array $options = []): ?bool {
+    $valid_tables = ['cv'];
+    $valid_columns = $this->getTableColumns($valid_tables);
+    $conditions = $this->dereferenceBuddyRecord($conditions);
+    $this->validateInput($conditions, $valid_columns);
+    $existing_records = $this->getCv($conditions, $options);
+    if (count($existing_records) > 0) {
+      if (count($existing_records) > 1) {
+        throw new ChadoBuddyException("ChadoBuddy deleteCv error, more than one record matched the specified values\n" . print_r($values, TRUE));
+      }
+      $cv_id = $existing_records[0]->getValue('cv.cv_id');
+
+      // Determine if there are referencing records.
+      $table_def = $this->chado_connection->schema()->getTableDef('cv', ['source' => 'database', 'format' => 'default']);
+      // Format is [referencing_table =>
+      // [cv column (cv_id) => referencing_table column], ].
+      $foreign_keys = $table_def['referenced_by'] ?? [];
+      $total_references = 0;
+      foreach ($foreign_keys as $referencing_table => $keydef) {
+        foreach ($keydef as $pkey => $refkey) {
+          $query = $this->chado_connection->select('1:' . $referencing_table);
+          $query->condition($refkey, $cv_id, '=');
+          $n = $query->countQuery()->execute()->fetchField();
+          $total_references += $n;
+        }
+      }
+
+      // If there are referencing records and cascade is not set, do nothing.
+      if ($total_references && !($options['cascade'] ?? FALSE)) {
+        return FALSE;
+      }
+      else {
+        // Perform the record deletion. This might fail if
+        // a foreign key is not defined as ON DELETE CASCADE.
+        $query = $this->chado_connection->delete('1:cv');
+        $query->condition('cv_id', $cv_id, '=');
+        try {
+          $query->execute();
+          return TRUE;
+        }
+        catch (\Exception $e) {
+          throw new ChadoBuddyException('ChadoBuddy deleteCv database error ' . $e->getMessage());
+        }
+      }
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
    * Adds not NULL columns to options.
    *
    * If there are additional not NULL columns in the linking table,

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -678,6 +678,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
+   *     - fail_when_referenced (bool; default TRUE)
+   *       If TRUE, throw an exception when the db indicated is referenced
+   *       by other records and cascade is FALSE. If FALSE, return
+   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the DB was
@@ -687,10 +691,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
-   *   - the conditions match more then one record.
+   *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the db.
    */
-  public function deleteDb(array $conditions, array $options = []): ?bool {
+  public function deleteDb(array $conditions, array $options = []): int {
     $valid_tables = ['db'];
     $valid_columns = $this->getTableColumns($valid_tables);
     $conditions = $this->dereferenceBuddyRecord($conditions);
@@ -714,9 +718,14 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
           $total_references += $n;
         }
       }
-      // If there are referencing records and cascade is not set, do nothing.
+      // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return self::FAILURE;
+        if ($options['fail_when_referenced'] ?? TRUE) {
+          throw new ChadoBuddyException('ChadoBuddy deleteDb error, cannot delete the db, other records reference it');
+        }
+        else {
+          return self::FAILURE;
+        }
       }
       else {
         // Perform the record deletion. This might fail if
@@ -763,6 +772,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
+   *     - fail_when_referenced (bool; default TRUE)
+   *       If TRUE, throw an exception when the dbxref indicated is referenced
+   *       by other records and cascade is FALSE. If FALSE, return
+   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the DB was
@@ -772,10 +785,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
-   *   - the conditions match more then one record.
+   *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the dbxref.
    */
-  public function deleteDbxref(array $conditions, array $options = []): ?bool {
+  public function deleteDbxref(array $conditions, array $options = []): int {
     $valid_tables = ['db', 'dbxref'];
     $valid_columns = $this->getTableColumns($valid_tables);
     $conditions = $this->dereferenceBuddyRecord($conditions);
@@ -800,9 +813,14 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
           $total_references += $n;
         }
       }
-      // If there are referencing records and cascade is not set, do nothing.
+      // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return self::FAILURE;
+        if ($options['fail_when_referenced'] ?? TRUE) {
+          throw new ChadoBuddyException('ChadoBuddy deleteDbxref error, cannot delete the dbxref, other records reference it');
+        }
+        else {
+          return self::FAILURE;
+        }
       }
       else {
         // Perform the record deletion. This might fail if

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -744,4 +744,88 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     }
   }
 
+  /**
+   * Delete a database crossreference.
+   *
+   * @param array $conditions
+   *   An associative array of the conditions to find the record to delete:
+   *     - dbxref.dbxref_id
+   *     - dbxref.db_id
+   *     - dbxref.description
+   *     - dbxref.accession
+   *     - dbxref.version
+   *     - db.db_id
+   *     - db.name
+   *     - db.url
+   *     - db.urlprefix
+   *     - buddy_record (object): a ChadoBuddyRecord can be used
+   *       in place of or in addition to other keys.
+   * @param array $options
+   *     - cascade
+   *       If TRUE, then delete even if there are foreign keys in use.
+   *       If ON DELETE CASCADE is defined for the foreign key, then
+   *       those records will also be deleted. If not, an exception will
+   *       be thrown.
+   *       Default is FALSE, and in this case, if any such referencing
+   *       records exist, the delete will be skipped and this function
+   *       will return FALSE.
+   *
+   * @return bool|NULL
+   *   Returns TRUE if the Dbxref was deleted.
+   *   Returns FALSE if the Dbxref was not deleted.
+   *   Returns NULL if the Dbxref did not exist.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If an error is encountered. This is most likely that another table
+   *   is referencing this Dbxref, typically cvterm.
+   */
+  public function deleteDbxref(array $conditions, array $options = []): ?bool {
+    $valid_tables = ['db', 'dbxref'];
+    $valid_columns = $this->getTableColumns($valid_tables);
+    $conditions = $this->dereferenceBuddyRecord($conditions);
+    $this->validateInput($conditions, $valid_columns);
+    $existing_records = $this->getDbxref($conditions, $options);
+    if (count($existing_records) > 0) {
+      if (count($existing_records) > 1) {
+        throw new ChadoBuddyException("ChadoBuddy deleteDbxref error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
+      }
+      $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
+
+      // Determine if there are referencing records.
+      $table_def = $this->chado_connection->schema()->getTableDef('dbxref', ['source' => 'database', 'format' => 'default']);
+      // Format is [referencing_table =>
+      // [dbxref column (dbxref_id) => referencing_table column], ].
+      $foreign_keys = $table_def['referenced_by'] ?? [];
+      $total_references = 0;
+      foreach ($foreign_keys as $referencing_table => $keydef) {
+        foreach ($keydef as $pkey => $refkey) {
+          $query = $this->chado_connection->select('1:' . $referencing_table);
+          $query->condition($refkey, $dbxref_id, '=');
+          $n = $query->countQuery()->execute()->fetchField();
+          $total_references += $n;
+        }
+      }
+      // If there are referencing records and cascade is not set, do nothing.
+      if ($total_references && !($options['cascade'] ?? FALSE)) {
+        return FALSE;
+      }
+      else {
+        // Perform the record deletion. This might fail if
+        // a foreign key is not defined as ON DELETE CASCADE.
+        $query = $this->chado_connection->delete('1:dbxref');
+        $query->condition('dbxref_id', $dbxref_id, '=');
+        try {
+          $query->execute();
+          return TRUE;
+        }
+        catch (\Exception $e) {
+          throw new ChadoBuddyException('ChadoBuddy deleteDbxref database error ' . $e->getMessage());
+        }
+      }
+    }
+    else {
+      return NULL;
+    }
+  }
+
 }

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -678,15 +678,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
-   *     - fail_when_referenced (bool; default TRUE)
-   *       If TRUE, throw an exception when the db indicated is referenced
-   *       by other records and cascade is FALSE. If FALSE, return
-   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the DB was
    *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
-   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
@@ -721,12 +716,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
       // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        if ($options['fail_when_referenced'] ?? TRUE) {
-          throw new ChadoBuddyException('ChadoBuddy deleteDb error, cannot delete the db, other records reference it');
-        }
-        else {
-          return self::FAILURE;
-        }
+        throw new ChadoBuddyException('ChadoBuddy deleteDb error, cannot delete the db, other records reference it');
       }
       else {
         // Perform the record deletion. This might fail if
@@ -773,15 +763,10 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       Default is FALSE, and in this case, if any such referencing
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
-   *     - fail_when_referenced (bool; default TRUE)
-   *       If TRUE, throw an exception when the dbxref indicated is referenced
-   *       by other records and cascade is FALSE. If FALSE, return
-   *       ChadoBuddyPluginBase::FAILURE.
    *
    * @return int
    *   Indicates whether the DB was
    *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
-   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
@@ -817,12 +802,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
       // If there are referencing records and cascade is not set.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        if ($options['fail_when_referenced'] ?? TRUE) {
-          throw new ChadoBuddyException('ChadoBuddy deleteDbxref error, cannot delete the dbxref, other records reference it');
-        }
-        else {
-          return self::FAILURE;
-        }
+        throw new ChadoBuddyException('ChadoBuddy deleteDbxref error, cannot delete the dbxref, other records reference it');
       }
       else {
         // Perform the record deletion. This might fail if

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -700,36 +700,22 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       $this->throwIfMultipleRecords($existing_records, 'db.db_id', 'deleteDb', $conditions);
       $db_id = $existing_records[0]->getValue('db.db_id');
 
-      // Determine if there are referencing records.
-      $table_def = $this->chado_connection->schema()->getTableDef('db', ['source' => 'database', 'format' => 'default']);
-      // Format is [referencing_table =>
-      // [db column (db_id) => referencing_table column], ].
-      $foreign_keys = $table_def['referenced_by'] ?? [];
-      $total_references = 0;
-      foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $refkey) {
-          $query = $this->chado_connection->select('1:' . $referencing_table);
-          $query->condition($refkey, $db_id, '=');
-          $n = $query->countQuery()->execute()->fetchField();
-          $total_references += $n;
-        }
+      // Throw an exception if there are referencing records and cascade
+      // is not set.
+      if (!($options['cascade'] ?? FALSE)) {
+        $this->throwIfReferencingRecords('db', $db_id, 'deleteDb');
       }
-      // If there are referencing records and cascade is not set.
-      if ($total_references && !($options['cascade'] ?? FALSE)) {
-        throw new ChadoBuddyException('ChadoBuddy deleteDb error, cannot delete the db, other records reference it');
+
+      // Perform the record deletion. This might fail if
+      // a foreign key is not defined as ON DELETE CASCADE.
+      $query = $this->chado_connection->delete('1:db');
+      $query->condition('db_id', $db_id, '=');
+      try {
+        $query->execute();
+        return self::SUCCESS;
       }
-      else {
-        // Perform the record deletion. This might fail if
-        // a foreign key is not defined as ON DELETE CASCADE.
-        $query = $this->chado_connection->delete('1:db');
-        $query->condition('db_id', $db_id, '=');
-        try {
-          $query->execute();
-          return self::SUCCESS;
-        }
-        catch (\Exception $e) {
-          throw new ChadoBuddyException('ChadoBuddy deleteDb database error ' . $e->getMessage());
-        }
+      catch (\Exception $e) {
+        throw new ChadoBuddyException('ChadoBuddy deleteDb database error ' . $e->getMessage());
       }
     }
     else {
@@ -785,37 +771,22 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       $this->throwIfMultipleRecords($existing_records, 'dbxref.dbxref_id', 'deleteDbxref', $conditions);
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
 
-      // Determine if there are referencing records.
-      $table_def = $this->chado_connection->schema()->getTableDef('dbxref',
-        ['source' => 'database', 'format' => 'default']);
-      // Format is [referencing_table =>
-      // [dbxref column (dbxref_id) => referencing_table column], ].
-      $foreign_keys = $table_def['referenced_by'] ?? [];
-      $total_references = 0;
-      foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $refkey) {
-          $query = $this->chado_connection->select('1:' . $referencing_table);
-          $query->condition($refkey, $dbxref_id, '=');
-          $n = $query->countQuery()->execute()->fetchField();
-          $total_references += $n;
-        }
+      // Throw an exception if there are referencing records and cascade
+      // is not set.
+      if (!($options['cascade'] ?? FALSE)) {
+        $this->throwIfReferencingRecords('dbxref', $dbxref_id, 'deleteDbxref');
       }
-      // If there are referencing records and cascade is not set.
-      if ($total_references && !($options['cascade'] ?? FALSE)) {
-        throw new ChadoBuddyException('ChadoBuddy deleteDbxref error, cannot delete the dbxref, other records reference it');
+
+      // Perform the record deletion. This might fail if
+      // a foreign key is not defined as ON DELETE CASCADE.
+      $query = $this->chado_connection->delete('1:dbxref');
+      $query->condition('dbxref_id', $dbxref_id, '=');
+      try {
+        $query->execute();
+        return self::SUCCESS;
       }
-      else {
-        // Perform the record deletion. This might fail if
-        // a foreign key is not defined as ON DELETE CASCADE.
-        $query = $this->chado_connection->delete('1:dbxref');
-        $query->condition('dbxref_id', $dbxref_id, '=');
-        try {
-          $query->execute();
-          return self::SUCCESS;
-        }
-        catch (\Exception $e) {
-          throw new ChadoBuddyException('ChadoBuddy deleteDbxref database error ' . $e->getMessage());
-        }
+      catch (\Exception $e) {
+        throw new ChadoBuddyException('ChadoBuddy deleteDbxref database error ' . $e->getMessage());
       }
     }
     else {

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -707,7 +707,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       $foreign_keys = $table_def['referenced_by'] ?? [];
       $total_references = 0;
       foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $pkey => $refkey) {
+        foreach ($keydef as $refkey) {
           $query = $this->chado_connection->select('1:' . $referencing_table);
           $query->condition($refkey, $db_id, '=');
           $n = $query->countQuery()->execute()->fetchField();
@@ -786,13 +786,14 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
 
       // Determine if there are referencing records.
-      $table_def = $this->chado_connection->schema()->getTableDef('dbxref', ['source' => 'database', 'format' => 'default']);
+      $table_def = $this->chado_connection->schema()->getTableDef('dbxref',
+        ['source' => 'database', 'format' => 'default']);
       // Format is [referencing_table =>
       // [dbxref column (dbxref_id) => referencing_table column], ].
       $foreign_keys = $table_def['referenced_by'] ?? [];
       $total_references = 0;
       foreach ($foreign_keys as $referencing_table => $keydef) {
-        foreach ($keydef as $pkey => $refkey) {
+        foreach ($keydef as $refkey) {
           $query = $this->chado_connection->select('1:' . $referencing_table);
           $query->condition($refkey, $dbxref_id, '=');
           $n = $query->countQuery()->execute()->fetchField();

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -703,7 +703,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     $existing_records = $this->getDb($conditions, $options);
     if (count($existing_records) > 0) {
       if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteDb error, more than one record matched the specified values\n" . print_r($values, TRUE));
+        throw new ChadoBuddyException("ChadoBuddy deleteDb error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
       }
       $db_id = $existing_records[0]->getValue('db.db_id');
 

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -691,6 +691,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
+   *   - Foreign key references exist to the record.
    *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the db.
    */
@@ -785,6 +786,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   Thrown in the following cases:
+   *   - Foreign key references exist to the record.
    *   - The conditions match more then one record.
    *   - SQL error encountered when deleting the dbxref.
    */

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -659,4 +659,83 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     return TRUE;
   }
 
+  /**
+   * Delete a database.
+   *
+   * @param array $conditions
+   *   An associative array of the conditions to find the record to delete:
+   *     - db.db_id
+   *     - db.name
+   *     - db.url
+   *     - db.urlprefix
+   *     - buddy_record (object): a ChadoBuddyRecord can be used
+   *       in place of or in addition to other keys.
+   * @param array $options
+   *     - cascade
+   *       If TRUE, then delete even if there are foreign keys in use.
+   *       If ON DELETE CASCADE is defined for the foreign key, then
+   *       those records will also be deleted. If not, an exception will
+   *       be thrown.
+   *       Default is FALSE, and in this case, if any such referencing
+   *       records exist, the delete will be skipped and this function
+   *       will return FALSE.
+   *
+   * @return bool|NULL
+   *   Returns TRUE if the DB was deleted.
+   *   Returns FALSE if the DB was not deleted.
+   *   Returns NULL if the DB did not exist.
+   *
+   * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
+   *   If an error is encountered. This is most likely that another table
+   *   is referencing this DB.
+   */
+  public function deleteDb(array $conditions, array $options = []): ?bool {
+    $valid_tables = ['db'];
+    $valid_columns = $this->getTableColumns($valid_tables);
+    $conditions = $this->dereferenceBuddyRecord($conditions);
+    $this->validateInput($conditions, $valid_columns);
+    $existing_records = $this->getDb($conditions, $options);
+    if (count($existing_records) > 0) {
+      if (count($existing_records) > 1) {
+        throw new ChadoBuddyException("ChadoBuddy deleteDb error, more than one record matched the specified values\n" . print_r($values, TRUE));
+      }
+      $db_id = $existing_records[0]->getValue('db.db_id');
+
+      // Determine if there are referencing records.
+      $table_def = $this->chado_connection->schema()->getTableDef('db', ['source' => 'database', 'format' => 'default']);
+      // Format is [referencing_table =>
+      // [db column (db_id) => referencing_table column], ].
+      $foreign_keys = $table_def['referenced_by'] ?? [];
+      $total_references = 0;
+      foreach ($foreign_keys as $referencing_table => $keydef) {
+        foreach ($keydef as $pkey => $refkey) {
+          $query = $this->chado_connection->select('1:' . $referencing_table);
+          $query->condition($refkey, $db_id, '=');
+          $n = $query->countQuery()->execute()->fetchField();
+          $total_references += $n;
+        }
+      }
+      // If there are referencing records and cascade is not set, do nothing.
+      if ($total_references && !($options['cascade'] ?? FALSE)) {
+        return FALSE;
+      }
+      else {
+        // Perform the record deletion. This might fail if
+        // a foreign key is not defined as ON DELETE CASCADE.
+        $query = $this->chado_connection->delete('1:db');
+        $query->condition('db_id', $db_id, '=');
+        try {
+          $query->execute();
+          return TRUE;
+        }
+        catch (\Exception $e) {
+          throw new ChadoBuddyException('ChadoBuddy deleteDb database error ' . $e->getMessage());
+        }
+      }
+    }
+    else {
+      return NULL;
+    }
+  }
+
 }

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -686,8 +686,9 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
-   *   If an error is encountered. This is most likely that another table
-   *   is referencing this DB.
+   *   Thrown in the following cases:
+   *   - the conditions match more then one record.
+   *   - SQL error encountered when deleting the db.
    */
   public function deleteDb(array $conditions, array $options = []): ?bool {
     $valid_tables = ['db'];
@@ -770,8 +771,9 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
-   *   If an error is encountered. This is most likely that another table
-   *   is referencing this Dbxref, typically cvterm.
+   *   Thrown in the following cases:
+   *   - the conditions match more then one record.
+   *   - SQL error encountered when deleting the dbxref.
    */
   public function deleteDbxref(array $conditions, array $options = []): ?bool {
     $valid_tables = ['db', 'dbxref'];

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -379,9 +379,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateDb error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'db.db_id', 'updateDb', $conditions);
     // Update query will only be based on the db.db_id, which we
     // can get from the retrieved record.
     $db_id = $existing_records[0]->getValue('db.db_id');
@@ -454,9 +452,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateDbxref error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'dbxref.dbxref_id', 'updateDbxref', $conditions);
 
     // Update query will only be based on the dbxref_id, which we
     // can get from the retrieved record.
@@ -522,9 +518,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
 
     $existing_records = $this->getDb($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertDb error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'db.db_id', 'upsertDb', $values);
       $new_record = $this->updateDb($values, $conditions, $options);
     }
     else {
@@ -575,9 +569,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
 
     $existing_records = $this->getDbxref($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertDbxref error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'dbxref.dbxref_id', 'upsertDbxref', $values);
       $new_record = $this->updateDbxref($values, $conditions, $options);
     }
     else {
@@ -677,6 +669,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *     - buddy_record (object): a ChadoBuddyRecord can be used
    *       in place of or in addition to other keys.
    * @param array $options
+   *   An associative array of options with the following keys supported:
    *     - cascade
    *       If TRUE, then delete even if there are foreign keys in use.
    *       If ON DELETE CASCADE is defined for the foreign key, then
@@ -686,10 +679,11 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
    *
-   * @return bool|NULL
-   *   Returns TRUE if the DB was deleted.
-   *   Returns FALSE if the DB was not deleted.
-   *   Returns NULL if the DB did not exist.
+   * @return int
+   *   Indicates whether the DB was
+   *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
+   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
+   *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   If an error is encountered. This is most likely that another table
@@ -702,9 +696,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     $this->validateInput($conditions, $valid_columns);
     $existing_records = $this->getDb($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteDb error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'db.db_id', 'deleteDb', $conditions);
       $db_id = $existing_records[0]->getValue('db.db_id');
 
       // Determine if there are referencing records.
@@ -723,7 +715,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
       // If there are referencing records and cascade is not set, do nothing.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return FALSE;
+        return self::FAILURE;
       }
       else {
         // Perform the record deletion. This might fail if
@@ -732,7 +724,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
         $query->condition('db_id', $db_id, '=');
         try {
           $query->execute();
-          return TRUE;
+          return self::SUCCESS;
         }
         catch (\Exception $e) {
           throw new ChadoBuddyException('ChadoBuddy deleteDb database error ' . $e->getMessage());
@@ -740,7 +732,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
     }
     else {
-      return NULL;
+      return self::NON_EXISTING;
     }
   }
 
@@ -761,6 +753,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *     - buddy_record (object): a ChadoBuddyRecord can be used
    *       in place of or in addition to other keys.
    * @param array $options
+   *   An associative array of options with the following keys supported:
    *     - cascade
    *       If TRUE, then delete even if there are foreign keys in use.
    *       If ON DELETE CASCADE is defined for the foreign key, then
@@ -770,10 +763,11 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *       records exist, the delete will be skipped and this function
    *       will return FALSE.
    *
-   * @return bool|NULL
-   *   Returns TRUE if the Dbxref was deleted.
-   *   Returns FALSE if the Dbxref was not deleted.
-   *   Returns NULL if the Dbxref did not exist.
+   * @return int
+   *   Indicates whether the DB was
+   *   - deleted (ChadoBuddyPluginBase::SUCCESS = 4)
+   *   - not deleted (ChadoBuddyPluginBase::FAILURE = 5)
+   *   - did not exist (ChadoBuddyPluginBase::NON_EXISTING = 3)
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   If an error is encountered. This is most likely that another table
@@ -786,9 +780,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
     $this->validateInput($conditions, $valid_columns);
     $existing_records = $this->getDbxref($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy deleteDbxref error, more than one record matched the specified conditions\n" . print_r($conditions, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'dbxref.dbxref_id', 'deleteDbxref', $conditions);
       $dbxref_id = $existing_records[0]->getValue('dbxref.dbxref_id');
 
       // Determine if there are referencing records.
@@ -807,7 +799,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
       // If there are referencing records and cascade is not set, do nothing.
       if ($total_references && !($options['cascade'] ?? FALSE)) {
-        return FALSE;
+        return self::FAILURE;
       }
       else {
         // Perform the record deletion. This might fail if
@@ -816,7 +808,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
         $query->condition('dbxref_id', $dbxref_id, '=');
         try {
           $query->execute();
-          return TRUE;
+          return self::SUCCESS;
         }
         catch (\Exception $e) {
           throw new ChadoBuddyException('ChadoBuddy deleteDbxref database error ' . $e->getMessage());
@@ -824,7 +816,7 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
       }
     }
     else {
-      return NULL;
+      return self::NON_EXISTING;
     }
   }
 

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
@@ -310,9 +310,7 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
     if (count($existing_records) < 1) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateOrganism error, more than one record matched the conditions specified:\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, 'organism.organism_id', 'updateOrganism', $conditions);
 
     // Validate the organism rank.
     $values = $this->validateOrganismRankCvterm($values, $options);
@@ -390,9 +388,7 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
 
     $existing_records = $this->getOrganism($conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertOrganism error, more than one record matched the specified values:\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, 'organism.organism_id', 'upsertOrganism', $values);
       $new_record = $this->updateOrganism($values, $conditions, $options);
     }
     else {
@@ -427,9 +423,7 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
     if (count($organism_records) < 1) {
       throw new ChadoBuddyException("ChadoBuddy getOrganismScientificName error, could not find an organism record that matches the specified conditions:\n" . print_r($conditions, TRUE));
     }
-    elseif (count($organism_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy getOrganismScientificName error, more than one organism record matches the specified conditions:\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($organism_records, 'organism.organism_id', 'getOrganismScientificName', $conditions);
     // Grab the genus and species.
     $organism_values = $organism_records[0]->getValues();
     $organism_name = $organism_values['organism.genus'] . ' ' . $organism_values['organism.species'];
@@ -621,9 +615,7 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
         // If a cvterm was retrieved, set organism.type_id to the cvterm_id.
         if ($cvterm_records) {
           // Ensure that we didn't retrieve multiple possible cvterms.
-          if (count($cvterm_records) > 1) {
-            throw new ChadoBuddyException("ChadoBuddy validateOrganismRankCvterm error, more than one record matched the values specified:\n" . print_r($cvterm_values, TRUE));
-          }
+          $this->throwIfMultipleRecords($cvterm_records, 'cvterm.cvterm', 'validateOrganismRankCvterm', $cvterm_values);
           $values['organism.type_id'] = $cvterm_records[0]->getValue('cvterm.cvterm_id', ['strict' => FALSE]);
         }
         // If a cvterm could not be found, try to create it if the required

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
@@ -615,7 +615,7 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
         // If a cvterm was retrieved, set organism.type_id to the cvterm_id.
         if ($cvterm_records) {
           // Ensure that we didn't retrieve multiple possible cvterms.
-          $this->throwIfMultipleRecords($cvterm_records, 'cvterm.cvterm', 'validateOrganismRankCvterm', $cvterm_values);
+          $this->throwIfMultipleRecords($cvterm_records, 'cvterm.cvterm_id', 'validateOrganismRankCvterm', $cvterm_values);
           $values['organism.type_id'] = $cvterm_records[0]->getValue('cvterm.cvterm_id', ['strict' => FALSE]);
         }
         // If a cvterm could not be found, try to create it if the required

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoPropertyBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoPropertyBuddy.php
@@ -387,9 +387,7 @@ class ChadoPropertyBuddy extends ChadoBuddyPluginBase {
     if (count($existing_records) == 0) {
       return FALSE;
     }
-    if (count($existing_records) > 1) {
-      throw new ChadoBuddyException("ChadoBuddy updateProperty error, more than one record matched the conditions specified\n" . print_r($conditions, TRUE));
-    }
+    $this->throwIfMultipleRecords($existing_records, $property_table . '.' . $pkey, 'updateProperty', $conditions);
 
     $query = $this->chado_connection->update('1:' . $property_table);
     // We can now reduce conditions to just the property table primary key.
@@ -473,6 +471,7 @@ class ChadoPropertyBuddy extends ChadoBuddyPluginBase {
    */
   public function upsertProperty(string $base_table, int $record_id, array $values, array $options = []) {
     $property_table = $options['property_table'] ?? $base_table . 'prop';
+    $pkey = $options['pkey'] ?? $property_table . '_id';
 
     $valid_tables = ['cvterm', 'cv', 'dbxref', 'db', $base_table, $property_table];
     $valid_columns = $this->getTableColumns($valid_tables);
@@ -489,9 +488,7 @@ class ChadoPropertyBuddy extends ChadoBuddyPluginBase {
 
     $existing_records = $this->getProperty($base_table, $record_id, $conditions, $options);
     if (count($existing_records) > 0) {
-      if (count($existing_records) > 1) {
-        throw new ChadoBuddyException("ChadoBuddy upsertProperty error, more than one record matched the specified values\n" . print_r($values, TRUE));
-      }
+      $this->throwIfMultipleRecords($existing_records, $property_table . '.' . $pkey, 'upsertProperty', $values);
       $new_record = $this->updateProperty($base_table, $record_id, $values, $conditions, $options);
     }
     else {

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -176,7 +176,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
-    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a cv that has a foreign key");
+    $this->assertStringContainsString('records from the following tables reference the cv record', $exception_message, "We did not get the exception message expected deleting a cv that has a foreign key");
     $n = $this->chado_connection->select('1:cv')
       ->condition('cv_id', $cv_id, '=')
       ->countQuery()
@@ -477,8 +477,15 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $this->assertEquals(1, $n, "The dbxref was incorrectly deleted in the database");
 
     // TEST: we can delete a cvterm and its dbxref.
-    $records = $instance->getCvterm(['cvterm.name' => 'newCvterm003']);
-    $this->assertNotEmpty($records, 'Failed getting cvterm created earlier');
+    $instance->insertCvterm([
+      'cvterm.name' => 'newCvterm007',
+      'cvterm.definition' => 'def007',
+      'cv.name' => 'local',
+      'db.name' => 'local',
+      'dbxref.accession' => 'newAcc007',
+    ]);
+    $records = $instance->getCvterm(['cvterm.name' => 'newCvterm007']);
+    $this->assertNotEmpty($records, 'Failed getting cvterm just created');
     $cvterm_id = $records[0]->getValue('cvterm.cvterm_id');
     $dbxref_id = $records[0]->getValue('dbxref.dbxref_id');
     $result = $instance->deleteCvterm(['cvterm.cvterm_id' => $cvterm_id], ['drop_dbxref' => TRUE]);

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -177,6 +177,15 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(1, $n, "The cv was incorrectly deleted from the database");
+    // Without setting 'fail_when_referenced' should throw an exception.
+    $exception_message = '';
+    try {
+      $result = $instance->deleteCv(['cv.cv_id' => $cv_id], []);
+    }
+    catch (\Exception $e) {
+      $exception_message = $e->getMessage();
+    }
+    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a cv that has a foreign key");
 
     // TEST: Updating a non-existent Cvterm should return FALSE.
     $chado_buddy_records = $instance->updateCvterm(['cvterm.name' => 'newCvterm002', 'cvterm.definition' => 'def002'],
@@ -443,6 +452,12 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       'We did not get the correct cvterm_id for the upserted Cvterm with synonym "syn006"');
     $this->assertEquals(7, $values['get']['cvtermsynonym.type_id'],
       'We did not update the type_id for the upserted Cvterm with synonym "syn006"');
+
+    // TEST: delete a cv or cvterm that does not exist.
+    $result = $instance->deleteCv(['cv.name' => 'zzzzzzzzz']);
+    $this->assertEquals(ChadoBuddyPluginBase::NON_EXISTING, $result, 'Unexpected result deleting a non-existing CV');
+    $result = $instance->deleteCvterm(['cvterm.name' => 'zzzzzzzzz']);
+    $this->assertEquals(ChadoBuddyPluginBase::NON_EXISTING, $result, 'Unexpected result deleting a non-existing cvterm');
 
     // TEST: we can delete a cvterm.
     $records = $instance->getCvterm(['cvterm.name' => 'newCvterm002']);

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -117,6 +117,17 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $values = ['buddy_record' => $chado_buddy_records[0]];
     $chado_buddy_records = $instance->getCv($values, []);
     $this->assertEquals(1, count($chado_buddy_records), "We did not receive the Cv when querying using a ChadoBuddyRecord");
+
+    // TEST: we can delete a cv.
+    $cv_id = $chado_buddy_records[0]->getValue('cv.cv_id');
+    $result = $instance->deleteCv(['cv.cv_id' => $cv_id]);
+    $this->assertTrue($result, "We did not delete a Cv using its pkey");
+    $n = $this->chado_connection->select('1:cv')
+      ->condition('cv_id', $cv_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The cv was not deleted in the database");
   }
 
   /**
@@ -155,6 +166,16 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $this->assertTrue(is_numeric($cvterm_id), 'We did not retrieve an integer cvterm_id for the new Cvterm "newCvterm001"');
     $cv_id = $values['get']['cv.cv_id'];
     $this->assertTrue(is_numeric($cv_id), 'We did not retrieve an integer cv_id for the new Cvterm "newCvterm001"');
+
+    // TEST: we can not delete a cv if it is in use by a cvterm.
+    $result = $instance->deleteCv(['cv.cv_id' => $cv_id]);
+    $this->assertFalse($result, "We deleted a Cv that is in use by a Cvterm");
+    $n = $this->chado_connection->select('1:cv')
+      ->condition('cv_id', $cv_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The cv was incorrectly deleted from the database");
 
     // TEST: Updating a non-existent Cvterm should return FALSE.
     $chado_buddy_records = $instance->updateCvterm(['cvterm.name' => 'newCvterm002', 'cvterm.definition' => 'def002'],
@@ -421,6 +442,29 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       'We did not get the correct cvterm_id for the upserted Cvterm with synonym "syn006"');
     $this->assertEquals(7, $values['get']['cvtermsynonym.type_id'],
       'We did not update the type_id for the upserted Cvterm with synonym "syn006"');
+
+    // TEST: we can delete a cv even if it is in use by a cvterm.
+    // Do this last as we are also destroying any cvterms because
+    // the foreign key has ON DELETE CASCADE set.
+    $cv_id = $this->chado_connection->select('1:cv', 'cv')
+      ->fields('cv', ['cv_id'])
+      ->condition('name', 'local', '=')
+      ->execute()
+      ->fetchField();
+    $result = $instance->deleteCv(['cv.name' => 'local'], ['cascade' => TRUE]);
+    $this->assertTrue($result, "We should have deleted a CV that is in use by a CV term");
+    $n = $this->chado_connection->select('1:cv')
+      ->condition('cv_id', $cv_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The cv was not deleted from the database");
+    $n = $this->chado_connection->select('1:cvterm')
+      ->condition('cv_id', $cv_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The cvterms were not deleted from the database");
 
     // TEST: If we disable auto-lookup of linking columns and specify one
     // then we should be fine...

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\tripal_chado\Kernel\Plugin\ChadoBuddy;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal_chado\ChadoBuddy\ChadoBuddyPluginBase;
 use Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -121,7 +122,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     // TEST: we can delete a cv.
     $cv_id = $chado_buddy_records[0]->getValue('cv.cv_id');
     $result = $instance->deleteCv(['cv.cv_id' => $cv_id]);
-    $this->assertTrue($result, "We did not delete a Cv using its pkey");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We did not delete a Cv using its pkey");
     $n = $this->chado_connection->select('1:cv')
       ->condition('cv_id', $cv_id, '=')
       ->countQuery()
@@ -169,7 +170,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
 
     // TEST: we can not delete a cv if it is in use by a cvterm.
     $result = $instance->deleteCv(['cv.cv_id' => $cv_id]);
-    $this->assertFalse($result, "We deleted a Cv that is in use by a Cvterm");
+    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a Cv that is in use by a Cvterm");
     $n = $this->chado_connection->select('1:cv')
       ->condition('cv_id', $cv_id, '=')
       ->countQuery()
@@ -449,7 +450,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $cvterm_id = $records[0]->getValue('cvterm.cvterm_id');
     $dbxref_id = $records[0]->getValue('dbxref.dbxref_id');
     $result = $instance->deleteCvterm(['cvterm.cvterm_id' => $cvterm_id]);
-    $this->assertTrue($result, "We did not delete a Cvterm using its pkey");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We did not delete a Cvterm using its pkey");
     $n = $this->chado_connection->select('1:cvterm')
       ->condition('cvterm_id', $cvterm_id, '=')
       ->countQuery()
@@ -469,7 +470,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $cvterm_id = $records[0]->getValue('cvterm.cvterm_id');
     $dbxref_id = $records[0]->getValue('dbxref.dbxref_id');
     $result = $instance->deleteCvterm(['cvterm.cvterm_id' => $cvterm_id], ['drop_dbxref' => TRUE]);
-    $this->assertTrue($result, "We did not delete a Cvterm using its pkey");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We did not delete a Cvterm using its pkey");
     $n = $this->chado_connection->select('1:cvterm')
       ->condition('cvterm_id', $cvterm_id, '=')
       ->countQuery()
@@ -492,7 +493,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       ->execute()
       ->fetchField();
     $result = $instance->deleteCv(['cv.name' => 'local'], ['cascade' => TRUE]);
-    $this->assertTrue($result, "We should have deleted a CV that is in use by a CV term");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We should have deleted a CV that is in use by a CV term");
     $n = $this->chado_connection->select('1:cv')
       ->condition('cv_id', $cv_id, '=')
       ->countQuery()

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -169,7 +169,7 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $this->assertTrue(is_numeric($cv_id), 'We did not retrieve an integer cv_id for the new Cvterm "newCvterm001"');
 
     // TEST: we can not delete a cv if it is in use by a cvterm.
-    $result = $instance->deleteCv(['cv.cv_id' => $cv_id]);
+    $result = $instance->deleteCv(['cv.cv_id' => $cv_id], ['fail_when_referenced' => FALSE]);
     $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a Cv that is in use by a Cvterm");
     $n = $this->chado_connection->select('1:cv')
       ->condition('cv_id', $cv_id, '=')

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -443,6 +443,46 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $this->assertEquals(7, $values['get']['cvtermsynonym.type_id'],
       'We did not update the type_id for the upserted Cvterm with synonym "syn006"');
 
+    // TEST: we can delete a cvterm.
+    $records = $instance->getCvterm(['cvterm.name' => 'newCvterm002']);
+    $this->assertNotEmpty($records, 'Failed getting cvterm created earlier');
+    $cvterm_id = $records[0]->getValue('cvterm.cvterm_id');
+    $dbxref_id = $records[0]->getValue('dbxref.dbxref_id');
+    $result = $instance->deleteCvterm(['cvterm.cvterm_id' => $cvterm_id]);
+    $this->assertTrue($result, "We did not delete a Cvterm using its pkey");
+    $n = $this->chado_connection->select('1:cvterm')
+      ->condition('cvterm_id', $cvterm_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The cvterm was not deleted in the database");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('dbxref_id', $dbxref_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The dbxref was incorrectly deleted in the database");
+
+    // TEST: we can delete a cvterm and its dbxref.
+    $records = $instance->getCvterm(['cvterm.name' => 'newCvterm003']);
+    $this->assertNotEmpty($records, 'Failed getting cvterm created earlier');
+    $cvterm_id = $records[0]->getValue('cvterm.cvterm_id');
+    $dbxref_id = $records[0]->getValue('dbxref.dbxref_id');
+    $result = $instance->deleteCvterm(['cvterm.cvterm_id' => $cvterm_id], ['drop_dbxref' => TRUE]);
+    $this->assertTrue($result, "We did not delete a Cvterm using its pkey");
+    $n = $this->chado_connection->select('1:cvterm')
+      ->condition('cvterm_id', $cvterm_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The cvterm was not deleted in the database");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('dbxref_id', $dbxref_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The dbxref was incorrectly retained in the database");
+
     // TEST: we can delete a cv even if it is in use by a cvterm.
     // Do this last as we are also destroying any cvterms because
     // the foreign key has ON DELETE CASCADE set.

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -169,15 +169,6 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $this->assertTrue(is_numeric($cv_id), 'We did not retrieve an integer cv_id for the new Cvterm "newCvterm001"');
 
     // TEST: we can not delete a cv if it is in use by a cvterm.
-    $result = $instance->deleteCv(['cv.cv_id' => $cv_id], ['fail_when_referenced' => FALSE]);
-    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a Cv that is in use by a Cvterm");
-    $n = $this->chado_connection->select('1:cv')
-      ->condition('cv_id', $cv_id, '=')
-      ->countQuery()
-      ->execute()
-      ->fetchField();
-    $this->assertEquals(1, $n, "The cv was incorrectly deleted from the database");
-    // Without setting 'fail_when_referenced' should throw an exception.
     $exception_message = '';
     try {
       $result = $instance->deleteCv(['cv.cv_id' => $cv_id], []);
@@ -186,6 +177,12 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       $exception_message = $e->getMessage();
     }
     $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a cv that has a foreign key");
+    $n = $this->chado_connection->select('1:cv')
+      ->condition('cv_id', $cv_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The cv was incorrectly deleted from the database");
 
     // TEST: Updating a non-existent Cvterm should return FALSE.
     $chado_buddy_records = $instance->updateCvterm(['cvterm.name' => 'newCvterm002', 'cvterm.definition' => 'def002'],

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -306,7 +306,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
-    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a db that has a foreign key");
+    $this->assertStringContainsString('records from the following tables reference the db record', $exception_message, "We did not get the exception message expected deleting a db that has a foreign key");
     $n = $this->chado_connection->select('1:db')
       ->condition('name', 'newDb006', '=')
       ->countQuery()
@@ -353,7 +353,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
-    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a dbxref that has a foreign key");
+    $this->assertStringContainsString('records from the following tables reference the dbxref record', $exception_message, "We did not get the exception message expected deleting a dbxref that has a foreign key");
     $n = $this->chado_connection->select('1:dbxref')
       ->condition('accession', 'newDbxref008', '=')
       ->countQuery()

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -286,6 +286,12 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $this->assertIsInt($status, "We did not retrieve an integer when associating a dbxref with the base table \"$base_table\"");
     $this->assertEquals(2, $status, "We did not retrieve 2 when reassociating a dbxref with the base table \"$base_table\"");
 
+    // TEST: delete a db or dbxref that does not exist.
+    $result = $instance->deleteDb(['db.name' => 'zzzzzzzzz']);
+    $this->assertEquals(ChadoBuddyPluginBase::NON_EXISTING, $result, 'Unexpected result deleting a non-existing DB');
+    $result = $instance->deleteDbxref(['dbxref.accession' => 'zzzzzzzzz']);
+    $this->assertEquals(ChadoBuddyPluginBase::NON_EXISTING, $result, 'Unexpected result deleting a non-existing dbxref');
+
     // TEST: we can not delete a db if it is in use by a dbxref.
     // Note that cascade won't handle continuing on to a cvterm,
     // so this test is limited to just db + dbxref.
@@ -301,6 +307,15 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(1, $n, "The db newDb006 was incorrectly deleted from the database");
+    // Without setting 'fail_when_referenced' should throw an exception.
+    $exception_message = '';
+    try {
+      $result = $instance->deleteDb(['db.name' => 'newDb006'], []);
+    }
+    catch (\Exception $e) {
+      $exception_message = $e->getMessage();
+    }
+    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a db that has a foreign key");
 
     // TEST: we can delete a db if we set cascade.
     $result = $instance->deleteDb(['db.name' => 'newDb006'], ['cascade' => TRUE]);
@@ -342,6 +357,15 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(1, $n, "The dbxref newDbxref008 was incorrectly deleted from the database");
+    // Without setting 'fail_when_referenced' should throw an exception.
+    $exception_message = '';
+    try {
+      $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], []);
+    }
+    catch (\Exception $e) {
+      $exception_message = $e->getMessage();
+    }
+    $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a dbxref that has a foreign key");
 
     // TEST: delete a dbxref with a foreign key but cascade set should succeed.
     $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['cascade' => TRUE]);

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -293,7 +293,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $this->assertIsObject($result, 'Failed setup for test inserting db newDb006');
     $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref006', 'db.name' => 'newDb006']);
     $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref006');
-    $result = $instance->deleteDb(['db.name' => 'newDb006']);
+    $result = $instance->deleteDb(['db.name' => 'newDb006'], ['fail_when_referenced' => FALSE]);
     $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a db that is in use by a dbxref");
     $n = $this->chado_connection->select('1:db')
       ->condition('name', 'newDb006', '=')
@@ -334,7 +334,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->fields(['dbxref_id' => $dbxref_id])
       ->execute();
     $this->assertEquals(1, $n, "The test biomaterial was not inserted");
-    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008']);
+    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['fail_when_referenced' => FALSE]);
     $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We incorrectly deleted a dbxref that has a foreign key");
     $n = $this->chado_connection->select('1:dbxref')
       ->condition('accession', 'newDbxref008', '=')

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -310,6 +310,47 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(0, $n, "The db newDb006 was not deleted from the database");
+
+    // TEST: delete a dbxref with no foreign keys should succeed.
+    $result = $instance->insertDb(['db.name' => 'newDb007-8', 'db.description' => 'desc007']);
+    $this->assertIsObject($result, 'Failed setup for test inserting db newDb007');
+    $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref007', 'db.name' => 'newDb007-8']);
+    $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref007');
+    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref007']);
+    $this->assertTrue($result, "We deleted a dbxref that has no foreign keys");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('accession', 'newDbxref007', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The dbxref newDbxref007 was incorrectly retained in the database");
+
+    // TEST: delete a dbxref with a foreign key should fail.
+    $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref008', 'db.name' => 'newDb007-8']);
+    $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref008');
+    $dbxref_id = $result->getValue('dbxref.dbxref_id');
+    $n = $this->chado_connection->insert('1:biomaterial')
+      ->fields(['dbxref_id' => $dbxref_id])
+      ->execute();
+    $this->assertEquals(1, $n, "The test biomaterial was not inserted");
+    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008']);
+    $this->assertFalse($result, "We incorrectly deleted a dbxref that has a foreign key");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('accession', 'newDbxref008', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The dbxref newDbxref008 was incorrectly deleted from the database");
+
+    // TEST: delete a dbxref with a foreign key but cascade set should succeed.
+    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['cascade' => TRUE]);
+    $this->assertTrue($result, "We failed to delete a dbxref that has a foreign key with cascade set");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('accession', 'newDbxref008', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The dbxref newDbxref008 was incorrectly retained in the database");
   }
 
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -132,6 +132,17 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     // TEST: case insensitive override should work.
     $chado_buddy_records = $instance->getDb(['db.name' => 'NEWdb003'], ['case_insensitive' => 'db.name']);
     $this->assertEquals(1, count($chado_buddy_records), "We did not receive case insensitive results for getDb when we should have");
+
+    // TEST: we can delete a db.
+    $db_id = $chado_buddy_records[0]->getValue('db.db_id');
+    $result = $instance->deleteDb(['db.db_id' => $db_id]);
+    $this->assertTrue($result, "We did not delete a db using its pkey");
+    $n = $this->chado_connection->select('1:db')
+      ->condition('db_id', $db_id, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The db was not deleted in the database");
   }
 
   /**
@@ -273,6 +284,32 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $status = $instance->associateDbxref($base_table, 1, $chado_buddy_records[0], []);
     $this->assertIsBool($status, "We did not retrieve a boolean when associating a dbxref with the base table \"$base_table\"");
     $this->assertTrue($status, "We did not retrieve TRUE when associating a dbxref with the base table \"$base_table\"");
+
+    // TEST: we can not delete a db if it is in use by a dbxref.
+    // Note that cascade won't handle continuing on to a cvterm,
+    // so this test is limited to just db + dbxref.
+    $result = $instance->insertDb(['db.name' => 'newDb006', 'db.description' => 'desc006']);
+    $this->assertIsObject($result, 'Failed setup for test inserting db newDb006');
+    $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref006', 'db.name' => 'newDb006']);
+    $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref006');
+    $result = $instance->deleteDb(['db.name' => 'newDb006']);
+    $this->assertFalse($result, "We deleted a db that is in use by a dbxref");
+    $n = $this->chado_connection->select('1:db')
+      ->condition('name', 'newDb006', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The db newDb006 was incorrectly deleted from the database");
+
+    // TEST: we can delete a db if we set cascade.
+    $result = $instance->deleteDb(['db.name' => 'newDb006'], ['cascade' => TRUE]);
+    $this->assertTrue($result, "We did not delete a db that is in use by a dbxref with cascade set");
+    $n = $this->chado_connection->select('1:db')
+      ->condition('name', 'newDb006', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $n, "The db newDb006 was not deleted from the database");
   }
 
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -299,15 +299,6 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $this->assertIsObject($result, 'Failed setup for test inserting db newDb006');
     $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref006', 'db.name' => 'newDb006']);
     $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref006');
-    $result = $instance->deleteDb(['db.name' => 'newDb006'], ['fail_when_referenced' => FALSE]);
-    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a db that is in use by a dbxref");
-    $n = $this->chado_connection->select('1:db')
-      ->condition('name', 'newDb006', '=')
-      ->countQuery()
-      ->execute()
-      ->fetchField();
-    $this->assertEquals(1, $n, "The db newDb006 was incorrectly deleted from the database");
-    // Without setting 'fail_when_referenced' should throw an exception.
     $exception_message = '';
     try {
       $result = $instance->deleteDb(['db.name' => 'newDb006'], []);
@@ -316,6 +307,12 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       $exception_message = $e->getMessage();
     }
     $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a db that has a foreign key");
+    $n = $this->chado_connection->select('1:db')
+      ->condition('name', 'newDb006', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The db newDb006 was incorrectly deleted from the database");
 
     // TEST: we can delete a db if we set cascade.
     $result = $instance->deleteDb(['db.name' => 'newDb006'], ['cascade' => TRUE]);
@@ -349,15 +346,6 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->fields(['dbxref_id' => $dbxref_id])
       ->execute();
     $this->assertEquals(1, $n, "The test biomaterial was not inserted");
-    $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['fail_when_referenced' => FALSE]);
-    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We incorrectly deleted a dbxref that has a foreign key");
-    $n = $this->chado_connection->select('1:dbxref')
-      ->condition('accession', 'newDbxref008', '=')
-      ->countQuery()
-      ->execute()
-      ->fetchField();
-    $this->assertEquals(1, $n, "The dbxref newDbxref008 was incorrectly deleted from the database");
-    // Without setting 'fail_when_referenced' should throw an exception.
     $exception_message = '';
     try {
       $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], []);
@@ -366,6 +354,12 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       $exception_message = $e->getMessage();
     }
     $this->assertStringContainsString('other records reference it', $exception_message, "We did not get the exception message expected deleting a dbxref that has a foreign key");
+    $n = $this->chado_connection->select('1:dbxref')
+      ->condition('accession', 'newDbxref008', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $n, "The dbxref newDbxref008 was incorrectly deleted from the database");
 
     // TEST: delete a dbxref with a foreign key but cascade set should succeed.
     $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['cascade' => TRUE]);

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\tripal_chado\Kernel\Plugin\ChadoBuddy;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal_chado\ChadoBuddy\ChadoBuddyPluginBase;
 use Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -136,7 +137,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     // TEST: we can delete a db.
     $db_id = $chado_buddy_records[0]->getValue('db.db_id');
     $result = $instance->deleteDb(['db.db_id' => $db_id]);
-    $this->assertTrue($result, "We did not delete a db using its pkey");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We did not delete a db using its pkey");
     $n = $this->chado_connection->select('1:db')
       ->condition('db_id', $db_id, '=')
       ->countQuery()
@@ -293,7 +294,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref006', 'db.name' => 'newDb006']);
     $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref006');
     $result = $instance->deleteDb(['db.name' => 'newDb006']);
-    $this->assertFalse($result, "We deleted a db that is in use by a dbxref");
+    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We deleted a db that is in use by a dbxref");
     $n = $this->chado_connection->select('1:db')
       ->condition('name', 'newDb006', '=')
       ->countQuery()
@@ -303,7 +304,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
 
     // TEST: we can delete a db if we set cascade.
     $result = $instance->deleteDb(['db.name' => 'newDb006'], ['cascade' => TRUE]);
-    $this->assertTrue($result, "We did not delete a db that is in use by a dbxref with cascade set");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We did not delete a db that is in use by a dbxref with cascade set");
     $n = $this->chado_connection->select('1:db')
       ->condition('name', 'newDb006', '=')
       ->countQuery()
@@ -317,7 +318,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     $result = $instance->insertDbxref(['dbxref.accession' => 'newDbxref007', 'db.name' => 'newDb007-8']);
     $this->assertIsObject($result, 'Failed setup for test inserting dbxref newDbxref007');
     $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref007']);
-    $this->assertTrue($result, "We deleted a dbxref that has no foreign keys");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We deleted a dbxref that has no foreign keys");
     $n = $this->chado_connection->select('1:dbxref')
       ->condition('accession', 'newDbxref007', '=')
       ->countQuery()
@@ -334,7 +335,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->execute();
     $this->assertEquals(1, $n, "The test biomaterial was not inserted");
     $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008']);
-    $this->assertFalse($result, "We incorrectly deleted a dbxref that has a foreign key");
+    $this->assertEquals(ChadoBuddyPluginBase::FAILURE, $result, "We incorrectly deleted a dbxref that has a foreign key");
     $n = $this->chado_connection->select('1:dbxref')
       ->condition('accession', 'newDbxref008', '=')
       ->countQuery()
@@ -344,7 +345,7 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
 
     // TEST: delete a dbxref with a foreign key but cascade set should succeed.
     $result = $instance->deleteDbxref(['dbxref.accession' => 'newDbxref008'], ['cascade' => TRUE]);
-    $this->assertTrue($result, "We failed to delete a dbxref that has a foreign key with cascade set");
+    $this->assertEquals(ChadoBuddyPluginBase::SUCCESS, $result, "We failed to delete a dbxref that has a foreign key with cascade set");
     $n = $this->chado_connection->select('1:dbxref')
       ->condition('accession', 'newDbxref008', '=')
       ->countQuery()

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
@@ -518,7 +518,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
           'organism.abbreviation' => 'Trp',
         ],
       ],
-      "ChadoBuddy getOrganismScientificName error, more than one organism record matches the specified conditions:",
+      "ChadoBuddy getOrganismScientificName error, more than one record",
     ];
 
     return $scenarios;

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
@@ -420,7 +420,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
           'organism.infraspecific_name' => 'chadoii',
         ],
       ],
-      "ChadoBuddy validateOrganismRankCvterm error, more than one record matched the values specified:",
+      "ChadoBuddy validateOrganismRankCvterm error, more than one record",
     ];
 
     // #4: updateOrganism() finds more than one organism record that matches.
@@ -434,7 +434,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
           'organism.abbreviation' => 'Trp',
         ],
       ],
-      "ChadoBuddy updateOrganism error, more than one record matched the conditions specified:",
+      "ChadoBuddy updateOrganism error, more than one record",
     ];
 
     // #5: updateOrganism() with a cvterm_id that does not exist.
@@ -495,7 +495,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
           'organism.abbreviation' => 'Trp',
         ],
       ],
-      "ChadoBuddy upsertOrganism error, more than one record matched the specified values:",
+      "ChadoBuddy upsertOrganism error, more than one record",
     ];
 
     // #9: getOrganismScientificName() does not find a matching organism.

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoPropertyBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoPropertyBuddyTest.php
@@ -166,7 +166,7 @@ class ChadoPropertyBuddyTest extends ChadoTestBuddyBase {
       $exception_message = $e->getMessage();
     }
     $this->assertTrue($exception_caught, 'We should get an exception when updating a property record that matches multiple properties.');
-    $this->assertStringContainsString('more than one record matched', $exception_message, "We did not get the exception message we expected when updating a property that matches multiple properties.");
+    $this->assertStringContainsString('more than one record', $exception_message, "We did not get the exception message we expected when updating a property that matches multiple properties.");
     // Test that the update was not performed.
     $chado_buddy_records = $instance->getProperty('project', 1, ['projectprop.value' => 'propfail']);
     $this->assertEquals(0, count($chado_buddy_records), "An update was incorrectly performed for conditions that match more than one record");
@@ -189,7 +189,7 @@ class ChadoPropertyBuddyTest extends ChadoTestBuddyBase {
       $exception_message = $e->getMessage();
     }
     $this->assertTrue($exception_caught, 'We should get an exception when upserting a property record that matches multiple properties.');
-    $this->assertStringContainsString('more than one record matched', $exception_message, "We did not get the exception message we expected when upserting a property that matches multiple properties.");
+    $this->assertStringContainsString('more than one record', $exception_message, "We did not get the exception message we expected when upserting a property that matches multiple properties.");
     $chado_buddy_records = $instance->getProperty('project', 1, ['projectprop.rank' => 5], []);
     $this->assertEquals(2, count($chado_buddy_records), "The upsert appears to have changed number of records");
 


### PR DESCRIPTION
# New Feature

### Closes #2448

## Description

This adds several delete functions to chado buddies.

These will be used in an upcoming PR to have views to manage db, cv, and cvterm records.

## Testing?

As these functions are not currently used, phpunit tests will hopefully provide good coverage of the new functions.
