### PR TITLE
Drupal+Twig Deprecation: checkSecurity() will take a 4th argument

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -62,3 +62,9 @@
 # Deprecation: Method "Consolidation\AnnotatedCommand\State\SavableState::currentState()" might add "State" as a native return type declaration in the future. Do the same in implementation "Drush\Commands\DrushCommands" now to avoid errors or add an explicit @return annotation to suppress this message.
 # Example test that triggers this: testDrushMviewPopulate
 %Method "Consolidation\\AnnotatedCommand\\State\\SavableState::currentState\(\)" might add "State"%
+
+# Module: Drupal 11.4+
+# Location: web/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:51
+# Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will take a 4th "array $tests" argument in 4.0; not declaring it is deprecated.
+# Example test that triggers this: testTripalAccessOwnContentCheck
+%TwigSandboxPolicy::checkSecurity\(\)" method will take a 4th "array \$tests" argument%


### PR DESCRIPTION
# Bug Fix

### Closes #2533

## Description

This adds a deprecation ignore temporarily until Drupal fixes this.
See #2533 for details.
<img width="480" height="178" alt="11 4_failing" src="https://github.com/user-attachments/assets/0b683459-399d-4716-b0e9-77b221f63c44" />


## Testing?

Observe no deprecation notice in the tests on 11.4 and 11.x
https://github.com/tripal/tripal/actions/runs/29108753719