### PR TITLE
Tv4g1 issue2540 tripal entity type list builder sort method

### DIFF
--- a/tripal/src/Controller/TripalEntityUIController.php
+++ b/tripal/src/Controller/TripalEntityUIController.php
@@ -38,7 +38,7 @@ class TripalEntityUIController extends ControllerBase {
     // See \Drupal\Core\Config\Entity\ConfigEntityBase::sort().
     uasort($bundle_entities, [
       TripalEntityType::class,
-      'sortByCategory',
+      'sort',
     ]);
 
     // Now compile them into variables to be used in twig.

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -3,6 +3,7 @@
 namespace Drupal\tripal\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\Attribute\ConfigEntityType;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
@@ -845,14 +846,12 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    */
 
   /**
-   * Sorts Tripal Entity Types first by category and then by Label.
+   * {@inheritdoc}
    *
-   * @param TripalEntityTypeInterface $a
-   *   The first Tripal Entity Type object.
-   * @param TripalEntityTypeInterface $b
-   *   The second Tripal Entity Type object.
+   * Overrides the default label-only sort to first group Tripal Entity
+   * Types by category (with "General" always first) and then by label.
    */
-  public static function sortByCategory(TripalEntityTypeInterface $a, TripalEntityTypeInterface $b) {
+  public static function sort(ConfigEntityInterface $a, ConfigEntityInterface $b) {
     $a_value = $a->getCategory();
     $b_value = $b->getCategory();
     if ($a_value == $b_value) {
@@ -869,7 +868,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
       return 1;
     }
     else {
-      return strnatcasecmp($b_value, $a_value);
+      return strnatcasecmp($a_value, $b_value);
     }
   }
 

--- a/tripal/src/ListBuilders/TripalEntityTypeListBuilder.php
+++ b/tripal/src/ListBuilders/TripalEntityTypeListBuilder.php
@@ -62,25 +62,6 @@ class TripalEntityTypeListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function load() {
-    $entity_ids = $this
-      ->getEntityIds();
-    $entities = $this->storage
-      ->loadMultipleOverrideFree($entity_ids);
-
-    // Sort the entities using the entity class's sort() method.
-    // See \Drupal\Core\Config\Entity\ConfigEntityBase::sort().
-    uasort($entities, array(
-      $this->entityType
-        ->getClass(),
-      'sortByCategory',
-    ));
-    return $entities;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function render() {
     $build = parent::render();
 

--- a/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
@@ -7,7 +7,9 @@ use Drupal\tripal\Entity\TripalEntityType;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Tests TripalEntityType::sort(), used to order Tripal Content Types in
+ * Tests TripalEntityType::sort().
+ * 
+ * This function is used to order Tripal Content Types in
  * both TripalEntityTypeListBuilder and TripalEntityUIController.
  *
  * @group TripalEntityType

--- a/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\tripal\Kernel\Entity;
 use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
 use Drupal\tripal\Entity\TripalEntityType;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests TripalEntityType::sort().

--- a/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
@@ -66,7 +66,7 @@ class TripalEntityTypeSortTest extends TripalTestKernelBase {
   /**
    * Within the same category, types should be sorted alphabetically by label.
    */
-  public function testTypesWithinACategoryAreSortedByLabel() {
+  public function testTypesWithinCategoryAreSortedByLabel() {
 
     $types = [
       $this->createType('t_orange', 'Orange', 'Genetic'),

--- a/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * @group TripalEntityType
  */
 #[Group('tripal-content')]
+#[RunTestsInSeparateProcesses]
 class TripalEntityTypeSortTest extends TripalTestKernelBase {
 
   /**

--- a/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
+++ b/tripal/tests/src/Kernel/Entity/TripalEntityTypeSortTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\Tests\tripal\Kernel\Entity;
+
+use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use Drupal\tripal\Entity\TripalEntityType;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests TripalEntityType::sort(), used to order Tripal Content Types in
+ * both TripalEntityTypeListBuilder and TripalEntityUIController.
+ *
+ * @group TripalEntityType
+ */
+#[Group('tripal-content')]
+class TripalEntityTypeSortTest extends TripalTestKernelBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'tripal'];
+
+  /**
+   * Creates an unsaved TripalEntityType with the given id/label/category.
+   *
+   * The entities are intentionally not saved since TripalEntityType::sort()
+   * only relies on getCategory() and label(), which are both usable on
+   * in-memory entities.
+   */
+  protected function createType(string $id, string $label, string $category): TripalEntityType {
+    return TripalEntityType::create([
+      'id' => $id,
+      'label' => $label,
+      'category' => $category,
+    ]);
+  }
+
+  /**
+   * Categories should be sorted alphabetically, with "General" always first.
+   *
+   * This is a regression test: the comparator previously had its arguments
+   * swapped (`strnatcasecmp($b_value, $a_value)`), which sorted all
+   * non-"General" categories in reverse-alphabetical order.
+   */
+  public function testCategoriesAreSortedAlphabeticallyWithGeneralFirst() {
+
+    $types = [
+      $this->createType('t_germplasm', 'Germplasm Type', 'Germplasm'),
+      $this->createType('t_genomic', 'Genomic Type', 'Genomic'),
+      $this->createType('t_genetic', 'Genetic Type', 'Genetic'),
+      $this->createType('t_expression', 'Expression Type', 'Expression'),
+      $this->createType('t_general', 'General Type', 'General'),
+    ];
+
+    usort($types, [TripalEntityType::class, 'sort']);
+
+    $ordered_categories = array_map(fn($type) => $type->getCategory(), $types);
+
+    $this->assertEquals(
+      ['General', 'Expression', 'Genetic', 'Genomic', 'Germplasm'],
+      $ordered_categories,
+      'Categories should be sorted with "General" first and all other categories in ascending alphabetical order.'
+    );
+  }
+
+  /**
+   * Within the same category, types should be sorted alphabetically by label.
+   */
+  public function testTypesWithinACategoryAreSortedByLabel() {
+
+    $types = [
+      $this->createType('t_orange', 'Orange', 'Genetic'),
+      $this->createType('t_monkey', 'Monkey', 'Genetic'),
+      $this->createType('t_eagle', 'Eagle', 'Genetic'),
+    ];
+
+    usort($types, [TripalEntityType::class, 'sort']);
+
+    $ordered_labels = array_map(fn($type) => $type->label(), $types);
+
+    $this->assertEquals(
+      ['Eagle', 'Monkey', 'Orange'],
+      $ordered_labels,
+      'Types within the same category should be sorted alphabetically by label.'
+    );
+  }
+
+  /**
+   * Multiple "General" types should be sorted by label among themselves.
+   */
+  public function testMultipleGeneralTypesAreSortedByLabel() {
+
+    $types = [
+      $this->createType('t_general_b', 'Bravo', 'General'),
+      $this->createType('t_general_a', 'Alpha', 'General'),
+      $this->createType('t_other_d', 'Delta', 'Other'),
+    ];
+
+    usort($types, [TripalEntityType::class, 'sort']);
+
+    $ordered_labels = array_map(fn($type) => $type->label(), $types);
+
+    $this->assertEquals(
+      ['Alpha', 'Bravo', 'Delta'],
+      $ordered_labels,
+      '"General" types should sort before all other categories, and be sorted by label among themselves.'
+    );
+  }
+
+}


### PR DESCRIPTION
<!--- Thank you for contributing! -->
<!--- Provide a general summary of your changes in the Title above -->
<!--- See our Contribution Guidelines here:
          https://tripaldoc.readthedocs.io/en/latest/contributing.html -->


<!---  Please set the header below based on the PR type:
# New Feature
# Bug Fix
# Tripal 4 Core Dev Task  --->

# Bug Fix

### Issue #2540

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Sorting Tripal Content Types on the Category listing page uses the incorrect sorting method. 

The changes include removing a redundant function (`load()`) that held sorting logic and instead rename the actual sorting function in the TripalEntityType class from `sortByCategory()` to just `sort()`. Also, this change reverses the sort order so that it is in alphabetical order (previously it was reversed, z->a).

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Visit `admin/structure/bio_data` on this branch and view the order of the content types. They should be in order, alphabetically, first by category and then by label. "General" is a special case which always gets sorted to the top. If you have 1 or fewer categories installed, use the "+ Import type collection" button at the top to install more categories.
