### PR TITLE
Add missing category annotation field to ChadoPhylotreeVisTypeDefault

### DIFF
--- a/tripal_chado/src/Plugin/Field/FieldType/ChadoPhylotreeVisTypeDefault.php
+++ b/tripal_chado/src/Plugin/Field/FieldType/ChadoPhylotreeVisTypeDefault.php
@@ -15,6 +15,7 @@ use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
  */
 #[TripalFieldType(
   id: 'chado_phylotreevis_type_default',
+  category: 'tripal_chado',
   label: new TranslatableMarkup('Chado Phylogenetic Visualization Field Type'),
   description: new TranslatableMarkup('Visualization of a phylogenetic tree.'),
   default_widget: 'chado_phylotreevis_widget_default',


### PR DESCRIPTION
# Bug Fix

### Closes #2531

### Depends on #2533

## Description

This just adds the missing `category:` annotation field to the ChadoPhylotreeVisTypeDefault field

## Testing?

This field should no longer appear at the top level
1. rebuild cache if you switched branches
2. Tripal -> Page Structure
3. On any content type select "Manage Fields"
4. Click on "+ Create a new field"
5. Observe that "Chado Phylogenetic Visualization Field Type" is at the top level

**Before**
<img width="1128" height="611" alt="Image" src="https://github.com/user-attachments/assets/5d7c19d4-f9b4-4098-9f84-2bdf9482de11" />

**On this branch**
<img width="1122" height="501" alt="phylotreefieldafter" src="https://github.com/user-attachments/assets/ee9dc4c1-d8ed-4d09-aa90-7ea05d8b4935" />

**Field now in the list where it belongs**
<img width="495" height="353" alt="phylotreefieldinlist" src="https://github.com/user-attachments/assets/d5e3d0af-e267-4f91-886d-8821d6fa6a50" />
