### PR TITLE
Fix and renumber update hook 10421

### DIFF
--- a/tripal_chado/tripal_chado.install
+++ b/tripal_chado/tripal_chado.install
@@ -1271,12 +1271,13 @@ function tripal_chado_update_10420() {
 }
 
 /**
- * Adds field properties for datetime chado columns. PR 2524.
+ * Adds field properties for datetime chado columns. PR 2524 + PR 2560.
  */
-function tripal_chado_update_10421() {
+function tripal_chado_update_10422() {
+  // This hook was renumbered from 10421 to 10422 by PR 2560 to fix a bug.
   tripal_chado_field_reload(['chado_analysis_type_default'], ['analysis_timeexecuted'], FALSE);
   // Tripal doesn't define any default instances of these fields,
   // but they may have been discovered.
-  tripal_chado_field_reload(['chado_feature_type_default'], ['gene_timeaccessioned', 'gene_timelastmodified', 'mrna_timeaccessioned', 'mrna_timelastmodified'], FALSE);
+  tripal_chado_field_reload(['chado_feature_type_default'], ['feature_timeaccessioned', 'feature_timelastmodified'], FALSE);
   tripal_chado_field_reload(['chado_assay_type_default'], ['assay_assaydate'], FALSE);
 }


### PR DESCRIPTION
# Bug Fix

### Closes #2559

## Description

A bug in the field naming is present in tripal_chado update hook 10421. On a site that had the genomic content type collection installed before this hook was introduced (PR #2524), it crashes and burns.

This PR fixes the bug, and renumbers the hook so that it can be run again if someone is in this broken state.

## Testing?
1.  We start by rolling back the version before this bug was introduced:
`git checkout 524c24fa`
2. Now build an "old" docker to best test this
`n=2559`
3. `drupalver=11.4`
4. `phpver=8.5`
5. `postgresqlversion=18`
6. Pick a port e.g. `port=11111`
7. `docker build --tag=tripalproject/tripaldocker-drupal:drupal${drupalver}.x-dev-php${phpver}-pgsql${postgresqlversion} --build-arg phpversion="${phpver}" --build-arg drupalversion="${drupalver}.x-dev" --build-arg postgresqlversion="${postgresqlversion}" --file=tripaldocker/drupal.Dockerfile ./`
8. `docker build --build-arg chadoschema="$chadoschema" --build-arg phpversion="${phpver}" --build-arg drupalversion="${drupalver}.x-dev" --build-arg postgresqlversion="${postgresqlversion}" --tag=tripalproject/tripaldocker:drupal${drupalver}.x-dev-php${phpver}-pgsql${postgresqlversion} ./`
9. `docker run --publish=${port}:80 -tid --name=$n --volume=$(pwd):/var/www/drupal9/web/modules/contrib/tripal --volume=$HOME/docker_prepare:/usr/local/bin/docker_common tripalproject/tripaldocker:drupal${drupalver}.x-dev-php${phpver}-pgsql${postgresqlversion}`
10. `docker exec -it $n bash -c "drush trp-import-types --collection_id genomic_chado"`
11. Return to current state:
`git checkout tv4g1-issue2559-fix-hook-10421`
12. Run the update hook, it should complete successfully both if you ran hook 10421 before or if you didn't:
`docker exec -it $n bash -c "drush updatedb"`
```
 -------------- ----------- --------------- ----------------------------------- 
  Module         Update ID   Type            Description                        
 -------------- ----------- --------------- ----------------------------------- 
  tripal_chado   10422       hook_update_n   10422 - Adds field properties for  
                                             datetime chado columns. PR 2524 +  
                                             PR 2560.                           
 -------------- ----------- --------------- ----------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: tripal_chado_update_10422
>  [notice] Update completed: tripal_chado_update_10422
>  [notice] Message: Updating properties for Drupal table "tripal_entity__phylotree_analysis",  
> field "phylotree_analysis"
> 
>  [notice] Message: Updating properties for Drupal table "tripal_entity__project_analysis", field  
> "project_analysis"
> 
>  [notice] Message: Updating properties for Drupal table "tripal_entity__speciestree_analysis",  
> field "speciestree_analysis"
> 
>  [notice] Message: Added 0 properties, updated 3 properties for chado_analysis_type_default
> 
>  [notice] Message: Added 0 properties, updated 0 properties for chado_feature_type_default
> 
>  [notice] Message: Added 0 properties, updated 0 properties for chado_assay_type_default
> 
 [success] Finished performing updates.
```