### PR TITLE
Organism buddy find by scientific name infraspecies fix

### DIFF
--- a/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
+++ b/tripal_chado/src/ChadoBuddy/ChadoBuddyPluginBase.php
@@ -428,13 +428,13 @@ abstract class ChadoBuddyPluginBase extends PluginBase implements ChadoBuddyInte
     // Conditions are not aliased.
     $n = 0;
     foreach ($conditions as $key => $value) {
-      if (in_array($key, $insensitive_columns)) {
+      if ($value === NULL) {
+        $query->isNull($key);
+      }
+      elseif (in_array($key, $insensitive_columns)) {
         $query->where('LOWER(' . $key . ') = LOWER(:value' . $n . ')',
                       [':value' . $n => $value]);
         $n++;
-      }
-      elseif ($value === NULL) {
-        $query->isNull($key);
       }
       else {
         $query->condition($key, $value, '=');

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
@@ -497,20 +497,27 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
     // else specified by $options will be checked.
     // Split our string up into a maximum of 4 substrings or parts.
     $parts = preg_split('/\s+/', $scientific_name, 4);
-    // $scientific_name could be a single word, so make sure this is defined.
-    $parts[1] = $parts[1] ?? '';
-
+    // $scientific_name could be a single word, so make sure a
+    // placeholder for species is defined.
+    $parts[1] ??= '';
+    // Supply null defaults for organisms without infraspecies.
+    $parts[2] ??= NULL;
+    $parts[3] ??= NULL;
+    if ($parts[2]) {
+      // Expand the abbreviation from rank if it exists.
+      $parts[2] = $this->unabbreviateInfraspecificRank($parts[2]);
+    }
     // Setup our conditions for lookup.
     $conditions = [
       'organism.genus' => $parts[0],
       'organism.species' => $parts[1],
+      'organism.infraspecific_name' => $parts[3],
     ];
-    // Remove the abbreviation from rank if it exists.
-    if (array_key_exists(2, $parts)) {
-      $conditions['cvterm.name'] = $this->unabbreviateInfraspecificRank($parts[2]);
+    if ($parts[2]) {
+      $conditions['cvterm.name'] = $parts[2];
     }
-    if (array_key_exists(3, $parts)) {
-      $conditions['organism.infraspecific_name'] = $parts[3];
+    else {
+      $conditions['organism.type_id'] = NULL;
     }
 
     // Check 'case_sensitive' option and pass it through to our getter.

--- a/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
+++ b/tripal_chado/src/Plugin/ChadoBuddy/ChadoOrganismBuddy.php
@@ -503,10 +503,6 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
     // Supply null defaults for organisms without infraspecies.
     $parts[2] ??= NULL;
     $parts[3] ??= NULL;
-    if ($parts[2]) {
-      // Expand the abbreviation from rank if it exists.
-      $parts[2] = $this->unabbreviateInfraspecificRank($parts[2]);
-    }
     // Setup our conditions for lookup.
     $conditions = [
       'organism.genus' => $parts[0],
@@ -514,7 +510,8 @@ class ChadoOrganismBuddy extends ChadoBuddyPluginBase implements ChadoBuddyInter
       'organism.infraspecific_name' => $parts[3],
     ];
     if ($parts[2]) {
-      $conditions['cvterm.name'] = $parts[2];
+      // Expand the abbreviation from rank if it exists.
+      $conditions['cvterm.name'] = $this->unabbreviateInfraspecificRank($parts[2]);
     }
     else {
       $conditions['organism.type_id'] = NULL;

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
@@ -234,10 +234,24 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
     $no_infraspecific_organism_values = [
       'organism.genus' => 'Genus03',
       'organism.species' => 'species03',
+      'organism.type_id' => NULL,
+      'organism.infraspecific_name' => NULL,
+    ];
+    $exception_caught = FALSE;
+    try {
+      $no_infraspecific_rank_organism_name = $instance->getOrganismScientificName($no_infraspecific_organism_values);
+    }
+    catch (\Exception $e) {
+      $exception_caught = TRUE;
+    }
+    $this->assertTrue($exception_caught, 'Expected an exception for conditions not matching any organism');
+    // If we don't include infraspecies, the species should be returned.
+    $no_infraspecific_organism_values = [
+      'organism.genus' => 'Genus03',
+      'organism.species' => 'species03',
     ];
     $no_infraspecific_rank_organism_name = $instance->getOrganismScientificName($no_infraspecific_organism_values);
-    $this->assertEmpty($no_infraspecific_rank_organism_name, 'We retrieved the incorrect organism (' . $no_infraspecific_rank_organism_name . ') for one without infraspecies (Genus03 species03)');
-
+    $this->assertEquals('Genus03 species03 null infra03', $no_infraspecific_rank_organism_name, 'We failed to retrieve the expected organism: Genus03 species03 null infra03');
   }
 
   /**
@@ -661,6 +675,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
     ];
 
     // #3: Multiple organisms with the same genus and species.
+    // When no infraspecies in the name, must be likewise in the organism.
     $scenarios[] = [
       [
         [
@@ -678,7 +693,7 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
       ],
       'Tripalus databasica',
       [],
-      2,
+      0,
     ];
 
     // #4: An organism with an abbreviation

--- a/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
+++ b/tripal_chado/tests/src/Kernel/Plugin/ChadoBuddy/ChadoOrganismBuddyTest.php
@@ -220,6 +220,24 @@ class ChadoOrganismBuddyTest extends ChadoTestBuddyBase {
     ]);
     $this->assertEquals('Tripalus databasica brandnewcvtermname varietum', $infraspecific_newrank_organism_name, 'We did not retrieve the correct scientific name for an organism we updated with infraspecific rank: Tripalus databasica brandnewcvtermname varietum');
 
+    // TEST: Try to grab an organism without infraspecies when only
+    // an organism with infraspecies exists. Expect no organism returned.
+    $infraspecific_organism_values = [
+      'organism.genus' => 'Genus03',
+      'organism.species' => 'species03',
+      'organism.type_id' => 1,
+      'organism.infraspecific_name' => 'infra03',
+    ];
+    $instance->insertOrganism($infraspecific_organism_values);
+    $infraspecific_organism_name = $instance->getOrganismScientificName($infraspecific_organism_values);
+    $this->assertEquals('Genus03 species03 null infra03', $infraspecific_organism_name, 'We did not retrieve the correct scientific name for an organism we inserted');
+    $no_infraspecific_organism_values = [
+      'organism.genus' => 'Genus03',
+      'organism.species' => 'species03',
+    ];
+    $no_infraspecific_rank_organism_name = $instance->getOrganismScientificName($no_infraspecific_organism_values);
+    $this->assertEmpty($no_infraspecific_rank_organism_name, 'We retrieved the incorrect organism (' . $no_infraspecific_rank_organism_name . ') for one without infraspecies (Genus03 species03)');
+
   }
 
   /**


### PR DESCRIPTION
# Bug Fix

### Closes #2572 

### Depends on #2571

## Description

This fixes the case where if you ony have organism "Genus1 species2 subsp. infra3", and try to lookup by scientific name "Genus1 species2", you should not get any matches returned.
Right now on 4.x, you will get the organism with infraspecies returned.

## Testing?

I have phpunit now catching this. Scenario 3 in provideOrganismFromScientificNameScenarios should return no organisms, rather than two.

I also now test getOrganism with and without specifying infraspecies.

Manual testing can be done easily by generating a tree
1. Import one organism by NCBI taxidthat has an infraspecific type_id and name:
Use this value: 79196
2. Run the job
3. Generate a tree: Tripal -> Data Loaders -> Taxonomy Tree Generator
4. Run the job
5. This line should NOT be in the output any more:
`Import phylotree: Associated <em class="placeholder">Daucus carota</em> to organism_id: <em class="placeholder">1</em>`