### PR TITLE
Fix publishing of boolean fields with Drupal caching off

### DIFF
--- a/tripal/src/TripalStorage/BoolStoragePropertyType.php
+++ b/tripal/src/TripalStorage/BoolStoragePropertyType.php
@@ -32,11 +32,16 @@ class BoolStoragePropertyType extends StoragePropertyTypeBase {
   /**
    * Returns the default empty value of the correct type for this property.
    *
-   * @return bool
-   *   A boolean FALSE value.
+   * Drupal uses integers for booleans for compatibility with various database
+   * engines. If we return a FALSE here, it may be replaced with an empty
+   * string when placeholders are substituted deep inside Drupal and Postgres
+   * will throw an exception.
+   *
+   * @return int
+   *   A boolean FALSE value encoded as an integer.
    */
   public function getDefaultValue() {
-    return FALSE;
+    return 0;
   }
 
 }

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -438,6 +438,7 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     $this->assertEquals(1, $n, 'Did not delete null publication from chado where pub_id=1');
 
     $states = ['drupal caching on' => TRUE, 'drupal caching off' => FALSE];
+    $entity_id_offset = 0;
     foreach ($states as $label => $state) {
       // Sets the state of caching in Drupal field tables.
       \Drupal::configFactory()
@@ -451,11 +452,10 @@ class ChadoPublishTest extends ChadoTestKernelBase {
         'schema_name' => $this->testSchemaName,
         'republish' => 1,
       ];
-      $published_entities = $this->chado_publish->publish($publish_options);
-      // Expected count here is same as max_delta.
-      $this->assertCount(100, $published_entities,
-        'We did not publish the expected number of entities with ' . $label);
-      // Verify that a field table was populated
+      $this->chado_publish->publish($publish_options);
+      $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
+      $this->assertCount(150, $drupal_records, 'Number of published records is incorrect with ' . $label);
+      // Verify that a field table was populated for each publication.
       // Because this is a test environment, we know that the entity IDs
       // that we just published will start with 1, but because of the
       // "null" contact, we will just check the project table.
@@ -467,8 +467,23 @@ class ChadoPublishTest extends ChadoTestKernelBase {
         $ids = $query->execute();
         $this->assertEquals(1, count($ids), 'We did not retrieve the publication title field with ' . $label);
         $entity_id = reset($ids);
-        $this->assertEquals($i - 1, $entity_id, 'We did not retrieve the expected publication entity id from its field with ' . $label);
+        $this->assertEquals($i - 1 + $entity_id_offset, $entity_id, 'We did not retrieve the expected publication entity id from its field with ' . $label);
       }
+
+      // Unpublish them all.
+      $publish_options = [
+        'bundle' => 'pub',
+        'datastore' => 'chado_storage',
+        'schema_name' => $this->testSchemaName,
+        'unpublish' => TRUE,
+        'orphaned' => FALSE,
+      ];
+      $this->chado_publish->publish($publish_options);
+      $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
+      $this->assertEmpty($drupal_records, count($drupal_records) . ' publications were not unpublished with ' . $label);
+
+      // Advance entity IDs for next pass.
+      $entity_id_offset += 150;
     }
   }
 

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -431,14 +431,12 @@ class ChadoPublishTest extends ChadoTestKernelBase {
    * Tests publishing with Drupal caching turned off.
    */
   public function testTripalPublishServiceNoCaching() {
-    // Simplify this test by removing the null publication from chado.
-    $n = $this->connection->delete('1:pub')
-      ->condition('pub_id', 1, '=')
-      ->execute();
-    $this->assertEquals(1, $n, 'Did not delete null publication from chado where pub_id=1');
+    // The cache states that we will test.
+    $states = [
+      'drupal caching on' => TRUE,
+      'drupal caching off' => FALSE,
+    ];
 
-    $states = ['drupal caching on' => TRUE, 'drupal caching off' => FALSE];
-    $entity_id_offset = 0;
     foreach ($states as $label => $state) {
       // Sets the state of caching in Drupal field tables.
       \Drupal::configFactory()
@@ -450,24 +448,16 @@ class ChadoPublishTest extends ChadoTestKernelBase {
         'bundle' => 'pub',
         'datastore' => 'chado_storage',
         'schema_name' => $this->testSchemaName,
-        'republish' => 1,
       ];
       $this->chado_publish->publish($publish_options);
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
-      $this->assertCount(150, $drupal_records, 'Number of published records is incorrect with ' . $label);
+      // The null publication will also be published.
+      $this->assertCount(151, $drupal_records, 'Number of published records is incorrect with ' . $label);
       // Verify that a field table was populated for each publication.
-      // Because this is a test environment, we know that the entity IDs
-      // that we just published will start with 1, but because of the
-      // "null" contact, we will just check the project table.
-      for ($i = 2; $i <= 151; $i++) {
-        $query = \Drupal::entityQuery('tripal_entity')
-          ->condition('type', 'pub')
-          ->condition('pub_title.record_id', $i, '=')
-          ->accessCheck(TRUE);
-        $ids = $query->execute();
-        $this->assertEquals(1, count($ids), 'We did not retrieve the publication title field with ' . $label);
-        $entity_id = reset($ids);
-        $this->assertEquals($i - 1 + $entity_id_offset, $entity_id, 'We did not retrieve the expected publication entity id from its field with ' . $label);
+      $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
+      $this->assertCount(151, $drupal_records, 'Incorrect number of publications published with ' . $label);
+      for ($pkey = 1; $pkey <= 151; $pkey++) {
+        $this->assertArrayHasKey($pkey, $drupal_records, 'Missing pub_id $pkey when published with ' . $label);
       }
 
       // Unpublish them all.
@@ -481,9 +471,6 @@ class ChadoPublishTest extends ChadoTestKernelBase {
       $this->chado_publish->publish($publish_options);
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
       $this->assertEmpty($drupal_records, count($drupal_records) . ' publications were not unpublished with ' . $label);
-
-      // Advance entity IDs for next pass.
-      $entity_id_offset += 150;
     }
   }
 

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -428,6 +428,51 @@ class ChadoPublishTest extends ChadoTestKernelBase {
   }
 
   /**
+   * Tests publishing with Drupal caching turned off.
+   */
+  public function testTripalPublishServiceNoCaching() {
+    // Simplify this test by removing the null publication from chado.
+    $n = $this->connection->delete('1:pub')
+      ->condition('pub_id', 1, '=')
+      ->execute();
+    $this->assertEquals(1, $n, 'Did not delete null publication from chado where pub_id=1');
+
+    $states = ['drupal caching on' => TRUE, 'drupal caching off' => FALSE];
+    foreach ($states as $label => $state) {
+      // Sets the state of caching in Drupal field tables.
+      \Drupal::configFactory()
+        ->getEditable('tripal.settings')
+        ->set('tripal_entity_type.default_cache_backend_field_values', $state)
+        ->save();
+
+      $publish_options = [
+        'bundle' => 'pub',
+        'datastore' => 'chado_storage',
+        'schema_name' => $this->testSchemaName,
+        'republish' => 1,
+      ];
+      $published_entities = $this->chado_publish->publish($publish_options);
+      // Expected count here is same as max_delta.
+      $this->assertCount(100, $published_entities,
+        'We did not publish the expected number of entities with ' . $label);
+      // Verify that a field table was populated
+      // Because this is a test environment, we know that the entity IDs
+      // that we just published will start with 1, but because of the
+      // "null" contact, we will just check the project table.
+      for ($i = 2; $i <= 151; $i++) {
+        $query = \Drupal::entityQuery('tripal_entity')
+          ->condition('type', 'pub')
+          ->condition('pub_title.record_id', $i, '=')
+          ->accessCheck(TRUE);
+        $ids = $query->execute();
+        $this->assertEquals(1, count($ids), 'We did not retrieve the publication title field with ' . $label);
+        $entity_id = reset($ids);
+        $this->assertEquals($i - 1, $entity_id, 'We did not retrieve the expected publication entity id from its field with ' . $label);
+      }
+    }
+  }
+
+  /**
    * Returns a count of number of entries in a Drupal field table.
    *
    * @param string $table_name

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -512,25 +512,22 @@ class ChadoPublishTest extends ChadoTestKernelBase {
         'datastore' => 'chado_storage',
         'schema_name' => $this->testSchemaName,
       ];
+     $expected_count = 151;
+
       $this->chado_publish->publish($publish_options);
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
       // The null publication will also be published.
-      $this->assertCount(151, $drupal_records, 'Number of published records is incorrect with ' . $label);
+      $this->assertCount($expected_count, $drupal_records, 'Number of published records is incorrect with ' . $label);
       // Verify that a field table was populated for each publication.
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
-      $this->assertCount(151, $drupal_records, 'Incorrect number of publications published with ' . $label);
-      for ($pkey = 1; $pkey <= 151; $pkey++) {
+      $this->assertCount($expected_count, $drupal_records, 'Incorrect number of publications published with ' . $label);
+      for ($pkey = 1; $pkey <= $expected_count; $pkey++) {
         $this->assertArrayHasKey($pkey, $drupal_records, 'Missing pub_id $pkey when published with ' . $label);
       }
 
       // Unpublish them all.
-      $publish_options = [
-        'bundle' => 'pub',
-        'datastore' => 'chado_storage',
-        'schema_name' => $this->testSchemaName,
-        'unpublish' => TRUE,
-        'orphaned' => FALSE,
-      ];
+      $publish_options['unpublish'] = TRUE;
+      $publish_options['orphaned'] = FALSE;
       $this->chado_publish->publish($publish_options);
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
       $this->assertEmpty($drupal_records, count($drupal_records) . ' publications were not unpublished with ' . $label);

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -512,17 +512,23 @@ class ChadoPublishTest extends ChadoTestKernelBase {
         'datastore' => 'chado_storage',
         'schema_name' => $this->testSchemaName,
       ];
-     $expected_count = 151;
+      $expected_count = 151;
 
       $this->chado_publish->publish($publish_options);
+      // Check that there were the correct number of publications published
+      // to the Drupal field table.
+      // NOTE: The null publication will also be published.
       $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
-      // The null publication will also be published.
       $this->assertCount($expected_count, $drupal_records, 'Number of published records is incorrect with ' . $label);
-      // Verify that a field table was populated for each publication.
-      $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_title', 'pub_title_record_id');
-      $this->assertCount($expected_count, $drupal_records, 'Incorrect number of publications published with ' . $label);
       for ($pkey = 1; $pkey <= $expected_count; $pkey++) {
         $this->assertArrayHasKey($pkey, $drupal_records, 'Missing pub_id $pkey when published with ' . $label);
+      }
+      // Verify that a field table was populated for each publication
+      // for the is_obsolete field which is a boolean field.
+      $drupal_records = $this->getPublicTableRecords('tripal_entity__pub_is_obsolete', 'pub_is_obsolete_value');
+      foreach ($drupal_records as $record) {
+        $this->assertObjectHasProperty('pub_is_obsolete_value', $record, 'Missing pub_is_obsolete_value when published with ' . $label);
+        $this->assertEquals(0, $record->pub_is_obsolete_value, 'pub_is_obsolete_value is not 0 when published with ' . $label);
       }
 
       // Unpublish them all.

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1271,13 +1271,12 @@ function tripal_chado_update_10420() {
 }
 
 /**
- * Adds field properties for datetime chado columns. PR 2524 + PR 2560.
+ * Adds field properties for datetime chado columns. PR 2524.
  */
-function tripal_chado_update_10422() {
-  // This hook was renumbered from 10421 to 10422 by PR 2560 to fix a bug.
+function tripal_chado_update_10421() {
   tripal_chado_field_reload(['chado_analysis_type_default'], ['analysis_timeexecuted'], FALSE);
   // Tripal doesn't define any default instances of these fields,
   // but they may have been discovered.
-  tripal_chado_field_reload(['chado_feature_type_default'], ['feature_timeaccessioned', 'feature_timelastmodified'], FALSE);
+  tripal_chado_field_reload(['chado_feature_type_default'], ['gene_timeaccessioned', 'gene_timelastmodified', 'mrna_timeaccessioned', 'mrna_timelastmodified'], FALSE);
   tripal_chado_field_reload(['chado_assay_type_default'], ['assay_assaydate'], FALSE);
 }

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1271,12 +1271,13 @@ function tripal_chado_update_10420() {
 }
 
 /**
- * Adds field properties for datetime chado columns. PR 2524.
+ * Adds field properties for datetime chado columns. PR 2524 + PR 2560.
  */
-function tripal_chado_update_10421() {
+function tripal_chado_update_10422() {
+  // This hook was renumbered from 10421 to 10422 by PR 2560 to fix a bug.
   tripal_chado_field_reload(['chado_analysis_type_default'], ['analysis_timeexecuted'], FALSE);
   // Tripal doesn't define any default instances of these fields,
   // but they may have been discovered.
-  tripal_chado_field_reload(['chado_feature_type_default'], ['gene_timeaccessioned', 'gene_timelastmodified', 'mrna_timeaccessioned', 'mrna_timelastmodified'], FALSE);
+  tripal_chado_field_reload(['chado_feature_type_default'], ['feature_timeaccessioned', 'feature_timelastmodified'], FALSE);
   tripal_chado_field_reload(['chado_assay_type_default'], ['assay_assaydate'], FALSE);
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2548

## Description
Publishing of content with a boolean field is failing if Drupal caching is turned off.
Drupal uses integers for booleans for compatibility with various database engines. Currently `getDefaultValue()` for the boolean field returns FALSE. This boolean value may be replaced with an empty string when placeholders are substituted deep inside Drupal, and Postgres will throw an exception.

 - [x] Add a phpunit test to catch this - first commit [7acaa18](https://github.com/tripal/tripal/pull/2549/commits/7acaa18837437107ad409df4a3ab214a54e24ae4) will test this
 - [x] Fix it by returning an integer for the default value [da9871a](https://github.com/tripal/tripal/pull/2549/commits/da9871a9a4347f6f2c0de4227476599d6ffb97a2)

## Testing?
This is now tested by phpunit. For a manual test:
1. Create a publication through the UI (or other content with a boolean field) or even just let the null publication be published.
2. Turn off Drupal caching: Tripal -> Configuration -> Tripal Entity Settings -> uncheck "Cache Backend Storage field values in Drupal"
3. Save
4. Try republish `drush trp-chado-pub pub --republish`
5. Error should not appear