### PR TITLE
Allow discover() to pass display options

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -80,3 +80,9 @@
 # Deprecation: Since Drupal 11.5: Using the SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated in drupal:11.5.0 and is removed from drupal:12.0.0. See https://www.drupal.org/node/3594014
 # Example test that triggers this: ConfigTest::testConfigYaml
 %SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated%
+
+# Module: Drupal 11.5
+# Location: themes/contrib/gin/gin.theme
+# Deprecation: Using gin.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0. Use classes instead. See https://www.drupal.org/node/3581222
+# Example test that triggers this: testTripalAccessOwnContentCheck
+%Using gin.theme is deprecated in drupal:11.5.0%

--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -85,4 +85,4 @@
 # Location: themes/contrib/gin/gin.theme
 # Deprecation: Using gin.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0. Use classes instead. See https://www.drupal.org/node/3581222
 # Example test that triggers this: testTripalAccessOwnContentCheck
-%Using gin.theme is deprecated in drupal:11.5.0%
+%.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0%

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -1143,7 +1143,7 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    *   Keys recognized here:
    *   - 'display': Used to override default display settings.
    *     For example, to hide the field label, we would use:
-   *     'display' => ['default']['label'] = 'hidden'.
+   *     'display' => ['view']['default']['label'] = 'hidden'.
    *
    * @return array
    *   The same array with plugin IDs added.

--- a/tripal_chado/src/TripalField/ChadoFieldItemBase.php
+++ b/tripal_chado/src/TripalField/ChadoFieldItemBase.php
@@ -1123,8 +1123,8 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
       $field_list = $field_list + self::discoverLinked($bundle, $field_id, $field_types, $field_instances, $options);
     }
 
-    // Adds collection plugin IDs
-    $field_list = self::discoverPostprocess($field_list);
+    // Adds collection plugin IDs and display options.
+    $field_list = self::discoverPostprocess($field_list, $options);
 
     return $field_list;
   }
@@ -1134,17 +1134,27 @@ abstract class ChadoFieldItemBase extends TripalFieldItemBase {
    *
    * Used for the field discovery process if a DB or CV
    * is not a tripal collection yet.
+   * Also allows overriding of the default display settings.
    *
    * @param array $field_list
    *   Discoverd field definitions.
+   * @param array $options
+   *   Specific options from the field's discover() function.
+   *   Keys recognized here:
+   *   - 'display': Used to override default display settings.
+   *     For example, to hide the field label, we would use:
+   *     'display' => ['default']['label'] = 'hidden'.
    *
    * @return array
    *   The same array with plugin IDs added.
    */
-  public static function discoverPostprocess(array $field_list): array {
+  public static function discoverPostprocess(array $field_list, array $options = []): array {
     foreach ($field_list as $key => $field) {
       $field_list[$key]['settings']['id_space_plugin_id'] = 'chado_id_space';
       $field_list[$key]['settings']['vocabulary_plugin_id'] = 'chado_vocabulary';
+      if (array_key_exists('display', $options)) {
+        $field_list[$key]['display'] = $options['display'];
+      }
     }
     return $field_list;
   }


### PR DESCRIPTION
# New Feature

### Closes #2563

## Description

Use case: A field formatter that presents information as a table.
In this case we may not want the field label to be displayed, because the table has column headings.
In this case, the field `discover()` function should hide the field label by default.

<img width="309" height="150" alt="Image" src="https://github.com/user-attachments/assets/26c44e50-b1b8-48dd-8f7c-b20066e515c2" />

## Testing?

This will be used in the tripal file module, PR #2273, not on any current fields.
You can test this feature on that branch by discovering fields on various content types, e.g. organism or project, and adding the file field.
After the file field is added, the display settings should look like:
<img width="1254" height="64" alt="file_on_organism_is_hidden" src="https://github.com/user-attachments/assets/49915cb0-ed25-415e-9199-7efa65f40d16" />

