### PR TITLE
filter module dependency as of drupal 11.4

### DIFF
--- a/tripal/tests/src/Kernel/TripalField/FieldType/TripalFieldTypeSettingsTest.php
+++ b/tripal/tests/src/Kernel/TripalField/FieldType/TripalFieldTypeSettingsTest.php
@@ -136,6 +136,7 @@ class TripalFieldTypeSettingsTest extends TripalTestKernelBase {
     // Build the form using the Drupal form builder.
     $formBuilder = FieldStorageConfigEditForm::create($this->container);
     $formBuilder->setEntity($fieldStorage);
+    $formBuilder->setEntityTypeManager(\Drupal::entityTypeManager());
     $form_state = new FormState();
     $form_state->set('field_config', $fieldConfig);
     $form_state->set('entity_type_id', 'tripal_entity');

--- a/tripal_chado/tests/src/Kernel/Services/TripalChadoRebuildServiceTest.php
+++ b/tripal_chado/tests/src/Kernel/Services/TripalChadoRebuildServiceTest.php
@@ -22,7 +22,7 @@ class TripalChadoRebuildServiceTest extends ChadoTestKernelBase {
    *
    * @var array
    */
-  protected static $modules = ['system', 'user', 'tripal', 'tripal_chado', 'views'];
+  protected static $modules = ['system', 'user', 'tripal', 'tripal_chado', 'filter', 'views'];
 
   /**
    * Module handler service.

--- a/tripal_layout/tests/src/Kernel/Services/TripalLayoutRebuildServiceTest.php
+++ b/tripal_layout/tests/src/Kernel/Services/TripalLayoutRebuildServiceTest.php
@@ -22,7 +22,7 @@ class TripalLayoutRebuildServiceTest extends ChadoTestKernelBase {
    *
    * @var array
    */
-  protected static $modules = ['system', 'user', 'tripal', 'tripal_chado', 'tripal_layout', 'views'];
+  protected static $modules = ['system', 'user', 'tripal', 'tripal_chado', 'tripal_layout', 'filter', 'views'];
 
   /**
    * Module handler service.


### PR DESCRIPTION
# Bug Fix

### Closes #2457

## Description

With this change added to Drupal https://www.drupal.org/project/drupal/issues/2536594 there is a new deprecation showing up for the dev version of drupal 11.4

See here for a description https://www.drupal.org/node/3035368

The short version of the story is that we need to make sure we have the `filter` module installed for the tests showing the deprecations.

## Testing?

This is a deprecation, so make sure the 11.x workflow no longer has the deprecation notice and no longer has a `Call to a member function getStorage() on null` error