### PR TITLE
Add more errors to skip when www.ebi.ac.uk is down part 2

### DIFF
--- a/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalImporter/OboImporterTest.php
@@ -110,6 +110,7 @@ class OboImporterTest extends ChadoTestKernelBase {
     '/Service Temporarily Unavailable/' => 'skip',
     '/Invalid hostname in URL/' => 'skip',
     '/Unable to get response from/' => 'skip',
+    '/404 Not Found/' => 'skip',
     '/502 Bad Gateway/' => 'skip',
     '/504 Gateway Time-out/' => 'skip',
   ];


### PR DESCRIPTION
# Bug Fix

### Issue #2143

## Description

Another error appears on occasion during the obo importer test, see this comment https://github.com/tripal/tripal/issues/2143#issuecomment-4612271178

This PR adds this to the list of messages (see PR #2476) to cause the test to be skipped.

## Testing?

Just code review because this is so infrequent!