### PR TITLE
Biosample organism widget

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -62,3 +62,9 @@
 # Deprecation: Method "Consolidation\AnnotatedCommand\State\SavableState::currentState()" might add "State" as a native return type declaration in the future. Do the same in implementation "Drush\Commands\DrushCommands" now to avoid errors or add an explicit @return annotation to suppress this message.
 # Example test that triggers this: testDrushMviewPopulate
 %Method "Consolidation\\AnnotatedCommand\\State\\SavableState::currentState\(\)" might add "State"%
+
+# Module: Drupal 11.4+
+# Location: web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:51
+# Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will take a 4th "array $tests" argument in 4.0; not declaring it is deprecated.
+# Example test that triggers this: testTripalAccessOwnContentCheck
+%TwigSandboxPolicy::checkSecurity\(\)" method will take a 4th "array \$tests" argument%

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAnalysisWidgetDefault.php
@@ -37,7 +37,7 @@ class ChadoAnalysisWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $analysis_id = $item_vals['analysis_id'] ?? 0;
+    $analysis_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoAssayWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoAssayWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $assay_id = $item_vals['assay_id'] ?? 0;
+    $assay_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoBiomaterialWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoBiomaterialWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $biomaterial_id = $item_vals['biomaterial_id'] ?? 0;
+    $biomaterial_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoFeatureWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoFeatureWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $feature_id = $item_vals['feature_id'] ?? 0;
+    $feature_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoOrganismWidgetDefault.php
@@ -39,7 +39,7 @@ class ChadoOrganismWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $organism_id = $item_vals['organism_id'] ?? 0;
+    $organism_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoPubWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoPubWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $pub_id = $item_vals['pub_id'] ?? 0;
+    $pub_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockCollectionWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockCollectionWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoStockCollectionWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $stockcollection_id = $item_vals['stockcollection_id'] ?? 0;
+    $stockcollection_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStockWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoStockWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $stock_id = $item_vals['stock_id'] ?? 0;
+    $stock_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [

--- a/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldWidget/ChadoStudyWidgetDefault.php
@@ -38,7 +38,7 @@ class ChadoStudyWidgetDefault extends ChadoWidgetBase {
     $record_id = $item_vals['record_id'] ?? 0;
     $linker_id = $item_vals['linker_id'] ?? 0;
     $link = $item_vals['link'] ?? 0;
-    $study_id = $item_vals['study_id'] ?? 0;
+    $study_id = $item_vals[$linker_fkey_column] ?? 0;
 
     $elements = [];
     $elements['record_id'] = [


### PR DESCRIPTION
# Bug Fix

### Closes #2528

## Description

Some chado tables use different column names than the foreign key they refer to. See here: https://github.com/tripal/tripal_doc/issues/32#issuecomment-1837532399
biomaterial FOREIGN KEY (taxon_id) REFERENCES organism(organism_id)

The fix will be a one-liner for the organism widget to do as the contact widget already does: https://github.com/tripal/tripal/pull/2529/commits/43614238fd61ca8326f272c1d7b0f87e741c93d3

For good measure, the same fix is applied to several other fields https://github.com/tripal/tripal/pull/2529/commits/bf64fd69d0021d484dcf7d45a6351a2351a94037 for potentially supporting similar discrepancies in foreign keys. A good number of widgets were already correctly using this way of referencing.

## Testing?

1. Create an organism
2. Import the expression content type collection
3. Create a biological sample
4. Now edit it, the organism field default value should show the organism you specified.
