### PR TITLE
fix: correct typo in phpunit config file paths

### DIFF
--- a/phpunit.11.xml
+++ b/phpunit.11.xml
@@ -74,7 +74,7 @@
       <file>tripal_chado/tripal_chado.module</file>
       <directory suffix=".php">tripal_layout/src</directory>
       <file>tripal_layout/tripal_layout.module</file>
-      <directory suffix=".php">tripal_search_viewsh_views/src</directory>
+      <directory suffix=".php">tripal_search_views/src</directory>
       <file>tripal_search_views/tripal_search_views.module</file>
     </include>
     <exclude>

--- a/phpunit.12.xml
+++ b/phpunit.12.xml
@@ -86,7 +86,7 @@
       <file>tripal_chado/tripal_chado.module</file>
       <directory suffix=".php">tripal_layout/src</directory>
       <file>tripal_layout/tripal_layout.module</file>
-      <directory suffix=".php">tripal_search_viewsh_views/src</directory>
+      <directory suffix=".php">tripal_search_views/src</directory>
       <file>tripal_search_views/tripal_search_views.module</file>
     </include>
     <exclude>


### PR DESCRIPTION
## Summary
Corrects a typo in two PHPUnit configuration files where the path contains an extra 'h':
- phpunit.11.xml line 77: `tripal_search_viewsh_views/src` → `tripal_search_views/src`
- phpunit.12.xml line 89: `tripal_search_viewsh_views/src` → `tripal_search_views/src`

## Changes
2 files changed, 2 insertions(+), 2 deletions(-)

## References
- Fixes tripal/tripal#2579 (Good First Issue)
- Author: Jah-yee