### PR TITLE
Add a title to the null publication

### DIFF
--- a/tripal_chado/chado_schema/initialize-1.3.sql
+++ b/tripal_chado/chado_schema/initialize-1.3.sql
@@ -22,7 +22,8 @@ INSERT INTO cvterm (name, cv_id, dbxref_id) VALUES (
   (SELECT dbxref_id FROM dbxref WHERE accession = 'local:null')
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO pub (miniref, uniquename, type_id) VALUES (
+INSERT INTO pub (title, miniref, uniquename, type_id) VALUES (
+  'No publication',
   'null',
   'null',
   (SELECT cvterm_id FROM cvterm WHERE name = 'null')

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
@@ -72,11 +72,6 @@ class ChadoPubFormatterDefault extends ChadoFormatterBase {
         'pubplace' => $item->get('pub_pubplace')->getString(),
       ];
 
-      // Change the non-user-friendly 'null' publication.
-      if ($values['uniquename'] == 'null') {
-        $values['uniquename'] = 'Unknown';
-      }
-
       // Substitute values in token string to generate displayed string.
       $displayed_string = $token_string;
       foreach ($values as $key => $value) {

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoPubFormatterDefault.php
@@ -72,6 +72,11 @@ class ChadoPubFormatterDefault extends ChadoFormatterBase {
         'pubplace' => $item->get('pub_pubplace')->getString(),
       ];
 
+      // Change the non-user-friendly 'null' publication.
+      if ($values['uniquename'] == 'null') {
+        $values['uniquename'] = 'No publication';
+      }
+
       // Substitute values in token string to generate displayed string.
       $displayed_string = $token_string;
       foreach ($values as $key => $value) {

--- a/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
+++ b/tripal_chado/src/Plugin/TripalImporter/GFF3Importer.php
@@ -973,8 +973,8 @@ class GFF3Importer extends ChadoImporterBase implements ContainerFactoryPluginIn
     if ($result_count == 0) {
       $this->logger->notice("Inserting the null publication.");
       $pub_sql = "
-        INSERT INTO {1:pub} (uniquename,type_id)
-        VALUES (:uname,
+        INSERT INTO {1:pub} (title, uniquename, type_id)
+        VALUES (:title, :uname,
           (SELECT cvterm_id
            FROM {1:cvterm} CVT
              INNER JOIN {1:dbxref} DBX ON DBX.dbxref_id = CVT.dbxref_id
@@ -982,6 +982,7 @@ class GFF3Importer extends ChadoImporterBase implements ContainerFactoryPluginIn
            WHERE CVT.name = :type_id))
       ";
       $status = $this->connection->query($pub_sql, [
+        ':title' => 'No publication',
         ':uname' => 'null',
         ':type_id' => 'null',
       ]);

--- a/tripal_chado/tests/fixtures/fill_chado_test_prepare.sql
+++ b/tripal_chado/tests/fixtures/fill_chado_test_prepare.sql
@@ -6847,7 +6847,7 @@ INSERT INTO chado.cvterm VALUES (3185, 12, 'collection of specimens', 'A materia
 INSERT INTO chado.cvterm VALUES (3186, 33, 'progeny', '', 3493, 0, 0);
 INSERT INTO chado.cvterm VALUES (3187, 19, 'Graphics Visualization', 'Computer methods for creating images, diagrams or animations.', 3494, 0, 0);
 INSERT INTO chado.contact VALUES (1, NULL, 'null', 'null');
-INSERT INTO chado.pub VALUES (1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'null', 'null', 1, false, NULL, NULL);
+INSERT INTO chado.pub VALUES (1, 'No publication', NULL, NULL, NULL, NULL, NULL, NULL, 'null', 'null', 1, false, NULL, NULL);
 INSERT INTO chado.chadoprop VALUES (1, 2, '1.3', 0);
 INSERT INTO chado.cv_root_mview VALUES ('sequence_attribute', 812, 23, 'sequence');
 INSERT INTO chado.cv_root_mview VALUES ('taxonomic_rank', 2878, 24, 'taxonomic_rank');

--- a/tripal_chado/tests/src/Functional/ChadoImporter/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoImporter/TaxonomyImporterTest.php
@@ -28,6 +28,21 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
   protected string $mock_error = '';
 
   /**
+   * Messages encountered when NCBI is down or broken.
+   *
+   * @var array
+   *   A list of error messages encountered when the external
+   *   web site is down or not functioning normally are tagged
+   *   with 'skip', messages normally encountered are tagged
+   *   with 'normal'.
+   */
+  protected array $message_actions = [
+    '/Error contacting NCBI/' => 'skip',
+    '/Invalid XML returned/' => 'skip',
+    '/500 Internal Server Error/' => 'skip',
+  ];
+
+  /**
    *
    */
   protected function setUp() :void {
@@ -130,11 +145,27 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
    */
   protected function checkForNetworkError() {
     if ($this->mock_error) {
-      if (preg_match('/Error contacting NCBI/', $this->mock_error) || preg_match('/Invalid XML returned/', $this->mock_error)) {
-        $this->markTestSkipped('Test skipped due to network error: ' . $this->mock_error);
+      // If we get a specific known message due to the NCBI external
+      // database being down, then mark this test as skipped.
+      $matched_any = FALSE;
+      // For each expected external message...
+      foreach ($this->message_actions as $pattern => $action) {
+        // If it's in our list with an action of skip
+        // then we indicate the test should be skipped.
+        if (preg_match($pattern, $this->mock_error) && $action == 'skip') {
+          $matched_any = TRUE;
+        }
+      }
+      if ($matched_any) {
+        $this->markTestSkipped("We received only known external error messages and chose to ignore them. Specifically:\n"
+          . $this->mock_error);
+      }
+      else {
+        // If it doesn't match any of our pattern then it is a new
+        // unanticipated error and we want to immediately fail.
+        $this->fail('Unanticipated error: ' . $this->mock_error);
       }
     }
-    $this->assertEmpty($this->mock_error, 'Unexpected error: ' . $this->mock_error);
   }
 
 }


### PR DESCRIPTION
# New Feature

### Closes #2465

### Depends on #2494

## Description

This adds a title to the null publication. This publication is used as a workaround for tables that have a pub_id with a NOT NULL constraint, but there is not actually a relevant publication.

During chado install, this record is created with the `miniref` and `uniquenames` set to the text string "null", and the `type_id` set to the "null" cvterm. All other columns without defaults are set to actual NULL values.

But when we publish publications, we get this annoying warning:
`[warning] WARNING: 1 entities have blank titles. You should either update the source records, or modify the title format tokens, and then republish.`

The GFF3 importer and synonym field find the null publication by its uniquename being the text string "null", so any other field can have any value.

This PR adds a title of "No publication".
It is also added to the test chado SQL.

## Testing?

Build a new docker, and publish the publication content type. There should be no warning, and the null pub should have a title now.