### PR TITLE
Existing buddy associate functions return int instead of bool

### DIFF
--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -15,6 +15,16 @@ use Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException;
 abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInterface, ContainerFactoryPluginInterface {
 
   /**
+   * Indicates an association was newly created.
+   */
+  const NEW = 1;
+
+  /**
+   * Indicates an association already existed.
+   */
+  const EXISTING = 2;
+
+  /**
    * Provides the TripalDBX connection to chado.
    *
    * @var Drupal\tripal_chado\Database\ChadoConnection
@@ -79,7 +89,7 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
    * @param string $table_name
    *   The table name to query.
    *
-   * @return array|NULL
+   * @return array|null
    *   The table schema, or NULL if the table does not exist.
    */
   public function getChadoTableDef(string $table_name): ?array {

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoCvtermBuddy.php
@@ -978,6 +978,9 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *     additional columns, which may cause the insert to fail if any NOT NULL
    *     columns are not specified. Default TRUE.
    *
+   *   Both the cvterm and the chado record indicated by $record_id
+   *   MUST ALREADY EXIST.
+   *
    *   While the column name options above are optional, they will incur a
    *   slight performance hit if not included due to needing to look them up
    *   via the schema. See the table below for which columns apply to which
@@ -1000,15 +1003,16 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
    *   | stock_relationship_cvterm   | yes null | -absent     | -absent     | -absent        |
    *   phpcs:enable
    *
-   * @return bool
-   *   Returns TRUE if successful.
-   *   Both the cvterm and the chado record indicated by $record_id
-   *   MUST ALREADY EXIST.
+   * @return int
+   *   Indicates whether the association was
+   *   - created (ChadoBuddyPluginBase::NEW = 1)
+   *   - already existed (ChadoBuddyPluginBase::EXISTING = 2)
+   *   If the association request was not successful, an exception is thrown.
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   If an error is encountered.
    */
-  public function associateCvterm(string $base_table, int $record_id, ChadoBuddyRecord $cvterm, array $options = []) {
+  public function associateCvterm(string $base_table, int $record_id, ChadoBuddyRecord $cvterm, array $options = []): int {
     $linking_table = $base_table . '_cvterm';
 
     // Get the primary key of the base table.
@@ -1042,13 +1046,15 @@ class ChadoCvtermBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInterfa
         $query = $this->chado_connection->insert('1:' . $linking_table);
         $query->fields($fields);
         $query->execute();
+        return self::NEW;
+      }
+      else {
+        return self::EXISTING;
       }
     }
     catch (\Exception $e) {
       throw new ChadoBuddyException('ChadoBuddy associateCvterm database error ' . $e->getMessage());
     }
-
-    return TRUE;
   }
 
   /**

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoDbxrefBuddy.php
@@ -608,15 +608,19 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
    *   Also pass in any other columns used in the linking table, some of which
    *   may have a NOT NULL constraint.
    *
-   * @return bool
-   *   Returns true if successful.
    *   Both the dbxref and the chado record indicated by $record_id
    *   MUST ALREADY EXIST.
+   *
+   * @return int
+   *   Indicates whether the association was
+   *   - created (ChadoBuddyPluginBase::NEW = 1)
+   *   - already existed (ChadoBuddyPluginBase::EXISTING = 2)
+   *   If the association request was not successful, an exception is thrown.
    *
    * @throws Drupal\tripal_chado\ChadoBuddy\Exceptions\ChadoBuddyException
    *   If an error is encountered.
    */
-  public function associateDbxref(string $base_table, int $record_id, ChadoBuddyRecord $dbxref, array $options = []) {
+  public function associateDbxref(string $base_table, int $record_id, ChadoBuddyRecord $dbxref, array $options = []): int {
     $linking_table = $base_table . '_dbxref';
 
     // Get the primary key of the base table.
@@ -650,13 +654,15 @@ class ChadoDbxrefBuddy extends ChadoBuddyPluginBase {
         $query = $this->chado_connection->insert('1:' . $linking_table);
         $query->fields($this->removeTablePrefix($fields));
         $query->execute();
+        return self::NEW;
+      }
+      else {
+        return self::EXISTING;
       }
     }
     catch (\Exception $e) {
       throw new ChadoBuddyException('ChadoBuddy associateDbxref database error ' . $e->getMessage());
     }
-
-    return TRUE;
   }
 
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoCvtermBuddyTest.php
@@ -285,8 +285,8 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
       ->execute();
     $linking_table = $base_table . '_cvterm';
     $status = $instance->associateCvterm($base_table, 1, $chado_buddy_records[0], []);
-    $this->assertIsBool($status, "We did not retrieve a boolean when associating a cvterm with the base table \"$base_table\"");
-    $this->assertTrue($status, "We did not retrieve TRUE when associating a cvterm with the base table \"$base_table\"");
+    $this->assertIsInt($status, "We did not retrieve an integer when associating a cvterm with the base table \"$base_table\"");
+    $this->assertEquals(1, $status, "We did not retrieve 1 when associating a cvterm with the base table \"$base_table\"");
     $query = $this->chado_connection->select('1:' . $linking_table, 'lt')
       ->fields('lt', ['cvterm_id'])
       ->execute();
@@ -301,8 +301,8 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     // TEST: associate a cvterm with a base table but it already exists.
     // Just repeat the same association, should not be an error.
     $status = $instance->associateCvterm($base_table, 1, $chado_buddy_records[0], []);
-    $this->assertIsBool($status, "We did not retrieve a boolean when re-associating a cvterm with the base table \"$base_table\"");
-    $this->assertTrue($status, "We did not retrieve TRUE when re-associating a cvterm with the base table \"$base_table\"");
+    $this->assertIsInt($status, "We did not retrieve an integer when re-associating a cvterm with the base table \"$base_table\"");
+    $this->assertEquals(2, $status, "We did not retrieve 2 when re-associating a cvterm with the base table \"$base_table\"");
 
     // TEST: associate a cvterm with a base table where there are required
     // columns in the linking table (i.e. pub_id), but we disable automatic
@@ -337,8 +337,8 @@ class ChadoCvtermBuddyTest extends ChadoTestBuddyBase {
     $linking_table = $base_table . '_cvterm';
     $options = [];
     $status = $instance->associateCvterm($base_table, 1, $chado_buddy_records[0], $options);
-    $this->assertIsBool($status, "We did not retrieve a boolean when associating a cvterm with the base table \"$base_table\"");
-    $this->assertTrue($status, "We did not retrieve TRUE when associating a cvterm with the base table \"$base_table\"");
+    $this->assertIsInt($status, "We did not retrieve an integer when associating a cvterm with the base table \"$base_table\"");
+    $this->assertEquals(1, $status, "We did not retrieve 1 when associating a cvterm with the base table \"$base_table\"");
     $query = $this->chado_connection->select('1:' . $linking_table, 'lt')
       ->fields('lt', ['cvterm_id', 'pub_id'])
       ->execute();

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoDbxrefBuddyTest.php
@@ -255,8 +255,8 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
       ->execute();
     $linking_table = $base_table . '_dbxref';
     $status = $instance->associateDbxref($base_table, 1, $chado_buddy_records[0], []);
-    $this->assertIsBool($status, "We did not retrieve a boolean when associating a dbxref with the base table \"$base_table\"");
-    $this->assertTrue($status, "We did not retrieve TRUE when associating a dbxref with the base table \"$base_table\"");
+    $this->assertIsInt($status, "We did not retrieve an integer when associating a dbxref with the base table \"$base_table\"");
+    $this->assertEquals(1, $status, "We did not retrieve 1 when associating a dbxref with the base table \"$base_table\"");
     $query = $this->chado_connection->select('1:' . $linking_table, 'lt')
       ->fields('lt', ['dbxref_id'])
       ->execute();
@@ -271,8 +271,8 @@ class ChadoDbxrefBuddyTest extends ChadoTestBuddyBase {
     // TEST: associate a dbxref with a base table but record already exists.
     // To do so, we just associate the same record a second time.
     $status = $instance->associateDbxref($base_table, 1, $chado_buddy_records[0], []);
-    $this->assertIsBool($status, "We did not retrieve a boolean when associating a dbxref with the base table \"$base_table\"");
-    $this->assertTrue($status, "We did not retrieve TRUE when associating a dbxref with the base table \"$base_table\"");
+    $this->assertIsInt($status, "We did not retrieve an integer when associating a dbxref with the base table \"$base_table\"");
+    $this->assertEquals(2, $status, "We did not retrieve 2 when reassociating a dbxref with the base table \"$base_table\"");
   }
 
 }


### PR DESCRIPTION
# New Feature

### Closes #2459

### Depends on #2412

## Description

In development of the stock buddy, it was decided the return value of associate should indicate the difference between created and already existing, thus return an int instead of a boolean.
https://github.com/tripal/tripal/issues/2359#issuecomment-4130070348

This PR does this for the existing buddies.

## Testing?

phpunit tests have been updated to detect and check int return values