### PR TITLE
Add an assertion to ChadoFieldTestTrait to check chado table values

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -62,3 +62,9 @@
 # Deprecation: Method "Consolidation\AnnotatedCommand\State\SavableState::currentState()" might add "State" as a native return type declaration in the future. Do the same in implementation "Drush\Commands\DrushCommands" now to avoid errors or add an explicit @return annotation to suppress this message.
 # Example test that triggers this: testDrushMviewPopulate
 %Method "Consolidation\\AnnotatedCommand\\State\\SavableState::currentState\(\)" might add "State"%
+
+# Module: Drupal 11.4+
+# Location: web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:51
+# Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will take a 4th "array $tests" argument in 4.0; not declaring it is deprecated.
+# Example test that triggers this: testTripalAccessOwnContentCheck
+%TwigSandboxPolicy::checkSecurity\(\)" method will take a 4th "array \$tests" argument%

--- a/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest-TestInfo.yml
@@ -63,13 +63,20 @@ scenarios:
         metaphysical_props:
         - record_id: 0
           value: 'soothing, calming, healing from grief'
-      expected:
+      expected_field_values:
         project_name:
         - record_id: 1
           value: 'amazonite'
         metaphysical_props:
         - record_id: 1
           value: 'soothing, calming, healing from grief'
+      expected_chado_values:
+        project:
+          conditions:
+            project_id: 1
+          expectations:
+            name: 'amazonite'
+            description: 'soothing, calming, healing from grief'
     edit:
       title: 'TEST Gemstones <em>Amazonite</em> Entity #1'
       url: '/test/test_gemstone/amazonite/1'
@@ -80,13 +87,20 @@ scenarios:
         metaphysical_props:
         - record_id: 1
           value: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'
-      expected:
+      expected_field_values:
         project_name:
         - record_id: 1
           value: 'Amazonite'
         metaphysical_props:
         - record_id: 1
           value: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'
+      expected_chado_values:
+        project:
+          conditions:
+            project_id: 1
+          expectations:
+            name: 'Amazonite'
+            description: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'
   - label: 'Use format with read_value for title + URL + override url on edit'
     description: 'Create a page where every field has one value.'
     create:
@@ -104,7 +118,7 @@ scenarios:
           linker_id: 1
           link: 1
           contact_id: 2
-      expected:
+      expected_field_values:
         project_name:
         - record_id: 1
           value: 'amazonite'
@@ -118,6 +132,13 @@ scenarios:
           contact_id: 2
           contact_name: 'Zhanna Beissekova'
           contact_description: 'Enjoys grading and is fascinated by how each stone is different, even within the same species'
+      expected_chado_values:
+        project:
+          conditions:
+            project_id: 1
+          expectations:
+            name: 'amazonite'
+            description: 'soothing, calming, healing from grief'
     edit:
       title: 'TEST Gemstones <em>Amazonite</em> Entity #1 acquired by Zhanna Beissekova'
       url: '/my/user/set/url/alias'
@@ -135,7 +156,7 @@ scenarios:
           contact_id: 2
         path:
         - alias: '/my/user/set/url/alias'
-      expected:
+      expected_field_values:
         project_name:
         - record_id: 1
           value: 'Amazonite'
@@ -149,3 +170,10 @@ scenarios:
           contact_id: 2
           contact_name: 'Zhanna Beissekova'
           contact_description: 'Enjoys grading and is fascinated by how each stone is different, even within the same species'
+      expected_chado_values:
+        project:
+          conditions:
+            project_id: 1
+          expectations:
+            name: 'Amazonite'
+            description: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'

--- a/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest-TestInfo.yml
+++ b/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest-TestInfo.yml
@@ -71,11 +71,11 @@ scenarios:
         - record_id: 1
           value: 'soothing, calming, healing from grief'
       expected_chado_values:
-        project:
+        - table: 'project'
           conditions:
             project_id: 1
           expectations:
-            name: 'amazonite'
+          - name: 'amazonite'
             description: 'soothing, calming, healing from grief'
     edit:
       title: 'TEST Gemstones <em>Amazonite</em> Entity #1'
@@ -95,11 +95,11 @@ scenarios:
         - record_id: 1
           value: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'
       expected_chado_values:
-        project:
+        - table: 'project'
           conditions:
             project_id: 1
           expectations:
-            name: 'Amazonite'
+          - name: 'Amazonite'
             description: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'
   - label: 'Use format with read_value for title + URL + override url on edit'
     description: 'Create a page where every field has one value.'
@@ -133,11 +133,11 @@ scenarios:
           contact_name: 'Zhanna Beissekova'
           contact_description: 'Enjoys grading and is fascinated by how each stone is different, even within the same species'
       expected_chado_values:
-        project:
+        - table: 'project'
           conditions:
             project_id: 1
           expectations:
-            name: 'amazonite'
+          - name: 'amazonite'
             description: 'soothing, calming, healing from grief'
     edit:
       title: 'TEST Gemstones <em>Amazonite</em> Entity #1 acquired by Zhanna Beissekova'
@@ -171,9 +171,9 @@ scenarios:
           contact_name: 'Zhanna Beissekova'
           contact_description: 'Enjoys grading and is fascinated by how each stone is different, even within the same species'
       expected_chado_values:
-        project:
+        - table: 'project'
           conditions:
             project_id: 1
           expectations:
-            name: 'Amazonite'
+          - name: 'Amazonite'
             description: 'Amazonite is a stone of peace, truth, harmony, and communication. It gently soothes the nerves, and it’s energies can be felt to the touch. It brings emotional balance, mental clarity and physical health benefits while encouraging spiritual growth & energy work.'

--- a/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest.php
+++ b/tripal_chado/tests/src/Kernel/Entity/TripalEntityChadoFieldTest.php
@@ -173,7 +173,8 @@ class TripalEntityChadoFieldTest extends ChadoTestKernelBase {
 
     // 2. Load the entity we just created so we can check the values.
     $created_entity = TripalEntity::load($entity->id());
-    $this->assertFieldValuesMatch($current_scenario['create']['expected'], $created_entity, '"' . $current_scenario['label'] . '" being created. ');
+    $this->assertFieldValuesMatch($current_scenario['create']['expected_field_values'], $created_entity, '"' . $current_scenario['label'] . '" being created in drupal.');
+    $this->assertChadoValuesMatch($current_scenario['create']['expected_chado_values'], $current_scenario['label'] . '" being created in chado.');
     // -- Title.
     $this->assertNotEquals($submitted_title, $created_entity->getTitle(), "The submitted title should never be used but it was when CREATING the entity for the '" . $current_scenario['label'] . "' scenario.");
     $this->assertEquals($current_scenario['create']['title'], $created_entity->getTitle(), "We did not get the title we expected when CREATING the entity for the '" . $current_scenario['label'] . "' scenario.");
@@ -194,7 +195,8 @@ class TripalEntityChadoFieldTest extends ChadoTestKernelBase {
     // 4. Load the entity we just updated so we can check the values.
     $updated_entity = TripalEntity::load($created_entity->id());
     // @debug print_r($updated_entity->toArray());
-    $this->assertFieldValuesMatch($current_scenario['edit']['expected'], $updated_entity, '"' . $current_scenario['label'] . '" being updated. ');
+    $this->assertFieldValuesMatch($current_scenario['edit']['expected_field_values'], $updated_entity, '"' . $current_scenario['label'] . '" being updated in drupal.');
+    $this->assertChadoValuesMatch($current_scenario['edit']['expected_chado_values'], $current_scenario['label'] . '" being updated in chado.');
     // -- Title.
     $this->assertNotEquals($submitted_title, $updated_entity->getTitle(), "The submitted title should never be used but it was when UPDATING the entity for the '" . $current_scenario['label'] . "' scenario.");
     $this->assertEquals($current_scenario['edit']['title'], $updated_entity->getTitle(), "We did not get the title we expected when UPDATING the entity for the '" . $current_scenario['label'] . "' scenario.");

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -163,6 +163,8 @@ trait ChadoFieldTestTrait {
    */
   public function assertChadoValuesMatch(array $expected_values, string $message_prefix = ''): void {
     foreach ($expected_values as $chado_table => $config) {
+      $this->assertArrayHasKey('conditions', $config, "YAML configuration for chado table \"$table\" does not have any conditions");
+      $this->assertArrayHasKey('expectations', $config, "YAML configuration for chado table \"$table\" does not have any expectations");
       $count = $config['count'] ?? 1;
       $query = $this->chado_connection->select('1:' . $chado_table, 'T');
       foreach ($config['conditions'] as $column_name => $chado_value) {
@@ -172,7 +174,7 @@ trait ChadoFieldTestTrait {
         $query->addField('T', $column_name);
       }
 
-      // Checks the number of chado records, generally we expect one.
+      // Checks the number of chado records. Only 0 and 1 are supported.
       $chado_count = $query->countQuery()->execute()->fetchField();
       $this->assertEquals($count, $chado_count, $message_prefix . "Chado record count for table \"$chado_table\" does not match expectation");
 

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -142,6 +142,54 @@ trait ChadoFieldTestTrait {
   }
 
   /**
+   * Confirms that the retrieved chado values match the expected ones.
+   *
+   * @param array $expected_values
+   *   A nested array of expected values following the format:
+   *    - chado table name
+   *      - conditions
+   *        - table_column: value_for_condition
+   *      - expectations
+   *        - table_column: expected_value
+   *          another_column: another_value
+   *      - count: int (defaults to 1).
+   *   Count can be used to indicate when we do NOT expect a value for the
+   *   conditions. Do so by setting it to zero.
+   * @param string $message_prefix
+   *   A short string that all assert messages will be prefixed with.
+   *
+   * @return void
+   *   No return value, just performs assertions.
+   */
+  public function assertChadoValuesMatch(array $expected_values, string $message_prefix = ''): void {
+    foreach ($expected_values as $chado_table => $config) {
+      $count = $config['count'] ?? 1;
+      $query = $this->chado_connection->select('1:' . $chado_table, 'T');
+      foreach ($config['conditions'] as $column_name => $chado_value) {
+        $query->condition($column_name, $chado_value, '=');
+      }
+      foreach (array_keys($config['expectations']) as $column_name) {
+        $query->addField('T', $column_name);
+      }
+
+      // Checks the number of chado records, generally we expect one.
+      $chado_count = $query->countQuery()->execute()->fetchField();
+      $this->assertEquals($count, $chado_count, $message_prefix . "Chado record count for table \"$chado_table\" does not match expectation");
+
+      // Checks the actual values in chado.
+      $result = $query->execute();
+      if ($count !== 0) {
+        while ($row = $result->fetchAssoc()) {
+          foreach ($config['expectations'] as $column_name => $expected_value) {
+            $actual_value = $row[$column_name];
+            $this->assertEquals($expected_value, $actual_value, $message_prefix . "Table \"$chado_table\" column \"$column_name\" does not have the expected value");
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Recursive check that an array contains a set of elements.
    *
    * NOTE: Only the keys passed in will be checked. Additional keys will be

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -163,8 +163,8 @@ trait ChadoFieldTestTrait {
    */
   public function assertChadoValuesMatch(array $expected_values, string $message_prefix = ''): void {
     foreach ($expected_values as $chado_table => $config) {
-      $this->assertArrayHasKey('conditions', $config, "YAML configuration for chado table \"$table\" does not have any conditions");
-      $this->assertArrayHasKey('expectations', $config, "YAML configuration for chado table \"$table\" does not have any expectations");
+      $this->assertArrayHasKey('conditions', $config, "YAML configuration for chado table \"$chado_table\" does not have any conditions");
+      $this->assertArrayHasKey('expectations', $config, "YAML configuration for chado table \"$chado_table\" does not have any expectations");
       $count = $config['count'] ?? 1;
       $query = $this->chado_connection->select('1:' . $chado_table, 'T');
       foreach ($config['conditions'] as $column_name => $chado_value) {

--- a/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
+++ b/tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php
@@ -145,16 +145,21 @@ trait ChadoFieldTestTrait {
    * Confirms that the retrieved chado values match the expected ones.
    *
    * @param array $expected_values
-   *   A nested array of expected values following the format:
-   *    - chado table name
-   *      - conditions
-   *        - table_column: value_for_condition
-   *      - expectations
-   *        - table_column: expected_value
+   *   A nested array of expected values following the YAML format:
+   *    - table: chado_table_name (required)
+   *      conditions:
+   *        table_column: value_for_condition (at least one required)
+   *      order_by: column (optional)
+   *      count: int (optional, defaults to 1).
+   *      expectations:
+   *        - a_table_column: expected_value
    *          another_column: another_value
-   *      - count: int (defaults to 1).
-   *   Count can be used to indicate when we do NOT expect a value for the
-   *   conditions. Do so by setting it to zero.
+   *        - a_table_column: expected_second_value
+   *          another_column: another_second_value
+   *   Count can be used to indicate when we do NOT expect a value for
+   *   the conditions. Do so by setting it to zero and omitting expectations.
+   *   If you expect more than one record, order_by is recommended so that
+   *   the order is deterministic.
    * @param string $message_prefix
    *   A short string that all assert messages will be prefixed with.
    *
@@ -162,30 +167,39 @@ trait ChadoFieldTestTrait {
    *   No return value, just performs assertions.
    */
   public function assertChadoValuesMatch(array $expected_values, string $message_prefix = ''): void {
-    foreach ($expected_values as $chado_table => $config) {
-      $this->assertArrayHasKey('conditions', $config, "YAML configuration for chado table \"$chado_table\" does not have any conditions");
-      $this->assertArrayHasKey('expectations', $config, "YAML configuration for chado table \"$chado_table\" does not have any expectations");
+    foreach ($expected_values as $config) {
+      $this->assertArrayHasKey('table', $config, "YAML configuration does not have a table key: " . print_r($config, TRUE));
+      $chado_table = $config['table'];
+      $this->assertArrayHasKey('conditions', $config, "YAML configuration does not have any conditions: " . print_r($config, TRUE));
       $count = $config['count'] ?? 1;
+      if ($count) {
+        $this->assertArrayHasKey('expectations', $config, "YAML configuration does not have any expectations: " . print_r($config, TRUE));
+      }
       $query = $this->chado_connection->select('1:' . $chado_table, 'T');
       foreach ($config['conditions'] as $column_name => $chado_value) {
         $query->condition($column_name, $chado_value, '=');
       }
-      foreach (array_keys($config['expectations']) as $column_name) {
-        $query->addField('T', $column_name);
+      $query->fields('T');
+
+      // Make order deterministic if expecting multiple records.
+      if (isset($config['order_by'])) {
+        $query->orderBy($config['order_by']);
       }
 
-      // Checks the number of chado records. Only 0 and 1 are supported.
+      // Checks the number of chado records.
       $chado_count = $query->countQuery()->execute()->fetchField();
       $this->assertEquals($count, $chado_count, $message_prefix . "Chado record count for table \"$chado_table\" does not match expectation");
 
       // Checks the actual values in chado.
-      $result = $query->execute();
-      if ($count !== 0) {
+      if ($count > 0) {
+        $result = $query->execute();
+        $row_index = 0;
         while ($row = $result->fetchAssoc()) {
-          foreach ($config['expectations'] as $column_name => $expected_value) {
+          foreach ($config['expectations'][$row_index] as $column_name => $expected_value) {
             $actual_value = $row[$column_name];
             $this->assertEquals($expected_value, $actual_value, $message_prefix . "Table \"$chado_table\" column \"$column_name\" does not have the expected value");
           }
+          $row_index++;
         }
       }
     }


### PR DESCRIPTION
# New Feature

### Closes #2526

## Description

I would like to add a function **assertChadoValuesMatch()** to `tripal_chado/tests/src/Traits/ChadoFieldTestTrait.php` to easily allow verification of the values stored in chado tables.

Currently we have a function in `tripal/tests/src/Traits/TripalEntityFieldTestTrait.php` to check the drupal field tables, i.e. function **assertFieldValuesMatch()**

This PR introduces an analogous function to check the values in chado tables.

## Testing?

I have updated TripalEntityChadoFieldTest to use this new function to verify that it works.