### PR TITLE
path_item can be null on latest drupal version

### DIFF
--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -398,9 +398,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       if ($entities) {
 
         // Reset the internal path field.
-        $path_item = $this->path->first();
-        $path_item->set('alias', '');
-        $path_item->set('pid', NULL);
+        $path_item = $this->get('path')->first();
+        if ($path_item) {
+          $path_item->set('alias', '');
+          $path_item->set('pid', NULL);
+        }
 
         // Keep track of the duplicates here but DO NOT throw the exception
         // until the end so we can still remove previous alias' if that applies.
@@ -416,8 +418,10 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       // The field will create the alias for us so we just need to ensure
       // its set to the new one here.
       if ($during_save) {
-        $path_item = $this->path->first();
-        $path_item->set('alias', $new_alias);
+        $path_item = $this->get('path')->first();
+        if ($path_item) {
+          $path_item->set('alias', $new_alias);
+        }
       }
       // We have to create the path alias ourselves.
       else {
@@ -431,9 +435,11 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
         }
         $new_alias_object->save();
         // And update the internal path field.
-        $path_item = $this->path->first();
-        $path_item->set('alias', $new_alias);
-        $path_item->set('pid', $new_alias_object->id());
+        $path_item = $this->get('path')->first();
+        if ($path_item) {
+          $path_item->set('alias', $new_alias);
+          $path_item->set('pid', $new_alias_object->id());
+        }
       }
     }
     // If an alias already exists, and is different...
@@ -448,17 +454,21 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
       if (empty($duplicates)) {
         $existing_alias_object->setAlias($new_alias);
         $existing_alias_object->save();
-        $path_item = $this->path->first();
-        $path_item->set('alias', $new_alias);
-        $path_item->set('pid', $existing_alias['id']);
+        $path_item = $this->get('path')->first();
+        if ($path_item) {
+          $path_item->set('alias', $new_alias);
+          $path_item->set('pid', $existing_alias['id']);
+        }
       }
       // If there are duplcates then we just remove the alias.
       // An exception will be thrown below to inform the user what happened.
       else {
         $existing_alias_object->delete();
-        $path_item = $this->path->first();
-        $path_item->set('alias', '');
-        $path_item->set('pid', NULL);
+        $path_item = $this->get('path')->first();
+        if ($path_item) {
+          $path_item->set('alias', '');
+          $path_item->set('pid', NULL);
+        }
       }
     }
 

--- a/tripal/src/Entity/TripalEntity.php
+++ b/tripal/src/Entity/TripalEntity.php
@@ -417,14 +417,16 @@ class TripalEntity extends ContentEntityBase implements TripalEntityInterface {
     if (!$existing_alias and $new_alias and empty($duplicates)) {
       // The field will create the alias for us so we just need to ensure
       // its set to the new one here.
+      $alias_set = FALSE;
       if ($during_save) {
         $path_item = $this->get('path')->first();
         if ($path_item) {
           $path_item->set('alias', $new_alias);
+          $alias_set = TRUE;
         }
       }
       // We have to create the path alias ourselves.
-      else {
+      if (!$alias_set) {
         $system_path = '/bio_data/' . $this->getID();
         $new_alias_object = \Drupal::entityTypeManager()->getStorage('path_alias')->create([
           'path' => $system_path,


### PR DESCRIPTION
# Bug Fix

### Closes #2494

## Description

A recent change in drupal results in now getting a NULL for code of the format
`$path_item = $this->path->first();`

In the past, the object would be defined, but be effectively empty, i.e. just a language code.
Now it will be NULL.

The change here simply checks if the object is truthy before proceeding.

Also update `$this->path` to `$this->get('path')` to avoid using the magic path method.


## Testing?

1. Tests should again pass on 11.x
2. You can test creating a publication through the UI with a number of properties included.
