### PR TITLE
Change workflow configuration to get red X if any docker build fails

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -18,8 +18,8 @@ permissions: read-all
 jobs:
   push_to_registry:
     runs-on: 'ubuntu-latest'
-    continue-on-error: true
     strategy:
+      # A failure will not prevent other matrix jobs from running.
       fail-fast: false
       matrix:
         php-version:

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -9,8 +9,6 @@ on:
   schedule:
     # Run at 2am every night.
     - cron: '0 2 * * *'
-  # TEMPORARY FOR TESTING
-  push:
 
 permissions: read-all
 
@@ -22,21 +20,20 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-        #  - '8.2'
-        #  - '8.3'
-        #  - '8.4'
+          - '8.2'
+          - '8.3'
+          - '8.4'
           - '8.5'
         pgsql-version:
-        #  - '14'
-        #  - '15'
-        #  - '16'
-        #  - '17'
+          - '14'
+          - '15'
+          - '16'
+          - '17'
           - '18'
         drupal-version:
           - '10.6.x'
           - '11.3.x'
           - '11.4.x'
-          - '13.3.x'
           - '11.x-dev'
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5

--- a/.github/workflows/SCHEDULE-buildDrupalDocker.yml
+++ b/.github/workflows/SCHEDULE-buildDrupalDocker.yml
@@ -9,31 +9,34 @@ on:
   schedule:
     # Run at 2am every night.
     - cron: '0 2 * * *'
+  # TEMPORARY FOR TESTING
+  push:
 
 permissions: read-all
 
 jobs:
   push_to_registry:
     runs-on: 'ubuntu-latest'
-    continue-on-error: true
     strategy:
+      # A failure will not prevent other matrix jobs from running.
       fail-fast: false
       matrix:
         php-version:
-          - '8.2'
-          - '8.3'
-          - '8.4'
+        #  - '8.2'
+        #  - '8.3'
+        #  - '8.4'
           - '8.5'
         pgsql-version:
-          - '14'
-          - '15'
-          - '16'
-          - '17'
+        #  - '14'
+        #  - '15'
+        #  - '16'
+        #  - '17'
           - '18'
         drupal-version:
           - '10.6.x'
           - '11.3.x'
           - '11.4.x'
+          - '13.3.x'
           - '11.x-dev'
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5


### PR DESCRIPTION
# Tripal 4 Core Dev Task

### Closes #2517

## Description

We want every matrix combination to run completely, but still have the overall workflow run to be marked as failed if any individual combination fails. Removing `continue-on-error` is claimed to have this effect.

## Testing?

I am initially testing with a non-existent drupal version so that workflow should definitely fail.
https://github.com/tripal/tripal/actions/runs/28198953074

1. Overall workflow has the red X
<img width="684" height="78" alt="2517 1" src="https://github.com/user-attachments/assets/2a42ec02-0dc1-46a0-afce-84c03b417dff" />

2. Only one of the matrix runs failed.
<img width="270" height="214" alt="2517 2" src="https://github.com/user-attachments/assets/f9448120-d336-486c-8f1f-f74a102ed4e8" />

3. After testing, I removed the testing invalid drupal version and the build on push setting, so this should be ready to merge.