### PR TITLE
Chado time field - field properties

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAnalysisFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAnalysisFormatterDefault.php
@@ -26,6 +26,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
     '[sourcename]',
     '[sourceversion]',
     '[sourceuri]',
+    '[timeexecuted]',
   ],
 )]
 class ChadoAnalysisFormatterDefault extends ChadoFormatterBase {
@@ -59,7 +60,7 @@ class ChadoAnalysisFormatterDefault extends ChadoFormatterBase {
         'sourcename' => $item->get('analysis_sourcename')->getString(),
         'sourceversion' => $item->get('analysis_sourceversion')->getString(),
         'sourceuri' => $item->get('analysis_sourceuri')->getString(),
-        // timeexecuted not implemented
+        'timeexecuted' => $item->get('analysis_timeexecuted')->getString(),
       ];
 
       // Substitute values in token string to generate displayed string.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAssayFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoAssayFormatterDefault.php
@@ -27,6 +27,7 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
     '[operator]',
     '[database_name]',
     '[database_accession]',
+    '[assaydate]',
   ],
 )]
 class ChadoAssayFormatterDefault extends ChadoFormatterBase {
@@ -61,6 +62,7 @@ class ChadoAssayFormatterDefault extends ChadoFormatterBase {
         'operator' => $item->get('assay_operator')->getString(),
         'database_name' => $item->get('assay_database_name')->getString(),
         'database_accession' => $item->get('assay_database_accession')->getString(),
+        'assaydate' => $item->get('assay_assaydate')->getString(),
       ];
 
       // Substitute values in token string to generate displayed string.

--- a/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureFormatterDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldFormatter/ChadoFeatureFormatterDefault.php
@@ -34,6 +34,8 @@ use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
     '[infraname]',
     '[abbreviation]',
     '[common_name]',
+    '[timeaccessioned]',
+    '[timelastmodified]',
   ],
 )]
 class ChadoFeatureFormatterDefault extends ChadoFormatterBase {
@@ -74,8 +76,9 @@ class ChadoFeatureFormatterDefault extends ChadoFormatterBase {
         'infraname' => $item->get('feature_infraspecific_name')->getString(),
         'abbreviation' => $item->get('feature_abbreviation')->getString(),
         'common_name' => $item->get('feature_common_name')->getString(),
+        'timeaccessioned' => $item->get('feature_timeaccessioned')->getString(),
+        'timelastmodified' => $item->get('feature_timelastmodified')->getString(),
         // residues is not implemented in this field since it can be millions of characters long
-        // timeaccessioned, timelastmodified not implemented
       ];
 
       // Substitute values in token string to generate displayed string.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAnalysisTypeDefault.php
@@ -6,6 +6,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -129,6 +130,7 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $value['analysis_sourcename'] = '';
     $value['analysis_sourceversion'] = '';
     $value['analysis_sourceuri'] = '';
+    $value['analysis_timeexecuted'] = '2001-01-01 01:01:01';
 
     return [$value];
   }
@@ -179,7 +181,8 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
     $sourceversion_len = $object_schema_def['fields']['sourceversion']['size'];
     // Text.
     $sourceuri_term = self::getColumnTermId($object_table, 'sourceuri', 'data:1047');
-    // @todo timeexecuted not yet implemented
+    $timeexecuted_term = self::getColumnTermId($object_table, 'timeexecuted', 'local:timeexecuted');
+
     // Linker table, when used, requires specifying the linker table and column.
     [$linker_table, $linker_fkey_column] = self::get_linker_table_and_column($storage_settings, $base_table, $object_pkey_col);
 
@@ -346,7 +349,14 @@ class ChadoAnalysisTypeDefault extends ChadoFieldItemBase {
       'as' => 'analysis_sourceuri',
     ]);
 
-    // @todo timeexecuted not yet implemented - not null, default CURRENT_TIMESTAMP
+    // The analysis timeexecuted - not null, default CURRENT_TIMESTAMP.
+    $properties[] = new ChadoDatetimeStoragePropertyType($entity_type_id, self::$id, 'analysis_timeexecuted', $timeexecuted_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';timeexecuted',
+      'as' => 'analysis_timeexecuted',
+    ]);
+
     return $properties;
   }
 

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -6,6 +6,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -118,6 +119,8 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $value['assay_operator'] = '';
     $value['assay_database_accession'] = '';
     $value['assay_database_name'] = '';
+    $value['assay_database_name'] = '';
+    $value['assay_assaydate'] = '2001-01-01 01:01:01';
 
     return [$value];
   }
@@ -156,6 +159,7 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $description_term = self::getColumnTermId($object_table, 'description', 'schema_description');
     $arrayidentifier_term = self::getColumnTermId($object_table, 'arrayidentifier', 'data:0842');
     $arraybatchidentifier_term = self::getColumnTermId($object_table, 'arraybatchidentifier', 'local:array_batch_identifier');
+    $assaydate_term = self::getColumnTermId($object_table, 'assaydate', 'NCIT:C25164');
 
     // Columns from linked tables.
     $arraydesign_term = self::getColumnTermId('arraydesign', 'name', 'schema:name');
@@ -294,6 +298,13 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
       'drupal_store' => FALSE,
       'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';arraybatchidentifier',
       'as' => 'assay_arraybatchidentifier',
+    ]);
+
+    $properties[] = new ChadoDatetimeStoragePropertyType($entity_type_id, self::$id, 'assay_assaydate', $assaydate_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';assaydate',
+      'as' => 'assay_assaydate',
     ]);
 
     // Values from tables linked to by the object table.

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php
@@ -108,8 +108,6 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
     $value['linker_rank'] = 0;
 
     // Object table properties.
-    // @todo 'assay_database_accession' and 'assay_database_name' is included
-    // twice in properties, confirm if this is intentional.
     $value['assay_name'] = '';
     $value['assay_description'] = '';
     $value['assay_arrayidentifier'] = '';
@@ -330,22 +328,6 @@ class ChadoAssayTypeDefault extends ChadoFieldItemBase {
       'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
       . ';' . $object_table . '.operator_id>contact.contact_id;name',
       'as' => 'assay_operator',
-    ]);
-
-    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_accession', $dbxref_term, [
-      'action' => 'read_value',
-      'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
-      . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;accession',
-      'as' => 'assay_database_accession',
-    ]);
-
-    $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_name', $db_term, [
-      'action' => 'read_value',
-      'drupal_store' => FALSE,
-      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col
-      . ';' . $object_table . '.dbxref_id>dbxref.dbxref_id;dbxref.db_id>db.db_id;name',
-      'as' => 'assay_database_name',
     ]);
 
     $properties[] = new ChadoTextStoragePropertyType($entity_type_id, self::$id, 'assay_database_accession', $dbxref_term, [

--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoFeatureTypeDefault.php
@@ -6,6 +6,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal\TripalField\Attribute\TripalFieldType;
 use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
+use Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
 use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
@@ -137,6 +138,8 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $value['feature_common_name'] = '';
     $value['feature_database_accession'] = '';
     $value['feature_database_name'] = '';
+    $value['feature_timeaccessioned'] = '2001-01-01 01:01:01';
+    $value['feature_timelastmodified'] = '2001-01-01 01:01:01';
 
     return [$value];
   }
@@ -183,7 +186,8 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
     $is_analysis_term = self::getColumnTermId($object_table, 'is_analysis', 'local:is_analysis');
     // Boolean.
     $is_obsolete_term = self::getColumnTermId($object_table, 'is_obsolete', 'local:is_obsolete');
-    // @todo timeaccessioned, timelastmodified not yet implemented
+    $timeaccessioned_term = self::getColumnTermId($object_table, 'timeaccessioned', 'local:timeaccessioned');
+    $timelastmodified_term = self::getColumnTermId($object_table, 'timelastmodified', 'local:timelastmodified');
     // Columns from linked tables.
     $dbxref_term = self::getColumnTermId('dbxref', 'accession', 'data:2091');
     $db_term = self::getColumnTermId('db', 'name', 'ERO:0001716');
@@ -349,7 +353,22 @@ class ChadoFeatureTypeDefault extends ChadoFieldItemBase {
       'as' => 'feature_is_obsolete',
     ]);
 
-    // @todo timeaccessioned, timelastmodified not yet implemented - not null, default CURRENT_TIMESTAMP
+    // Feature timeaccessioned - not null, default CURRENT_TIMESTAMP.
+    $properties[] = new ChadoDatetimeStoragePropertyType($entity_type_id, self::$id, 'feature_timeaccessioned', $timeaccessioned_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';timeaccessioned',
+      'as' => 'feature_timeaccessioned',
+    ]);
+
+    // Feature timelastmodified - not null, default CURRENT_TIMESTAMP.
+    $properties[] = new ChadoDatetimeStoragePropertyType($entity_type_id, self::$id, 'feature_timelastmodified', $timelastmodified_term, [
+      'action' => 'read_value',
+      'drupal_store' => FALSE,
+      'path' => $linker_table . '.' . $linker_fkey_column . '>' . $object_table . '.' . $object_pkey_col . ';timelastmodified',
+      'as' => 'feature_timelastmodified',
+    ]);
+
     // The type of feature.
     $properties[] = new ChadoVarCharStoragePropertyType($entity_type_id, self::$id, 'feature_type', $type_term, $type_len, [
       'action' => 'read_value',

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoField/FieldStaticMethodTest-TestInfo.yml
@@ -51,6 +51,7 @@ scenarios:
         analysis_sourcename: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         analysis_sourceversion: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         analysis_sourceuri: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        analysis_timeexecuted: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Analysis in base table'
       field_type: 'chado_analysis_type_default'
@@ -77,6 +78,7 @@ scenarios:
         analysis_sourcename: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         analysis_sourceversion: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         analysis_sourceuri: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        analysis_timeexecuted: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Array Design in base table'
       field_type: 'chado_array_design_type_default'
@@ -146,6 +148,7 @@ scenarios:
         assay_operator: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         assay_database_accession: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
         assay_database_name: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        assay_assaydate: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Assay in base table'
       field_type: 'chado_assay_type_default'
@@ -174,6 +177,7 @@ scenarios:
         assay_operator: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         assay_database_accession: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
         assay_database_name: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        assay_assaydate: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Biomaterial through linking table'
       field_type: 'chado_biomaterial_type_default'
@@ -445,6 +449,8 @@ scenarios:
         feature_common_name: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         feature_database_accession: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
         feature_database_name: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        feature_timeaccessioned: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
+        feature_timelastmodified: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Feature linked in base table'
       field_type: 'chado_feature_type_default'
@@ -479,6 +485,8 @@ scenarios:
         feature_common_name: 'Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType'
         feature_database_accession: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
         feature_database_name: 'Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType'
+        feature_timeaccessioned: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
+        feature_timelastmodified: 'Drupal\tripal_chado\TripalStorage\ChadoDatetimeStoragePropertyType'
   -
       label: 'Feature MAP through linking table'
       field_type: 'chado_featuremap_type_default'

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -449,13 +449,14 @@ function tripal_chado_field_reload(array $upgradable_types, array $upgradable_pr
         }
       }
     }
+    $types = implode(', ', $upgradable_types);
     if ($update_only) {
-      $messenger->addMessage(t("Updated @n_updated properties",
-          ['@n_updated' => $n_updated]));
+      $messenger->addMessage(t("Updated @n_updated properties for @types",
+          ['@n_updated' => $n_updated, '@types' => $types]));
     }
     else {
-      $messenger->addMessage(t("Added @n_added properties, updated @n_updated properties",
-          ['@n_added' => $n_added, '@n_updated' => $n_updated]));
+      $messenger->addMessage(t("Added @n_added properties, updated @n_updated properties for @types",
+          ['@n_added' => $n_added, '@n_updated' => $n_updated, '@types' => $types]));
     }
   }
   catch (\Exception $e) {
@@ -1267,4 +1268,15 @@ function tripal_chado_update_10420() {
   catch (\Exception $e) {
     throw new UpdateException('Could not add datetime fields: ' . $e->getMessage());
   }
+}
+
+/**
+ * Adds field properties for datetime chado columns. PR 2524.
+ */
+function tripal_chado_update_10421() {
+  tripal_chado_field_reload(['chado_analysis_type_default'], ['analysis_timeexecuted'], FALSE);
+  // Tripal doesn't define any default instances of these fields,
+  // but they may have been discovered.
+  tripal_chado_field_reload(['chado_feature_type_default'], ['gene_timeaccessioned', 'gene_timelastmodified', 'mrna_timeaccessioned', 'mrna_timelastmodified'], FALSE);
+  tripal_chado_field_reload(['chado_assay_type_default'], ['assay_assaydate'], FALSE);
 }


### PR DESCRIPTION
# New Feature

### Closes #2184

## Description

This PR adds datetime **properties** to several fields, for example to the analysis field.
If you have an analysis linked to a project, you could include the timeexecuted value in the title format for the analysis and see that on the project page.
Maybe not super useful, but for completeness we want all properties available, and we forgot to do this in PR #2483

While I was in there, I resolved this 
https://github.com/tripal/tripal/blob/b319ad5650533af4e5297ca26cbde4a1d23921ee/tripal_chado/src/Plugin/Field/FieldType/ChadoAssayTypeDefault.php#L109-L111
with commit https://github.com/tripal/tripal/pull/2524/commits/320dd485102824d90bcc7390d855692e9d23f68c

## Testing?
1. There is an update hook, but it will only add three properties because that's how many are defined by default. Build a docker on 4.x, import all type collections, then switch to this branch and run `drush updatedb`
```
root@b8a42bb35c53:/var/www/drupal# drush updatedb            
 -------------- ----------- --------------- ----------------------------------- 
  Module         Update ID   Type            Description                        
 -------------- ----------- --------------- ----------------------------------- 
  tripal_chado   10421       hook_update_n   10421 - Adds field properties for  
                                             datetime chado columns. PR 2524.   
 -------------- ----------- --------------- ----------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: tripal_chado_update_10421
>  [notice] Update completed: tripal_chado_update_10421
>  [notice] Message: Updating properties for Drupal table "tripal_entity__phylotree_analysis",  
> field "phylotree_analysis"
> 
>  [notice] Message: Updating properties for Drupal table "tripal_entity__project_analysis", field  
> "project_analysis"
> 
>  [notice] Message: Updating properties for Drupal table "tripal_entity__speciestree_analysis",  
> field "speciestree_analysis"
> 
>  [notice] Message: Added 3 properties, updated 0 properties for chado_analysis_type_default
> 
>  [notice] Message: Added 0 properties, updated 0 properties for chado_feature_type_default
> 
>  [notice] Message: Added 0 properties, updated 0 properties for chado_assay_type_default
> 
 [success] Finished performing updates.
```

2. Create an analysis 
3. Update the title format for the **analysis** field on the **project** content type to include time, e.g.
<img width="735" height="272" alt="time1" src="https://github.com/user-attachments/assets/0d1d2f70-fb21-41a3-ac9f-22c617b14978" />

4. Create a project, and link the analysis
5. The time should be displayed
<img width="375" height="321" alt="time2" src="https://github.com/user-attachments/assets/9b8247ed-c6d9-4be3-963d-790b55d00a99" />
