### PR TITLE
turn off dry run

### DIFF
--- a/.github/workflows/SCHEDULE-Dockerhub-Expire.yml
+++ b/.github/workflows/SCHEDULE-Dockerhub-Expire.yml
@@ -33,3 +33,4 @@ jobs:
           password: '${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN_RWD }}'
           repositories: 'tripalproject/tripaldocker-drupal, tripalproject/tripaldocker'
           rules: 'BUILT:0, latest, drupal'
+          dry-run: false


### PR DESCRIPTION
# Bug Fix

### Issue #2506

## Description
We need to explicitly turn off dry-run, because it defaults to on for safety.

## Testing?
I can trigger the workflow on this branch to test
https://github.com/tripal/tripal/actions/runs/28462174579/job/84352593480
It is now deleting as it should be.
```
...
[2026-06-30 17:06:48 UTC] Keeping digest 735450a with tags BUILT202606301417-11.3.x-8.5-17, drupal11.3.x-php8.5-pgsql17
[2026-06-30 17:06:50 UTC] Deleted digest f5cd62b tripaldocker-drupal:BUILT202606241637-11.3.x-8.5-16
...
```
<img width="338" height="635" alt="20260630_action" src="https://github.com/user-attachments/assets/0f6ccd8c-88e9-4249-aec3-fdf36d51a112" />

