### PR TITLE
Fix two bugs in the phylogenetic tree generator

### DIFF
--- a/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
@@ -653,12 +653,11 @@ class TreeGenerator extends ChadoImporterBase implements ContainerFactoryPluginI
         return 2;
       }
 
-      // Prepare organism buddy, organism array parameter.
+      // Prepare organism buddy, organism array parameter, this has all of
+      // the columns in the organism table unique key.
       $organism_param = [];
       foreach (['genus', 'species', 'infraspecific_name', 'type_id'] as $fld) {
-        if (!empty($organism->{$fld})) {
-          $organism_param['organism.' . $fld] = $organism->{$fld};
-        }
+        $organism_param['organism.' . $fld] = $organism->{$fld};
       }
 
       $sci_name = $this->organism_buddy->getOrganismScientificName($organism_param);

--- a/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
+++ b/tripal_chado/src/Plugin/TripalImporter/TreeGenerator.php
@@ -300,7 +300,8 @@ class TreeGenerator extends ChadoImporterBase implements ContainerFactoryPluginI
       }
       elseif ($status == 3) {
         // Save a list of problematic organisms for a final warning message.
-        $message = 'id:' . $organism->organism_id . ' name:' . $this->organism_buddy->getOrganismScientificName($organism);
+        $organism_param = ['organism.organism_id' => $organism->organism_id];
+        $message = 'id:' . $organism->organism_id . ' name:' . $this->organism_buddy->getOrganismScientificName($organism_param);
         $omitted_organisms[] = $message;
       }
     }
@@ -415,14 +416,14 @@ class TreeGenerator extends ChadoImporterBase implements ContainerFactoryPluginI
         continue;
       }
 
-      $sci_name = $this->organism_buddy->getOrganismScientificName($organism);
+      $organism_param = ['organism.organism_id' => $organism->organism_id];
+      $sci_name = $this->organism_buddy->getOrganismScientificName($organism_param);
       $leaf_rank = 'species';
       if (property_exists($organism, 'type_id') and $organism->type_id and ($organism->type != 'no_rank')) {
         $leaf_rank = $organism->type;
       }
 
       // Now add in the leaf node, which is the organism.
-      $sci_name = $this->organism_buddy->getOrganismScientificName($organism);
       $node = [
         'name' => $sci_name,
         'depth' => $depth,


### PR DESCRIPTION
# Bug Fix

### Closes #2570

## Description

This fixes both of the bugs identified in issue #2570

## Testing?

1. Import organisms by NCBI taxid, one with an infraspecific type_id and name, one without:
Tripal -> Data Loaders -> NCBI Taxonomy Loader:
Use these values: 4039  79196
2. Manually create a fake organism through the UI, this will test an organism having no lineage.
3. Generate a tree: Tripal -> Data Loaders -> Taxonomy Tree Generator
4. This should succeed on this branch, and the two real organisms should be associated to nodes. The fake organism should, as expected, fail to be included in the tree.
```
...
WARNING: The following 1 organisms do not have a taxonomic lineage stored in Chado, and have not been included in the tree: "id:3 name:Tripalus bogusii"
[site http://default] [TRIPAL] WARNING: The following 1 organisms do not have a taxonomic lineage stored in Chado, and have not been included in the tree: "id:3 name:Tripalus bogusii"
Import phylotree: Associated <em class="placeholder">Daucus carota</em> to organism_id: <em class="placeholder">2</em>
Import phylotree: Associated <em class="placeholder">Daucus carota subsp. carota</em> to organism_id: <em class="placeholder">2</em>
Import phylotree summary: <em class="placeholder">2</em> nodes were successfully associated to content, <em class="placeholder">0</em> nodes could not be associated
...
```