### PR TITLE
Ignore various .theme deprecations

### DIFF
--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -80,3 +80,9 @@
 # Deprecation: Since Drupal 11.5: Using the SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated in drupal:11.5.0 and is removed from drupal:12.0.0. See https://www.drupal.org/node/3594014
 # Example test that triggers this: ConfigTest::testConfigYaml
 %SYMFONY_DEPRECATIONS_HELPER environment variable to configure test runs is deprecated%
+
+# Module: Drupal 11.5
+# Location: themes/contrib/gin/gin.theme
+# Deprecation: Using gin.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0. Use classes instead. See https://www.drupal.org/node/3581222
+# Example test that triggers this: testTripalAccessOwnContentCheck
+%Using gin.theme is deprecated in drupal:11.5.0%

--- a/.tripal-deprecation-ignore.txt
+++ b/.tripal-deprecation-ignore.txt
@@ -85,4 +85,4 @@
 # Location: themes/contrib/gin/gin.theme
 # Deprecation: Using gin.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0. Use classes instead. See https://www.drupal.org/node/3581222
 # Example test that triggers this: testTripalAccessOwnContentCheck
-%Using gin.theme is deprecated in drupal:11.5.0%
+%.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0%


### PR DESCRIPTION
# Bug Fix

### Closes #2484

## Description

This ignores the gin.theme deprecations until the gin team fixes them.

## Testing?

The many deprecation messages on Drupal 11.x should go away on this branch.

```
    /var/www/drupal/web/core/lib/Drupal/Core/Hook/ThemeHookCollectorPass.php:113
    Using gin.theme is deprecated in drupal:11.5.0 and is removed from drupal:13.0.0. Use classes instead. See https://www.drupal.org/node/3581222

Triggered by:

    Drupal\Tests\tripal\Functional\Entity\EntityAccessTest::testTripalAccessOwnContentCheck
    /var/www/drupal/web/modules/contrib/tripal/tripal/tests/src/Functional/Entity/EntityAccessTest.php:34

    Drupal\Tests\tripal\Functional\Entity\EntityAccessTest::testTripalEntityAccessControlHandler
    /var/www/drupal/web/modules/contrib/tripal/tripal/tests/src/Functional/Entity/EntityAccessTest.php:51

    Drupal\Tests\tripal\Functional\Entity\TripalContentTest::testTripalContentCRUD
    /var/www/drupal/web/modules/contrib/tripal/tripal/tests/src/Functional/Entity/TripalContentTest.php:26
...
```