### PR TITLE
Temporary fix for schema issues caused by Drupal fields on Tripal Content

### DIFF
--- a/tripal/config/schema/tripal.schema.yml
+++ b/tripal/config/schema/tripal.schema.yml
@@ -96,7 +96,7 @@ field.storage.tripal_entity.*:
           label: 'Term Accession'
         max_length:
           type: integer
-          label: 'Storage Maximum length'
+          label: 'Maximum length'
         debug:
           type: boolean
           label: 'Flag to Enable field debugging'

--- a/tripal/src/Hook/TripalEntityHooks.php
+++ b/tripal/src/Hook/TripalEntityHooks.php
@@ -116,7 +116,11 @@ class TripalEntityHooks {
     // Temporary fix for Issue #1999.
     // We will collect the storage settings for all non-tripal fields and
     // manually add them to the field storage definition for tripal_entity.
-    // -- on tripal_entity.
+    // NOTE: there are some conflicts between drupal field settings, which is
+    // why this is only a temporary fix. For now, we will manually skip any
+    // settings which are known to be different.
+    $skipped_settings = ['allowed_values'];
+    // Now, for each field storage definition, we will check for settings...
     foreach ($definitions as $key => $field_settings) {
       if (str_starts_with($key, 'field.storage_settings.') && !str_starts_with($key, 'field.storage.tripal_entity.')) {
         // If this field doesn't have any settings, we can skip it.
@@ -132,13 +136,13 @@ class TripalEntityHooks {
             // -- on field collection yaml.
             $definitions['tripal.tripalfield_collection.*']['mapping']['fields']['sequence']['mapping']['storage_settings']['mapping'][$setting_key] = $setting;
           }
-          else {
+          elseif (!in_array($setting_key, $skipped_settings)) {
             // If the setting already exists, we should check to make sure it
             // is the same. If not, we should log a warning.
             if ($definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key] != $setting) {
-              \Drupal::logger('tripal')->warning(
-                'The field storage setting @setting_key for field @field_name is different in the tripal_entity field storage definition than in the field storage definition for @field_name. This may cause issues with field storage and retrieval. Please check the field storage definitions for both tripal_entity and @field_name to ensure they are consistent.',
-                ['@setting_key' => $setting_key, '@field_name' => str_replace('field.storage_settings.', '', $key)]
+              $field_name = str_replace('field.storage_settings.', '', $setting_key);
+              throw new \Exception(
+                "The field storage setting $setting_key for field $field_name is different in the tripal_entity field storage definition than in the field storage definition for $field_name. This may cause issues with field storage and retrieval. Please check the field storage definitions for both tripal_entity and $field_name to ensure they are consistent. Tripal Entity definition: " . print_r($definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key], TRUE) . " Field definition: " . print_r($setting, TRUE)
               );
             }
           }

--- a/tripal/src/Hook/TripalEntityHooks.php
+++ b/tripal/src/Hook/TripalEntityHooks.php
@@ -101,4 +101,50 @@ class TripalEntityHooks {
     }
   }
 
+  /**
+   * Implements hook_config_schema_info_alter().
+   *
+   * Specifically, we are altering config schema set in the tripal module.
+   * We use this approach to ensure we are extending the existing schema
+   * which makes these changes available to extension modules defining their
+   * own yml files.
+   */
+  #[Hook('config_schema_info_alter')]
+  public function configSchemaInfoAlter(&$definitions) {
+
+    // print_r(array_keys($definitions));
+    // Temporary fix for Issue #1999.
+    // We will collect the storage settings for all non-tripal fields and
+    // manually add them to the field storage definition for tripal_entity.
+    // -- on tripal_entity.
+    foreach ($definitions as $key => $field_settings) {
+      if (str_starts_with($key, 'field.storage_settings.') && !str_starts_with($key, 'field.storage.tripal_entity.')) {
+        // If this field doesn't have any settings, we can skip it.
+        if (!array_key_exists('mapping', $field_settings)) {
+          continue;
+        }
+        // For each setting this field defines, see if we have it in our
+        // tripal_entity field storage definition. If not, add it.
+        foreach ($field_settings['mapping'] as $setting_key => $setting) {
+          if (!isset($definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key])) {
+            // -- on entity.
+            $definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key] = $setting;
+            // -- on field collection yaml.
+            $definitions['tripal.tripalfield_collection.*']['mapping']['fields']['sequence']['mapping']['storage_settings']['mapping'][$setting_key] = $setting;
+          }
+          else {
+            // If the setting already exists, we should check to make sure it
+            // is the same. If not, we should log a warning.
+            if ($definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key] != $setting) {
+              \Drupal::logger('tripal')->warning(
+                'The field storage setting @setting_key for field @field_name is different in the tripal_entity field storage definition than in the field storage definition for @field_name. This may cause issues with field storage and retrieval. Please check the field storage definitions for both tripal_entity and @field_name to ensure they are consistent.',
+                ['@setting_key' => $setting_key, '@field_name' => str_replace('field.storage_settings.', '', $key)]
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/tripal/src/Hook/TripalEntityHooks.php
+++ b/tripal/src/Hook/TripalEntityHooks.php
@@ -119,7 +119,7 @@ class TripalEntityHooks {
     // NOTE: there are some conflicts between drupal field settings, which is
     // why this is only a temporary fix. For now, we will manually skip any
     // settings which are known to be different.
-    $skipped_settings = ['allowed_values'];
+    $skipped_settings = [];
     // Now, for each field storage definition, we will check for settings...
     foreach ($definitions as $key => $field_settings) {
       if (str_starts_with($key, 'field.storage_settings.') && !str_starts_with($key, 'field.storage.tripal_entity.')) {
@@ -135,6 +135,15 @@ class TripalEntityHooks {
             $definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key] = $setting;
             // -- on field collection yaml.
             $definitions['tripal.tripalfield_collection.*']['mapping']['fields']['sequence']['mapping']['storage_settings']['mapping'][$setting_key] = $setting;
+          }
+          elseif ($setting_key == 'allowed_values') {
+            // There are two conflicting Drupal field definitions for this
+            // setting. One uses integer keys and the other uses float keys.
+            // Here we choose float as that should work in both cases.
+            // -- on entity.
+            $definitions['field.storage.tripal_entity.*']['mapping']['settings']['mapping'][$setting_key]['sequence']['mapping']['value']['type'] = 'float';
+            // -- on field collection yaml.
+            $definitions['tripal.tripalfield_collection.*']['mapping']['fields']['sequence']['mapping']['storage_settings']['mapping'][$setting_key]['sequence']['mapping']['value']['type'] = 'float';
           }
           elseif (!in_array($setting_key, $skipped_settings)) {
             // If the setting already exists, we should check to make sure it

--- a/tripal/src/Hook/TripalEntityHooks.php
+++ b/tripal/src/Hook/TripalEntityHooks.php
@@ -112,7 +112,6 @@ class TripalEntityHooks {
   #[Hook('config_schema_info_alter')]
   public function configSchemaInfoAlter(&$definitions) {
 
-    // print_r(array_keys($definitions));
     // Temporary fix for Issue #1999.
     // We will collect the storage settings for all non-tripal fields and
     // manually add them to the field storage definition for tripal_entity.
@@ -158,6 +157,7 @@ class TripalEntityHooks {
         }
       }
     }
+
   }
 
 }

--- a/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\Tests\tripal\Kernel\Entity;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests schema alterations for TripalEntity storage configuration.
+ */
+#[RunTestsInSeparateProcesses]
+class TripalEntityConfigAlterTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'field',
+    'tripal',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // IMPORTANT: reset cached schema definitions.
+    $this->container
+      ->get('config.typed')
+      ->clearCachedDefinitions();
+
+  }
+
+  /**
+   * Tests that the config schema is properly altered.
+   *
+   * @see TripalEntityHooks::configSchemaInfoAlter()
+   */
+  public function testSchemaIsAltered() {
+
+    // Fetch the altered schema definition.
+    $definition = $this->container->get('config.typed')->getDefinition('field.storage.tripal_entity.test');
+    $this->assertNotEmpty($definition, 'Tripal entity storage schema exists.');
+
+    // Navigate to the altered mapping.
+    $this->assertArrayHasKey('mapping', $definition);
+    $this->assertArrayHasKey('settings', $definition['mapping']);
+    $this->assertArrayHasKey('mapping', $definition['mapping']['settings']);
+    $settings_mapping = $definition['mapping']['settings']['mapping'] ?? [];
+
+    // Check that a setting from the Drupal string field is available now.
+    $this->assertArrayHasKey(
+      'case_sensitive',
+      $settings_mapping,
+      'Setting from Drupal field storage was copied to tripal entity.'
+    );
+
+    // Check that a setting from Tripal fields is still available.
+    $this->assertArrayHasKey(
+      'storage_plugin_id',
+      $settings_mapping,
+      'Setting from Tripal field storage is still available.'
+    );
+
+    // Check that a setting shared between Drupal and Tripal fields
+    // is still correctly defined.
+    $expected_maxlength_definition = [
+      'type' => 'integer',
+      'label' => 'Storage Maximum length',
+    ];
+    $this->assertArrayHasKey(
+      'max_length',
+      $settings_mapping,
+      'Setting from Tripal field storage is still available.'
+    );
+    $this->assertEquals($expected_maxlength_definition, $settings_mapping['max_length'], 'Shared setting is still correctly defined.');
+  }
+
+}

--- a/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
@@ -17,6 +17,7 @@ class TripalEntityConfigAlterTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'field',
+    'options',
     'tripal',
   ];
 
@@ -76,6 +77,20 @@ class TripalEntityConfigAlterTest extends KernelTestBase {
       'Setting from Tripal field storage is still available.'
     );
     $this->assertEquals($expected_maxlength_definition, $settings_mapping['max_length'], 'Shared setting is still correctly defined.');
+
+    // Check that allowed_values is correctly defined with float keys.
+    $this->assertArrayHasKey(
+      'allowed_values',
+      $settings_mapping,
+      'Setting with conflicting definitions is still available.'
+    );
+    $allowed_values_definition = $settings_mapping['allowed_values'];
+    $this->assertArrayHasKey('sequence', $allowed_values_definition);
+    $this->assertArrayHasKey('mapping', $allowed_values_definition['sequence']);
+    $this->assertArrayHasKey('value', $allowed_values_definition['sequence']['mapping']);
+    $this->assertArrayHasKey('type', $allowed_values_definition['sequence']['mapping']['value']);
+    $this->assertEquals('float', $allowed_values_definition['sequence']['mapping']['value']['type'], 'allowed_values is correctly defined with more permissivefloat keys.');
+
   }
 
 }

--- a/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
@@ -89,7 +89,7 @@ class TripalEntityConfigAlterTest extends KernelTestBase {
     $this->assertArrayHasKey('mapping', $allowed_values_definition['sequence']);
     $this->assertArrayHasKey('value', $allowed_values_definition['sequence']['mapping']);
     $this->assertArrayHasKey('type', $allowed_values_definition['sequence']['mapping']['value']);
-    $this->assertEquals('float', $allowed_values_definition['sequence']['mapping']['value']['type'], 'allowed_values is correctly defined with more permissivefloat keys.');
+    $this->assertEquals('float', $allowed_values_definition['sequence']['mapping']['value']['type'], 'allowed_values is correctly defined with more permissive float keys.');
 
   }
 

--- a/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityConfigAlterTest.php
@@ -68,7 +68,7 @@ class TripalEntityConfigAlterTest extends KernelTestBase {
     // is still correctly defined.
     $expected_maxlength_definition = [
       'type' => 'integer',
-      'label' => 'Storage Maximum length',
+      'label' => 'Maximum length',
     ];
     $this->assertArrayHasKey(
       'max_length',

--- a/tripal/tripal.module
+++ b/tripal/tripal.module
@@ -395,6 +395,18 @@ function tripal_tripal_entity_storage_load(&$entities) {
 }
 
 /**
+ * Implements hook_config_schema_info_alter().
+ *
+ * This legacy hook is only run for Drupal < 11, and is replaced by class
+ * Drupal\tripal\Hook\TripalEntityHooks in
+ * tripal/src/Hook/TripalEntityHooks.php.
+ */
+#[LegacyHook]
+function tripal_config_schema_info_alter(&$definitions) {
+  \Drupal::service('tripal.entity_hooks')->configSchemaInfoAlter($definitions);
+}
+
+/**
  * Implements hook_views_query_alter().
  *
  * This legacy hook is only run for Drupal < 11, and is replaced by class


### PR DESCRIPTION

# Bug Fix

### Issue #1999

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds a temporary solution to the schema issues described in the linked issue. In short the issue is that our entity schema definitions are not written such that they adopt non-tripal field settings. This causes schema issues whenever you try to test a drupal field on a tripalentity 🙈 

This PR loops through the field storage settings defined by non-tripal fields and adds them to the tripal field storage definition. This is clearly not ideal as there can be conflicts between Drupal fields and now all fields can have all settings (i.e. setting schema are no longer specific to their field).

How we have attempted to mitigate the concerns with this temporary solution:

1. We only add the Drupal field setting to the schema if there is not a tripal field setting with the same name.
2. If there is a tripal field setting with the same name, we check for them to agree.
3. If they don't agree, we throw an exception.

Even so, there are disagreements between fields in drupal 🤦‍♀️ This is why I added a `$skipped_settings` array which allows us to manually inspect any disagreements and add acceptable ones to a whitelist.

Current disagreements:
- `allowed_values`: two Drupal fields define this setting slightly differently but they are compatible. Specifically, one defines the key as an integer and the other a float. We have chosen the float version as it should work for both fields.

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

### Automated testing

I added `TripalEntityConfigAlterTest` which clears all the config definitions and then gets the tripal entity field definitions specifically. It checks:

1. A setting from a Drupal field which was not available before is now available.
2. A setting from Tripal Fields is still available.
3. A setting shared by both is also available and correct.

### Manual Testing

This can only be tested manually by adding a Drupal field to an existing test and confirming you no longer get schema errors 😜  [I have done that in this dependant PR](https://github.com/tripal/tripal/pull/2474/changes#diff-7ff609b0aeaed77ded07e482b6532e03e3b2c6de639b7b47453e2b2755e217cfR37-R47) and the tests do not show schema errors anymore.

If you want to test the exception, you can comment out the else-block for `allowed_values` and see it fail spectacularly when you clear the cache 😜.