### PR TITLE
Text type cast deprecation

### DIFF
--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -316,7 +316,7 @@ WHERE pg_attribute.attnum > 0
 AND NOT pg_attribute.attisdropped
 AND pg_attribute.attrelid = :key::regclass
 AND (format_type(pg_attribute.atttypid, pg_attribute.atttypmod) = 'bytea'
-OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')
+OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid)::text LIKE 'nextval%')
 EOD;
         $result = $this->connection
           ->query($sql, [

--- a/tripal/src/TripalDBX/TripalDbxSchema.php
+++ b/tripal/src/TripalDBX/TripalDbxSchema.php
@@ -479,8 +479,8 @@ EOD;
           AND n.nspname = :schema
         )
       WHERE
-        p.proname ILIKE :function_name
-        AND pg_get_function_identity_arguments(p.oid) ILIKE :func_args
+        p.proname::text ILIKE :function_name
+        AND pg_get_function_identity_arguments(p.oid)::text ILIKE :func_args
     ";
     $args = [
       ':function_name' => $function_name,
@@ -599,10 +599,10 @@ EOD;
     $constraint_exists = $this->connection->query("
       SELECT TRUE
       FROM information_schema.table_constraints
-      WHERE table_name ILIKE :table
-        AND table_schema ILIKE :schema
-        AND constraint_type ILIKE :type
-        AND constraint_name ILIKE :name
+      WHERE table_name::text ILIKE :table
+        AND table_schema::text ILIKE :schema
+        AND constraint_type::text ILIKE :type
+        AND constraint_name::text ILIKE :name
       ;",
       [
         ':table' => $table,
@@ -674,8 +674,8 @@ EOD;
     $constraint_exists = $this->connection->query(
       "SELECT TRUE
       FROM information_schema.table_constraints
-      WHERE table_name ILIKE :table
-        AND table_schema ILIKE :schema
+      WHERE table_name::text ILIKE :table
+        AND table_schema::text ILIKE :schema
         AND constraint_type = 'PRIMARY KEY';",
       [
         ':table' => $table,

--- a/tripal/src/TripalDBX/pg-clone-schema/clone_schema.sql
+++ b/tripal/src/TripalDBX/pg-clone-schema/clone_schema.sql
@@ -485,8 +485,8 @@ BEGIN
   LOOP
     cnt := cnt + 1;
     IF data_type = 'USER-DEFINED' THEN
-        -- RAISE WARNING ' Table (%) has column(s) with user-defined types that will reference the source schema after they are created with the CREATE TABLE LIKE construct. Please modify after cloning.',tblname;
-        RAISE WARNING ' Table (%) has column(s) with user-defined types so using tripal_get_table_ddl() instead of CREATE TABLE LIKE construct.',tblname;
+        -- RAISE WARNING ' Table (%) has column(s) with user-defined types that will reference the source schema after they are created with the CREATE TABLE L I K E construct. Please modify after cloning.',tblname;
+        RAISE WARNING ' Table (%) has column(s) with user-defined types so using tripal_get_table_ddl() instead of CREATE TABLE L I K E construct.',tblname;
     END IF;
 
     buffer := quote_ident(dest_schema) || '.' || quote_ident(tblname);
@@ -888,7 +888,7 @@ BEGIN
     -- -- Matches everything till the first ')' included and replace the rest.
     -- SELECT regexp_replace(qry, '^([^\)]+\)).*$', '\1 RETURNS VOID LANGUAGE plpgsql AS $_$BEGIN END;$_$;', 'is') INTO dest_qry;
     -- -- Matches everything inside the parenthesis (function parameters) that has
-    -- -- something like " OUT,", " INOUT,", " INOUT)" or " OUT)" and removes the
+    -- -- something similar to " OUT,", " INOUT,", " INOUT)" or " OUT)" and removes the
     -- -- "RETURNS VOID" part if so, to avoid inconsistencies.
     -- SELECT regexp_replace(dest_qry, '(\((?:.+\s(?:IN)?OUT\s*,.+|.+\s(?:IN)?OUT\s*)\))\s* RETURNS VOID ', '\1', 'is') INTO dest_qry;
     -- SELECT replace(dest_qry, quote_ident(source_schema) || '.', quote_ident(dest_schema) || '.') INTO dest_qry;
@@ -975,7 +975,7 @@ BEGIN
         FROM information_schema.COLUMNS
        WHERE table_schema = source_schema
          AND TABLE_NAME = tblname
-         AND column_default ~* ('(^|\W)' || quote_ident(source_schema) || '\.')
+         AND column_default::text ~* ('(^|\W)' || quote_ident(source_schema) || '\.')
     LOOP
       IF ddl_only THEN
         -- May need to come back and revisit this since previous sql will not return anything since no schema as created!
@@ -993,7 +993,7 @@ BEGIN
       WHERE
         tablename = tblname
         AND schemaname = dest_schema
-        AND indexdef ~* ('(^|\W)' || quote_ident(source_schema) || '\.')
+        AND indexdef::text ~* ('(^|\W)' || quote_ident(source_schema) || '\.')
     LOOP
       buffer := regexp_replace(buffer::text, '(^|\W)' || quote_ident(source_schema) || '\.', '\1' || quote_ident(dest_schema) || '.', 'gis');
 

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -795,7 +795,7 @@ function tripal_tripal_admin_notifications_schema() {
         'not null' => TRUE,
       ],
       'actions' => [
-        'description' => 'Actions that can be performed on the notification, like disimissal or import.',
+        'description' => 'Actions that can be performed on the notification, e.g. dismissal or import.',
         'type' => 'text',
         'not null' => FALSE,
       ],

--- a/tripal_chado/src/Controller/ChadoCVTermAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoCVTermAutocompleteController.php
@@ -52,7 +52,7 @@ class ChadoCVTermAutocompleteController extends ControllerBase {
           FROM {1:cvterm} AS ct
             LEFT JOIN {1:dbxref} AS dx USING(dbxref_id)
             LEFT JOIN {1:db} USING(db_id)
-          WHERE LOWER(ct.name) LIKE :keyword";
+          WHERE LOWER(ct.name)::text LIKE :keyword";
         $args = [':keyword' => $keyword, ':limit' => $count];
         // Limit terms to selected CV when this is specified.
         if ($cv_id) {

--- a/tripal_chado/src/Controller/ChadoOrganismAutocompleteController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismAutocompleteController.php
@@ -135,7 +135,7 @@ class ChadoOrganismAutocompleteController extends ChadoGenericAutocompleteContro
       // A single "%" wildcard is used to indicate that we should return
       // all records. This is used for a form select element.
       if ($string != '%') {
-        $query->where("CONCAT_WS(' ', genus, species, name, infraspecific_name) ILIKE :value",
+        $query->where("CONCAT_WS(' ', genus, species, name, infraspecific_name)::text ILIKE :value",
             [':value' => $condition_value]);
       }
       $query->orderBy('organism', 'ASC');

--- a/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
+++ b/tripal_chado/src/Controller/ChadoOrganismFormElementController.php
@@ -109,7 +109,7 @@ class ChadoOrganismFormElementController extends ChadoGenericAutocompleteControl
       // Note: We don't need to trim here since this is a partial string
       // comparison.
       if ($string != '%') {
-        $query->where("CONCAT_WS(' ', genus, species, name, infraspecific_name) ILIKE :value",
+        $query->where("CONCAT_WS(' ', genus, species, name, infraspecific_name)::text ILIKE :value",
             [':value' => $condition_value]);
       }
       $query->orderBy('organism', 'ASC');

--- a/tripal_chado/src/Database/ChadoConnection.php
+++ b/tripal_chado/src/Database/ChadoConnection.php
@@ -314,7 +314,7 @@ class ChadoConnection extends TripalDbxConnection {
     // Remove all matching schemas.
     $db = \Drupal::database();
     $schemas = $db->query(
-      "SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '$test_schema%';"
+      "SELECT schema_name FROM information_schema.schemata WHERE schema_name::text LIKE '$test_schema%';"
     );
     $dropped = [];
     foreach ($schemas as $schema) {

--- a/tripal_chado/tests/src/Functional/ChadoImporter/GFF3ImporterTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoImporter/GFF3ImporterTest.php
@@ -160,7 +160,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     // Do checks on the featureprop table as well. Ensures the bio type value got added
     $results = $chado->query("SELECT * FROM {1:featureprop}
-      WHERE feature_id = :feature_id AND value LIKE :value;", [
+      WHERE feature_id = :feature_id AND value::text LIKE :value;", [
       ':feature_id' => $gene_feature_id,
       ':value' => 'protein_coding'
     ]);
@@ -172,7 +172,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     // Ensures the GAP value got added
     $results = $chado->query("SELECT * FROM {1:featureprop}
-      WHERE feature_id = :feature_id AND value LIKE :value;", [
+      WHERE feature_id = :feature_id AND value::text LIKE :value;", [
       ':feature_id' => $gene_feature_id,
       ':value' => 'test_gap_1'
     ]);
@@ -183,7 +183,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     // Ensures the NOTE value got added
     $results = $chado->query("SELECT * FROM {1:featureprop}
-      WHERE feature_id = :feature_id AND value LIKE :value;", [
+      WHERE feature_id = :feature_id AND value::text LIKE :value;", [
       ':feature_id' => $gene_feature_id,
       ':value' => 'test_gene_001_note'
     ]);
@@ -1050,7 +1050,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     $gff3_importer->postRun();
 
     $results = $chado->query("SELECT COUNT(*) as c1 FROM {1:featureprop}
-      WHERE value ILIKE :value",[
+      WHERE value::text ILIKE :value",[
       ':value' => 'T'
     ]);
     foreach ($results as $row) {
@@ -1058,7 +1058,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     }
 
     $results = $chado->query("SELECT COUNT(*) as c1 FROM {1:featureprop}
-      WHERE value ILIKE :value",[
+      WHERE value::text ILIKE :value",[
       ':value' => 'EST'
     ]);
     foreach ($results as $row) {
@@ -1111,7 +1111,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
     $gff3_importer->postRun();
 
     $results = $chado->query("SELECT COUNT(*) as c1 FROM {1:featureprop}
-      WHERE value ILIKE :value",[
+      WHERE value::text ILIKE :value",[
       ':value' => 'T,EST'
     ]);
     foreach ($results as $row) {
@@ -1166,7 +1166,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     // Check that the chr1_h1 feature (which is a landmark was added to feature table)
     $results = $chado->query("SELECT count(*) as c1 FROM {1:feature}
-      WHERE uniquename ILIKE :value",[
+      WHERE uniquename::text ILIKE :value",[
       ':value' => 'chr1_h1'
     ]);
     foreach ($results as $row) {
@@ -1182,7 +1182,7 @@ class GFF3ImporterTest extends ChadoTestBrowserBase
 
     // Check if the same chr1_h1 has type_id of chromosome_type_id
     $results = $chado->query("SELECT count(*) as c1 FROM {1:feature}
-      WHERE uniquename ILIKE :value AND type_id = :type_id",[
+      WHERE uniquename::text ILIKE :value AND type_id = :type_id",[
       ':value' => 'chr1_h1',
       ':type_id' => $chromosome_type_id
     ]);


### PR DESCRIPTION
# Bug Fix

### Closes #2582

## Description

This deals with the following deprecation on Drupal 11.x-dev
 1) /var/www/drupal/web/core/modules/pgsql/src/Driver/Database/pgsql/Connection.php:282
  Relying on the PostgreSQL database driver to add a ::text type-cast to fields used with LIKE and regular
  expression operators in SQL passed as a string is deprecated in drupal:11.5.0 and is removed from
  drupal:13.0.0. Add the ::text cast to the field explicitly or use the query builder.
  See https://www.drupal.org/node/3615418

A couple are false deprecation detections, but we'll change the wording as the simplest fix.

## Testing?

Besides code review, this is tested only through phpunit, there should be no deprecations on 11.x