### PR TITLE
Germplasm collection field changed to optional

### DIFF
--- a/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.germplasm_chado.yml
@@ -147,7 +147,7 @@ fields:
         type: 'chado_stockcollection_type_default'
         description: 'The stock collections that this germplasm is part of.'
         cardinality: -1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: 'chado_storage'
             storage_plugin_settings:
@@ -448,7 +448,7 @@ fields:
         type: 'chado_stockcollection_type_default'
         description: 'The stock collections that this cross is part of.'
         cardinality: -1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: 'chado_storage'
             storage_plugin_settings:
@@ -749,7 +749,7 @@ fields:
         type: 'chado_stockcollection_type_default'
         description: 'The stock collections that this germplasm variety is part of.'
         cardinality: -1
-        required: true
+        required: false
         storage_settings:
             storage_plugin_id: 'chado_storage'
             storage_plugin_settings:

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -508,6 +508,38 @@ function reload_content_type_collection(string $contentTypeCollection): void {
 }
 
 /**
+ * Updates the required status of one or more fields.
+ *
+ * @param array $field_ids
+ *   A list of fields to update.
+ * @param bool $required
+ *   The desired state of the required flag.
+ * @param string $context
+ *   A message to print if an error occurs.
+ *
+ * @return void
+ *   No return value.
+ */
+function tripal_chado_set_field_required_status(array $field_ids, bool $required, string $context): void {
+  try {
+    $messenger = \Drupal::messenger();
+    foreach ($field_ids as $field_id) {
+      /** Drupal\field\Entity\FieldConfig **/
+      $field = FieldConfig::load($field_id);
+      $state = $field->isRequired();
+      if ($state != $required) {
+        $field->setRequired($required);
+        $field->save();
+        $messenger->addMessage("Changed field $field_id to be " .($required?'':'not '). 'required');
+      }
+    }
+  }
+  catch (\Exception $e) {
+    throw new UpdateException($context . ': ' . $e->getMessage());
+  }
+}
+
+/**
  * Reads a YAML file and adds the specified fields.
  *
  * @param string $yaml_path
@@ -776,23 +808,11 @@ function tripal_chado_update_10408() {
  * consistent with chado. PR 2029
  */
 function tripal_chado_update_10409() {
-  try {
-    $messenger = \Drupal::messenger();
-    $field_ids = ['tripal_entity.pub.pub_title', 'tripal_entity.pub.pub_pyear'];
-    foreach ($field_ids as $field_id) {
-      /** Drupal\field\Entity\FieldConfig **/
-      $field = FieldConfig::load($field_id);
-      $required = $field->isRequired();
-      if ($required) {
-        $field->setRequired(FALSE);
-        $field->save();
-        $messenger->addMessage("Changed field $field_id to be not required");
-      }
-    }
-  }
-  catch (\Exception $e) {
-    throw new UpdateException('Could not set title and publication year required setting: ' . $e->getMessage());
-  }
+  $field_ids = [
+    'tripal_entity.pub.pub_title',
+    'tripal_entity.pub.pub_pyear',
+  ];
+  tripal_chado_set_field_required_status($field_ids, FALSE, 'Could not set title and publication year required setting');
 }
 
 /**
@@ -1212,4 +1232,17 @@ function tripal_chado_update_10418() {
   catch (\Exception $e) {
     throw new UpdateException('Could not update phylotree: ' . $e->getMessage());
   }
+}
+
+/**
+ * Sets germplasm collection fields as non-required.
+ */
+function tripal_chado_update_10419() {
+  // This hook added by PR 2498.
+  $field_ids = [
+    'tripal_entity.germplasm.germplasm_collection',
+    'tripal_entity.breeding_cross.breeding_cross_collection',
+    'tripal_entity.germplasm_variety.germplasmvariety_collection',
+  ];
+  tripal_chado_set_field_required_status($field_ids, FALSE, 'Could not set germplasm collection required setting');
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2496

## Description

Try to enter a new Germplasm Accession, Germplasm Variety, or Breeding Cross Variety - you can't because you have to enter a germplasm collection reference.
This is not a NOT NULL column in the stock table, but a record through a linker table, so should be optional.

Note that I moved existing update hook code used to set required status into a reusable function.

## Testing?

Import the germplasm content type collection
Try to enter each of the content types in the collection, observe that the germplasm collection field is now optional (no asterisk) and you can proceed.

If you build on 4.x then update to this branch, there is an update hook to test
```
root@2dc85e6ff897:/var/www/drupal# drush updatedb
 -------------- ----------- --------------- ----------------------------------- 
  Module         Update ID   Type            Description                        
 -------------- ----------- --------------- ----------------------------------- 
  tripal_chado   10419       hook_update_n   10419 - Sets germplasm collection  
                                             fields as non-required.            
 -------------- ----------- --------------- ----------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: tripal_chado_update_10419
>  [notice] Update completed: tripal_chado_update_10419
>  [notice] Message: Changed field tripal_entity.germplasm.germplasm_collection to be not required
> 
>  [notice] Message: Changed field tripal_entity.breeding_cross.breeding_cross_collection to be  
> not required
> 
>  [notice] Message: Changed field tripal_entity.germplasm_variety.germplasmvariety_collection to  
> be not required
> 
 [success] Finished performing updates.
```