### PR TITLE
SYMFONY_DEPRECATIONS_HELPER is deprecated

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -74,3 +74,9 @@
 # Deprecation: Since twig/twig 3.28: The "Drupal\Core\Template\TwigSandboxPolicy::checkSecurity()" method will require a new "string[] $tests" argument in the next major version of its interface "Twig\Sandbox\SecurityPolicyInterface", not defining it is deprecated.
 # Example test that triggers this: TripalCultivate::testResultWindowDisplay
 %TwigSandboxPolicy::checkSecurity\(\)" method will require a new "string\[\] \$tests" argument%
+
+# Module: Drupal 11.5
+# Location: /var/www/drupal/web/core/tests/Drupal/Tests/DrupalTestCaseTrait.php:75
+# Deprecation: Since Drupal 11.5: Using the SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated in drupal:11.5.0 and is removed from drupal:12.0.0. See https://www.drupal.org/node/3594014
+# Example test that triggers this: ConfigTest::testConfigYaml
+%SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated%

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,9 @@ RUN service apache2 start \
   && rm -rf /tripal_app \
   && allmodules="${tripalmodules} ${modules}" \
   && vendor/bin/drush en ${allmodules} -y \
-  && rm web/modules/contrib/tripal/phpunit.xml \
-  && bash web/modules/contrib/tripal/set_phpunit_config.sh \
+  && cd web/modules/contrib/tripal \
+  && rm phpunit.xml \
+  && bash set_phpunit_config.sh \
   && service postgresql stop
 
 RUN service apache2 start \

--- a/phpunit.11.xml
+++ b/phpunit.11.xml
@@ -51,7 +51,7 @@
       <parameter name="enableProjectIgnores" value="true"/>
       <!-- The path to a file containing the deprecation ignore patterns.
         Relative paths are resolved against Drupal's root directory. -->
-      <parameter name="projectIgnoreFile" value="modules/contrib/tripal/.tripal-deprecation-ignore.txt"/>
+      <parameter name="projectIgnoreFile" value="modules/contrib/tripal/.deprecation-ignore.txt"/>
       <!-- Set to true to enable Symfony's DebugClassLoader.
         See https://github.com/symfony/error-handler -->
       <parameter name="enableDebugClassLoader" value="true"/>

--- a/phpunit.11.xml
+++ b/phpunit.11.xml
@@ -33,9 +33,6 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
-    <!-- Defines regular expressions for deprecations in external modules
-      that we want to ignore. Includes those defined by Drupal. -->
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt"/>
     <!-- Handling of functional tests. See core/phpunit.xml.dist -->
     <env name="MINK_DRIVER_CLASS" value=""/>
     <env name="MINK_DRIVER_ARGS" value=""/>
@@ -46,6 +43,18 @@
     <bootstrap class="Drupal\TestTools\Extension\Dump\DebugDump">
       <parameter name="colors" value="true"/>
       <parameter name="printCaller" value="true"/>
+    </bootstrap>
+    <bootstrap class="Drupal\TestTools\Extension\DeprecationBridge\DeprecationHandler">
+      <!-- Set to true to enable project level deprecation ignore patterns.
+        The deprecations ignored with this mechanism are not relayed to PHPUnit
+        for processing. -->
+      <parameter name="enableProjectIgnores" value="true"/>
+      <!-- The path to a file containing the deprecation ignore patterns.
+        Relative paths are resolved against Drupal's root directory. -->
+      <parameter name="projectIgnoreFile" value="modules/contrib/tripal/.tripal-deprecation-ignore.txt"/>
+      <!-- Set to true to enable Symfony's DebugClassLoader.
+        See https://github.com/symfony/error-handler -->
+      <parameter name="enableDebugClassLoader" value="true"/>
     </bootstrap>
   </extensions>
   <testsuites>

--- a/phpunit.12.xml
+++ b/phpunit.12.xml
@@ -2,7 +2,7 @@
 <!--
   generated for use with
 
-  PHPUnit 11
+  PHPUnit 12
 
   -->
 <!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->

--- a/phpunit.12.xml
+++ b/phpunit.12.xml
@@ -44,6 +44,18 @@
       <parameter name="colors" value="true"/>
       <parameter name="printCaller" value="true"/>
     </bootstrap>
+    <bootstrap class="Drupal\TestTools\Extension\DeprecationBridge\DeprecationHandler">
+      <!-- Set to true to enable project level deprecation ignore patterns.
+        The deprecations ignored with this mechanism are not relayed to PHPUnit
+        for processing. -->
+      <parameter name="enableProjectIgnores" value="true"/>
+      <!-- The path to a file containing the deprecation ignore patterns.
+        Relative paths are resolved against Drupal's root directory. -->
+      <parameter name="projectIgnoreFile" value="modules/contrib/tripal/.deprecation-ignore.txt"/>
+      <!-- Set to true to enable Symfony's DebugClassLoader.
+        See https://github.com/symfony/error-handler -->
+      <parameter name="enableDebugClassLoader" value="true"/>
+    </bootstrap>
   </extensions>
   <testsuites>
     <testsuite name="unit">

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -25,11 +25,8 @@ print "- " . $tripal_ignore_file . "\n\n";
 // If we are on a dev version, increment minor version by 1 so that we can
 // distinguish 11.x from 11.4 for example.
 $drupal_version = \Drupal::VERSION;
-if (preg_match('/-dev/', $drupal_version)) {
-  preg_replace('/-dev/', '', $drupal_version);
-  $drupal_version = floatval($drupal_version) + 0.1;
-}
-if (version_compare($drupal_version, '11.5', '<')) {
+if (version_compare($drupal_version, '11.4.2', '<=') && ($drupal_version !== '11.4-dev')) {
+  print "We are using Symphony deprecation helper. This should only be used for Drupal versions less than and including 11.4.2.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }
 
@@ -39,5 +36,6 @@ $exclude_text = file_get_contents($drupal_ignore_file);
 $exclude_text .= file_get_contents($tripal_ignore_file);
 file_put_contents($combined_ignore_file, $exclude_text);
 
+print "Drupal $drupal_version by the Drupal Community.\n";
 // Tripal preprocessing is done, now call Drupal's bootstrap.php.
 include DRUPAL_ROOT . '/core/tests/bootstrap.php';

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -22,11 +22,15 @@ print "- " . $tripal_ignore_file . "\n\n";
 
 // Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
 // combined ignore file but only in Drupal versions less than 11.5.
-// If we are on a dev version, increment minor version by 1 so that we can
-// distinguish 11.x from 11.4 for example.
+// If we are on a dev version, then the path handling has changed for the
+// deprecation helper so catch that specifically.
 $drupal_version = \Drupal::VERSION;
-if (version_compare($drupal_version, '11.4.2', '<=') && ($drupal_version !== '11.4-dev')) {
-  print "We are using Symphony deprecation helper. This should only be used for Drupal versions less than and including 11.4.2.\n\n";
+if ($drupal_version === '11.4-dev') {
+  print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";
+  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=/modules/contrib/tripal/.deprecation-ignore.txt');
+}
+elseif (version_compare($drupal_version, '11.4.666', '<=')) {
+  print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }
 

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -9,8 +9,6 @@
  * modules. Because there can only be one phpunit exclusion file, we first
  * copy Drupal's exclusions, and then append the additional ones we define
  * here. We can then proceed to call Drupal's bootstrap.php.
- *
- * This is only used for Drupal 10.x.
  */
 
 // Define exclusion file names.
@@ -22,15 +20,11 @@ print "\nTripal is ignoring the deprecation warnings defined in:\n";
 print "- " . $drupal_ignore_file . "\n";
 print "- " . $tripal_ignore_file . "\n\n";
 
-$version = \Drupal::VERSION;
-if (version_compare($version, '11.0.0', '<')) {
-
-  // Append Tripal's phpunit deprecation exclusions to those already
-  // defined by Drupal.
-  $exclude_text = file_get_contents($drupal_ignore_file);
-  $exclude_text .= file_get_contents($tripal_ignore_file);
-  file_put_contents($combined_ignore_file, $exclude_text);
-}
+// Append Tripal's phpunit deprecation exclusions to those already
+// defined by Drupal.
+$exclude_text = file_get_contents($drupal_ignore_file);
+$exclude_text .= file_get_contents($tripal_ignore_file);
+file_put_contents($combined_ignore_file, $exclude_text);
 
 // Tripal preprocessing is done, now call Drupal's bootstrap.php.
 include DRUPAL_ROOT . '/core/tests/bootstrap.php';

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -22,9 +22,12 @@ print "- " . $tripal_ignore_file . "\n\n";
 
 // Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
 // combined ignore file but only in Drupal versions less than 11.5.
-// Cleanup -dev or .x versions first.
-$drupal_version = preg_replace('/\.x/', '999', \Drupal::VERSION);
-$drupal_version = preg_replace('/[^0-9.]/', '', $drupal_version);
+// If we are on a dev version, increment minor version by 1 so that we can
+// distinguish 11.x from 11.4 for example.
+$drupal_version = \Drupal::VERSION;
+if (preg_replace('/-dev/', '', $drupal_version)) {
+  $drupal_version = floatval($drupal_version) + 0.1;
+}
 if (version_compare($drupal_version, '11.5', '<')) {
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -21,16 +21,16 @@ print "- " . $drupal_ignore_file . "\n";
 print "- " . $tripal_ignore_file . "\n\n";
 
 // Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
-// combined ignore file but only in Drupal versions less than 11.5.
-// If we are on a dev version, then the path handling has changed for the
-// deprecation helper so catch that specifically.
+// combined ignore file. If we are on a dev version starting with 11.4-dev,
+// then the path handling has changed for the deprecation helper so catch
+// that specifically.
 $drupal_version = \Drupal::VERSION;
 if ($drupal_version === '11.4-dev') {
-  print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";
+  print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions 11.5 and higher.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=modules/contrib/tripal/.deprecation-ignore.txt');
 }
 elseif (version_compare($drupal_version, '11.4.666', '<=')) {
-  print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";
+  print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.4.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }
 

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -22,7 +22,10 @@ print "- " . $tripal_ignore_file . "\n\n";
 
 // Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
 // combined ignore file but only in Drupal versions less than 11.5.
-if (version_compare(\Drupal::VERSION, '11.5', '<')) {
+// Cleanup -dev or .x versions first.
+$drupal_version = preg_replace('/\.x/', '999', \Drupal::VERSION);
+$drupal_version = preg_replace('/[^0-9.]/', '', $drupal_version);
+if (version_compare($drupal_version, '11.5', '<')) {
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }
 

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -25,7 +25,8 @@ print "- " . $tripal_ignore_file . "\n\n";
 // If we are on a dev version, increment minor version by 1 so that we can
 // distinguish 11.x from 11.4 for example.
 $drupal_version = \Drupal::VERSION;
-if (preg_replace('/-dev/', '', $drupal_version)) {
+if (preg_match('/-dev/', $drupal_version)) {
+  preg_replace('/-dev/', '', $drupal_version);
   $drupal_version = floatval($drupal_version) + 0.1;
 }
 if (version_compare($drupal_version, '11.5', '<')) {

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -25,7 +25,7 @@ print "- " . $tripal_ignore_file . "\n\n";
 // then the path handling has changed for the deprecation helper so catch
 // that specifically.
 $drupal_version = \Drupal::VERSION;
-if ($drupal_version === '11.4-dev' ) {
+if ($drupal_version === '11.4-dev') {
   print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions 11.5 and higher.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=modules/contrib/tripal/.deprecation-ignore.txt');
 }

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -25,11 +25,11 @@ print "- " . $tripal_ignore_file . "\n\n";
 // then the path handling has changed for the deprecation helper so catch
 // that specifically.
 $drupal_version = \Drupal::VERSION;
-if ($drupal_version === '11.4-dev') {
+if ($drupal_version === '11.4-dev' || version_compare($drupal_version, '11.4.666', '>') {
   print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions 11.5 and higher.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=modules/contrib/tripal/.deprecation-ignore.txt');
 }
-elseif (version_compare($drupal_version, '11.4.666', '<=')) {
+else
   print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.4.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -9,6 +9,8 @@
  * modules. Because there can only be one phpunit exclusion file, we first
  * copy Drupal's exclusions, and then append the additional ones we define
  * here. We can then proceed to call Drupal's bootstrap.php.
+ *
+ * This is only used for Drupal 10.x.
  */
 
 // Define exclusion file names.
@@ -20,11 +22,15 @@ print "\nTripal is ignoring the deprecation warnings defined in:\n";
 print "- " . $drupal_ignore_file . "\n";
 print "- " . $tripal_ignore_file . "\n\n";
 
-// Append Tripal's phpunit deprecation exclusions to those already
-// defined by Drupal.
-$exclude_text = file_get_contents($drupal_ignore_file);
-$exclude_text .= file_get_contents($tripal_ignore_file);
-file_put_contents($combined_ignore_file, $exclude_text);
+$version = \Drupal::VERSION;
+if (version_compare($version, '11.0.0', '<')) {
+
+  // Append Tripal's phpunit deprecation exclusions to those already
+  // defined by Drupal.
+  $exclude_text = file_get_contents($drupal_ignore_file);
+  $exclude_text .= file_get_contents($tripal_ignore_file);
+  file_put_contents($combined_ignore_file, $exclude_text);
+}
 
 // Tripal preprocessing is done, now call Drupal's bootstrap.php.
 include DRUPAL_ROOT . '/core/tests/bootstrap.php';

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -25,11 +25,11 @@ print "- " . $tripal_ignore_file . "\n\n";
 // then the path handling has changed for the deprecation helper so catch
 // that specifically.
 $drupal_version = \Drupal::VERSION;
-if ($drupal_version === '11.4-dev' || version_compare($drupal_version, '11.4.666', '>') {
+if ($drupal_version === '11.4-dev' ) {
   print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions 11.5 and higher.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=modules/contrib/tripal/.deprecation-ignore.txt');
 }
-else
+elseif (version_compare($drupal_version, '11.4.666', '<=')) {
   print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.4.\n\n";
   putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -22,8 +22,8 @@ print "- " . $tripal_ignore_file . "\n\n";
 
 // Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
 // combined ignore file but only in Drupal versions less than 11.5.
-if (version_compare(\Drupal::VERSION, '11.4.x-dev', '<=')) {
-  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=' . $combined_ignore_file);
+if (version_compare(\Drupal::VERSION, '11.5', '<')) {
+  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=../../../modules/contrib/tripal/.deprecation-ignore.txt');
 }
 
 // Append Tripal's phpunit deprecation exclusions to those already

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -27,7 +27,7 @@ print "- " . $tripal_ignore_file . "\n\n";
 $drupal_version = \Drupal::VERSION;
 if ($drupal_version === '11.4-dev') {
   print "We are using Symphony deprecation helper with the updated path handling.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";
-  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=/modules/contrib/tripal/.deprecation-ignore.txt');
+  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=modules/contrib/tripal/.deprecation-ignore.txt');
 }
 elseif (version_compare($drupal_version, '11.4.666', '<=')) {
   print "We are using Symphony deprecation helper.\nThis should only be used for Drupal versions less than and including 11.5.\n\n";

--- a/tripal/tests/tripal-bootstrap.php
+++ b/tripal/tests/tripal-bootstrap.php
@@ -20,6 +20,12 @@ print "\nTripal is ignoring the deprecation warnings defined in:\n";
 print "- " . $drupal_ignore_file . "\n";
 print "- " . $tripal_ignore_file . "\n\n";
 
+// Set the SYMFONY_DEPRECATIONS_HELPER environment variable to point to the
+// combined ignore file but only in Drupal versions less than 11.5.
+if (version_compare(\Drupal::VERSION, '11.4.x-dev', '<=')) {
+  putenv('SYMFONY_DEPRECATIONS_HELPER=ignoreFile=' . $combined_ignore_file);
+}
+
 // Append Tripal's phpunit deprecation exclusions to those already
 // defined by Drupal.
 $exclude_text = file_get_contents($drupal_ignore_file);


### PR DESCRIPTION
# Bug Fix

### Closes #2537

## Description

Using the SYMFONY_DEPRECATIONS_HELPER environment variable for deprecation ignore rules is deprecated in Drupal 11.5 (as of last night).
See this issue:
https://www.drupal.org/node/3594014
which provides instructions for updating.

## Getting the drupal version

We can get the drupal version with
`drush core-status --field=drupal-version`
but this does not return what we expect on the `11.x-dev` branch, because the active minor development branch is 11.4.x and we get back `11.4-dev`

Fix this by interpreting `-dev` in the version as a one-higher minor version number, i.e. 11.5

## Testing?

This is all phpunit testing, there should be no more error messages on 11.x.