### PR TITLE
Fix Drupal docker build failing by bringing variables into build scope.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG postgresqlversion='18'
 ARG buildplatform='linux/amd64'
 FROM --platform=${buildplatform} tripalproject/tripaldocker-drupal:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
-## Redefine the core args so that they are within the build scope.
+## Redefine the global args so that they are within the build scope.
+# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG phpversion='8.4'
 ARG drupalversion='11.3.x'
 ARG postgresqlversion='18'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ FROM --platform=${buildplatform} tripalproject/tripaldocker-drupal:drupal${drupa
 
 ## Redefine the global args so that they are within the build scope.
 # See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG phpversion='8.4'
-ARG drupalversion='11.3.x'
-ARG postgresqlversion='18'
+ARG phpversion
+ARG drupalversion
+ARG postgresqlversion
 
 ## Now define the args only needed within the build scope.
 ARG modules='devel devel_php field_group field_group_table'

--- a/tripaldocker/drupal.Dockerfile
+++ b/tripaldocker/drupal.Dockerfile
@@ -1,11 +1,12 @@
 ARG phpversion='8.3'
 FROM php:${phpversion}-apache-bookworm
 
-# PHP Version above is defined in the global scope. We need to redefine it here in the build stage scope to be able to use it in the RUN commands below.
+## PHP Version above is defined in the global scope.
+# We need to redefine it here in the build stage scope to be able to use it in the RUN commands below.
 # See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG phpversion
 
-# Set build arguments with default values. These can be overridden at build time using --build-arg.
+## Now define the args only needed within the build scope.
 ARG drupalversion='11.3.x'
 ARG postgresqlversion='18'
 ARG modules='devel devel_php field_group field_group_table'

--- a/tripaldocker/drupal.Dockerfile
+++ b/tripaldocker/drupal.Dockerfile
@@ -1,6 +1,11 @@
 ARG phpversion='8.3'
 FROM php:${phpversion}-apache-bookworm
 
+# PHP Version above is defined in the global scope. We need to redefine it here in the build stage scope to be able to use it in the RUN commands below.
+# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG phpversion
+
+# Set build arguments with default values. These can be overridden at build time using --build-arg.
 ARG drupalversion='11.3.x'
 ARG postgresqlversion='18'
 ARG modules='devel devel_php field_group field_group_table'


### PR DESCRIPTION

# Tripal 4 Core Dev Task
### Issue #2515 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Building a number of the drupal images (base image for our TripalDocker) was failing due to the phpversion arg not being in scope. This happened due to a change in a recent PR which mistakenly removed a perceived duplicated definition of the arg.

Both declarations were needed to ensure the arguments were in the correct scope. See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact for more information but essentially:

> An ARG declared before a FROM is outside of a build stage, so it can't be used in any instruction after a FROM. To use the default value of an ARG declared before the first FROM use an ARG instruction without a value inside of a build stage.

[These were the failing images](https://github.com/tripal/tripal/actions/runs/27980660542/job/82809594105):

<img width="312" height="507" alt="Image" src="https://github.com/user-attachments/assets/af6a29f3-d30d-4d6c-8a62-a49f40445e1a" />


## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

Build some of the failing drupal images locally. For example,

```
docker build -f tripaldocker/drupal.Dockerfile --build-arg drupalversion=11.x-dev --build-arg postgresqlversion=18 --build-arg phpversion=8.5 .
```