### PR TITLE
Drupal+Twig Deprecation: checkSecurity() will require a new more specific argument 😒 

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -68,3 +68,9 @@
 # Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will take a 4th "array $tests" argument in 4.0; not declaring it is deprecated.
 # Example test that triggers this: testTripalAccessOwnContentCheck
 %TwigSandboxPolicy::checkSecurity\(\)" method will take a 4th "array \$tests" argument%
+
+# Module: Drupal 11.4+
+# Location: /var/www/drupal/vendor/symfony/error-handler/DebugClassLoader.php:363
+# Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will require a new "string[] $tests" argument in the next major version of its interface "Twig\Sandbox\SecurityPolicyInterface", not defining it is deprecated.
+# Example test that triggers this: TripalCultivate::testResultWindowDisplay
+%TwigSandboxPolicy::checkSecurity\(\)" method will require a new "string\[\] \$tests" argument%

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -16,6 +16,10 @@ $drupal_ignore_file = DRUPAL_ROOT . '/core/.deprecation-ignore.txt';
 $tripal_ignore_file = __DIR__ . '/../../.tripal-deprecation-ignore.txt';
 $combined_ignore_file = __DIR__ . '/../../.deprecation-ignore.txt';
 
+print "\nTripal is ignoring the deprecation warnings defined in:\n";
+print "- " . $drupal_ignore_file . "\n";
+print "- " . $tripal_ignore_file . "\n\n";
+
 // Append Tripal's phpunit deprecation exclusions to those already
 // defined by Drupal.
 $exclude_text = file_get_contents($drupal_ignore_file);


### PR DESCRIPTION
### Issue #2533

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are actually two deprecation messages associated with this Twig issue. The one that Tripal core triggered regarding the 4th argument which is thrown by Twig directly (handled in PR #2534) and another one that my extension modules triggered 🙈 which is thrown by Drupal 😫 This second deprecation is ignored in this PR.

[The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will require a new "string[] $tests" argument in the next major version of its interface "Twig\Sandbox\SecurityPolicyInterface", not defining it is deprecated.](https://github.com/TripalCultivate/TripalCultivate/actions/runs/29226886014/job/86943611771#step:3:431)

Additionally, I got tired of worrying that the file is not being referenced correctly in extension modules and decided that making it extra clear that deprecations are being ignored is a good thing 😅 so I added some print messages to Tripal Bootstrap. This is only ever run by PHP so I think it's fine 🤷 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->

Run automated testing on this branch and confirm you see the new print statements and that no tests break.

Trust me that it does fix this in Tripalcultivate? 🤷 

```
phpunit --stop-on-deprecation

Tripal is ignoring the deprecation warnings defined in:
- /var/www/drupal/web/core/.deprecation-ignore.txt
- /var/www/drupal/web/modules/contrib/tripal/tripal/tests/../../.tripal-deprecation-ignore.txt

PHPUnit 11.5.56 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.8
Configuration: /var/www/drupal/web/modules/contrib/TripalCultivate/phpunit.11.xml

...............................................................  63 / 226 ( 27%)
............................................................... 126 / 226 ( 55%)
............................................................... 189 / 226 ( 83%)
.....................................                           226 / 226 (100%)

Time: 06:33.363, Memory: 28.00 MB

OK (226 tests, 2222 assertions)
```
