### PR TITLE
Update email addresses for Drupal installation

### DIFF
--- a/tripaldocker/drupal.Dockerfile
+++ b/tripaldocker/drupal.Dockerfile
@@ -203,10 +203,10 @@ RUN cd /var/www/drupal \
   && sleep 30 \
   && /var/www/drupal/vendor/drush/drush/drush site-install standard \
   --db-url=pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb \
-  --account-mail="drupaladmin@localhost" \
+  --account-mail="drupaladmin@local.dev" \
   --account-name=drupaladmin \
   --account-pass=some_admin_password \
-  --site-mail="drupaladmin@localhost" \
+  --site-mail="drupaladmin@local.dev" \
   --site-name="Tripal 4.x-dev on Drupal ${drupalversion}" \
   && service apache2 stop \
   && service postgresql stop


### PR DESCRIPTION
Per the recommendation, use drupaladmin@local.dev. `local.dev` is technically owned by Google but it seems they promise/guarantee that there is no active mailbox/listener there.

<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #2477

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Modifies the default administrator email address so that it passes a newly introduced Drupal requirement for email address to have a full <name>@<domain>.<tld> format. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Build a brand new Docker image for Drupal. It should not fail when the admin user is automatically created. 