### PR TITLE
Bundles must have at least one required field to permit publish

### DIFF
--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -205,7 +205,7 @@ class TripalEntityLookup {
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
       // required field for every content type. If not, we cannot continue.
-      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At lease one is needed to lookup entity ID from record ID.");
+      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At least one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,
@@ -290,7 +290,7 @@ class TripalEntityLookup {
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
       // required field for every content type. If not, we cannot continue.
-      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At lease one is needed to lookup entity ID from record ID.");
+      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At least one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,

--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -192,6 +192,11 @@ class TripalEntityLookup {
    *   returned array may have more than one entity id. This would happen
    *   in Tripal 3, for example if an analysis is published as both
    *   "Analysis", and as "Genome Assembly".
+   *
+   * @throws \Exception
+   *   If the content type has no required fields. This can happen if
+   *   a user created a new content type and did not mark any of the
+   *   fields as required.
    */
   public function getEntityIdFromRecordId($record_id, $bundle_id, $entity_type) : array {
 
@@ -199,8 +204,8 @@ class TripalEntityLookup {
     $required_fields = $this->getRequiredFields($bundle_id, $entity_type);
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
-      // required field for every content type. If not, we cannot create a link.
-      return $ids;
+      // required field for every content type. If not, we cannot continue.
+      throw new \Exception("Bundle \"$bundle_id\" does not have any reqired fields. At lease one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,
@@ -272,6 +277,11 @@ class TripalEntityLookup {
    * @return array
    *   A list of all published entities in the bundle.
    *   The key will be the chado table record ID, the values will be the entity IDs.
+   *
+   * @throws \Exception
+   *   If the content type has no required fields. This can happen if
+   *   a user created a new content type and did not mark any of the
+   *   fields as required.
    */
   public function getPublishedEntityIds($bundle_id, $entity_type = 'tripal_entity') : array {
 
@@ -280,7 +290,7 @@ class TripalEntityLookup {
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
       // required field for every content type. If not, we cannot continue.
-      return $ids;
+      throw new \Exception("Bundle \"$bundle_id\" does not have any reqired fields. At lease one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,

--- a/tripal/src/Services/TripalEntityLookup.php
+++ b/tripal/src/Services/TripalEntityLookup.php
@@ -205,7 +205,7 @@ class TripalEntityLookup {
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
       // required field for every content type. If not, we cannot continue.
-      throw new \Exception("Bundle \"$bundle_id\" does not have any reqired fields. At lease one is needed to lookup entity ID from record ID.");
+      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At lease one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,
@@ -290,7 +290,7 @@ class TripalEntityLookup {
     if (!$required_fields) {
       // Everything is based on the assumption that there is at least one
       // required field for every content type. If not, we cannot continue.
-      throw new \Exception("Bundle \"$bundle_id\" does not have any reqired fields. At lease one is needed to lookup entity ID from record ID.");
+      throw new \Exception("Bundle \"$bundle_id\" does not have any required fields. At lease one is needed to lookup entity ID from record ID.");
     }
 
     // We only need to evaluate for one of the required fields,

--- a/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.expression_chado.yml
@@ -11,7 +11,7 @@ fields:
         type: chado_text_type_default
         description: The name of the item.
         cardinality: 1
-        required: false
+        required: true
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genetic_chado.yml
@@ -11,7 +11,7 @@ fields:
         type: chado_string_type_default
         description: The name of the item.
         cardinality: 1
-        required: false
+        required: true
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:

--- a/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
+++ b/tripal_chado/config/install/tripal.tripalfield_collection.genomic_chado.yml
@@ -1210,7 +1210,7 @@ fields:
         type: chado_string_type_default
         description: The name of the item.
         cardinality: 1
-        required: false
+        required: true
         storage_settings:
             storage_plugin_id: chado_storage
             storage_plugin_settings:

--- a/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
+++ b/tripal_chado/src/Plugin/TripalBackendPublish/ChadoPublish.php
@@ -1432,7 +1432,14 @@ class ChadoPublish extends TripalBackendPublishBase {
 
     // Get a list of already-published entities. The key will be the
     // chado table record ID, the values will be the entity IDs.
-    $this->existing_published_entities = $this->entity_lookup_manager->getPublishedEntityIds($this->bundle, 'tripal_entity');
+    // An exception is thrown if the bundle has no required fields.
+    try {
+      $this->existing_published_entities = $this->entity_lookup_manager->getPublishedEntityIds($this->bundle, 'tripal_entity');
+    }
+    catch (\Exception $e) {
+      $this->logger->error($e->getMessage());
+      return [];
+    }
 
     // If not republishing everything, remove any already published records.
     if (!$this->republish) {

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -35,7 +35,7 @@ class ChadoPublishTest extends ChadoTestKernelBase {
   protected $chado_publish;
 
   /**
-   * The most recent error message from the mocked tripal logger.
+   * The most recent warning and error messages from the mocked tripal logger.
    *
    * @var string
    */
@@ -55,9 +55,14 @@ class ChadoPublishTest extends ChadoTestKernelBase {
 
     // Create a mocked logger so we can access error messages from the Tripal logger.
     $mock_logger = $this->getMockBuilder(TripalLogger::class)
-      ->onlyMethods(['warning'])
+      ->onlyMethods(['warning', 'error'])
       ->getMock();
     $mock_logger->method('warning')
+      ->willReturnCallback(function ($message, $context, $options) {
+          $this->mock_warning .= str_replace(array_keys($context), $context, $message);
+          return NULL;
+      });
+    $mock_logger->method('error')
       ->willReturnCallback(function ($message, $context, $options) {
           $this->mock_warning .= str_replace(array_keys($context), $context, $message);
           return NULL;
@@ -375,6 +380,20 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     $final_drupal_records = $this->getPublicTableRecords('tripal_entity__organism_genus', 'organism_genus_record_id');
     $this->assertEquals($initial_chado_records, $final_chado_records, 'Unexpected change to chado organism table');
     $this->assertEmpty($final_drupal_records, 'There are field records remaining that were not unpublished');
+
+    // Test that an exception is thrown if the bundle has no required fields.
+    // We will just remove the cached values for simplicity.
+    $cache_id = 'tripal_required_fields';
+    $cache = \Drupal::cache()->get($cache_id);
+    $data = $cache->data;
+    $data['organism'] = [];
+    \Drupal::cache()->set($cache_id, $data, time() + 3600);
+
+    // Now publish, and expecte a logger error message to be generated.
+    $this->mock_warning = '';
+    $publish_options = ['bundle' => 'organism', 'datastore' => 'chado_storage', 'schema_name' => $this->testSchemaName];
+    $published_entities = $this->chado_publish->publish($publish_options);
+    $this->assertStringContainsString('Bundle "organism" does not have any reqired fields', $this->mock_warning, 'Expected an exception message');
   }
 
   /**

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -400,7 +400,7 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     $data['organism'] = [];
     \Drupal::cache()->set($cache_id, $data, time() + 3600);
 
-    // Now publish, and expecte a logger error message to be generated.
+    // Now publish, and expect a logger error message to be generated.
     $this->mock_warning = '';
     $publish_options = ['bundle' => 'organism', 'datastore' => 'chado_storage', 'schema_name' => $this->testSchemaName];
     $published_entities = $this->chado_publish->publish($publish_options);

--- a/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/TripalBackendPublish/ChadoPublishTest.php
@@ -393,7 +393,7 @@ class ChadoPublishTest extends ChadoTestKernelBase {
     $this->mock_warning = '';
     $publish_options = ['bundle' => 'organism', 'datastore' => 'chado_storage', 'schema_name' => $this->testSchemaName];
     $published_entities = $this->chado_publish->publish($publish_options);
-    $this->assertStringContainsString('Bundle "organism" does not have any reqired fields', $this->mock_warning, 'Expected an exception message');
+    $this->assertStringContainsString('Bundle "organism" does not have any required fields', $this->mock_warning, 'Expected an exception message');
   }
 
   /**

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1292,9 +1292,9 @@ function tripal_chado_update_10423() {
   // ID for a published entity. It is not unreasonable to make the name
   // field required for these.
   $field_ids = [
-    'tripal_entity.expression.biosample_name',
-    'tripal_entity.genomic.physical_map_name',
-    'tripal_entity.genetic.genetic_map_name',
+    'tripal_entity.biosample.biosample_name',
+    'tripal_entity.physical_map.physical_map_name',
+    'tripal_entity.genetic_map.genetic_map_name',
   ];
   tripal_chado_set_field_required_status($field_ids, TRUE, 'Could not set field required setting');
 }

--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1281,3 +1281,20 @@ function tripal_chado_update_10422() {
   tripal_chado_field_reload(['chado_feature_type_default'], ['feature_timeaccessioned', 'feature_timelastmodified'], FALSE);
   tripal_chado_field_reload(['chado_assay_type_default'], ['assay_assaydate'], FALSE);
 }
+
+/**
+ * Sets some fields as required to allow republish.
+ */
+function tripal_chado_update_10423() {
+  // This hook added by PR 2556. The corresponding columns are not defined
+  // as NOT NULL by chado, but we require that every content type has at
+  // least one required field, so that republish can determine chado record
+  // ID for a published entity. It is not unreasonable to make the name
+  // field required for these.
+  $field_ids = [
+    'tripal_entity.expression.biosample_name',
+    'tripal_entity.genomic.physical_map_name',
+    'tripal_entity.genetic.genetic_map_name',
+  ];
+  tripal_chado_set_field_required_status($field_ids, TRUE, 'Could not set field required setting');
+}


### PR DESCRIPTION
# Bug Fix

### Closes #2555

## Description

Scenario: A user creates a new content type, and neglects to set any of the fields as required.

Publish depends on having at least one required field to detect existing published entities.

Existing behavior is to republish every entity every time publish is run, creating duplicate published entities for a single chado record.

Because we need at least one required field to detect entity_id, the new behavior will be to display an error message and halt publishing.

A serious problem is that the `biomaterial` table does not have any required columns other than `biomaterial_id` so we can't republish this either.
Also `featuremap` table lacks any required columns.
Resolved this by making the name field required for both of these, and added an update hook to do likewise. https://github.com/tripal/tripal/pull/2556/commits/6a5fb208c80a1c4229a248629b2b9abeda124b59

## Testing?

Phpunit testing has been extended to cover this.

To test manually, create a new content type and don't make any field required.
e.g use contact table, create content type "Lab", and add only the `name` field (Chado String Field Type)
Make sure it is not required!

<img width="186" height="52" alt="not_required" src="https://github.com/user-attachments/assets/0d12b222-d8a3-45f5-ae67-16a48b96216c" />

Fix the page title format if you want, but this is not required to test
You can enter a new "Lab" through the UI
Republish should fail thusly:
```
drush trp-chado-pub lab --republish
 [notice] Initializing publish
 [notice] Finding all candidate records in the "contact" chado table
 [error]  ERROR: Bundle "lab" does not have any required fields. At least one is needed to lookup entity ID from record ID. 
[site http://default] [TRIPAL] ERROR: Bundle "lab" does not have any required fields. At least one is needed to lookup entity ID from record ID.
 [notice] There are no records to publish for this content type
```

To test the update hook, you would need to build a docker on 4.x, and import the Expression, Genetic, and Genomic content type collections. Then you can switch to this branch, and run the update hook. Verify that the name field is now required on biosample, genetic map, and physical map.