### PR TITLE
Skip another case where NCBI is down

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TaxonomyImporter.php
@@ -596,6 +596,12 @@ class TaxonomyImporter extends ChadoImporterBase implements ContainerFactoryPlug
     else {
       $xml = new \SimpleXMLElement($xml_text);
       $taxon = $xml->Taxon;
+      if (count(get_object_vars($taxon)) == 0) {
+        $this->logger->error("Empty taxon returned for taxid @taxid, NCBI may be down.",
+          ['@taxid' => $taxid]
+        );
+        return FALSE;
+      }
 
       // Get the genus and species from the xml.
       $parent = (string) $taxon->ParentTaxId;

--- a/tripal_chado/tests/src/Functional/ChadoImporter/TaxonomyImporterTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoImporter/TaxonomyImporterTest.php
@@ -40,6 +40,7 @@ class TaxonomyImporterTest extends ChadoTestBrowserBase {
     '/Error contacting NCBI/' => 'skip',
     '/Invalid XML returned/' => 'skip',
     '/500 Internal Server Error/' => 'skip',
+    '/Empty taxon returned/' => 'skip',
   ];
 
   /**


### PR DESCRIPTION
# Bug Fix

### Closes #2143

## Description

Today NCBI is returning valid but nearly empty XML

This skips over that case.

## Testing?

This happens on this PR so we can check!
On the 8.5 18 11.4.x test with the error:
```
...............................................................  63 / 715 (  8%)
.......II....E...................IIII.......................... 126 / 715 ( 17%)
................I.............................................. 189 / 715 ( 26%)
```
On 8.5 18 11.4.x this PR branch the test is skipped successfully
```
...............................................................  63 / 715 (  8%)
.......II....S...................IIII.......................... 126 / 715 ( 17%)
................I.............................................. 189 / 715 ( 26%)
...
```
```
There was 1 skipped test:

1) Drupal\Tests\tripal_chado\Functional\ChadoImporter\TaxonomyImporterTest::testTaxonomyImporterSimpleTest
We received only known external error messages and chose to ignore them. Specifically:
Empty taxon returned for taxid 3702, NCBI may be down.
```