### PR TITLE
Add more errors to skip when www.ebi.ac.uk is down

### DIFF
--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -108,6 +108,7 @@ class OboImporterTest extends ChadoTestKernelBase {
     '/a lookup will be performed with the EBI Ontology Lookup Service/' => 'normal',
     '/Cannot find the ontology via an EBI OLS lookup/' => 'skip',
     '/Service Temporarily Unavailable/' => 'skip',
+    '/Invalid hostname in URL/' => 'skip',
   ];
 
   /**

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -109,6 +109,9 @@ class OboImporterTest extends ChadoTestKernelBase {
     '/Cannot find the ontology via an EBI OLS lookup/' => 'skip',
     '/Service Temporarily Unavailable/' => 'skip',
     '/Invalid hostname in URL/' => 'skip',
+    '/Unable to get response from/' => 'skip',
+    '/502 Bad Gateway/' => 'skip',
+    '/504 Gateway Time-out/' => 'skip',
   ];
 
   /**


### PR DESCRIPTION
# Bug Fix

### Issue #2143
( see comment https://github.com/tripal/tripal/issues/2143#issuecomment-4412962914 )

## Description
We have started to see a new error as observed in https://github.com/tripal/tripal/actions/runs/25595777291/job/75141339757 and multiple other workflows:

There was 1 failure:

1\) Drupal\Tests\tripal_chado\Kernel\Plugin\TripalImporter\OboImporterTest::testOboImporter with data set #0 (0, 'TO subset vocabulary')
Unanticipated error: Invalid hostname in URL http://www.ebi.ac.uk/ols/api/ontologies/bfo/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FBFO_0000002: cURL error 28: Operation timed out after 30001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://www.ebi.ac.uk/ols4/api/ontologies/bfo/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FBFO_0000002

/var/www/drupal/web/modules/contrib/tripal/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php:325
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

And there are multiple other errors observed

## Testing?

Tests on this PR should show the offending test is now skipped.
