### PR TITLE
deprecated node20 and action_branch_name

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: 'actions/checkout@v6'
         name: 'Check out code'
       ## Build images tagged drupal{VER}-php{VER}-pgsqlVER
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build & push Full matrix of Docker images'
         with:
           image: 'tripalproject/tripaldocker'
@@ -83,7 +83,7 @@ jobs:
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build images tagged drupal{VER}-php{VER}-pgsqlVER-noChado without chado installed!
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build & push Full matrix of Docker images WITH NO CHADO'
         with:
           image: 'tripalproject/tripaldocker'
@@ -94,7 +94,7 @@ jobs:
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }},installchado=FALSE'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build Images tagged drupal{VER} focused on php 8.5 + postgresql 18
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build & push Docker image Drupal focused Docker images.'
         if: ${{ matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:
@@ -106,7 +106,7 @@ jobs:
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'tripal.branch=4.x,drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build latest using 11.3.x-dev, PHP 8.5, PgSQL 18'
         if: ${{ matrix.drupal-version == '11.3.x-dev' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:

--- a/.github/workflows/PR-branchNameCheck.yml
+++ b/.github/workflows/PR-branchNameCheck.yml
@@ -7,7 +7,15 @@ jobs:
   branch-naming-rules:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'deepakputhraya/action-branch-name@v1.0.0'
-        with:
-          regex: 'tv4g\d+-(issue){0,1}\d+-{0,1}\w*' # Regex the branch should match.
-          ignore: '4.x' # Ignore exactly matching branch names from convention
+
+      - name: "Validate branch name matches our standards"
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          STANDARD='^tv4g[0-9]+-(issue){0,1}[0-9]+-?[a-zA-Z0-9_-]*$'
+
+          if [[ ! $BRANCH_NAME =~ $STANDARD ]] && [[ ! $BRANCH_NAME == '4.x' ]]; then
+            echo "::error::Branch name '$BRANCH_NAME' does not match our standard '$STANDARD'"
+            exit 1
+          fi
+
+          echo "✅ Branch name '$BRANCH_NAME' matches our standard '$STANDARD' 🎉"

--- a/.github/workflows/PR-branchNameCheck.yml
+++ b/.github/workflows/PR-branchNameCheck.yml
@@ -9,11 +9,12 @@ jobs:
     steps:
 
       - name: "Validate branch name matches our standards"
+        env:
+          BRANCH_NAME: '${{ github.head_ref }}'
         run: |
-          BRANCH_NAME="${{ github.head_ref }}"
           STANDARD='^tv4g[0-9]+-(issue){0,1}[0-9]+-?[a-zA-Z0-9_-]*$'
 
-          if [[ ! $BRANCH_NAME =~ $STANDARD ]] && [[ ! $BRANCH_NAME == '4.x' ]]; then
+          if [[ ! "$BRANCH_NAME" =~ $STANDARD ]] && [[ ! "$BRANCH_NAME" == '4.x' ]]; then
             echo "::error::Branch name '$BRANCH_NAME' does not match our standard '$STANDARD'"
             exit 1
           fi

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: 'actions/checkout@v6'
         name: 'Check out code'
       ## Build images tagged drupal{VER}-php{VER}-pgsql{VER}
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build & push Full matrix of Docker images'
         with:
           image: 'tripalproject/tripaldocker-drupal'
@@ -81,7 +81,7 @@ jobs:
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build Images tagged drupal{VER} focused on php 8.5 + postgresql 18
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build & push Docker image Drupal focused Docker images.'
         if: ${{ matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:
@@ -94,7 +94,7 @@ jobs:
           buildArgs: 'drupalversion=${{ matrix.drupal-version }},postgresqlversion=${{ matrix.pgsql-version }},phpversion=${{ matrix.php-version }}'
           labels: 'drupal.version.label=${{ matrix.drupal-version }},php.version.label=${{ matrix.php-version }}, postgresql.version.label=${{ matrix.pgsql-version }}'
       ## Build the image tagged as latest which is the highest version combo that we feel is well supported.
-      - uses: 'mr-smithers-excellent/docker-build-push@v6'
+      - uses: 'mr-smithers-excellent/docker-build-push@v7'
         name: 'Build latest using 11.3.x-dev, PHP 8.5, PgSQL 18'
         if: ${{ matrix.drupal-version == '11.3.x-dev' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:


### PR DESCRIPTION
# Bug Fix

### Issue #2478

## Description

1. update mr-smithers-excellent/docker-build-push to v7 (node24)
2. replace unmaintained deepakputhraya/action-branch-name action
3. ? setup-php in some unknown dependency - we don't know yet how to fix this so not in this PR, so issue can remain open - see comment https://github.com/tripal/tripal/issues/2478#issuecomment-4500722787

## Testing?
1. node20 deprecation should be gone
2. this PR should have a successful branch name check. See https://github.com/tripal/tripal/actions/runs/26230230543/job/77188231862?pr=2479
<img width="813" height="662" alt="branch-name-check" src="https://github.com/user-attachments/assets/452d52e4-d5a2-4e99-9638-fc4c2b134ee2" />
