### PR TITLE
Tripal entity permissions bug

### DIFF
--- a/tripal/src/Access/TripalEntityAccessControlHandler.php
+++ b/tripal/src/Access/TripalEntityAccessControlHandler.php
@@ -310,7 +310,7 @@ class TripalEntityAccessControlHandler extends EntityAccessControlHandler {
       // If we have a specific list of content types, then generate the
       // permissions string for each one.
       foreach ($content_types as $content_type) {
-        $permission = $operation . ' ' . $mode . ' ' . $content_type . ' content';
+        $permission = $operation . ' all ' . $content_type . ' content';
         if ($account->hasPermission($permission)) {
           $access_granted++;
         }

--- a/tripal/src/Access/TripalEntityAccessControlHandler.php
+++ b/tripal/src/Access/TripalEntityAccessControlHandler.php
@@ -310,7 +310,7 @@ class TripalEntityAccessControlHandler extends EntityAccessControlHandler {
       // If we have a specific list of content types, then generate the
       // permissions string for each one.
       foreach ($content_types as $content_type) {
-        $permission = $operation . ' ' . $content_type . ' content';
+        $permission = $operation . ' ' . $mode . ' ' . $content_type . ' content';
         if ($account->hasPermission($permission)) {
           $access_granted++;
         }

--- a/tripal/src/Plugin/views/access/TripalContentViewAccessHandler.php
+++ b/tripal/src/Plugin/views/access/TripalContentViewAccessHandler.php
@@ -73,7 +73,7 @@ class TripalContentViewAccessHandler extends AccessPluginBase {
     $form['content_types'] = [
       '#type' => 'select',
       '#title' => $this->t('Content Types'),
-      '#default_value' => $this->options['content_types'],
+      '#default_value' => $this->options['content_types'] ?? '',
       '#options' => $content_type_options,
       '#description' => $this->t('Select which content types whose Tripal Content permissions you want to apply to this view.'),
       '#multiple' => TRUE,
@@ -211,7 +211,7 @@ class TripalContentViewAccessHandler extends AccessPluginBase {
    */
   public function summaryTitle() {
 
-    $num_content_types = count($this->options['content_types']);
+    $num_content_types = count($this->options['content_types'] ?? []);
     $operation = $this->options['operation'];
 
     // Expand mode to fit in the statement.
@@ -221,7 +221,7 @@ class TripalContentViewAccessHandler extends AccessPluginBase {
     }
 
     // If the 'all' content type options was chosen then change the statement.
-    if (array_key_exists('all', $this->options['content_types'])) {
+    if (array_key_exists('all', $this->options['content_types'] ?? [])) {
       $num_content_types = 'the existing';
     }
 

--- a/tripal/src/Plugin/views/access/TripalContentViewAccessHandler.php
+++ b/tripal/src/Plugin/views/access/TripalContentViewAccessHandler.php
@@ -130,7 +130,7 @@ class TripalContentViewAccessHandler extends AccessPluginBase {
     $operation = $access_options['operation'];
     // - Expand mode to fit in the statement.
     $mode_string = 'at least 1 of';
-    if ($this->options['mode'] === 'all') {
+    if ($access_options['mode'] === 'all') {
       $mode_string = 'all of';
     }
     // - if all selected...


### PR DESCRIPTION
# Bug Fix

### Closes #2469

## Description
Tripal entity permissions are always denied for a view, the linked issue describes in more detail.

## Testing?

On 4.x on Drupal 11.x you can only get this far:
1. Structure -> Views -> +Add view
2. View name: analysis
3. View settings, Show: Tripal Content
4. of type: Analysis
5. Page settings: Create a page checked
6. Save and edit
7. Access: Click on Unrestricted
8. Check Use Tripal Content permissions
9. Apply - nothing happens
10. If you close, and refresh, you get a WSOD:

The website encountered an unexpected error. Try again later.

TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in count() 
(line 214 of modules/contrib/tripal/tripal/src/Plugin/views/access/TripalContentViewAccessHandler.php). 

To test with changes in this PR, you can also use PR https://github.com/tripal/tripal/pull/2468 (which will be dependent on this PR) where the views are defined.
You will need a role that can access one content type but not another.
And then a user with that role.
Then Update the views to use permissions as described here.